### PR TITLE
Capture TPC‑DS compile errors

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -21,6 +21,9 @@
 - Added deterministic timestamp via `SOURCE_DATE_EPOCH` for TPC-DS golden tests (2025-07-15 06:39 UTC).
 - Enhanced TPC-DS golden tests to emit `.cpp` files and capture compilation errors (2025-07-15 06:57 UTC).
 
+## Recent Enhancements (2025-07-15 07:14 UTC)
+- Captured compilation failures for all TPC-DS queries via `tpcds_golden_test.go`.
+
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.
 - [ ] Support TPCH q1 and q5 compilation and execution.

--- a/tests/dataset/tpc-ds/compiler/cpp/q1.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q1.error
@@ -1,0 +1,325 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:75:12: error: ‘sr’ was not declared in this scope
+   75 |   decltype(sr.sr_customer_sk) customer_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:75:12: error: ‘sr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:76:12: error: ‘sr’ was not declared in this scope
+   76 |   decltype(sr.sr_store_sk) store_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:76:12: error: ‘sr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:79:12: error: ‘sr’ was not declared in this scope
+   79 |   decltype(sr) sr;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:79:12: error: ‘sr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:80:12: error: ‘d’ was not declared in this scope
+   80 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:80:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:235:23: error: no match for ‘operator==’ (operand types are ‘CustomerTotalReturn’ and ‘CustomerTotalReturn’)
+  235 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   |      CustomerTotalReturn
+      |                   CustomerTotalReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:236:43: error: cannot convert ‘StoreReturn’ to ‘int’ in initialization
+  236 |             __g.items.push_back(__struct6{sr, d});
+      |                                           ^~
+      |                                           |
+      |                                           StoreReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:243:65: error: cannot convert ‘StoreReturn’ to ‘int’ in initialization
+  243 |               __struct7{__key, std::vector<__struct6>{__struct6{sr, d}}});
+      |                                                                 ^~
+      |                                                                 |
+      |                                                                 StoreReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:243:71: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  243 |               __struct7{__key, std::vector<__struct6>{__struct6{sr, d}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:253:60: error: ‘struct __struct6’ has no member named ‘sr_return_amt’
+  253 |             std::vector<decltype(std::declval<__struct6>().sr_return_amt)>
+      |                                                            ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:253:60: error: ‘struct __struct6’ has no member named ‘sr_return_amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:253:74: error: template argument 1 is invalid
+  253 |             std::vector<decltype(std::declval<__struct6>().sr_return_amt)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:253:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:256:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  256 |               __items.push_back(x.sr_return_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:256:35: error: ‘struct __struct6’ has no member named ‘sr_return_amt’
+  256 |               __items.push_back(x.sr_return_amt);
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:252:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:251:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  251 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:251:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  251 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:262:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  226 |   std::vector<__struct6> customer_total_return = ([&]() {
+      |                                                  ~~~~~~~~
+  227 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  228 |     for (auto sr : store_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  229 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  230 |         if (!(((sr.sr_returned_date_sk == d.d_date_sk) && (d.d_year == 1998))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  231 |           continue;
+      |           ~~~~~~~~~
+  232 |         auto __key = CustomerTotalReturn{sr.sr_customer_sk, sr.sr_store_sk};
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  233 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  234 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  235 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  236 |             __g.items.push_back(__struct6{sr, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  237 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  238 |             break;
+      |             ~~~~~~
+  239 |           }
+      |           ~
+  240 |         }
+      |         ~
+  241 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  242 |           __groups.push_back(
+      |           ~~~~~~~~~~~~~~~~~~~
+  243 |               __struct7{__key, std::vector<__struct6>{__struct6{sr, d}}});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  244 |         }
+      |         ~
+  245 |       }
+      |       ~
+  246 |     }
+      |     ~
+  247 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  248 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |           g.key.customer_sk, g.key.store_sk, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  252 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  253 |             std::vector<decltype(std::declval<__struct6>().sr_return_amt)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  254 |                 __items;
+      |                 ~~~~~~~~
+  255 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |               __items.push_back(x.sr_return_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |             }
+      |             ~
+  258 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  259 |           })())});
+      |           ~~~~~~~~
+  260 |     }
+      |     ~
+  261 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  262 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:265:18: error: ‘c’ was not declared in this scope
+  265 |         decltype(c.c_customer_id),
+      |                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:266:75: error: template argument 2 is invalid
+  266 |         decltype(std::unordered_map<std::string, decltype(c.c_customer_id)>{
+      |                                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:266:75: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:266:9: error: template argument 1 is invalid
+  266 |         decltype(std::unordered_map<std::string, decltype(c.c_customer_id)>{
+      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  267 |             {std::string("c_customer_id"), c.c_customer_id}})>>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:266:9: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:267:62: error: template argument 1 is invalid
+  267 |             {std::string("c_customer_id"), c.c_customer_id}})>>
+      |                                                              ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:267:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:271:21: error: ‘struct __struct6’ has no member named ‘ctr_store_sk’
+  271 |         if (!((ctr1.ctr_store_sk == s.s_store_sk)))
+      |                     ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:274:23: error: ‘struct __struct6’ has no member named ‘ctr_customer_sk’
+  274 |           if (!((ctr1.ctr_customer_sk == c.c_customer_sk)))
+      |                       ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:276:24: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  276 |           if (!(((ctr1.ctr_total_return >
+      |                        ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:279:61: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  279 |                          decltype(std::declval<__struct6>().ctr_total_return)>
+      |                                                             ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:279:61: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:279:78: error: template argument 1 is invalid
+  279 |                          decltype(std::declval<__struct6>().ctr_total_return)>
+      |                                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:279:78: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:282:36: error: ‘struct __struct6’ has no member named ‘ctr_store_sk’
+  282 |                        if (!((ctr1.ctr_store_sk == ctr2.ctr_store_sk)))
+      |                                    ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:282:57: error: ‘struct __struct6’ has no member named ‘ctr_store_sk’
+  282 |                        if (!((ctr1.ctr_store_sk == ctr2.ctr_store_sk)))
+      |                                                         ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:284:32: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  284 |                        __items.push_back(ctr2.ctr_total_return);
+      |                                ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:284:47: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  284 |                        __items.push_back(ctr2.ctr_total_return);
+      |                                               ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:277:25: error: no matching function for call to ‘__avg(int)’
+  277 |                   (__avg(([&]() {
+      |                    ~~~~~^~~~~~~~~
+  278 |                      std::vector<
+      |                      ~~~~~~~~~~~~
+  279 |                          decltype(std::declval<__struct6>().ctr_total_return)>
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  280 |                          __items;
+      |                          ~~~~~~~~
+  281 |                      for (auto ctr2 : customer_total_return) {
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  282 |                        if (!((ctr1.ctr_store_sk == ctr2.ctr_store_sk)))
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  283 |                          continue;
+      |                          ~~~~~~~~~
+  284 |                        __items.push_back(ctr2.ctr_total_return);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |                      }
+      |                      ~   
+  286 |                      return __items;
+      |                      ~~~~~~~~~~~~~~~
+  287 |                    })()) *
+      |                    ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:91:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   91 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:91:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:277:25: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  277 |                   (__avg(([&]() {
+      |                    ~~~~~^~~~~~~~~
+  278 |                      std::vector<
+      |                      ~~~~~~~~~~~~
+  279 |                          decltype(std::declval<__struct6>().ctr_total_return)>
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  280 |                          __items;
+      |                          ~~~~~~~~
+  281 |                      for (auto ctr2 : customer_total_return) {
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  282 |                        if (!((ctr1.ctr_store_sk == ctr2.ctr_store_sk)))
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  283 |                          continue;
+      |                          ~~~~~~~~~
+  284 |                        __items.push_back(ctr2.ctr_total_return);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |                      }
+      |                      ~   
+  286 |                      return __items;
+      |                      ~~~~~~~~~~~~~~~
+  287 |                    })()) *
+      |                    ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:291:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  291 |           __items.push_back(
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:298:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  298 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:298:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  298 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:301:75: error: template argument 2 is invalid
+  301 |         decltype(std::unordered_map<std::string, decltype(c.c_customer_id)>{
+      |                                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:301:75: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:302:62: error: template argument 1 is invalid
+  302 |             {std::string("c_customer_id"), c.c_customer_id}})>
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:302:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:304:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  304 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:304:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  304 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq12050320517/001/prog.cpp:305:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+  305 |       __res.push_back(p.second);
+      |             ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q10.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q10.error
@@ -1,0 +1,341 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:82:8: error: redefinition of ‘struct Customer’
+   82 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:53:8: note: previous definition of ‘struct Customer’
+   53 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:102:8: error: redefinition of ‘struct StoreSale’
+  102 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:73:8: note: previous definition of ‘struct StoreSale’
+   73 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:106:8: error: redefinition of ‘struct DateDim’
+  106 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:77:8: note: previous definition of ‘struct DateDim’
+   77 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:112:12: error: ‘a’ was not declared in this scope
+  112 |   decltype(a.cd_gender) gender;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:112:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:113:12: error: ‘a’ was not declared in this scope
+  113 |   decltype(a.cd_marital_status) marital;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:113:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:114:12: error: ‘a’ was not declared in this scope
+  114 |   decltype(a.cd_education_status) education;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:114:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:115:12: error: ‘a’ was not declared in this scope
+  115 |   decltype(a.cd_purchase_estimate) purchase;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:115:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:116:12: error: ‘a’ was not declared in this scope
+  116 |   decltype(a.cd_credit_rating) credit;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:116:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:117:12: error: ‘a’ was not declared in this scope
+  117 |   decltype(a.cd_dep_count) dep;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:117:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:118:12: error: ‘a’ was not declared in this scope
+  118 |   decltype(a.cd_dep_employed_count) depemp;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:118:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:119:12: error: ‘a’ was not declared in this scope
+  119 |   decltype(a.cd_dep_college_count) depcol;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:119:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:122:12: error: ‘a’ was not declared in this scope
+  122 |   decltype(a) a;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:122:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:264:13: error: redefinition of ‘void __json(const Customer&)’
+  264 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:144:13: note: ‘void __json(const Customer&)’ previously defined here
+  144 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:424:13: error: redefinition of ‘void __json(const DateDim&)’
+  424 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:229:13: note: ‘void __json(const DateDim&)’ previously defined here
+  229 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:489:13: error: redefinition of ‘void __json(const StoreSale&)’
+  489 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:249:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  249 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:526:26: error: ‘cd’ was not declared in this scope
+  526 |     std::vector<decltype(cd)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:526:29: error: template argument 1 is invalid
+  526 |     std::vector<decltype(cd)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:526:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:536:42: error: ‘ss’ was not declared in this scope
+  536 |                     std::vector<decltype(ss)> __items;
+      |                                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:536:45: error: template argument 1 is invalid
+  536 |                     std::vector<decltype(ss)> __items;
+      |                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:536:45: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:546:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  546 |                         __items.push_back(ss);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:551:24: error: request for member ‘empty’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & store_sales), (* & date_dim), c}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  551 |                       .empty())))
+      |                        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:553:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  553 |           __items.push_back(cd);
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:561:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  561 |     for (auto a : active) {
+      |                   ^~~~~~
+      |                   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:561:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  561 |     for (auto a : active) {
+      |                   ^~~~~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:580:65: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  580 |             __struct8{__key, std::vector<__struct7>{__struct7{a}}});
+      |                                                                 ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq103714614541/001/prog.cpp:641:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  559 |   std::vector<__struct7> result = ([&]() {
+      |                                   ~~~~~~~~
+  560 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  561 |     for (auto a : active) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  562 |       auto __key = Result{a.cd_gender,
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  563 |                           a.cd_marital_status,
+      |                           ~~~~~~~~~~~~~~~~~~~~
+  564 |                           a.cd_education_status,
+      |                           ~~~~~~~~~~~~~~~~~~~~~~
+  565 |                           a.cd_purchase_estimate,
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~
+  566 |                           a.cd_credit_rating,
+      |                           ~~~~~~~~~~~~~~~~~~~
+  567 |                           a.cd_dep_count,
+      |                           ~~~~~~~~~~~~~~~
+  568 |                           a.cd_dep_employed_count,
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~
+  569 |                           a.cd_dep_college_count};
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~
+  570 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  571 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  572 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  573 |           __g.items.push_back(__struct7{a});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  574 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  575 |           break;
+      |           ~~~~~~
+  576 |         }
+      |         ~
+  577 |       }
+      |       ~
+  578 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  579 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  580 |             __struct8{__key, std::vector<__struct7>{__struct7{a}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  581 |       }
+      |       ~
+  582 |     }
+      |     ~
+  583 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  584 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  585 |       __items.push_back(__struct9{g.key.gender, g.key.marital, g.key.education,
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  586 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  587 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  588 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  589 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  590 |                                      }
+      |                                      ~
+  591 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  592 |                                    })()
+      |                                    ~~~~
+  593 |                                        .size()),
+      |                                        ~~~~~~~~~
+  594 |                                   g.key.purchase,
+      |                                   ~~~~~~~~~~~~~~~
+  595 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  596 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  597 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  598 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  599 |                                      }
+      |                                      ~
+  600 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  601 |                                    })()
+      |                                    ~~~~
+  602 |                                        .size()),
+      |                                        ~~~~~~~~~
+  603 |                                   g.key.credit,
+      |                                   ~~~~~~~~~~~~~
+  604 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  605 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  606 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  607 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  608 |                                      }
+      |                                      ~
+  609 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  610 |                                    })()
+      |                                    ~~~~
+  611 |                                        .size()),
+      |                                        ~~~~~~~~~
+  612 |                                   g.key.dep,
+      |                                   ~~~~~~~~~~
+  613 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  614 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  615 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  616 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  617 |                                      }
+      |                                      ~
+  618 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  619 |                                    })()
+      |                                    ~~~~
+  620 |                                        .size()),
+      |                                        ~~~~~~~~~
+  621 |                                   g.key.depemp,
+      |                                   ~~~~~~~~~~~~~
+  622 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  623 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  624 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  625 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  626 |                                      }
+      |                                      ~
+  627 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  628 |                                    })()
+      |                                    ~~~~
+  629 |                                        .size()),
+      |                                        ~~~~~~~~~
+  630 |                                   g.key.depcol,
+      |                                   ~~~~~~~~~~~~~
+  631 |                                   ((int)([&]() {
+      |                                   ~~~~~~~~~~~~~~
+  632 |                                      std::vector<__struct7> __items;
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  633 |                                      for (auto _ : g.items) {
+      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+  634 |                                        __items.push_back(_);
+      |                                        ~~~~~~~~~~~~~~~~~~~~~
+  635 |                                      }
+      |                                      ~
+  636 |                                      return __items;
+      |                                      ~~~~~~~~~~~~~~~
+  637 |                                    })()
+      |                                    ~~~~
+  638 |                                        .size())});
+      |                                        ~~~~~~~~~~~
+  639 |     }
+      |     ~
+  640 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  641 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q11.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q11.error
@@ -1,0 +1,125 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:70:8: error: redefinition of ‘struct Customer’
+   70 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:54:8: note: previous definition of ‘struct Customer’
+   54 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:76:8: error: redefinition of ‘struct StoreSale’
+   76 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:60:8: note: previous definition of ‘struct StoreSale’
+   60 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:81:8: error: redefinition of ‘struct WebSale’
+   81 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:65:8: note: previous definition of ‘struct WebSale’
+   65 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:156:13: error: redefinition of ‘void __json(const Customer&)’
+  156 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:91:13: note: ‘void __json(const Customer&)’ previously defined here
+   91 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:201:13: error: redefinition of ‘void __json(const StoreSale&)’
+  201 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:116:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  116 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:221:13: error: redefinition of ‘void __json(const WebSale&)’
+  221 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:136:13: note: ‘void __json(const WebSale&)’ previously defined here
+  136 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:251:26: error: ‘ss’ was not declared in this scope; did you mean ‘ss98’?
+  251 |     std::vector<decltype(ss.ss_ext_list_price)> __items;
+      |                          ^~
+      |                          ss98
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:251:47: error: template argument 1 is invalid
+  251 |     std::vector<decltype(ss.ss_ext_list_price)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:251:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:255:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  255 |       __items.push_back(ss.ss_ext_list_price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:250:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:249:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  249 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:249:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  249 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:262:26: error: ‘ss’ was not declared in this scope; did you mean ‘ss99’?
+  262 |     std::vector<decltype(ss.ss_ext_list_price)> __items;
+      |                          ^~
+      |                          ss99
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:262:47: error: template argument 1 is invalid
+  262 |     std::vector<decltype(ss.ss_ext_list_price)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:262:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:266:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  266 |       __items.push_back(ss.ss_ext_list_price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:261:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:260:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  260 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:260:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  260 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:273:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  273 |     std::vector<decltype(ws.ws_ext_list_price)> __items;
+      |                          ^~
+      |                          std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:2:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:273:47: error: template argument 1 is invalid
+  273 |     std::vector<decltype(ws.ws_ext_list_price)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:273:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:277:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  277 |       __items.push_back(ws.ws_ext_list_price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:272:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:271:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  271 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:271:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  271 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:284:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  284 |     std::vector<decltype(ws.ws_ext_list_price)> __items;
+      |                          ^~
+      |                          std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:284:47: error: template argument 1 is invalid
+  284 |     std::vector<decltype(ws.ws_ext_list_price)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:284:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:288:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  288 |       __items.push_back(ws.ws_ext_list_price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:283:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:282:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  282 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq113309808398/001/prog.cpp:282:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  282 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q12.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q12.error
@@ -1,0 +1,559 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:73:8: error: redefinition of ‘struct WebSale’
+   73 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:56:8: note: previous definition of ‘struct WebSale’
+   56 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:78:8: error: redefinition of ‘struct Item’
+   78 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:61:8: note: previous definition of ‘struct Item’
+   61 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:86:8: error: redefinition of ‘struct DateDim’
+   86 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:69:8: note: previous definition of ‘struct DateDim’
+   69 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+   91 |   decltype(i.i_item_id) id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   92 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   92 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   93 |   decltype(i.i_category) cat;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   93 |   decltype(i.i_category) cat;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   94 |   decltype(i.i_class) class;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   94 |   decltype(i.i_class) class;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:94:28: error: expected identifier before ‘;’ token
+   94 |   decltype(i.i_class) class;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:94:3: error: multiple types in one declaration
+   94 |   decltype(i.i_class) class;
+      |   ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   95 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   95 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:98:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   98 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:98:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   98 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+   99 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+  100 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:110:42: error: expected unqualified-id before ‘class’
+  110 |   decltype(std::declval<__struct6>().key.class) i_class;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  115 |   decltype(std::declval<__struct5>().i_class) key;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:119:48: error: expected identifier before ‘;’ token
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:119:3: error: multiple types in one declaration
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:119:48: error: declaration does not declare anything [-fpermissive]
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  123 |   decltype(std::declval<__struct5>().i_item_id) i_item_id;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  124 |   decltype(std::declval<__struct5>().i_item_desc) i_item_desc;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+  125 |   decltype(std::declval<__struct5>().i_category) i_category;
+      |                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  126 |   decltype(std::declval<__struct5>().i_class) i_class;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  127 |   decltype(std::declval<__struct5>().i_current_price) i_current_price;
+      |                                      ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  128 |   decltype(std::declval<__struct5>().itemrevenue) itemrevenue;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:129:41: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype((((std::declval<__struct5>().itemrevenue * 100)) /
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:129:41: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype((((std::declval<__struct5>().itemrevenue * 100)) /
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In function ‘void __json(const ClassTotal&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:209:12: error: expected unqualified-id before ‘class’
+  209 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:217:13: error: redefinition of ‘void __json(const DateDim&)’
+  217 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:132:13: note: ‘void __json(const DateDim&)’ previously defined here
+  132 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:307:13: error: redefinition of ‘void __json(const Item&)’
+  307 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:147:13: note: ‘void __json(const Item&)’ previously defined here
+  147 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In function ‘void __json(const Filtered&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:364:12: error: expected unqualified-id before ‘class’
+  364 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:392:13: error: redefinition of ‘void __json(const WebSale&)’
+  392 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:182:13: note: ‘void __json(const WebSale&)’ previously defined here
+  182 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:449:61: error: too many initializers for ‘Filtered’
+  449 |                                 i.i_class, i.i_current_price};
+      |                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:453:45: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  453 |               __g.items.push_back(__struct5{ws, i, d});
+      |                                             ^~
+      |                                             |
+      |                                             WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:460:67: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{ws, i, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:460:76: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{ws, i, d}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:467:34: error: expected primary-expression before ‘{’ token
+  467 |       __items.push_back(__struct7{
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:481:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  425 |   std::vector<__struct5> filtered = ([&]() {
+      |                                     ~~~~~~~~
+  426 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  427 |     for (auto ws : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  429 |         if (!((ws.ws_item_sk == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |           continue;
+      |           ~~~~~~~~~
+  431 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |           if (!((ws.ws_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |             continue;
+      |             ~~~~~~~~~
+  434 |           if (!((((std::find(
+      |           ~~~~~~~~~~~~~~~~~~~
+  435 |                        std::vector<std::string>{
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~
+  436 |                            std::string("A"), std::string("B"), std::string("C")}
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |                            .begin(),
+      |                            ~~~~~~~~~
+  438 |                        std::vector<std::string>{
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~
+  439 |                            std::string("A"), std::string("B"), std::string("C")}
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  440 |                            .end(),
+      |                            ~~~~~~~
+  441 |                        i.i_category) !=
+      |                        ~~~~~~~~~~~~~~~~
+  442 |                    std::vector<std::string>{std::string("A"), std::string("B"),
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |                                             std::string("C")}
+      |                                             ~~~~~~~~~~~~~~~~~
+  444 |                        .end()) &&
+      |                        ~~~~~~~~~~
+  445 |                   (d.d_date >= std::string("2001-01-15"))) &&
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  446 |                  (d.d_date <= std::string("2001-02-14")))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  447 |             continue;
+      |             ~~~~~~~~~
+  448 |           auto __key = Filtered{i.i_item_id, i.i_item_desc, i.i_category,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  449 |                                 i.i_class, i.i_current_price};
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  451 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  453 |               __g.items.push_back(__struct5{ws, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  455 |               break;
+      |               ~~~~~~
+  456 |             }
+      |             ~
+  457 |           }
+      |           ~
+  458 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  459 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{ws, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  461 |           }
+      |           ~
+  462 |         }
+      |         ~
+  463 |       }
+      |       ~
+  464 |     }
+      |     ~
+  465 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  466 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  467 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  468 |           g.key.id, g.key.desc, g.key.cat, g.key.class, g.key.price,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  470 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  472 |             std::vector<decltype(std::declval<__struct5>().ws_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  473 |                 __items;
+      |                 ~~~~~~~~
+  474 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  475 |               __items.push_back(x.ws_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  476 |             }
+      |             ~
+  477 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  478 |           })())});
+      |           ~~~~~~~~
+  479 |     }
+      |     ~
+  480 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  481 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:485:22: error: ‘struct __struct5’ has no member named ‘i_class’
+  485 |       auto __key = f.i_class;
+      |                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:505:60: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                            ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:505:60: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:505:72: error: template argument 1 is invalid
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:505:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:508:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  508 |               __items.push_back(x.itemrevenue);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:508:35: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  508 |               __items.push_back(x.itemrevenue);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:504:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:503:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:503:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:511:16: error: too many initializers for ‘ClassTotal’
+  511 |           })())});
+      |                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:514:5: error: conversion from ‘vector<ClassTotal>’ to non-scalar type ‘vector<__struct5>’ requested
+  482 |   std::vector<__struct5> class_totals = ([&]() {
+      |                                         ~~~~~~~~
+  483 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  484 |     for (auto f : filtered) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |       auto __key = f.i_class;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~
+  486 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  487 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  489 |           __g.items.push_back(__struct5{f});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  490 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  491 |           break;
+      |           ~~~~~~
+  492 |         }
+      |         ~
+  493 |       }
+      |       ~
+  494 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  495 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  496 |             __struct8{__key, std::vector<__struct5>{__struct5{f}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  497 |       }
+      |       ~
+  498 |     }
+      |     ~
+  499 |     std::vector<ClassTotal> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  500 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  501 |       __items.push_back(ClassTotal{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  502 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |                 __items;
+      |                 ~~~~~~~~
+  507 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |               __items.push_back(x.itemrevenue);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  509 |             }
+      |             ~
+  510 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  511 |           })())});
+      |           ~~~~~~~~
+  512 |     }
+      |     ~
+  513 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  514 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:517:54: error: ‘struct __struct5’ has no member named ‘i_category’
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:517:54: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:517:67: error: template argument 1 is invalid
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                   ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:517:73: error: template argument 1 is invalid
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:517:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:521:18: error: ‘struct __struct5’ has no member named ‘i_class’
+  521 |         if (!((f.i_class == t.class)))
+      |                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:521:31: error: expected unqualified-id before ‘class’
+  521 |         if (!((f.i_class == t.class)))
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:521:31: error: expected ‘)’ before ‘class’
+  521 |         if (!((f.i_class == t.class)))
+      |               ~               ^~~~~
+      |                               )
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:522:19: error: expected ‘)’ before ‘;’ token
+  522 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:521:14: note: to match this ‘(’
+  521 |         if (!((f.i_class == t.class)))
+      |              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:522:19: error: expected ‘)’ before ‘;’ token
+  522 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:521:12: note: to match this ‘(’
+  521 |         if (!((f.i_class == t.class)))
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:523:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  523 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:37: error: ‘struct __struct5’ has no member named ‘i_category’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:37: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:48: error: template argument 1 is invalid
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:52: error: ‘struct __struct5’ has no member named ‘i_category’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                    ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:524:66: error: ‘struct __struct5’ has no member named ‘i_class’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:525:52: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  525 |                                                  f.i_item_id, f.i_item_desc},
+      |                                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:525:65: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  525 |                                                  f.i_item_id, f.i_item_desc},
+      |                                                                 ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:526:23: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:526:36: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                    ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:526:51: error: ‘struct __struct5’ has no member named ‘i_category’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:526:65: error: ‘struct __struct5’ has no member named ‘i_class’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                                                 ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:527:23: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  527 |                     f.i_current_price, f.itemrevenue,
+      |                       ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:527:42: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  527 |                     f.i_current_price, f.itemrevenue,
+      |                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:528:26: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  528 |                     (((f.itemrevenue * 100)) / t.total)}});
+      |                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:528:50: error: ‘struct __struct5’ has no member named ‘total’
+  528 |                     (((f.itemrevenue * 100)) / t.total)}});
+      |                                                  ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:531:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  531 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:531:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  531 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:534:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  534 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq121431971664/001/prog.cpp:534:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  534 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q13.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q13.error
@@ -1,0 +1,419 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:88:8: error: redefinition of ‘struct StoreSale’
+   88 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:54:8: note: previous definition of ‘struct StoreSale’
+   54 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:100:8: error: redefinition of ‘struct Store’
+  100 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:66:8: note: previous definition of ‘struct Store’
+   66 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:118:8: error: redefinition of ‘struct DateDim’
+  118 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:84:8: note: previous definition of ‘struct DateDim’
+   84 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:123:12: error: ‘r’ was not declared in this scope
+  123 |   decltype(r) r;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:123:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:348:13: error: redefinition of ‘void __json(const DateDim&)’
+  348 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:183:13: note: ‘void __json(const DateDim&)’ previously defined here
+  183 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:378:13: error: redefinition of ‘void __json(const Store&)’
+  378 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:213:13: note: ‘void __json(const Store&)’ previously defined here
+  213 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:393:13: error: redefinition of ‘void __json(const StoreSale&)’
+  393 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:228:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  228 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:470:26: error: ‘ss’ was not declared in this scope
+  470 |     std::vector<decltype(ss)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:470:29: error: template argument 1 is invalid
+  470 |     std::vector<decltype(ss)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:470:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:493:25: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  493 |                 __items.push_back(ss);
+      |                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:504:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  504 |     for (auto r : filtered) {
+      |                   ^~~~~~~~
+      |                   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:504:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  504 |     for (auto r : filtered) {
+      |                   ^~~~~~~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:515:74: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  515 |         __groups.push_back(__struct8{__key, std::vector<Result>{Result{r}}});
+      |                                                                          ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:522:57: error: ‘struct Result’ has no member named ‘ss_quantity’
+  522 |             std::vector<decltype(std::declval<Result>().ss_quantity)> __items;
+      |                                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:522:57: error: ‘struct Result’ has no member named ‘ss_quantity’
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:522:69: error: template argument 1 is invalid
+  522 |             std::vector<decltype(std::declval<Result>().ss_quantity)> __items;
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:522:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:524:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  524 |               __items.push_back(x.ss_quantity);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:524:35: error: ‘struct Result’ has no member named ‘ss_quantity’
+  524 |               __items.push_back(x.ss_quantity);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:521:16: error: no matching function for call to ‘__avg(int)’
+  521 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  522 |             std::vector<decltype(std::declval<Result>().ss_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  523 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  524 |               __items.push_back(x.ss_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  525 |             }
+      |             ~   
+  526 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  527 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  129 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:521:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  521 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  522 |             std::vector<decltype(std::declval<Result>().ss_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  523 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  524 |               __items.push_back(x.ss_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  525 |             }
+      |             ~   
+  526 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  527 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:529:57: error: ‘struct Result’ has no member named ‘ss_ext_sales_price’
+  529 |             std::vector<decltype(std::declval<Result>().ss_ext_sales_price)>
+      |                                                         ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:529:57: error: ‘struct Result’ has no member named ‘ss_ext_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:529:76: error: template argument 1 is invalid
+  529 |             std::vector<decltype(std::declval<Result>().ss_ext_sales_price)>
+      |                                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:529:76: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:532:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  532 |               __items.push_back(x.ss_ext_sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:532:35: error: ‘struct Result’ has no member named ‘ss_ext_sales_price’
+  532 |               __items.push_back(x.ss_ext_sales_price);
+      |                                   ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:528:16: error: no matching function for call to ‘__avg(int)’
+  528 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  529 |             std::vector<decltype(std::declval<Result>().ss_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  530 |                 __items;
+      |                 ~~~~~~~~
+  531 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  532 |               __items.push_back(x.ss_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  533 |             }
+      |             ~   
+  534 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  535 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  129 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:528:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  528 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  529 |             std::vector<decltype(std::declval<Result>().ss_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  530 |                 __items;
+      |                 ~~~~~~~~
+  531 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  532 |               __items.push_back(x.ss_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  533 |             }
+      |             ~   
+  534 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  535 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:537:57: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+  537 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |                                                         ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:537:57: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:537:79: error: template argument 1 is invalid
+  537 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:537:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:540:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  540 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:540:35: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+  540 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |                                   ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:536:16: error: no matching function for call to ‘__avg(int)’
+  536 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  537 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  538 |                 __items;
+      |                 ~~~~~~~~
+  539 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  540 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  541 |             }
+      |             ~   
+  542 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  543 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  129 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:129:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:536:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  536 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  537 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  538 |                 __items;
+      |                 ~~~~~~~~
+  539 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  540 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  541 |             }
+      |             ~   
+  542 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  543 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:547:57: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+  547 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |                                                         ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:547:57: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:547:79: error: template argument 1 is invalid
+  547 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:547:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:550:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  550 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:550:35: error: ‘struct Result’ has no member named ‘ss_ext_wholesale_cost’
+  550 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |                                   ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:546:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:545:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  545 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:545:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  545 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq1397465437/001/prog.cpp:556:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<Result>’ requested
+  502 |   std::vector<Result> result = ([&]() {
+      |                                ~~~~~~~~
+  503 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |     for (auto r : filtered) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |       auto __key = std::unordered_map<int, int>{};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  507 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  509 |           __g.items.push_back(Result{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  510 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  511 |           break;
+      |           ~~~~~~
+  512 |         }
+      |         ~
+  513 |       }
+      |       ~
+  514 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  515 |         __groups.push_back(__struct8{__key, std::vector<Result>{Result{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  516 |       }
+      |       ~
+  517 |     }
+      |     ~
+  518 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  519 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  520 |       __items.push_back(__struct9{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  522 |             std::vector<decltype(std::declval<Result>().ss_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  523 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  524 |               __items.push_back(x.ss_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  525 |             }
+      |             ~
+  526 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  527 |           })()),
+      |           ~~~~~~
+  528 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  529 |             std::vector<decltype(std::declval<Result>().ss_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  530 |                 __items;
+      |                 ~~~~~~~~
+  531 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  532 |               __items.push_back(x.ss_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  533 |             }
+      |             ~
+  534 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  535 |           })()),
+      |           ~~~~~~
+  536 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  537 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  538 |                 __items;
+      |                 ~~~~~~~~
+  539 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  540 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  541 |             }
+      |             ~
+  542 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  543 |           })()),
+      |           ~~~~~~
+  544 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  545 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  546 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  547 |             std::vector<decltype(std::declval<Result>().ss_ext_wholesale_cost)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  548 |                 __items;
+      |                 ~~~~~~~~
+  549 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  550 |               __items.push_back(x.ss_ext_wholesale_cost);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  551 |             }
+      |             ~
+  552 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  553 |           })())});
+      |           ~~~~~~~~
+  554 |     }
+      |     ~
+  555 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  556 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q14.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q14.error
@@ -1,0 +1,235 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:84:8: error: redefinition of ‘struct StoreSale’
+   84 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:55:8: note: previous definition of ‘struct StoreSale’
+   55 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:90:8: error: redefinition of ‘struct CatalogSale’
+   90 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:61:8: note: previous definition of ‘struct CatalogSale’
+   61 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:96:8: error: redefinition of ‘struct WebSale’
+   96 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:67:8: note: previous definition of ‘struct WebSale’
+   67 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:102:8: error: redefinition of ‘struct Item’
+  102 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:73:8: note: previous definition of ‘struct Item’
+   73 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:108:8: error: redefinition of ‘struct DateDim’
+  108 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:79:8: note: previous definition of ‘struct DateDim’
+   79 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:127:12: error: ‘ss’ was not declared in this scope
+  127 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:127:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:128:12: error: ‘d’ was not declared in this scope
+  128 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:128:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:342:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  342 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:147:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  147 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:367:13: error: redefinition of ‘void __json(const DateDim&)’
+  367 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:172:13: note: ‘void __json(const DateDim&)’ previously defined here
+  172 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:387:13: error: redefinition of ‘void __json(const Item&)’
+  387 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:192:13: note: ‘void __json(const Item&)’ previously defined here
+  192 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:412:13: error: redefinition of ‘void __json(const StoreSale&)’
+  412 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:217:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  217 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:452:13: error: redefinition of ‘void __json(const WebSale&)’
+  452 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:242:13: note: ‘void __json(const WebSale&)’ previously defined here
+  242 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:485:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  485 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  486 |           {std::string("ss_item_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  487 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |               {std::string("ss_item_sk"), 1}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:498:49: error: ‘ci’ was not declared in this scope
+  498 |                            std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                                 ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:498:63: error: template argument 1 is invalid
+  498 |                            std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:498:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:500:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  500 |                              __items.push_back(ci.ss_item_sk);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:500:51: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘ss_item_sk’
+  500 |                              __items.push_back(ci.ss_item_sk);
+      |                                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:504:31: error: request for member ‘begin’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & cross_items)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  504 |                              .begin(),
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:506:49: error: ‘ci’ was not declared in this scope
+  506 |                            std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                                 ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:506:63: error: template argument 1 is invalid
+  506 |                            std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:506:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:508:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  508 |                              __items.push_back(ci.ss_item_sk);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:508:51: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘ss_item_sk’
+  508 |                              __items.push_back(ci.ss_item_sk);
+      |                                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:512:31: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & cross_items)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  512 |                              .end(),
+      |                               ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:515:39: error: ‘ci’ was not declared in this scope
+  515 |                  std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                       ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:515:53: error: template argument 1 is invalid
+  515 |                  std::vector<decltype(ci.ss_item_sk)> __items;
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:515:53: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:517:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  517 |                    __items.push_back(ci.ss_item_sk);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:517:41: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘ss_item_sk’
+  517 |                    __items.push_back(ci.ss_item_sk);
+      |                                         ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:521:21: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & cross_items)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  521 |                    .end())))
+      |                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:526:23: error: no match for ‘operator==’ (operand types are ‘StoreFiltered’ and ‘StoreFiltered’)
+  526 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   |      StoreFiltered
+      |                   StoreFiltered
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:527:43: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  527 |             __g.items.push_back(__struct7{ss, d});
+      |                                           ^~
+      |                                           |
+      |                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:534:65: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  534 |               __struct8{__key, std::vector<__struct7>{__struct7{ss, d}}});
+      |                                                                 ^~
+      |                                                                 |
+      |                                                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:534:71: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  534 |               __struct8{__key, std::vector<__struct7>{__struct7{ss, d}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:544:61: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+  544 |             std::vector<decltype((std::declval<__struct7>().ss_quantity *
+      |                                                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:545:61: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+  545 |                                   std::declval<__struct7>().ss_list_price))>
+      |                                                             ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:544:61: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+  544 |             std::vector<decltype((std::declval<__struct7>().ss_quantity *
+      |                                                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:545:61: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+  545 |                                   std::declval<__struct7>().ss_list_price))>
+      |                                                             ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:545:76: error: template argument 1 is invalid
+  545 |                                   std::declval<__struct7>().ss_list_price))>
+      |                                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:545:76: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:548:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  548 |               __items.push_back((x.ss_quantity * x.ss_list_price));
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:548:36: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+  548 |               __items.push_back((x.ss_quantity * x.ss_list_price));
+      |                                    ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:548:52: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+  548 |               __items.push_back((x.ss_quantity * x.ss_list_price));
+      |                                                    ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:543:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:542:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  542 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq143968160570/001/prog.cpp:542:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  542 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q15.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q15.error
@@ -1,0 +1,623 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:75:8: error: redefinition of ‘struct CatalogSale’
+   75 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:56:8: note: previous definition of ‘struct CatalogSale’
+   56 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:80:8: error: redefinition of ‘struct Customer’
+   80 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:61:8: note: previous definition of ‘struct Customer’
+   61 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:89:8: error: redefinition of ‘struct DateDim’
+   89 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:70:8: note: previous definition of ‘struct DateDim’
+   70 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:95:12: error: ‘cs’ was not declared in this scope
+   95 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:95:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:96:12: error: ‘c’ was not declared in this scope; did you mean ‘cs’?
+   96 |   decltype(c) c;
+      |            ^
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:96:12: error: ‘c’ was not declared in this scope; did you mean ‘cs’?
+   96 |   decltype(c) c;
+      |            ^
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:97:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   97 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:97:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   97 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+   98 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:101:53: error: ‘ca’ was not declared in this scope
+  101 |   decltype(std::unordered_map<std::string, decltype(ca.ca_zip)>{
+      |                                                     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:101:53: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:101:63: error: template argument 2 is invalid
+  101 |   decltype(std::unordered_map<std::string, decltype(ca.ca_zip)>{
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:101:63: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:102:28: error: ‘ca’ was not declared in this scope
+  102 |       {std::string("zip"), ca.ca_zip}}) key;
+      |                            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:102:28: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:106:42: error: request for member ‘zip’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+  106 |   decltype(std::declval<__struct6>().key.zip) ca_zip;
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:106:42: error: request for member ‘zip’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:184:13: error: redefinition of ‘void __json(const Customer&)’
+  184 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:129:13: note: ‘void __json(const Customer&)’ previously defined here
+  129 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:234:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  234 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:109:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  109 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:254:13: error: redefinition of ‘void __json(const DateDim&)’
+  254 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:164:13: note: ‘void __json(const DateDim&)’ previously defined here
+  164 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:332:29: error: ‘substr’ was not declared in this scope
+  332 |                             substr(ca.ca_zip, 0, 5)) !=
+      |                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:27: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’)
+  361 |               if (__g.key == __key) {
+      |                   ~~~~~~~ ^~ ~~~~~
+      |                       |      |
+      |                       int    std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:3:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘const std::__new_allocator<_Tp>’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘const std::__new_allocator<_Tp>’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const _CharT*’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:7:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:361:30: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  361 |               if (__g.key == __key) {
+      |                              ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&, const allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:362:46: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  362 |                 __g.items.push_back(Filtered{cs, c, ca, d});
+      |                                              ^~
+      |                                              |
+      |                                              CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:369:57: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  369 |                   __key, std::vector<Filtered>{Filtered{cs, c, ca, d}}});
+      |                                                         ^~
+      |                                                         |
+      |                                                         CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:369:70: error: no matching function for call to ‘std::vector<Filtered>::vector(<brace-enclosed initializer list>)’
+  369 |                   __key, std::vector<Filtered>{Filtered{cs, c, ca, d}}});
+      |                                                                      ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; std::__type_identity_t<_Alloc> = std::allocator<Filtered>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; std::__type_identity_t<_Alloc> = std::allocator<Filtered>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; size_type = long unsigned int; value_type = Filtered; allocator_type = std::allocator<Filtered>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; size_type = long unsigned int; allocator_type = std::allocator<Filtered>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:376:58: error: request for member ‘zip’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+  376 |         std::pair<decltype(std::declval<__struct6>().key.zip), __struct7>>
+      |                                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:376:58: error: request for member ‘zip’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:376:64: error: template argument 1 is invalid
+  376 |         std::pair<decltype(std::declval<__struct6>().key.zip), __struct7>>
+      |                                                                ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:376:73: error: template argument 1 is invalid
+  376 |         std::pair<decltype(std::declval<__struct6>().key.zip), __struct7>>
+      |                                                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:376:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:379:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  379 |       __items.push_back(
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:380:18: error: request for member ‘zip’ in ‘g.__struct6::key’, which is of non-class type ‘int’
+  380 |           {g.key.zip,
+      |                  ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:382:22: error: request for member ‘zip’ in ‘g.__struct6::key’, which is of non-class type ‘int’
+  382 |                g.key.zip, ([&](auto v) {
+      |                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:385:64: error: ‘struct Filtered’ has no member named ‘cs_sales_price’
+  385 |                  std::vector<decltype(std::declval<Filtered>().cs_sales_price)>
+      |                                                                ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:385:64: error: ‘struct Filtered’ has no member named ‘cs_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:385:79: error: template argument 1 is invalid
+  385 |                  std::vector<decltype(std::declval<Filtered>().cs_sales_price)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:385:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:388:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  388 |                    __items.push_back(x.cs_sales_price);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:388:40: error: ‘struct Filtered’ has no member named ‘cs_sales_price’
+  388 |                    __items.push_back(x.cs_sales_price);
+      |                                        ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:384:18:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:383:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  383 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:383:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  383 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                    ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:393:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  393 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:393:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  393 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:396:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  396 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:396:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  396 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq151014854168/001/prog.cpp:399:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<Filtered>’ requested
+  305 |   std::vector<Filtered> filtered = ([&]() {
+      |                                    ~~~~~~~~
+  306 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  307 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  308 |       for (auto c : customer) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |         if (!((cs.cs_bill_customer_sk == c.c_customer_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |           continue;
+      |           ~~~~~~~~~
+  311 |         for (auto ca : customer_address) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |           if (!((c.c_current_addr_sk == ca.ca_address_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  313 |             continue;
+      |             ~~~~~~~~~
+  314 |           for (auto d : date_dim) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+  315 |             if (!((cs.cs_sold_date_sk == d.d_date_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  316 |               continue;
+      |               ~~~~~~~~~
+  317 |             if (!(((((((std::find(
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  318 |                             std::vector<std::string>{
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  319 |                                 std::string("85669"), std::string("86197"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  320 |                                 std::string("88274"), std::string("83405"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |                                 std::string("86475"), std::string("85392"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  322 |                                 std::string("85460"), std::string("80348"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |                                 std::string("81792")}
+      |                                 ~~~~~~~~~~~~~~~~~~~~~
+  324 |                                 .begin(),
+      |                                 ~~~~~~~~~
+  325 |                             std::vector<std::string>{
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |                                 std::string("85669"), std::string("86197"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  327 |                                 std::string("88274"), std::string("83405"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  328 |                                 std::string("86475"), std::string("85392"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  329 |                                 std::string("85460"), std::string("80348"),
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  330 |                                 std::string("81792")}
+      |                                 ~~~~~~~~~~~~~~~~~~~~~
+  331 |                                 .end(),
+      |                                 ~~~~~~~
+  332 |                             substr(ca.ca_zip, 0, 5)) !=
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  333 |                         std::vector<std::string>{
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |                             std::string("85669"), std::string("86197"),
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  335 |                             std::string("88274"), std::string("83405"),
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  336 |                             std::string("86475"), std::string("85392"),
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  337 |                             std::string("85460"), std::string("80348"),
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  338 |                             std::string("81792")}
+      |                             ~~~~~~~~~~~~~~~~~~~~~
+  339 |                             .end()) ||
+      |                             ~~~~~~~~~~
+  340 |                        (std::find(std::vector<std::string>{std::string("CA"),
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  341 |                                                            std::string("WA"),
+      |                                                            ~~~~~~~~~~~~~~~~~~
+  342 |                                                            std::string("GA")}
+      |                                                            ~~~~~~~~~~~~~~~~~~
+  343 |                                       .begin(),
+      |                                       ~~~~~~~~~
+  344 |                                   std::vector<std::string>{std::string("CA"),
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |                                                            std::string("WA"),
+      |                                                            ~~~~~~~~~~~~~~~~~~
+  346 |                                                            std::string("GA")}
+      |                                                            ~~~~~~~~~~~~~~~~~~
+  347 |                                       .end(),
+      |                                       ~~~~~~~
+  348 |                                   ca.ca_state) !=
+      |                                   ~~~~~~~~~~~~~~~
+  349 |                         std::vector<std::string>{std::string("CA"),
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                                                  std::string("WA"),
+      |                                                  ~~~~~~~~~~~~~~~~~~
+  351 |                                                  std::string("GA")}
+      |                                                  ~~~~~~~~~~~~~~~~~~
+  352 |                             .end())) ||
+      |                             ~~~~~~~~~~~
+  353 |                       (cs.cs_sales_price > 500))) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |                     (d.d_qoy == 1)) &&
+      |                     ~~~~~~~~~~~~~~~~~~
+  355 |                    (d.d_year == 2000))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~
+  356 |               continue;
+      |               ~~~~~~~~~
+  357 |             auto __key = std::unordered_map<std::string, decltype(ca.ca_zip)>{
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |                 {std::string("zip"), ca.ca_zip}};
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  360 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  362 |                 __g.items.push_back(Filtered{cs, c, ca, d});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  364 |                 break;
+      |                 ~~~~~~
+  365 |               }
+      |               ~
+  366 |             }
+      |             ~
+  367 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  368 |               __groups.push_back(__struct6{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                   __key, std::vector<Filtered>{Filtered{cs, c, ca, d}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |             }
+      |             ~
+  371 |           }
+      |           ~
+  372 |         }
+      |         ~
+  373 |       }
+      |       ~
+  374 |     }
+      |     ~
+  375 |     std::vector<
+      |     ~~~~~~~~~~~~
+  376 |         std::pair<decltype(std::declval<__struct6>().key.zip), __struct7>>
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |         __items;
+      |         ~~~~~~~~
+  378 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  379 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  380 |           {g.key.zip,
+      |           ~~~~~~~~~~~
+  381 |            __struct7{
+      |            ~~~~~~~~~~
+  382 |                g.key.zip, ([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~
+  383 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  384 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  385 |                  std::vector<decltype(std::declval<Filtered>().cs_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |                      __items;
+      |                      ~~~~~~~~
+  387 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |                    __items.push_back(x.cs_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |                  }
+      |                  ~
+  390 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  391 |                })())}});
+      |                ~~~~~~~~~
+  392 |     }
+      |     ~
+  393 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  395 |     std::vector<__struct7> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  397 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |     return __res;
+      |     ~~~~~~~~~~~~~
+  399 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q16.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q16.error
@@ -1,0 +1,379 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:79:8: error: redefinition of ‘struct CatalogSale’
+   79 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:55:8: note: previous definition of ‘struct CatalogSale’
+   55 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:88:8: error: redefinition of ‘struct DateDim’
+   88 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:64:8: note: previous definition of ‘struct DateDim’
+   64 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:96:8: error: redefinition of ‘struct CallCenter’
+   96 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:72:8: note: previous definition of ‘struct CallCenter’
+   72 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:101:12: error: ‘cs1’ was not declared in this scope
+  101 |   decltype(cs1) cs1;
+      |            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:101:12: error: ‘cs1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:102:12: error: ‘d’ was not declared in this scope
+  102 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:102:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:103:12: error: ‘ca’ was not declared in this scope
+  103 |   decltype(ca) ca;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:103:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:104:12: error: ‘cc’ was not declared in this scope; did you mean ‘ca’?
+  104 |   decltype(cc) cc;
+      |            ^~
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:104:12: error: ‘cc’ was not declared in this scope; did you mean ‘ca’?
+  104 |   decltype(cc) cc;
+      |            ^~
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:225:13: error: redefinition of ‘void __json(const CallCenter&)’
+  225 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:115:13: note: ‘void __json(const CallCenter&)’ previously defined here
+  115 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:240:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  240 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:140:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  140 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:280:13: error: redefinition of ‘void __json(const DateDim&)’
+  280 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:195:13: note: ‘void __json(const DateDim&)’ previously defined here
+  195 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:348:15: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  348 | auto distinct(auto xs) {
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:391:46: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  391 |                 __g.items.push_back(Filtered{cs1, d, ca, cc});
+      |                                              ^~~
+      |                                              |
+      |                                              CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:398:57: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  398 |                   __key, std::vector<Filtered>{Filtered{cs1, d, ca, cc}}});
+      |                                                         ^~~
+      |                                                         |
+      |                                                         CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:398:72: error: no matching function for call to ‘std::vector<Filtered>::vector(<brace-enclosed initializer list>)’
+  398 |                   __key, std::vector<Filtered>{Filtered{cs1, d, ca, cc}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; std::__type_identity_t<_Alloc> = std::allocator<Filtered>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; std::__type_identity_t<_Alloc> = std::allocator<Filtered>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; size_type = long unsigned int; value_type = Filtered; allocator_type = std::allocator<Filtered>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; size_type = long unsigned int; allocator_type = std::allocator<Filtered>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Filtered; _Alloc = std::allocator<Filtered>; allocator_type = std::allocator<Filtered>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Filtered; _Alloc = std::allocator<Filtered>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:408:59: error: ‘struct Filtered’ has no member named ‘cs_order_number’
+  408 |             std::vector<decltype(std::declval<Filtered>().cs_order_number)>
+      |                                                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:408:59: error: ‘struct Filtered’ has no member named ‘cs_order_number’
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:408:75: error: template argument 1 is invalid
+  408 |             std::vector<decltype(std::declval<Filtered>().cs_order_number)>
+      |                                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:408:75: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:411:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  411 |               __items.push_back(x.cs_order_number);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:411:35: error: ‘struct Filtered’ has no member named ‘cs_order_number’
+  411 |               __items.push_back(x.cs_order_number);
+      |                                   ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In instantiation of ‘auto distinct(auto:1) [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:407:19:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:350:3: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  350 |   for (auto x : xs) {
+      |   ^~~
+      |   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:350:3: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  350 |   for (auto x : xs) {
+      |   ^~~
+      |   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:351:19: error: ‘contains’ was not declared in this scope
+  351 |     if ((!contains(out, x))) {
+      |           ~~~~~~~~^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:418:63: error: ‘struct Filtered’ has no member named ‘cs_ext_ship_cost’
+  418 |                 std::vector<decltype(std::declval<Filtered>().cs_ext_ship_cost)>
+      |                                                               ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:418:63: error: ‘struct Filtered’ has no member named ‘cs_ext_ship_cost’
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:418:80: error: template argument 1 is invalid
+  418 |                 std::vector<decltype(std::declval<Filtered>().cs_ext_ship_cost)>
+      |                                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:418:80: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:421:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  421 |                   __items.push_back(x.cs_ext_ship_cost);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:421:39: error: ‘struct Filtered’ has no member named ‘cs_ext_ship_cost’
+  421 |                   __items.push_back(x.cs_ext_ship_cost);
+      |                                       ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:416:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:416:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  416 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:416:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  416 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:427:63: error: ‘struct Filtered’ has no member named ‘cs_net_profit’
+  427 |                 std::vector<decltype(std::declval<Filtered>().cs_net_profit)>
+      |                                                               ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:427:63: error: ‘struct Filtered’ has no member named ‘cs_net_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:427:77: error: template argument 1 is invalid
+  427 |                 std::vector<decltype(std::declval<Filtered>().cs_net_profit)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:427:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:430:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  430 |                   __items.push_back(x.cs_net_profit);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:430:39: error: ‘struct Filtered’ has no member named ‘cs_net_profit’
+  430 |                   __items.push_back(x.cs_net_profit);
+      |                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:425:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:425:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  425 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:425:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  425 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:436:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<Filtered>’ requested
+  359 |   std::vector<Filtered> filtered = ([&]() {
+      |                                    ~~~~~~~~
+  360 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |     for (auto cs1 : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  362 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |         if (!((((cs1.cs_ship_date_sk == d.d_date_sk) &&
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |                 (d.d_date >= std::string("2000-03-01"))) &&
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                (d.d_date <= std::string("2000-04-30")))))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |           continue;
+      |           ~~~~~~~~~
+  367 |         for (auto ca : customer_address) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |           if (!(((cs1.cs_ship_addr_sk == ca.ca_address_sk) &&
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                  (ca.ca_state == std::string("CA")))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |             continue;
+      |             ~~~~~~~~~
+  371 |           for (auto cc : call_center) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |             if (!(((cs1.cs_call_center_sk == cc.cc_call_center_sk) &&
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |                    (cc.cc_county == std::string("CountyA")))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |               continue;
+      |               ~~~~~~~~~
+  375 |             if (!((std::any_of(
+      |             ~~~~~~~~~~~~~~~~~~~
+  376 |                        catalog_sales.begin(), catalog_sales.end(),
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                        [&](auto cs2) {
+      |                        ~~~~~~~~~~~~~~~
+  378 |                          return ((cs1.cs_order_number == cs2.cs_order_number) &&
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  379 |                                  (cs1.cs_warehouse_sk != cs2.cs_warehouse_sk));
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |                        }) &&
+      |                        ~~~~~
+  381 |                    (std::any_of(catalog_returns.begin(), catalog_returns.end(),
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |                                 [&](auto cr) {
+      |                                 ~~~~~~~~~~~~~~
+  383 |                                   return (cs1.cs_order_number ==
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  384 |                                           cr.cr_order_number);
+      |                                           ~~~~~~~~~~~~~~~~~~~~
+  385 |                                 }) == false))))
+      |                                 ~~~~~~~~~~~~~~~
+  386 |               continue;
+      |               ~~~~~~~~~
+  387 |             auto __key = std::unordered_map<int, int>{};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  389 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  391 |                 __g.items.push_back(Filtered{cs1, d, ca, cc});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  392 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  393 |                 break;
+      |                 ~~~~~~
+  394 |               }
+      |               ~
+  395 |             }
+      |             ~
+  396 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  397 |               __groups.push_back(__struct6{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |                   __key, std::vector<Filtered>{Filtered{cs1, d, ca, cc}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  399 |             }
+      |             ~
+  400 |           }
+      |           ~
+  401 |         }
+      |         ~
+  402 |       }
+      |       ~
+  403 |     }
+      |     ~
+  404 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  405 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  406 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  407 |           distinct(([&]() {
+      |           ~~~~~~~~~~~~~~~~~
+  408 |             std::vector<decltype(std::declval<Filtered>().cs_order_number)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  409 |                 __items;
+      |                 ~~~~~~~~
+  410 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  411 |               __items.push_back(x.cs_order_number);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  412 |             }
+      |             ~
+  413 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  414 |           })())
+      |           ~~~~~
+  415 |               .size(),
+      |               ~~~~~~~~
+  416 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  417 |               ([&]() {
+      |               ~~~~~~~~
+  418 |                 std::vector<decltype(std::declval<Filtered>().cs_ext_ship_cost)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  419 |                     __items;
+      |                     ~~~~~~~~
+  420 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  421 |                   __items.push_back(x.cs_ext_ship_cost);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  422 |                 }
+      |                 ~
+  423 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  424 |               })()),
+      |               ~~~~~~
+  425 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  426 |               ([&]() {
+      |               ~~~~~~~~
+  427 |                 std::vector<decltype(std::declval<Filtered>().cs_net_profit)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |                     __items;
+      |                     ~~~~~~~~
+  429 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |                   __items.push_back(x.cs_net_profit);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |                 }
+      |                 ~
+  432 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  433 |               })())});
+      |               ~~~~~~~~
+  434 |     }
+      |     ~
+  435 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  436 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/usr/include/c++/13/bits/predefined_ops.h:318:23:   required from ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<int*, std::vector<int> >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algobase.h:2072:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<int*, vector<int> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:3)> >]’
+/usr/include/c++/13/bits/stl_algobase.h:2117:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<int*, vector<int> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:3)> >]’
+/usr/include/c++/13/bits/stl_algo.h:3923:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<int*, vector<int> >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algo.h:477:47:   required from ‘bool std::none_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<int*, vector<int> >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algo.h:496:27:   required from ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<int*, vector<int> >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:381:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq162701178739/001/prog.cpp:384:46: error: request for member ‘cr_order_number’ in ‘cr’, which is of non-class type ‘int’
+  384 |                                           cr.cr_order_number);
+      |                                           ~~~^~~~~~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q17.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q17.error
@@ -1,0 +1,252 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:88:8: error: redefinition of ‘struct StoreSale’
+   88 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:54:8: note: previous definition of ‘struct StoreSale’
+   54 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:96:8: error: redefinition of ‘struct StoreReturn’
+   96 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:62:8: note: previous definition of ‘struct StoreReturn’
+   62 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:103:8: error: redefinition of ‘struct CatalogSale’
+  103 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:69:8: note: previous definition of ‘struct CatalogSale’
+   69 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:109:8: error: redefinition of ‘struct DateDim’
+  109 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:75:8: note: previous definition of ‘struct DateDim’
+   75 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:113:8: error: redefinition of ‘struct Store’
+  113 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:79:8: note: previous definition of ‘struct Store’
+   79 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:117:8: error: redefinition of ‘struct Item’
+  117 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:83:8: note: previous definition of ‘struct Item’
+   83 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:123:12: error: ‘ss’ was not declared in this scope
+  123 |   decltype(ss.ss_quantity) qty;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:123:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:124:12: error: ‘sr’ was not declared in this scope
+  124 |   decltype(sr.sr_return_quantity) ret;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:124:12: error: ‘sr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:125:12: error: ‘cs’ was not declared in this scope
+  125 |   decltype(cs.cs_quantity) csq;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:125:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:126:12: error: ‘i’ was not declared in this scope
+  126 |   decltype(i.i_item_id) i_item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:126:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:127:12: error: ‘i’ was not declared in this scope
+  127 |   decltype(i.i_item_desc) i_item_desc;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:127:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:128:12: error: ‘s’ was not declared in this scope
+  128 |   decltype(s.s_state) s_state;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:128:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:304:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  304 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:164:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  164 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:329:13: error: redefinition of ‘void __json(const DateDim&)’
+  329 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:189:13: note: ‘void __json(const DateDim&)’ previously defined here
+  189 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:444:13: error: redefinition of ‘void __json(const Item&)’
+  444 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:204:13: note: ‘void __json(const Item&)’ previously defined here
+  204 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:499:13: error: redefinition of ‘void __json(const Store&)’
+  499 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:224:13: note: ‘void __json(const Store&)’ previously defined here
+  224 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:514:13: error: redefinition of ‘void __json(const StoreReturn&)’
+  514 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:239:13: note: ‘void __json(const StoreReturn&)’ previously defined here
+  239 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:544:13: error: redefinition of ‘void __json(const StoreSale&)’
+  544 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:269:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  269 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:645:27: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  645 |                         i.i_item_id, i.i_item_desc, s.s_state});
+      |                         ~~^~~~~~~~~
+      |                           |
+      |                           std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:662:21: error: no match for ‘operator==’ (operand types are ‘Result’ and ‘Result’)
+  662 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Result Result
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq172066913715/001/prog.cpp:726:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<Joined>’ requested
+  656 |   std::vector<Joined> result = ([&]() {
+      |                                ~~~~~~~~
+  657 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  658 |     for (auto j : joined) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  659 |       auto __key = Result{j.i_item_id, j.i_item_desc, j.s_state};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  660 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  661 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  662 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  663 |           __g.items.push_back(Joined{j});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  664 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  665 |           break;
+      |           ~~~~~~
+  666 |         }
+      |         ~
+  667 |       }
+      |       ~
+  668 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  669 |         __groups.push_back(__struct9{__key, std::vector<Joined>{Joined{j}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  670 |       }
+      |       ~
+  671 |     }
+      |     ~
+  672 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  673 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  674 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  675 |           g.key.i_item_id, g.key.i_item_desc, g.key.s_state,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  676 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  677 |              std::vector<Joined> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  678 |              for (auto _ : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  679 |                __items.push_back(_);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  680 |              }
+      |              ~
+  681 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  682 |            })()
+      |            ~~~~
+  683 |                .size()),
+      |                ~~~~~~~~~
+  684 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  685 |             std::vector<decltype(std::declval<Joined>().qty)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  686 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  687 |               __items.push_back(x.qty);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  688 |             }
+      |             ~
+  689 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  690 |           })()),
+      |           ~~~~~~
+  691 |           0, 0,
+      |           ~~~~~
+  692 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  693 |              std::vector<Joined> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  694 |              for (auto _ : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  695 |                __items.push_back(_);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  696 |              }
+      |              ~
+  697 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  698 |            })()
+      |            ~~~~
+  699 |                .size()),
+      |                ~~~~~~~~~
+  700 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  701 |             std::vector<decltype(std::declval<Joined>().ret)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  702 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  703 |               __items.push_back(x.ret);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  704 |             }
+      |             ~
+  705 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  706 |           })()),
+      |           ~~~~~~
+  707 |           0, 0,
+      |           ~~~~~
+  708 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  709 |              std::vector<Joined> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  710 |              for (auto _ : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  711 |                __items.push_back(_);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  712 |              }
+      |              ~
+  713 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  714 |            })()
+      |            ~~~~
+  715 |                .size()),
+      |                ~~~~~~~~~
+  716 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  717 |             std::vector<decltype(std::declval<Joined>().csq)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  718 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  719 |               __items.push_back(x.csq);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  720 |             }
+      |             ~
+  721 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  722 |           })()),
+      |           ~~~~~~
+  723 |           0, 0});
+      |           ~~~~~~~
+  724 |     }
+      |     ~
+  725 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  726 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q18.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q18.error
@@ -1,0 +1,262 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:91:8: error: redefinition of ‘struct CatalogSale’
+   91 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:53:8: note: previous definition of ‘struct CatalogSale’
+   53 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:108:8: error: redefinition of ‘struct Customer’
+  108 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:70:8: note: previous definition of ‘struct Customer’
+   70 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:121:8: error: redefinition of ‘struct DateDim’
+  121 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:83:8: note: previous definition of ‘struct DateDim’
+   83 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:125:8: error: redefinition of ‘struct Item’
+  125 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:87:8: note: previous definition of ‘struct Item’
+   87 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:130:12: error: ‘i’ was not declared in this scope
+  130 |   decltype(i.i_item_id) i_item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:130:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:131:12: error: ‘ca’ was not declared in this scope
+  131 |   decltype(ca.ca_country) ca_country;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:131:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:132:12: error: ‘ca’ was not declared in this scope
+  132 |   decltype(ca.ca_state) ca_state;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:132:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:133:12: error: ‘ca’ was not declared in this scope
+  133 |   decltype(ca.ca_county) ca_county;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:133:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:134:12: error: ‘cs’ was not declared in this scope
+  134 |   decltype(cs.cs_quantity) q;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:134:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:135:12: error: ‘cs’ was not declared in this scope
+  135 |   decltype(cs.cs_list_price) lp;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:135:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:136:12: error: ‘cs’ was not declared in this scope
+  136 |   decltype(cs.cs_coupon_amt) cp;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:136:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:137:12: error: ‘cs’ was not declared in this scope; did you mean ‘cp’?
+  137 |   decltype(cs.cs_sales_price) sp;
+      |            ^~
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:137:12: error: ‘cs’ was not declared in this scope; did you mean ‘cp’?
+  137 |   decltype(cs.cs_sales_price) sp;
+      |            ^~
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:138:12: error: ‘cs’ was not declared in this scope; did you mean ‘cp’?
+  138 |   decltype(cs.cs_net_profit) np;
+      |            ^~
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:138:12: error: ‘cs’ was not declared in this scope; did you mean ‘cp’?
+  138 |   decltype(cs.cs_net_profit) np;
+      |            ^~
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:139:12: error: ‘c’ was not declared in this scope; did you mean ‘cp’?
+  139 |   decltype(c.c_birth_year) by;
+      |            ^
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:139:12: error: ‘c’ was not declared in this scope; did you mean ‘cp’?
+  139 |   decltype(c.c_birth_year) by;
+      |            ^
+      |            cp
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:140:12: error: ‘cd1’ was not declared in this scope
+  140 |   decltype(cd1.cd_dep_count) dep;
+      |            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:140:12: error: ‘cd1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:333:13: error: redefinition of ‘void __json(const Customer&)’
+  333 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:223:13: note: ‘void __json(const Customer&)’ previously defined here
+  223 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:413:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  413 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:173:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  173 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:463:13: error: redefinition of ‘void __json(const DateDim&)’
+  463 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:303:13: note: ‘void __json(const DateDim&)’ previously defined here
+  303 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:623:13: error: redefinition of ‘void __json(const Item&)’
+  623 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:318:13: note: ‘void __json(const Item&)’ previously defined here
+  318 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:674:25: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  674 |                       i.i_item_id, ca.ca_country, ca.ca_state, ca.ca_county,
+      |                       ~~^~~~~~~~~
+      |                         |
+      |                         std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:693:21: error: no match for ‘operator==’ (operand types are ‘Result’ and ‘Result’)
+  693 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Result Result
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq181722201480/001/prog.cpp:758:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<Joined>’ requested
+  687 |   std::vector<Joined> result = ([&]() {
+      |                                ~~~~~~~~
+  688 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  689 |     for (auto j : joined) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  690 |       auto __key = Result{j.i_item_id, j.ca_country, j.ca_state, j.ca_county};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  691 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  692 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  693 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  694 |           __g.items.push_back(Joined{j});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  695 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  696 |           break;
+      |           ~~~~~~
+  697 |         }
+      |         ~
+  698 |       }
+      |       ~
+  699 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  700 |         __groups.push_back(__struct9{__key, std::vector<Joined>{Joined{j}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  701 |       }
+      |       ~
+  702 |     }
+      |     ~
+  703 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  704 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  705 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  706 |           g.key.i_item_id, g.key.ca_country, g.key.ca_state, g.key.ca_county,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  707 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  708 |             std::vector<decltype(std::declval<Joined>().q)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  709 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  710 |               __items.push_back(x.q);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  711 |             }
+      |             ~
+  712 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  713 |           })()),
+      |           ~~~~~~
+  714 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  715 |             std::vector<decltype(std::declval<Joined>().lp)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  716 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  717 |               __items.push_back(x.lp);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~
+  718 |             }
+      |             ~
+  719 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  720 |           })()),
+      |           ~~~~~~
+  721 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  722 |             std::vector<decltype(std::declval<Joined>().cp)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  723 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  724 |               __items.push_back(x.cp);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~
+  725 |             }
+      |             ~
+  726 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  727 |           })()),
+      |           ~~~~~~
+  728 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  729 |             std::vector<decltype(std::declval<Joined>().sp)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  730 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  731 |               __items.push_back(x.sp);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~
+  732 |             }
+      |             ~
+  733 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  734 |           })()),
+      |           ~~~~~~
+  735 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  736 |             std::vector<decltype(std::declval<Joined>().np)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  737 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  738 |               __items.push_back(x.np);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~
+  739 |             }
+      |             ~
+  740 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  741 |           })()),
+      |           ~~~~~~
+  742 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  743 |             std::vector<decltype(std::declval<Joined>().by)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  744 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  745 |               __items.push_back(x.by);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~
+  746 |             }
+      |             ~
+  747 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  748 |           })()),
+      |           ~~~~~~
+  749 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  750 |             std::vector<decltype(std::declval<Joined>().dep)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  751 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  752 |               __items.push_back(x.dep);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  753 |             }
+      |             ~
+  754 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  755 |           })())});
+      |           ~~~~~~~~
+  756 |     }
+      |     ~
+  757 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  758 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q19.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q19.error
@@ -1,0 +1,383 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:88:8: error: redefinition of ‘struct StoreSale’
+   88 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:56:8: note: previous definition of ‘struct StoreSale’
+   56 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:95:8: error: redefinition of ‘struct DateDim’
+   95 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:63:8: note: previous definition of ‘struct DateDim’
+   63 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:100:8: error: redefinition of ‘struct Item’
+  100 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:68:8: note: previous definition of ‘struct Item’
+   68 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:108:8: error: redefinition of ‘struct Customer’
+  108 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:76:8: note: previous definition of ‘struct Customer’
+   76 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:116:8: error: redefinition of ‘struct Store’
+  116 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:84:8: note: previous definition of ‘struct Store’
+   84 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:121:12: error: ‘i’ was not declared in this scope
+  121 |   decltype(i.i_brand) brand;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:121:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:122:12: error: ‘i’ was not declared in this scope
+  122 |   decltype(i.i_brand_id) brand_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:122:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:123:12: error: ‘i’ was not declared in this scope
+  123 |   decltype(i.i_manufact_id) man_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:123:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:124:12: error: ‘i’ was not declared in this scope
+  124 |   decltype(i.i_manufact) man;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:124:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:127:12: error: ‘d’ was not declared in this scope
+  127 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:127:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:128:12: error: ‘ss’ was not declared in this scope
+  128 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:128:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:129:12: error: ‘i’ was not declared in this scope
+  129 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:129:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:130:12: error: ‘c’ was not declared in this scope
+  130 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:130:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:131:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+  131 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:131:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+  131 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:132:12: error: ‘s’ was not declared in this scope
+  132 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:132:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:300:13: error: redefinition of ‘void __json(const Customer&)’
+  300 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:145:13: note: ‘void __json(const Customer&)’ previously defined here
+  145 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:330:13: error: redefinition of ‘void __json(const DateDim&)’
+  330 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:175:13: note: ‘void __json(const DateDim&)’ previously defined here
+  175 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:380:13: error: redefinition of ‘void __json(const Item&)’
+  380 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:195:13: note: ‘void __json(const Item&)’ previously defined here
+  195 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:415:13: error: redefinition of ‘void __json(const Store&)’
+  415 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:230:13: note: ‘void __json(const Store&)’ previously defined here
+  230 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:430:13: error: redefinition of ‘void __json(const StoreSale&)’
+  430 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:245:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  245 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:521:25: error: ‘substr’ was not declared in this scope
+  521 |                        (substr(ca.ca_zip, 0, 5) != substr(s.s_zip, 0, 5)))))
+      |                         ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:525:39: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  525 |                 auto __key = Result{i.i_brand, i.i_brand_id, i.i_manufact_id,
+      |                                     ~~^~~~~~~
+      |                                       |
+      |                                       std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:530:51: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  530 |                     __g.items.push_back(__struct8{d, ss, i, c, ca, s});
+      |                                                   ^
+      |                                                   |
+      |                                                   DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:538:56: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  538 |                       std::vector<__struct8>{__struct8{d, ss, i, c, ca, s}}});
+      |                                                        ^
+      |                                                        |
+      |                                                        DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:538:75: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  538 |                       std::vector<__struct8>{__struct8{d, ss, i, c, ca, s}}});
+      |                                                                           ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:559:51: error: ‘struct __struct8’ has no member named ‘ss_ext_sales_price’
+  559 |                                                  .ss_ext_sales_price)>
+      |                                                   ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:559:51: error: ‘struct __struct8’ has no member named ‘ss_ext_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:559:70: error: template argument 1 is invalid
+  559 |                                                  .ss_ext_sales_price)>
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:559:70: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:562:35: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  562 |                           __items.push_back(x.ss_ext_sales_price);
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:562:47: error: ‘struct __struct8’ has no member named ‘ss_ext_sales_price’
+  562 |                           __items.push_back(x.ss_ext_sales_price);
+      |                                               ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:557:25:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:556:50: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  556 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:556:61: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  556 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                           ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:552:24: error: no matching function for call to ‘std::vector<std::pair<std::vector<int>, __struct10> >::push_back(<brace-enclosed initializer list>)’
+  552 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  553 |           {std::vector<decltype(g.key.brand)>{g.key.brand},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  554 |            __struct10{g.key.brand, g.key.brand_id, g.key.man_id, g.key.man,
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  555 |                       ([&](auto v) {
+      |                       ~~~~~~~~~~~~~~
+  556 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  557 |                       })(([&]() {
+      |                       ~~~~~~~~~~~
+  558 |                         std::vector<decltype(std::declval<__struct8>()
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  559 |                                                  .ss_ext_sales_price)>
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  560 |                             __items;
+      |                             ~~~~~~~~
+  561 |                         for (auto x : g.items) {
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~
+  562 |                           __items.push_back(x.ss_ext_sales_price);
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  563 |                         }
+      |                         ~
+  564 |                         return __items;
+      |                         ~~~~~~~~~~~~~~~
+  565 |                       })())}});
+      |                       ~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<std::vector<int>, __struct10>; _Alloc = std::allocator<std::pair<std::vector<int>, __struct10> >; value_type = std::pair<std::vector<int>, __struct10>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<std::vector<int>, __struct10> >::value_type&’ {aka ‘const std::pair<std::vector<int>, __struct10>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<std::vector<int>, __struct10>; _Alloc = std::allocator<std::pair<std::vector<int>, __struct10> >; value_type = std::pair<std::vector<int>, __struct10>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<std::vector<int>, __struct10> >::value_type&&’ {aka ‘std::pair<std::vector<int>, __struct10>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq19387144039/001/prog.cpp:573:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  504 |   std::vector<__struct8> result = ([&]() {
+      |                                   ~~~~~~~~
+  505 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |     for (auto d : date_dim) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  507 |       for (auto ss : store_sales) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |         if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  509 |           continue;
+      |           ~~~~~~~~~
+  510 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  511 |           if (!(((ss.ss_item_sk == i.i_item_sk) && (i.i_manager_id == 10))))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  512 |             continue;
+      |             ~~~~~~~~~
+  513 |           for (auto c : customer) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+  514 |             if (!((ss.ss_customer_sk == c.c_customer_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  515 |               continue;
+      |               ~~~~~~~~~
+  516 |             for (auto ca : customer_address) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  517 |               if (!((c.c_current_addr_sk == ca.ca_address_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  518 |                 continue;
+      |                 ~~~~~~~~~
+  519 |               for (auto s : store) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~
+  520 |                 if (!(((ss.ss_store_sk == s.s_store_sk) &&
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |                        (substr(ca.ca_zip, 0, 5) != substr(s.s_zip, 0, 5)))))
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  522 |                   continue;
+      |                   ~~~~~~~~~
+  523 |                 if (!(((d.d_moy == 11) && (d.d_year == 1999))))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  524 |                   continue;
+      |                   ~~~~~~~~~
+  525 |                 auto __key = Result{i.i_brand, i.i_brand_id, i.i_manufact_id,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  526 |                                     i.i_manufact};
+      |                                     ~~~~~~~~~~~~~~
+  527 |                 bool __found = false;
+      |                 ~~~~~~~~~~~~~~~~~~~~~
+  528 |                 for (auto &__g : __groups) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  529 |                   if (__g.key == __key) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~
+  530 |                     __g.items.push_back(__struct8{d, ss, i, c, ca, s});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  531 |                     __found = true;
+      |                     ~~~~~~~~~~~~~~~
+  532 |                     break;
+      |                     ~~~~~~
+  533 |                   }
+      |                   ~
+  534 |                 }
+      |                 ~
+  535 |                 if (!__found) {
+      |                 ~~~~~~~~~~~~~~~
+  536 |                   __groups.push_back(__struct9{
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  537 |                       __key,
+      |                       ~~~~~~
+  538 |                       std::vector<__struct8>{__struct8{d, ss, i, c, ca, s}}});
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  539 |                 }
+      |                 ~
+  540 |               }
+      |               ~
+  541 |             }
+      |             ~
+  542 |           }
+      |           ~
+  543 |         }
+      |         ~
+  544 |       }
+      |       ~
+  545 |     }
+      |     ~
+  546 |     std::vector<std::pair<
+      |     ~~~~~~~~~~~~~~~~~~~~~~
+  547 |         decltype(std::vector<decltype(std::declval<__struct9>().key.brand)>{
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  548 |             std::declval<__struct9>().key.brand}),
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  549 |         __struct10>>
+      |         ~~~~~~~~~~~~
+  550 |         __items;
+      |         ~~~~~~~~
+  551 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  552 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  553 |           {std::vector<decltype(g.key.brand)>{g.key.brand},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  554 |            __struct10{g.key.brand, g.key.brand_id, g.key.man_id, g.key.man,
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  555 |                       ([&](auto v) {
+      |                       ~~~~~~~~~~~~~~
+  556 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  557 |                       })(([&]() {
+      |                       ~~~~~~~~~~~
+  558 |                         std::vector<decltype(std::declval<__struct8>()
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  559 |                                                  .ss_ext_sales_price)>
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~
+  560 |                             __items;
+      |                             ~~~~~~~~
+  561 |                         for (auto x : g.items) {
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~
+  562 |                           __items.push_back(x.ss_ext_sales_price);
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  563 |                         }
+      |                         ~
+  564 |                         return __items;
+      |                         ~~~~~~~~~~~~~~~
+  565 |                       })())}});
+      |                       ~~~~~~~~~
+  566 |     }
+      |     ~
+  567 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  568 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  569 |     std::vector<__struct10> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  570 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  571 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  572 |     return __res;
+      |     ~~~~~~~~~~~~~
+  573 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q2.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q2.error
@@ -1,0 +1,916 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:72:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   72 |   decltype(ws.ws_sold_date_sk) sold_date_sk;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:72:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   72 |   decltype(ws.ws_sold_date_sk) sold_date_sk;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:73:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   73 |   decltype(ws.ws_ext_sales_price) sales_price;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:73:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   73 |   decltype(ws.ws_ext_sales_price) sales_price;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:74:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   74 |   decltype(ws.ws_sold_date_name) day;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:74:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   74 |   decltype(ws.ws_sold_date_name) day;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:78:12: error: ‘d’ was not declared in this scope
+   78 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:78:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:81:53: error: ‘d’ was not declared in this scope
+   81 |   decltype(std::unordered_map<std::string, decltype(d.d_week_seq)>{
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:81:53: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:81:66: error: template argument 2 is invalid
+   81 |   decltype(std::unordered_map<std::string, decltype(d.d_week_seq)>{
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:81:66: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:82:33: error: ‘d’ was not declared in this scope
+   82 |       {std::string("week_seq"), d.d_week_seq}}) key;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:82:33: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:86:42: error: request for member ‘week_seq’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+   86 |   decltype(std::declval<__struct6>().key.week_seq) d_week_seq;
+      |                                          ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:86:42: error: request for member ‘week_seq’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:96:34: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+   96 |   decltype(std::declval<Wswsc>().d_week_seq) d_week_seq1;
+      |                                  ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:96:34: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:97:35: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+   97 |   decltype((std::declval<Wswsc>().sun_sales /
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:98:35: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+   98 |             std::declval<Wswsc>().sun_sales)) sun_ratio;
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:97:35: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+   97 |   decltype((std::declval<Wswsc>().sun_sales /
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:98:35: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+   98 |             std::declval<Wswsc>().sun_sales)) sun_ratio;
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:99:35: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+   99 |   decltype((std::declval<Wswsc>().mon_sales /
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:100:35: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+  100 |             std::declval<Wswsc>().mon_sales)) mon_ratio;
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:99:35: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+   99 |   decltype((std::declval<Wswsc>().mon_sales /
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:100:35: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+  100 |             std::declval<Wswsc>().mon_sales)) mon_ratio;
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:290:35: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  290 |                                ws.ws_sold_date_name});
+      |                                ~~~^~~~~~~~~~~~~~~~~
+      |                                   |
+      |                                   std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:298:35: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  298 |                                cs.cs_sold_date_name});
+      |                                ~~~^~~~~~~~~~~~~~~~~
+      |                                   |
+      |                                   std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:23: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’)
+  312 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   int    std::unordered_map<std::__cxx11::basic_string<char>, int>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, int> >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const _CharT*’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:7:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:312:26: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  312 |           if (__g.key == __key) {
+      |                          ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, int> >&, const allocator<pair<const __cxx11::basic_string<char>, int> >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, int> >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:313:42: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  313 |             __g.items.push_back(Wswsc{w, d});
+      |                                          ^
+      |                                          |
+      |                                          DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:319:75: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  319 |           __groups.push_back(__struct6{__key, std::vector<Wswsc>{Wswsc{w, d}}});
+      |                                                                           ^
+      |                                                                           |
+      |                                                                           DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:319:77: error: no matching function for call to ‘std::vector<Wswsc>::vector(<brace-enclosed initializer list>)’
+  319 |           __groups.push_back(__struct6{__key, std::vector<Wswsc>{Wswsc{w, d}}});
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Wswsc; _Alloc = std::allocator<Wswsc>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; allocator_type = std::allocator<Wswsc>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; std::__type_identity_t<_Alloc> = std::allocator<Wswsc>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; allocator_type = std::allocator<Wswsc>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; allocator_type = std::allocator<Wswsc>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; std::__type_identity_t<_Alloc> = std::allocator<Wswsc>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; size_type = long unsigned int; value_type = Wswsc; allocator_type = std::allocator<Wswsc>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; size_type = long unsigned int; allocator_type = std::allocator<Wswsc>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>; allocator_type = std::allocator<Wswsc>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Wswsc; _Alloc = std::allocator<Wswsc>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:326:17: error: request for member ‘week_seq’ in ‘g.__struct6::key’, which is of non-class type ‘int’
+  326 |           g.key.week_seq, ([&](auto v) {
+      |                 ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:329:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  329 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:329:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:329:68: error: template argument 1 is invalid
+  329 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:329:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:331:24: error: ‘struct Wswsc’ has no member named ‘day’
+  331 |               if (!((x.day == std::string("Sunday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:333:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  333 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:333:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  333 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:328:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:327:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  327 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:327:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  327 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:340:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  340 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:340:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:340:68: error: template argument 1 is invalid
+  340 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:340:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:342:24: error: ‘struct Wswsc’ has no member named ‘day’
+  342 |               if (!((x.day == std::string("Monday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:344:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  344 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:344:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  344 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:339:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:338:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  338 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:338:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  338 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:351:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  351 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:351:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:351:68: error: template argument 1 is invalid
+  351 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:351:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:353:24: error: ‘struct Wswsc’ has no member named ‘day’
+  353 |               if (!((x.day == std::string("Tuesday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:355:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  355 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:355:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  355 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:350:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:349:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  349 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:349:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  349 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:362:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  362 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:362:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:362:68: error: template argument 1 is invalid
+  362 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:362:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:364:24: error: ‘struct Wswsc’ has no member named ‘day’
+  364 |               if (!((x.day == std::string("Wednesday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:366:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  366 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:366:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  366 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:6)> [with auto:6 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:361:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:360:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  360 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:360:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  360 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:373:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  373 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:373:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:373:68: error: template argument 1 is invalid
+  373 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:373:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:375:24: error: ‘struct Wswsc’ has no member named ‘day’
+  375 |               if (!((x.day == std::string("Thursday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:377:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  377 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:377:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  377 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:7)> [with auto:7 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:372:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:371:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  371 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:371:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  371 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:384:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  384 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:384:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:384:68: error: template argument 1 is invalid
+  384 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:384:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:386:24: error: ‘struct Wswsc’ has no member named ‘day’
+  386 |               if (!((x.day == std::string("Friday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:388:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  388 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:388:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  388 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:8)> [with auto:8 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:383:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:382:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  382 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:382:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  382 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:395:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  395 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:395:56: error: ‘struct Wswsc’ has no member named ‘sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:395:68: error: template argument 1 is invalid
+  395 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:395:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:397:24: error: ‘struct Wswsc’ has no member named ‘day’
+  397 |               if (!((x.day == std::string("Saturday"))))
+      |                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:399:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  399 |               __items.push_back(x.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:399:35: error: ‘struct Wswsc’ has no member named ‘sales_price’
+  399 |               __items.push_back(x.sales_price);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:9)> [with auto:9 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:394:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:393:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  393 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:393:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  393 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:405:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<Wswsc>’ requested
+  302 |   std::vector<Wswsc> wswscs = ([&]() {
+      |                               ~~~~~~~~
+  303 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  304 |     for (auto w : wscs) {
+      |     ~~~~~~~~~~~~~~~~~~~~~
+  305 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  306 |         if (!((w.sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  307 |           continue;
+      |           ~~~~~~~~~
+  308 |         auto __key = std::unordered_map<std::string, decltype(d.d_week_seq)>{
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |             {std::string("week_seq"), d.d_week_seq}};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  311 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  313 |             __g.items.push_back(Wswsc{w, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  314 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  315 |             break;
+      |             ~~~~~~
+  316 |           }
+      |           ~
+  317 |         }
+      |         ~
+  318 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  319 |           __groups.push_back(__struct6{__key, std::vector<Wswsc>{Wswsc{w, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  320 |         }
+      |         ~
+  321 |       }
+      |       ~
+  322 |     }
+      |     ~
+  323 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  324 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  325 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |           g.key.week_seq, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  327 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  328 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  329 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  330 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  331 |               if (!((x.day == std::string("Sunday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |                 continue;
+      |                 ~~~~~~~~~
+  333 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |             }
+      |             ~
+  335 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  336 |           })()),
+      |           ~~~~~~
+  337 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  338 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  340 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  341 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |               if (!((x.day == std::string("Monday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |                 continue;
+      |                 ~~~~~~~~~
+  344 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |             }
+      |             ~
+  346 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  347 |           })()),
+      |           ~~~~~~
+  348 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  349 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  351 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |               if (!((x.day == std::string("Tuesday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |                 continue;
+      |                 ~~~~~~~~~
+  355 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  356 |             }
+      |             ~
+  357 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  358 |           })()),
+      |           ~~~~~~
+  359 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  360 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  362 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |               if (!((x.day == std::string("Wednesday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                 continue;
+      |                 ~~~~~~~~~
+  366 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |             }
+      |             ~
+  368 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  369 |           })()),
+      |           ~~~~~~
+  370 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  371 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  373 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |               if (!((x.day == std::string("Thursday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |                 continue;
+      |                 ~~~~~~~~~
+  377 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  378 |             }
+      |             ~
+  379 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  380 |           })()),
+      |           ~~~~~~
+  381 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  382 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  383 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  384 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  385 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |               if (!((x.day == std::string("Friday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  387 |                 continue;
+      |                 ~~~~~~~~~
+  388 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |             }
+      |             ~
+  390 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  391 |           })()),
+      |           ~~~~~~
+  392 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  393 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  395 |             std::vector<decltype(std::declval<Wswsc>().sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |               if (!((x.day == std::string("Saturday"))))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |                 continue;
+      |                 ~~~~~~~~~
+  399 |               __items.push_back(x.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  400 |             }
+      |             ~
+  401 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  402 |           })())});
+      |           ~~~~~~~~
+  403 |     }
+      |     ~
+  404 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  405 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:409:16: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+  409 |       if (!((w.d_week_seq == 1)))
+      |                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:418:16: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+  418 |       if (!((w.d_week_seq == 54)))
+      |                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:428:18: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+  428 |         if (!((y.d_week_seq == (z.d_week_seq - 53))))
+      |                  ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:428:35: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+  428 |         if (!((y.d_week_seq == (z.d_week_seq - 53))))
+      |                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:430:36: error: ‘struct Wswsc’ has no member named ‘d_week_seq’
+  430 |         __items.push_back(Result{y.d_week_seq, (y.sun_sales / z.sun_sales),
+      |                                    ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:430:51: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+  430 |         __items.push_back(Result{y.d_week_seq, (y.sun_sales / z.sun_sales),
+      |                                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:430:65: error: ‘struct Wswsc’ has no member named ‘sun_sales’
+  430 |         __items.push_back(Result{y.d_week_seq, (y.sun_sales / z.sun_sales),
+      |                                                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:431:37: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+  431 |                                  (y.mon_sales / z.mon_sales)});
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:431:51: error: ‘struct Wswsc’ has no member named ‘mon_sales’
+  431 |                                  (y.mon_sales / z.mon_sales)});
+      |                                                   ^~~~~~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:71:
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_equal_to_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >; _Iterator2 = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >]’:
+/usr/include/c++/13/bits/stl_algo.h:917:20:   required from ‘_ForwardIterator std::__unique(_ForwardIterator, _ForwardIterator, _BinaryPredicate) [with _ForwardIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _BinaryPredicate = __gnu_cxx::__ops::_Iter_equal_to_iter]’
+/usr/include/c++/13/bits/stl_algo.h:948:27:   required from ‘_FIter std::unique(_FIter, _FIter) [with _FIter = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:284:24:   required from ‘main()::<lambda(auto:1, auto:2)> [with auto:1 = std::vector<Wsc>; auto:2 = std::vector<Wsc>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:286:5:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:117:23: error: no match for ‘operator==’ (operand types are ‘Wsc’ and ‘Wsc’)
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1217 |     operator==(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1225 |     operator==(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘constexpr bool __gnu_cxx::__ops::_Iter_less_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >; _Iterator2 = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1819:14:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:283:14:   required from ‘main()::<lambda(auto:1, auto:2)> [with auto:1 = std::vector<Wsc>; auto:2 = std::vector<Wsc>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:286:5:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:45:23: error: no match for ‘operator<’ (operand types are ‘Wsc’ and ‘Wsc’)
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Val_less_iter::operator()(_Value&, _Iterator) const [with _Value = Wsc; _Iterator = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1799:20:   required from ‘void std::__unguarded_linear_insert(_RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Val_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1827:36:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:283:14:   required from ‘main()::<lambda(auto:1, auto:2)> [with auto:1 = std::vector<Wsc>; auto:2 = std::vector<Wsc>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:286:5:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:98:22: error: no match for ‘operator<’ (operand types are ‘Wsc’ and ‘Wsc’)
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_less_val::operator()(_Iterator, _Value&) const [with _Iterator = __gnu_cxx::__normal_iterator<Wsc*, std::vector<Wsc> >; _Value = Wsc]’:
+/usr/include/c++/13/bits/stl_heap.h:140:48:   required from ‘void std::__push_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Distance = long int; _Tp = Wsc; _Compare = __gnu_cxx::__ops::_Iter_less_val]’
+/usr/include/c++/13/bits/stl_heap.h:247:23:   required from ‘void std::__adjust_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Distance = long int; _Tp = Wsc; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_heap.h:356:22:   required from ‘void std::__make_heap(_RandomAccessIterator, _RandomAccessIterator, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1635:23:   required from ‘void std::__heap_select(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1910:25:   required from ‘void std::__partial_sort(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1926:27:   required from ‘void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Size = long int; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1947:25:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<Wsc*, vector<Wsc> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:283:14:   required from ‘main()::<lambda(auto:1, auto:2)> [with auto:1 = std::vector<Wsc>; auto:2 = std::vector<Wsc>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq23652354825/001/prog.cpp:286:5:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:69:22: error: no match for ‘operator<’ (operand types are ‘Wsc’ and ‘Wsc’)
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘Wsc’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q20.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q20.error
@@ -1,0 +1,546 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:73:8: error: redefinition of ‘struct CatalogSale’
+   73 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:56:8: note: previous definition of ‘struct CatalogSale’
+   56 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:78:8: error: redefinition of ‘struct Item’
+   78 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:61:8: note: previous definition of ‘struct Item’
+   61 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:86:8: error: redefinition of ‘struct DateDim’
+   86 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:69:8: note: previous definition of ‘struct DateDim’
+   69 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+   91 |   decltype(i.i_item_id) id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   92 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   92 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   93 |   decltype(i.i_category) cat;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   93 |   decltype(i.i_category) cat;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   94 |   decltype(i.i_class) class;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   94 |   decltype(i.i_class) class;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:94:28: error: expected identifier before ‘;’ token
+   94 |   decltype(i.i_class) class;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:94:3: error: multiple types in one declaration
+   94 |   decltype(i.i_class) class;
+      |   ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   95 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   95 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:98:12: error: ‘cs’ was not declared in this scope
+   98 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:98:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+   99 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+  100 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:110:42: error: expected unqualified-id before ‘class’
+  110 |   decltype(std::declval<__struct6>().key.class) i_class;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  115 |   decltype(std::declval<__struct5>().i_class) key;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:119:48: error: expected identifier before ‘;’ token
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:119:3: error: multiple types in one declaration
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:119:48: error: declaration does not declare anything [-fpermissive]
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  123 |   decltype(std::declval<__struct5>().i_item_id) i_item_id;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  124 |   decltype(std::declval<__struct5>().i_item_desc) i_item_desc;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+  125 |   decltype(std::declval<__struct5>().i_category) i_category;
+      |                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  126 |   decltype(std::declval<__struct5>().i_class) i_class;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  127 |   decltype(std::declval<__struct5>().i_current_price) i_current_price;
+      |                                      ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  128 |   decltype(std::declval<__struct5>().itemrevenue) itemrevenue;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:129:41: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype((((std::declval<__struct5>().itemrevenue * 100)) /
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:129:41: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype((((std::declval<__struct5>().itemrevenue * 100)) /
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In function ‘void __json(const ClassTotal&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:209:12: error: expected unqualified-id before ‘class’
+  209 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:217:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  217 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:132:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  132 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:237:13: error: redefinition of ‘void __json(const DateDim&)’
+  237 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:152:13: note: ‘void __json(const DateDim&)’ previously defined here
+  152 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:327:13: error: redefinition of ‘void __json(const Item&)’
+  327 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:167:13: note: ‘void __json(const Item&)’ previously defined here
+  167 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In function ‘void __json(const Filtered&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:384:12: error: expected unqualified-id before ‘class’
+  384 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:449:61: error: too many initializers for ‘Filtered’
+  449 |                                 i.i_class, i.i_current_price};
+      |                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:453:45: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  453 |               __g.items.push_back(__struct5{cs, i, d});
+      |                                             ^~
+      |                                             |
+      |                                             CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:460:67: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{cs, i, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:460:76: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{cs, i, d}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:467:34: error: expected primary-expression before ‘{’ token
+  467 |       __items.push_back(__struct7{
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:481:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  425 |   std::vector<__struct5> filtered = ([&]() {
+      |                                     ~~~~~~~~
+  426 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  427 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  429 |         if (!((cs.cs_item_sk == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |           continue;
+      |           ~~~~~~~~~
+  431 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |           if (!((cs.cs_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |             continue;
+      |             ~~~~~~~~~
+  434 |           if (!((((std::find(
+      |           ~~~~~~~~~~~~~~~~~~~
+  435 |                        std::vector<std::string>{
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~
+  436 |                            std::string("A"), std::string("B"), std::string("C")}
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |                            .begin(),
+      |                            ~~~~~~~~~
+  438 |                        std::vector<std::string>{
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~
+  439 |                            std::string("A"), std::string("B"), std::string("C")}
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  440 |                            .end(),
+      |                            ~~~~~~~
+  441 |                        i.i_category) !=
+      |                        ~~~~~~~~~~~~~~~~
+  442 |                    std::vector<std::string>{std::string("A"), std::string("B"),
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |                                             std::string("C")}
+      |                                             ~~~~~~~~~~~~~~~~~
+  444 |                        .end()) &&
+      |                        ~~~~~~~~~~
+  445 |                   (d.d_date >= std::string("2000-02-01"))) &&
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  446 |                  (d.d_date <= std::string("2000-03-02")))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  447 |             continue;
+      |             ~~~~~~~~~
+  448 |           auto __key = Filtered{i.i_item_id, i.i_item_desc, i.i_category,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  449 |                                 i.i_class, i.i_current_price};
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  451 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  453 |               __g.items.push_back(__struct5{cs, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  455 |               break;
+      |               ~~~~~~
+  456 |             }
+      |             ~
+  457 |           }
+      |           ~
+  458 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  459 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  460 |                 __struct6{__key, std::vector<__struct5>{__struct5{cs, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  461 |           }
+      |           ~
+  462 |         }
+      |         ~
+  463 |       }
+      |       ~
+  464 |     }
+      |     ~
+  465 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  466 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  467 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  468 |           g.key.id, g.key.desc, g.key.cat, g.key.class, g.key.price,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  470 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  472 |             std::vector<decltype(std::declval<__struct5>().cs_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  473 |                 __items;
+      |                 ~~~~~~~~
+  474 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  475 |               __items.push_back(x.cs_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  476 |             }
+      |             ~
+  477 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  478 |           })())});
+      |           ~~~~~~~~
+  479 |     }
+      |     ~
+  480 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  481 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:485:22: error: ‘struct __struct5’ has no member named ‘i_class’
+  485 |       auto __key = f.i_class;
+      |                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:505:60: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                            ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:505:60: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:505:72: error: template argument 1 is invalid
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:505:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:508:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  508 |               __items.push_back(x.itemrevenue);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:508:35: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  508 |               __items.push_back(x.itemrevenue);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:504:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:503:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:503:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:511:16: error: too many initializers for ‘ClassTotal’
+  511 |           })())});
+      |                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:514:5: error: conversion from ‘vector<ClassTotal>’ to non-scalar type ‘vector<__struct5>’ requested
+  482 |   std::vector<__struct5> class_totals = ([&]() {
+      |                                         ~~~~~~~~
+  483 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  484 |     for (auto f : filtered) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |       auto __key = f.i_class;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~
+  486 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  487 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  489 |           __g.items.push_back(__struct5{f});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  490 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  491 |           break;
+      |           ~~~~~~
+  492 |         }
+      |         ~
+  493 |       }
+      |       ~
+  494 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  495 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  496 |             __struct8{__key, std::vector<__struct5>{__struct5{f}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  497 |       }
+      |       ~
+  498 |     }
+      |     ~
+  499 |     std::vector<ClassTotal> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  500 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  501 |       __items.push_back(ClassTotal{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  502 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  505 |             std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |                 __items;
+      |                 ~~~~~~~~
+  507 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |               __items.push_back(x.itemrevenue);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  509 |             }
+      |             ~
+  510 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  511 |           })())});
+      |           ~~~~~~~~
+  512 |     }
+      |     ~
+  513 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  514 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:517:54: error: ‘struct __struct5’ has no member named ‘i_category’
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:517:54: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:517:67: error: template argument 1 is invalid
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                   ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:517:73: error: template argument 1 is invalid
+  517 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:517:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:521:18: error: ‘struct __struct5’ has no member named ‘i_class’
+  521 |         if (!((f.i_class == t.class)))
+      |                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:521:31: error: expected unqualified-id before ‘class’
+  521 |         if (!((f.i_class == t.class)))
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:521:31: error: expected ‘)’ before ‘class’
+  521 |         if (!((f.i_class == t.class)))
+      |               ~               ^~~~~
+      |                               )
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:522:19: error: expected ‘)’ before ‘;’ token
+  522 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:521:14: note: to match this ‘(’
+  521 |         if (!((f.i_class == t.class)))
+      |              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:522:19: error: expected ‘)’ before ‘;’ token
+  522 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:521:12: note: to match this ‘(’
+  521 |         if (!((f.i_class == t.class)))
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:523:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  523 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:37: error: ‘struct __struct5’ has no member named ‘i_category’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:37: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:48: error: template argument 1 is invalid
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:52: error: ‘struct __struct5’ has no member named ‘i_category’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                    ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:524:66: error: ‘struct __struct5’ has no member named ‘i_class’
+  524 |             {std::vector<decltype(f.i_category)>{f.i_category, f.i_class,
+      |                                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:525:52: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  525 |                                                  f.i_item_id, f.i_item_desc},
+      |                                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:525:65: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  525 |                                                  f.i_item_id, f.i_item_desc},
+      |                                                                 ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:526:23: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:526:36: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                    ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:526:51: error: ‘struct __struct5’ has no member named ‘i_category’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:526:65: error: ‘struct __struct5’ has no member named ‘i_class’
+  526 |              Result{f.i_item_id, f.i_item_desc, f.i_category, f.i_class,
+      |                                                                 ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:527:23: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  527 |                     f.i_current_price, f.itemrevenue,
+      |                       ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:527:42: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  527 |                     f.i_current_price, f.itemrevenue,
+      |                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:528:26: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  528 |                     (((f.itemrevenue * 100)) / t.total)}});
+      |                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:528:50: error: ‘struct __struct5’ has no member named ‘total’
+  528 |                     (((f.itemrevenue * 100)) / t.total)}});
+      |                                                  ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:531:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  531 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:531:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  531 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:534:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  534 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq203450721718/001/prog.cpp:534:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  534 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q21.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q21.error
@@ -1,0 +1,509 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:74:8: error: redefinition of ‘struct Inventory’
+   74 | struct Inventory {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:56:8: note: previous definition of ‘struct Inventory’
+   56 | struct Inventory {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:80:8: error: redefinition of ‘struct Warehouse’
+   80 | struct Warehouse {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:62:8: note: previous definition of ‘struct Warehouse’
+   62 | struct Warehouse {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:84:8: error: redefinition of ‘struct Item’
+   84 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:66:8: note: previous definition of ‘struct Item’
+   66 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:88:8: error: redefinition of ‘struct DateDim’
+   88 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:70:8: note: previous definition of ‘struct DateDim’
+   70 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:93:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   93 |   decltype(inv.inv_warehouse_sk) w;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:93:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   93 |   decltype(inv.inv_warehouse_sk) w;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:94:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   94 |   decltype(inv.inv_item_sk) i;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:94:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   94 |   decltype(inv.inv_item_sk) i;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:97:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   97 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:97:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   97 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+   98 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:109:8: error: redefinition of ‘struct __struct6’
+  109 | struct __struct6 {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:96:8: note: previous definition of ‘struct __struct6’
+   96 | struct __struct6 {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:118:12: error: ‘w’ was not declared in this scope
+  118 |   decltype(w.w_warehouse_name) w_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:118:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:119:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+  119 |   decltype(it.i_item_id) i_id;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:119:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+  119 |   decltype(it.i_item_id) i_id;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:120:38: error: ‘struct __struct6’ has no member named ‘qty’
+  120 |   decltype(std::declval<__struct6>().qty) before_qty;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:120:38: error: ‘struct __struct6’ has no member named ‘qty’
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:121:38: error: ‘struct __struct6’ has no member named ‘qty’
+  121 |   decltype(std::declval<__struct6>().qty) after_qty;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:121:38: error: ‘struct __struct6’ has no member named ‘qty’
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:122:39: error: ‘struct __struct6’ has no member named ‘qty’
+  122 |   decltype((std::declval<__struct6>().qty /
+      |                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:123:39: error: ‘struct __struct6’ has no member named ‘qty’
+  123 |             std::declval<__struct6>().qty)) ratio;
+      |                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:122:39: error: ‘struct __struct6’ has no member named ‘qty’
+  122 |   decltype((std::declval<__struct6>().qty /
+      |                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:123:39: error: ‘struct __struct6’ has no member named ‘qty’
+  123 |             std::declval<__struct6>().qty)) ratio;
+      |                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:201:13: error: redefinition of ‘void __json(const DateDim&)’
+  201 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:131:13: note: ‘void __json(const DateDim&)’ previously defined here
+  131 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:216:13: error: redefinition of ‘void __json(const Item&)’
+  216 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:171:13: note: ‘void __json(const Item&)’ previously defined here
+  171 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:231:13: error: redefinition of ‘void __json(const Inventory&)’
+  231 | inline void __json(const Inventory &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:146:13: note: ‘void __json(const Inventory&)’ previously defined here
+  146 | inline void __json(const Inventory &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:361:13: error: redefinition of ‘void __json(const Warehouse&)’
+  361 | inline void __json(const Warehouse &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:186:13: note: ‘void __json(const Warehouse&)’ previously defined here
+  186 | inline void __json(const Warehouse &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:397:23: error: no match for ‘operator==’ (operand types are ‘Before’ and ‘Before’)
+  397 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   Before Before
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:398:43: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  398 |             __g.items.push_back(__struct6{inv, d});
+      |                                           ^~~
+      |                                           |
+      |                                           Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:405:65: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  405 |               __struct7{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |                                                                 ^~~
+      |                                                                 |
+      |                                                                 Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:405:72: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  405 |               __struct7{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:416:52: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+  416 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                                                    ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:416:52: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:416:73: error: template argument 1 is invalid
+  416 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                                                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:416:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:419:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  419 |               __items.push_back(x.inv_quantity_on_hand);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:419:35: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+  419 |               __items.push_back(x.inv_quantity_on_hand);
+      |                                   ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:414:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:413:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  413 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:413:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  413 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:425:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  386 |   std::vector<__struct6> before = ([&]() {
+      |                                   ~~~~~~~~
+  387 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |     for (auto inv : inventory) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |         if (!((inv.inv_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  391 |           continue;
+      |           ~~~~~~~~~
+  392 |         if (!((d.d_date < std::string("2000-03-15"))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  393 |           continue;
+      |           ~~~~~~~~~
+  394 |         auto __key = Before{inv.inv_warehouse_sk, inv.inv_item_sk};
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  395 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  396 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  398 |             __g.items.push_back(__struct6{inv, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  399 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  400 |             break;
+      |             ~~~~~~
+  401 |           }
+      |           ~
+  402 |         }
+      |         ~
+  403 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  404 |           __groups.push_back(
+      |           ~~~~~~~~~~~~~~~~~~~
+  405 |               __struct7{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  406 |         }
+      |         ~
+  407 |       }
+      |       ~
+  408 |     }
+      |     ~
+  409 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  410 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  411 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  412 |           g.key.w, g.key.i, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  413 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  414 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  415 |             std::vector<
+      |             ~~~~~~~~~~~~
+  416 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  417 |                 __items;
+      |                 ~~~~~~~~
+  418 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  419 |               __items.push_back(x.inv_quantity_on_hand);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  420 |             }
+      |             ~
+  421 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  422 |           })())});
+      |           ~~~~~~~~
+  423 |     }
+      |     ~
+  424 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  425 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:437:23: error: no match for ‘operator==’ (operand types are ‘Before’ and ‘Before’)
+  437 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   Before Before
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:438:43: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  438 |             __g.items.push_back(__struct6{inv, d});
+      |                                           ^~~
+      |                                           |
+      |                                           Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:445:65: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  445 |               __struct9{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |                                                                 ^~~
+      |                                                                 |
+      |                                                                 Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:445:72: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  445 |               __struct9{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |                                                                        ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:456:52: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+  456 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                                                    ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:456:52: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:456:73: error: template argument 1 is invalid
+  456 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                                                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:456:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:459:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  459 |               __items.push_back(x.inv_quantity_on_hand);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:459:35: error: ‘struct __struct6’ has no member named ‘inv_quantity_on_hand’
+  459 |               __items.push_back(x.inv_quantity_on_hand);
+      |                                   ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:454:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:453:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  453 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:453:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  453 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:465:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  426 |   std::vector<__struct6> after = ([&]() {
+      |                                  ~~~~~~~~
+  427 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |     for (auto inv : inventory) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  429 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |         if (!((inv.inv_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |           continue;
+      |           ~~~~~~~~~
+  432 |         if (!((d.d_date >= std::string("2000-03-15"))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |           continue;
+      |           ~~~~~~~~~
+  434 |         auto __key = Before{inv.inv_warehouse_sk, inv.inv_item_sk};
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  435 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  436 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  438 |             __g.items.push_back(__struct6{inv, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  439 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  440 |             break;
+      |             ~~~~~~
+  441 |           }
+      |           ~
+  442 |         }
+      |         ~
+  443 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  444 |           __groups.push_back(
+      |           ~~~~~~~~~~~~~~~~~~~
+  445 |               __struct9{__key, std::vector<__struct6>{__struct6{inv, d}}});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  446 |         }
+      |         ~
+  447 |       }
+      |       ~
+  448 |     }
+      |     ~
+  449 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  451 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |           g.key.w, g.key.i, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  453 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  455 |             std::vector<
+      |             ~~~~~~~~~~~~
+  456 |                 decltype(std::declval<__struct6>().inv_quantity_on_hand)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  457 |                 __items;
+      |                 ~~~~~~~~
+  458 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  459 |               __items.push_back(x.inv_quantity_on_hand);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  460 |             }
+      |             ~
+  461 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  462 |           })())});
+      |           ~~~~~~~~
+  463 |     }
+      |     ~
+  464 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  465 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:470:19: error: ‘struct __struct6’ has no member named ‘w’
+  470 |         if (!(((b.w == a.w) && (b.i == a.i))))
+      |                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:470:26: error: ‘struct __struct6’ has no member named ‘w’
+  470 |         if (!(((b.w == a.w) && (b.i == a.i))))
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:470:35: error: ‘struct __struct6’ has no member named ‘i’
+  470 |         if (!(((b.w == a.w) && (b.i == a.i))))
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:470:42: error: ‘struct __struct6’ has no member named ‘i’
+  470 |         if (!(((b.w == a.w) && (b.i == a.i))))
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:473:40: error: ‘struct __struct6’ has no member named ‘w’
+  473 |           if (!((w.w_warehouse_sk == b.w)))
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:476:38: error: ‘struct __struct6’ has no member named ‘i’
+  476 |             if (!((it.i_item_sk == b.i)))
+      |                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:478:74: error: ‘struct __struct6’ has no member named ‘qty’
+  478 |             __items.push_back(Joined{w.w_warehouse_name, it.i_item_id, b.qty,
+      |                                                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:479:40: error: ‘struct __struct6’ has no member named ‘qty’
+  479 |                                      a.qty, (a.qty / b.qty)});
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:479:48: error: ‘struct __struct6’ has no member named ‘qty’
+  479 |                                      a.qty, (a.qty / b.qty)});
+      |                                                ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:479:56: error: ‘struct __struct6’ has no member named ‘qty’
+  479 |                                      a.qty, (a.qty / b.qty)});
+      |                                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq211527840675/001/prog.cpp:492:24: error: no matching function for call to ‘std::vector<std::pair<int, Result> >::push_back(<brace-enclosed initializer list>)’
+  492 |       __items.push_back({std::vector<decltype(r.w_name)>{r.w_name, r.i_id},
+      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  493 |                          Result{r.w_name, r.i_id, r.before_qty, r.after_qty}});
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<int, Result>; _Alloc = std::allocator<std::pair<int, Result> >; value_type = std::pair<int, Result>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<int, Result> >::value_type&’ {aka ‘const std::pair<int, Result>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<int, Result>; _Alloc = std::allocator<std::pair<int, Result> >; value_type = std::pair<int, Result>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<int, Result> >::value_type&&’ {aka ‘std::pair<int, Result>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q22.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q22.error
@@ -1,0 +1,241 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:69:8: error: redefinition of ‘struct Inventory’
+   69 | struct Inventory {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:53:8: note: previous definition of ‘struct Inventory’
+   53 | struct Inventory {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:74:8: error: redefinition of ‘struct DateDim’
+   74 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:58:8: note: previous definition of ‘struct DateDim’
+   58 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:78:8: error: redefinition of ‘struct Item’
+   78 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:62:8: note: previous definition of ‘struct Item’
+   62 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:86:12: error: ‘i’ was not declared in this scope
+   86 |   decltype(i.i_product_name) product_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:86:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:87:12: error: ‘i’ was not declared in this scope
+   87 |   decltype(i.i_brand) brand;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:87:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+   88 |   decltype(i.i_class) class;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:88:28: error: expected identifier before ‘;’ token
+   88 |   decltype(i.i_class) class;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:88:3: error: multiple types in one declaration
+   88 |   decltype(i.i_class) class;
+      |   ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:89:12: error: ‘i’ was not declared in this scope
+   89 |   decltype(i.i_category) category;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:89:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:92:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   92 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:92:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   92 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:93:12: error: ‘d’ was not declared in this scope
+   93 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:93:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+   94 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:111:42: error: expected unqualified-id before ‘class’
+  111 |   decltype(std::declval<__struct6>().key.class) i_class;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:180:13: error: redefinition of ‘void __json(const DateDim&)’
+  180 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:115:13: note: ‘void __json(const DateDim&)’ previously defined here
+  115 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:195:13: error: redefinition of ‘void __json(const Item&)’
+  195 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:150:13: note: ‘void __json(const Item&)’ previously defined here
+  150 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:255:13: error: redefinition of ‘void __json(const Inventory&)’
+  255 | inline void __json(const Inventory &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:130:13: note: ‘void __json(const Inventory&)’ previously defined here
+  130 | inline void __json(const Inventory &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp: In function ‘void __json(const Qoh&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:292:12: error: expected unqualified-id before ‘class’
+  292 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:342:71: error: too many initializers for ‘Qoh’
+  342 |               Qoh{i.i_product_name, i.i_brand, i.i_class, i.i_category};
+      |                                                                       ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:346:45: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  346 |               __g.items.push_back(__struct5{inv, d, i});
+      |                                             ^~~
+      |                                             |
+      |                                             Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:353:67: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  353 |                 __struct6{__key, std::vector<__struct5>{__struct5{inv, d, i}}});
+      |                                                                   ^~~
+      |                                                                   |
+      |                                                                   Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:353:77: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  353 |                 __struct6{__key, std::vector<__struct5>{__struct5{inv, d, i}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:360:34: error: expected primary-expression before ‘{’ token
+  360 |       __items.push_back(__struct7{
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq221703626238/001/prog.cpp:373:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  330 |   std::vector<__struct5> qoh = ([&]() {
+      |                                ~~~~~~~~
+  331 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |     for (auto inv : inventory) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  333 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |         if (!((inv.inv_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  335 |           continue;
+      |           ~~~~~~~~~
+  336 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  337 |           if (!((inv.inv_item_sk == i.i_item_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  338 |             continue;
+      |             ~~~~~~~~~
+  339 |           if (!(((d.d_month_seq >= 0) && (d.d_month_seq <= 11))))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  340 |             continue;
+      |             ~~~~~~~~~
+  341 |           auto __key =
+      |           ~~~~~~~~~~~~
+  342 |               Qoh{i.i_product_name, i.i_brand, i.i_class, i.i_category};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  344 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  346 |               __g.items.push_back(__struct5{inv, d, i});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  347 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  348 |               break;
+      |               ~~~~~~
+  349 |             }
+      |             ~
+  350 |           }
+      |           ~
+  351 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  352 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  353 |                 __struct6{__key, std::vector<__struct5>{__struct5{inv, d, i}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |           }
+      |           ~
+  355 |         }
+      |         ~
+  356 |       }
+      |       ~
+  357 |     }
+      |     ~
+  358 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |           g.key.product_name, g.key.brand, g.key.class, g.key.category,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  362 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  363 |             std::vector<
+      |             ~~~~~~~~~~~~
+  364 |                 decltype(std::declval<__struct5>().inv_quantity_on_hand)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                 __items;
+      |                 ~~~~~~~~
+  366 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |               __items.push_back(x.inv_quantity_on_hand);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |             }
+      |             ~
+  369 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  370 |           })())});
+      |           ~~~~~~~~
+  371 |     }
+      |     ~
+  372 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  373 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q23.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q23.error
@@ -1,0 +1,541 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:84:8: error: redefinition of ‘struct StoreSale’
+   84 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:55:8: note: previous definition of ‘struct StoreSale’
+   55 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:91:8: error: redefinition of ‘struct DateDim’
+   91 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:62:8: note: previous definition of ‘struct DateDim’
+   62 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:96:8: error: redefinition of ‘struct CatalogSale’
+   96 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:70:8: note: previous definition of ‘struct CatalogSale’
+   70 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:103:8: error: redefinition of ‘struct WebSale’
+  103 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:77:8: note: previous definition of ‘struct WebSale’
+   77 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:111:12: error: ‘i’ was not declared in this scope
+  111 |   decltype(i.i_item_sk) item_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:111:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:112:12: error: ‘d’ was not declared in this scope
+  112 |   decltype(d.d_date_sk) date_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:112:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:115:12: error: ‘ss’ was not declared in this scope
+  115 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:115:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:116:12: error: ‘d’ was not declared in this scope
+  116 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:116:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:124:12: error: ‘ss’ was not declared in this scope
+  124 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:124:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:127:42: error: ‘struct CustomerTotal’ has no member named ‘ss_customer_sk’
+  127 |   decltype(std::declval<CustomerTotal>().ss_customer_sk) key;
+      |                                          ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:127:42: error: ‘struct CustomerTotal’ has no member named ‘ss_customer_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:254:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  254 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:134:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  134 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:299:13: error: redefinition of ‘void __json(const DateDim&)’
+  299 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:164:13: note: ‘void __json(const DateDim&)’ previously defined here
+  164 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:334:13: error: redefinition of ‘void __json(const StoreSale&)’
+  334 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:194:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  194 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:394:13: error: redefinition of ‘void __json(const WebSale&)’
+  394 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:224:13: note: ‘void __json(const WebSale&)’ previously defined here
+  224 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:432:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  432 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |           {std::string("i_item_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  435 |               {std::string("i_item_sk"), 1}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  436 |           std::unordered_map<std::string, decltype(2)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |               {std::string("i_item_sk"), 2}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:449:37: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘i_item_sk’
+  449 |           if (!((ss.ss_item_sk == i.i_item_sk)))
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:453:41: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘i_item_sk’
+  453 |           auto __key = FrequentSsItem{i.i_item_sk, d.d_date_sk};
+      |                                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:457:45: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  457 |               __g.items.push_back(__struct6{ss, d, i});
+      |                                             ^~
+      |                                             |
+      |                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:464:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  464 |                 __struct7{__key, std::vector<__struct6>{__struct6{ss, d, i}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:464:76: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  464 |                 __struct7{__key, std::vector<__struct6>{__struct6{ss, d, i}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:476:5: error: conversion from ‘vector<int>’ to non-scalar type ‘vector<__struct6>’ requested
+  442 |   std::vector<__struct6> frequent_ss_items = ([&]() {
+      |                                              ~~~~~~~~
+  443 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  444 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  445 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  446 |         if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  447 |           continue;
+      |           ~~~~~~~~~
+  448 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  449 |           if (!((ss.ss_item_sk == i.i_item_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |             continue;
+      |             ~~~~~~~~~
+  451 |           if (!((d.d_year == 2000)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |             continue;
+      |             ~~~~~~~~~
+  453 |           auto __key = FrequentSsItem{i.i_item_sk, d.d_date_sk};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  455 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  456 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  457 |               __g.items.push_back(__struct6{ss, d, i});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  458 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  459 |               break;
+      |               ~~~~~~
+  460 |             }
+      |             ~
+  461 |           }
+      |           ~
+  462 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  463 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  464 |                 __struct7{__key, std::vector<__struct6>{__struct6{ss, d, i}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  465 |           }
+      |           ~
+  466 |         }
+      |         ~
+  467 |       }
+      |       ~
+  468 |     }
+      |     ~
+  469 |     std::vector<decltype(std::declval<__struct7>().key.item_sk)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  470 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |       if (!((((int)g.items.size()) > 4)))
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  472 |         continue;
+      |         ~~~~~~~~~
+  473 |       __items.push_back(g.key.item_sk);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  474 |     }
+      |     ~
+  475 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  476 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:484:45: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  484 |           __g.items.push_back(CustomerTotal{ss});
+      |                                             ^~
+      |                                             |
+      |                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:491:71: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  491 |             __struct9{__key, std::vector<CustomerTotal>{CustomerTotal{ss}}});
+      |                                                                       ^~
+      |                                                                       |
+      |                                                                       StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:491:74: error: no matching function for call to ‘std::vector<CustomerTotal>::vector(<brace-enclosed initializer list>)’
+  491 |             __struct9{__key, std::vector<CustomerTotal>{CustomerTotal{ss}}});
+      |                                                                          ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; allocator_type = std::allocator<CustomerTotal>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; std::__type_identity_t<_Alloc> = std::allocator<CustomerTotal>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; allocator_type = std::allocator<CustomerTotal>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; allocator_type = std::allocator<CustomerTotal>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; std::__type_identity_t<_Alloc> = std::allocator<CustomerTotal>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; size_type = long unsigned int; value_type = CustomerTotal; allocator_type = std::allocator<CustomerTotal>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; size_type = long unsigned int; allocator_type = std::allocator<CustomerTotal>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>; allocator_type = std::allocator<CustomerTotal>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = CustomerTotal; _Alloc = std::allocator<CustomerTotal>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:501:58: error: ‘struct CustomerTotal’ has no member named ‘ss_quantity’
+  501 |                            std::declval<CustomerTotal>().ss_quantity *
+      |                                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:502:58: error: ‘struct CustomerTotal’ has no member named ‘ss_sales_price’
+  502 |                            std::declval<CustomerTotal>().ss_sales_price))>
+      |                                                          ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:501:58: error: ‘struct CustomerTotal’ has no member named ‘ss_quantity’
+  501 |                            std::declval<CustomerTotal>().ss_quantity *
+      |                                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:502:58: error: ‘struct CustomerTotal’ has no member named ‘ss_sales_price’
+  502 |                            std::declval<CustomerTotal>().ss_sales_price))>
+      |                                                          ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:502:74: error: template argument 1 is invalid
+  502 |                            std::declval<CustomerTotal>().ss_sales_price))>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:502:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:505:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  505 |                          __items.push_back((x.ss_quantity * x.ss_sales_price));
+      |                                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:505:47: error: ‘struct CustomerTotal’ has no member named ‘ss_quantity’
+  505 |                          __items.push_back((x.ss_quantity * x.ss_sales_price));
+      |                                               ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:505:63: error: ‘struct CustomerTotal’ has no member named ‘ss_sales_price’
+  505 |                          __items.push_back((x.ss_quantity * x.ss_sales_price));
+      |                                                               ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:499:24:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:498:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  498 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:498:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  498 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                          ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:511:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<CustomerTotal>’ requested
+  477 |   std::vector<CustomerTotal> customer_totals = ([&]() {
+      |                                                ~~~~~~~~
+  478 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  479 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  480 |       auto __key = ss.ss_customer_sk;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  481 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  482 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  483 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  484 |           __g.items.push_back(CustomerTotal{ss});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  486 |           break;
+      |           ~~~~~~
+  487 |         }
+      |         ~
+  488 |       }
+      |       ~
+  489 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  490 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  491 |             __struct9{__key, std::vector<CustomerTotal>{CustomerTotal{ss}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  492 |       }
+      |       ~
+  493 |     }
+      |     ~
+  494 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  495 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  496 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  497 |           __struct10{g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  499 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  500 |                        std::vector<decltype((
+      |                        ~~~~~~~~~~~~~~~~~~~~~~
+  501 |                            std::declval<CustomerTotal>().ss_quantity *
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  502 |                            std::declval<CustomerTotal>().ss_sales_price))>
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  503 |                            __items;
+      |                            ~~~~~~~~
+  504 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |                          __items.push_back((x.ss_quantity * x.ss_sales_price));
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |                        }
+      |                        ~
+  507 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  508 |                      })())});
+      |                      ~~~~~~~~
+  509 |     }
+      |     ~
+  510 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  511 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:514:60: error: ‘struct CustomerTotal’ has no member named ‘sales’
+  514 |         std::vector<decltype(std::declval<CustomerTotal>().sales)> __items;
+      |                                                            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:514:60: error: ‘struct CustomerTotal’ has no member named ‘sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:514:66: error: template argument 1 is invalid
+  514 |         std::vector<decltype(std::declval<CustomerTotal>().sales)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:514:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:516:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  516 |           __items.push_back(c.sales);
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:516:31: error: ‘struct CustomerTotal’ has no member named ‘sales’
+  516 |           __items.push_back(c.sales);
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:520:12: error: request for member ‘begin’ in ‘<lambda closure object>main()::<lambda()>{customer_totals}.main()::<lambda()>()’, which is of non-class type ‘int’
+  520 |           .begin(),
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:522:60: error: ‘struct CustomerTotal’ has no member named ‘sales’
+  522 |         std::vector<decltype(std::declval<CustomerTotal>().sales)> __items;
+      |                                                            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:522:60: error: ‘struct CustomerTotal’ has no member named ‘sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:522:66: error: template argument 1 is invalid
+  522 |         std::vector<decltype(std::declval<CustomerTotal>().sales)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:522:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:524:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  524 |           __items.push_back(c.sales);
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:524:31: error: ‘struct CustomerTotal’ has no member named ‘sales’
+  524 |           __items.push_back(c.sales);
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:528:12: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>{customer_totals}.main()::<lambda()>()’, which is of non-class type ‘int’
+  528 |           .end()));
+      |            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:530:56: error: ‘struct CustomerTotal’ has no member named ‘cust’
+  530 |     std::vector<decltype(std::declval<CustomerTotal>().cust)> __items;
+      |                                                        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:530:56: error: ‘struct CustomerTotal’ has no member named ‘cust’
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:530:61: error: template argument 1 is invalid
+  530 |     std::vector<decltype(std::declval<CustomerTotal>().cust)> __items;
+      |                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:530:61: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:532:16: error: ‘struct CustomerTotal’ has no member named ‘sales’
+  532 |       if (!((c.sales > (0.95 * max_sales))))
+      |                ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:534:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  534 |       __items.push_back(c.cust);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:534:27: error: ‘struct CustomerTotal’ has no member named ‘cust’
+  534 |       __items.push_back(c.cust);
+      |                           ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:539:27: error: ‘cs’ was not declared in this scope
+  539 |     std::vector<decltype((cs.cs_quantity * cs.cs_list_price))> __items;
+      |                           ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:539:62: error: template argument 1 is invalid
+  539 |     std::vector<decltype((cs.cs_quantity * cs.cs_list_price))> __items;
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:539:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:545:45: error: request for member ‘begin’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  545 |                 (std::find(best_ss_customer.begin(), best_ss_customer.end(),
+      |                                             ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:545:71: error: request for member ‘end’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  545 |                 (std::find(best_ss_customer.begin(), best_ss_customer.end(),
+      |                                                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:547:35: error: request for member ‘end’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  547 |                  best_ss_customer.end())) &&
+      |                                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:551:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  551 |         __items.push_back((cs.cs_quantity * cs.cs_list_price));
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:557:27: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  557 |     std::vector<decltype((ws.ws_quantity * ws.ws_list_price))> __items;
+      |                           ^~
+      |                           std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:557:62: error: template argument 1 is invalid
+  557 |     std::vector<decltype((ws.ws_quantity * ws.ws_list_price))> __items;
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:557:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:563:45: error: request for member ‘begin’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  563 |                 (std::find(best_ss_customer.begin(), best_ss_customer.end(),
+      |                                             ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:563:71: error: request for member ‘end’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  563 |                 (std::find(best_ss_customer.begin(), best_ss_customer.end(),
+      |                                                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:565:35: error: request for member ‘end’ in ‘best_ss_customer’, which is of non-class type ‘int’
+  565 |                  best_ss_customer.end())) &&
+      |                                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:569:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  569 |         __items.push_back((ws.ws_quantity * ws.ws_list_price));
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:575:74:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:575:48: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  575 |       (([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:575:59: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  575 |       (([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:577:74:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:577:48: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  577 |        ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(web));
+      |                                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:577:59: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  577 |        ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(web));
+      |                                                         ~~^~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:71,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:2:
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_equals_val<_Value>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<__struct6*, std::vector<__struct6> >; _Value = const int]’:
+/usr/include/c++/13/bits/stl_algobase.h:2072:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct6*, vector<__struct6> >; _Predicate = __gnu_cxx::__ops::_Iter_equals_val<const int>]’
+/usr/include/c++/13/bits/stl_algobase.h:2117:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<__struct6*, vector<__struct6> >; _Predicate = __gnu_cxx::__ops::_Iter_equals_val<const int>]’
+/usr/include/c++/13/bits/stl_algo.h:3897:28:   required from ‘_IIter std::find(_IIter, _IIter, const _Tp&) [with _IIter = __gnu_cxx::__normal_iterator<__struct6*, vector<__struct6> >; _Tp = int]’
+/tmp/TestCPPCompiler_TPCDSQueriesq231477462587/001/prog.cpp:548:26:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:270:24: error: no match for ‘operator==’ (operand types are ‘__struct6’ and ‘const int’)
+  270 |         { return *__it == _M_value; }
+      |                  ~~~~~~^~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1217 |     operator==(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:270:24: note:   ‘__struct6’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+  270 |         { return *__it == _M_value; }
+      |                  ~~~~~~^~~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1225 |     operator==(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:270:24: note:   ‘__struct6’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+  270 |         { return *__it == _M_value; }
+      |                  ~~~~~~^~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q24.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q24.error
@@ -1,0 +1,474 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:95:8: error: redefinition of ‘struct StoreSale’
+   95 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:56:8: note: previous definition of ‘struct StoreSale’
+   56 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:102:8: error: redefinition of ‘struct StoreReturn’
+  102 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:63:8: note: previous definition of ‘struct StoreReturn’
+   63 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:106:8: error: redefinition of ‘struct Store’
+  106 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:67:8: note: previous definition of ‘struct Store’
+   67 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:113:8: error: redefinition of ‘struct Item’
+  113 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:74:8: note: previous definition of ‘struct Item’
+   74 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:121:8: error: redefinition of ‘struct Customer’
+  121 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:82:8: note: previous definition of ‘struct Customer’
+   82 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:135:12: error: ‘c’ was not declared in this scope
+  135 |   decltype(c.c_last_name) last;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:135:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:136:12: error: ‘c’ was not declared in this scope
+  136 |   decltype(c.c_first_name) first;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:136:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:137:12: error: ‘s’ was not declared in this scope
+  137 |   decltype(s.s_store_name) store_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:137:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:138:12: error: ‘i’ was not declared in this scope
+  138 |   decltype(i.i_color) color;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:138:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:141:12: error: ‘ss’ was not declared in this scope
+  141 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:141:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:142:12: error: ‘sr’ was not declared in this scope; did you mean ‘ss’?
+  142 |   decltype(sr) sr;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:142:12: error: ‘sr’ was not declared in this scope; did you mean ‘ss’?
+  142 |   decltype(sr) sr;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:143:12: error: ‘s’ was not declared in this scope; did you mean ‘sr’?
+  143 |   decltype(s) s;
+      |            ^
+      |            sr
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:143:12: error: ‘s’ was not declared in this scope; did you mean ‘sr’?
+  143 |   decltype(s) s;
+      |            ^
+      |            sr
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:144:12: error: ‘i’ was not declared in this scope
+  144 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:144:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:145:12: error: ‘c’ was not declared in this scope
+  145 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:145:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:146:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+  146 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:146:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+  146 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:168:38: error: ‘struct __struct8’ has no member named ‘c_last_name’
+  168 |   decltype(std::declval<__struct8>().c_last_name) c_last_name;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:168:38: error: ‘struct __struct8’ has no member named ‘c_last_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:169:38: error: ‘struct __struct8’ has no member named ‘c_first_name’
+  169 |   decltype(std::declval<__struct8>().c_first_name) c_first_name;
+      |                                      ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:169:38: error: ‘struct __struct8’ has no member named ‘c_first_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:170:38: error: ‘struct __struct8’ has no member named ‘s_store_name’
+  170 |   decltype(std::declval<__struct8>().s_store_name) s_store_name;
+      |                                      ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:170:38: error: ‘struct __struct8’ has no member named ‘s_store_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:171:38: error: ‘struct __struct8’ has no member named ‘netpaid’
+  171 |   decltype(std::declval<__struct8>().netpaid) paid;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:171:38: error: ‘struct __struct8’ has no member named ‘netpaid’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:338:13: error: redefinition of ‘void __json(const Customer&)’
+  338 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:173:13: note: ‘void __json(const Customer&)’ previously defined here
+  173 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:448:13: error: redefinition of ‘void __json(const Item&)’
+  448 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:228:13: note: ‘void __json(const Item&)’ previously defined here
+  228 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:508:13: error: redefinition of ‘void __json(const Store&)’
+  508 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:263:13: note: ‘void __json(const Store&)’ previously defined here
+  263 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:538:13: error: redefinition of ‘void __json(const StoreReturn&)’
+  538 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:293:13: note: ‘void __json(const StoreReturn&)’ previously defined here
+  293 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:553:13: error: redefinition of ‘void __json(const StoreSale&)’
+  553 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:308:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  308 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:658:26: error: ‘strings’ has not been declared
+  658 |                          strings::ToUpper(ca.ca_country)) &&
+      |                          ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:662:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  662 |                 auto __key = Ssale{c.c_last_name, c.c_first_name,
+      |                                    ~~^~~~~~~~~~~
+      |                                      |
+      |                                      std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:667:51: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  667 |                     __g.items.push_back(__struct8{ss, sr, s, i, c, ca});
+      |                                                   ^~
+      |                                                   |
+      |                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:675:56: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  675 |                       std::vector<__struct8>{__struct8{ss, sr, s, i, c, ca}}});
+      |                                                        ^~
+      |                                                        |
+      |                                                        StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:675:76: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  675 |                       std::vector<__struct8>{__struct8{ss, sr, s, i, c, ca}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:689:60: error: ‘struct __struct8’ has no member named ‘ss_net_paid’
+  689 |             std::vector<decltype(std::declval<__struct8>().ss_net_paid)>
+      |                                                            ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:689:60: error: ‘struct __struct8’ has no member named ‘ss_net_paid’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:689:72: error: template argument 1 is invalid
+  689 |             std::vector<decltype(std::declval<__struct8>().ss_net_paid)>
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:689:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:692:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  692 |               __items.push_back(x.ss_net_paid);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:692:35: error: ‘struct __struct8’ has no member named ‘ss_net_paid’
+  692 |               __items.push_back(x.ss_net_paid);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:688:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:687:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  687 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:687:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  687 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:698:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  638 |   std::vector<__struct8> ssales = ([&]() {
+      |                                   ~~~~~~~~
+  639 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  640 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  641 |       for (auto sr : store_returns) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  642 |         if (!(((ss.ss_ticket_number == sr.sr_ticket_number) &&
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  643 |                (ss.ss_item_sk == sr.sr_item_sk))))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  644 |           continue;
+      |           ~~~~~~~~~
+  645 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  646 |           if (!((ss.ss_store_sk == s.s_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  647 |             continue;
+      |             ~~~~~~~~~
+  648 |           for (auto i : item) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  649 |             if (!((ss.ss_item_sk == i.i_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  650 |               continue;
+      |               ~~~~~~~~~
+  651 |             for (auto c : customer) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  652 |               if (!((ss.ss_customer_sk == c.c_customer_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  653 |                 continue;
+      |                 ~~~~~~~~~
+  654 |               for (auto ca : customer_address) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  655 |                 if (!((c.c_current_addr_sk == ca.ca_address_sk)))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  656 |                   continue;
+      |                   ~~~~~~~~~
+  657 |                 if (!((((c.c_birth_country !=
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  658 |                          strings::ToUpper(ca.ca_country)) &&
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  659 |                         (s.s_zip == ca.ca_zip)) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  660 |                        (s.s_market_id == 5))))
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~
+  661 |                   continue;
+      |                   ~~~~~~~~~
+  662 |                 auto __key = Ssale{c.c_last_name, c.c_first_name,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  663 |                                    s.s_store_name, i.i_color};
+      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  664 |                 bool __found = false;
+      |                 ~~~~~~~~~~~~~~~~~~~~~
+  665 |                 for (auto &__g : __groups) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  666 |                   if (__g.key == __key) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~
+  667 |                     __g.items.push_back(__struct8{ss, sr, s, i, c, ca});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  668 |                     __found = true;
+      |                     ~~~~~~~~~~~~~~~
+  669 |                     break;
+      |                     ~~~~~~
+  670 |                   }
+      |                   ~
+  671 |                 }
+      |                 ~
+  672 |                 if (!__found) {
+      |                 ~~~~~~~~~~~~~~~
+  673 |                   __groups.push_back(__struct9{
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  674 |                       __key,
+      |                       ~~~~~~
+  675 |                       std::vector<__struct8>{__struct8{ss, sr, s, i, c, ca}}});
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  676 |                 }
+      |                 ~
+  677 |               }
+      |               ~
+  678 |             }
+      |             ~
+  679 |           }
+      |           ~
+  680 |         }
+      |         ~
+  681 |       }
+      |       ~
+  682 |     }
+      |     ~
+  683 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  684 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  685 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  686 |           g.key.last, g.key.first, g.key.store_name, g.key.color, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  687 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  688 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  689 |             std::vector<decltype(std::declval<__struct8>().ss_net_paid)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  690 |                 __items;
+      |                 ~~~~~~~~
+  691 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  692 |               __items.push_back(x.ss_net_paid);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  693 |             }
+      |             ~
+  694 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  695 |           })())});
+      |           ~~~~~~~~
+  696 |     }
+      |     ~
+  697 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  698 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:700:52: error: ‘struct __struct8’ has no member named ‘netpaid’
+  700 |     std::vector<decltype(std::declval<__struct8>().netpaid)> __items;
+      |                                                    ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:700:52: error: ‘struct __struct8’ has no member named ‘netpaid’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:700:60: error: template argument 1 is invalid
+  700 |     std::vector<decltype(std::declval<__struct8>().netpaid)> __items;
+      |                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:700:60: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:702:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  702 |       __items.push_back(x.netpaid);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:702:27: error: ‘struct __struct8’ has no member named ‘netpaid’
+  702 |       __items.push_back(x.netpaid);
+      |                           ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:699:24: error: no matching function for call to ‘__avg(int)’
+  699 |   auto avg_paid = __avg(([&]() {
+      |                   ~~~~~^~~~~~~~~
+  700 |     std::vector<decltype(std::declval<__struct8>().netpaid)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  701 |     for (auto x : ssales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  702 |       __items.push_back(x.netpaid);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  703 |     }
+      |     ~                   
+  704 |     return __items;
+      |     ~~~~~~~~~~~~~~~     
+  705 |   })());
+      |   ~~~~~                 
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:159:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  159 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:159:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:699:24: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  699 |   auto avg_paid = __avg(([&]() {
+      |                   ~~~~~^~~~~~~~~
+  700 |     std::vector<decltype(std::declval<__struct8>().netpaid)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  701 |     for (auto x : ssales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  702 |       __items.push_back(x.netpaid);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  703 |     }
+      |     ~                   
+  704 |     return __items;
+      |     ~~~~~~~~~~~~~~~     
+  705 |   })());
+      |   ~~~~~                 
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:708:54: error: ‘struct __struct8’ has no member named ‘c_last_name’
+  708 |         std::pair<decltype(std::declval<__struct8>().c_last_name), Result>>
+      |                                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:708:54: error: ‘struct __struct8’ has no member named ‘c_last_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:708:68: error: template argument 1 is invalid
+  708 |         std::pair<decltype(std::declval<__struct8>().c_last_name), Result>>
+      |                                                                    ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:708:74: error: template argument 1 is invalid
+  708 |         std::pair<decltype(std::declval<__struct8>().c_last_name), Result>>
+      |                                                                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:708:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:711:17: error: ‘struct __struct8’ has no member named ‘color’
+  711 |       if (!(((x.color == std::string("RED")) &&
+      |                 ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:712:17: error: ‘struct __struct8’ has no member named ‘netpaid’
+  712 |              (x.netpaid > (0.05 * avg_paid)))))
+      |                 ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:714:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  714 |       __items.push_back(
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:35: error: ‘struct __struct8’ has no member named ‘c_last_name’
+  715 |           {std::vector<decltype(x.c_last_name)>{x.c_last_name, x.c_first_name,
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:35: error: ‘struct __struct8’ has no member named ‘c_last_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:47: error: template argument 1 is invalid
+  715 |           {std::vector<decltype(x.c_last_name)>{x.c_last_name, x.c_first_name,
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:51: error: ‘struct __struct8’ has no member named ‘c_last_name’
+  715 |           {std::vector<decltype(x.c_last_name)>{x.c_last_name, x.c_first_name,
+      |                                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:715:66: error: ‘struct __struct8’ has no member named ‘c_first_name’
+  715 |           {std::vector<decltype(x.c_last_name)>{x.c_last_name, x.c_first_name,
+      |                                                                  ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:716:51: error: ‘struct __struct8’ has no member named ‘s_store_name’
+  716 |                                                 x.s_store_name},
+      |                                                   ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:717:21: error: ‘struct __struct8’ has no member named ‘c_last_name’
+  717 |            Result{x.c_last_name, x.c_first_name, x.s_store_name, x.netpaid}});
+      |                     ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:717:36: error: ‘struct __struct8’ has no member named ‘c_first_name’
+  717 |            Result{x.c_last_name, x.c_first_name, x.s_store_name, x.netpaid}});
+      |                                    ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:717:52: error: ‘struct __struct8’ has no member named ‘s_store_name’
+  717 |            Result{x.c_last_name, x.c_first_name, x.s_store_name, x.netpaid}});
+      |                                                    ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:717:68: error: ‘struct __struct8’ has no member named ‘netpaid’
+  717 |            Result{x.c_last_name, x.c_first_name, x.s_store_name, x.netpaid}});
+      |                                                                    ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:719:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  719 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:719:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  719 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:722:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  722 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq243444485236/001/prog.cpp:722:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  722 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q25.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q25.error
@@ -1,0 +1,460 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:90:8: error: redefinition of ‘struct StoreSale’
+   90 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:54:8: note: previous definition of ‘struct StoreSale’
+   54 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:98:8: error: redefinition of ‘struct StoreReturn’
+   98 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:62:8: note: previous definition of ‘struct StoreReturn’
+   62 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:105:8: error: redefinition of ‘struct CatalogSale’
+  105 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:69:8: note: previous definition of ‘struct CatalogSale’
+   69 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:111:8: error: redefinition of ‘struct DateDim’
+  111 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:75:8: note: previous definition of ‘struct DateDim’
+   75 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:116:8: error: redefinition of ‘struct Store’
+  116 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:80:8: note: previous definition of ‘struct Store’
+   80 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:121:8: error: redefinition of ‘struct Item’
+  121 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:85:8: note: previous definition of ‘struct Item’
+   85 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:127:12: error: ‘i’ was not declared in this scope
+  127 |   decltype(i.i_item_id) item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:127:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:128:12: error: ‘i’ was not declared in this scope
+  128 |   decltype(i.i_item_desc) item_desc;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:128:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:129:12: error: ‘s’ was not declared in this scope
+  129 |   decltype(s.s_store_id) s_store_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:129:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:130:12: error: ‘s’ was not declared in this scope
+  130 |   decltype(s.s_store_name) s_store_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:130:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:133:12: error: ‘ss’ was not declared in this scope
+  133 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:133:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:134:12: error: ‘sr’ was not declared in this scope; did you mean ‘ss’?
+  134 |   decltype(sr) sr;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:134:12: error: ‘sr’ was not declared in this scope; did you mean ‘ss’?
+  134 |   decltype(sr) sr;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:135:12: error: ‘cs’ was not declared in this scope; did you mean ‘ss’?
+  135 |   decltype(cs) cs;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:135:12: error: ‘cs’ was not declared in this scope; did you mean ‘ss’?
+  135 |   decltype(cs) cs;
+      |            ^~
+      |            ss
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:136:12: error: ‘d1’ was not declared in this scope
+  136 |   decltype(d1) d1;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:136:12: error: ‘d1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:137:12: error: ‘d2’ was not declared in this scope; did you mean ‘d1’?
+  137 |   decltype(d2) d2;
+      |            ^~
+      |            d1
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:137:12: error: ‘d2’ was not declared in this scope; did you mean ‘d1’?
+  137 |   decltype(d2) d2;
+      |            ^~
+      |            d1
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:138:12: error: ‘d3’ was not declared in this scope; did you mean ‘d2’?
+  138 |   decltype(d3) d3;
+      |            ^~
+      |            d2
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:138:12: error: ‘d3’ was not declared in this scope; did you mean ‘d2’?
+  138 |   decltype(d3) d3;
+      |            ^~
+      |            d2
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:139:12: error: ‘s’ was not declared in this scope; did you mean ‘cs’?
+  139 |   decltype(s) s;
+      |            ^
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:139:12: error: ‘s’ was not declared in this scope; did you mean ‘cs’?
+  139 |   decltype(s) s;
+      |            ^
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:140:12: error: ‘i’ was not declared in this scope
+  140 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:140:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:305:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  305 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:155:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  155 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:330:13: error: redefinition of ‘void __json(const DateDim&)’
+  330 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:180:13: note: ‘void __json(const DateDim&)’ previously defined here
+  180 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:390:13: error: redefinition of ‘void __json(const Item&)’
+  390 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:200:13: note: ‘void __json(const Item&)’ previously defined here
+  200 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:435:13: error: redefinition of ‘void __json(const Store&)’
+  435 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:220:13: note: ‘void __json(const Store&)’ previously defined here
+  220 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:455:13: error: redefinition of ‘void __json(const StoreReturn&)’
+  455 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:240:13: note: ‘void __json(const StoreReturn&)’ previously defined here
+  240 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:485:13: error: redefinition of ‘void __json(const StoreSale&)’
+  485 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:270:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  270 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:611:43: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  611 |                     auto __key = Result{i.i_item_id, i.i_item_desc,
+      |                                         ~~^~~~~~~~~
+      |                                           |
+      |                                           std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:617:39: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  617 |                             __struct8{ss, sr, cs, d1, d2, d3, s, i});
+      |                                       ^~
+      |                                       |
+      |                                       StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:625:48: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  625 |                                                ss, sr, cs, d1, d2, d3, s, i}}});
+      |                                                ^~
+      |                                                |
+      |                                                StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:625:77: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  625 |                                                ss, sr, cs, d1, d2, d3, s, i}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:641:64: error: ‘struct __struct8’ has no member named ‘ss_net_profit’
+  641 |                 std::vector<decltype(std::declval<__struct8>().ss_net_profit)>
+      |                                                                ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:641:64: error: ‘struct __struct8’ has no member named ‘ss_net_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:641:78: error: template argument 1 is invalid
+  641 |                 std::vector<decltype(std::declval<__struct8>().ss_net_profit)>
+      |                                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:641:78: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:644:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  644 |                   __items.push_back(x.ss_net_profit);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:644:39: error: ‘struct __struct8’ has no member named ‘ss_net_profit’
+  644 |                   __items.push_back(x.ss_net_profit);
+      |                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:639:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:639:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  639 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:639:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  639 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:650:64: error: ‘struct __struct8’ has no member named ‘sr_net_loss’
+  650 |                 std::vector<decltype(std::declval<__struct8>().sr_net_loss)>
+      |                                                                ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:650:64: error: ‘struct __struct8’ has no member named ‘sr_net_loss’
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:650:76: error: template argument 1 is invalid
+  650 |                 std::vector<decltype(std::declval<__struct8>().sr_net_loss)>
+      |                                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:650:76: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:653:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  653 |                   __items.push_back(x.sr_net_loss);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:653:39: error: ‘struct __struct8’ has no member named ‘sr_net_loss’
+  653 |                   __items.push_back(x.sr_net_loss);
+      |                                       ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:648:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:648:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  648 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:648:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  648 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:659:64: error: ‘struct __struct8’ has no member named ‘cs_net_profit’
+  659 |                 std::vector<decltype(std::declval<__struct8>().cs_net_profit)>
+      |                                                                ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:659:64: error: ‘struct __struct8’ has no member named ‘cs_net_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:659:78: error: template argument 1 is invalid
+  659 |                 std::vector<decltype(std::declval<__struct8>().cs_net_profit)>
+      |                                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:659:78: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:662:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  662 |                   __items.push_back(x.cs_net_profit);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:662:39: error: ‘struct __struct8’ has no member named ‘cs_net_profit’
+  662 |                   __items.push_back(x.cs_net_profit);
+      |                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:657:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:657:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  657 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:657:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  657 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq253623784142/001/prog.cpp:668:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  579 |   std::vector<__struct8> result = ([&]() {
+      |                                   ~~~~~~~~
+  580 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  581 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  582 |       for (auto sr : store_returns) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  583 |         if (!(((ss.ss_ticket_number == sr.sr_ticket_number) &&
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  584 |                (ss.ss_item_sk == sr.sr_item_sk))))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  585 |           continue;
+      |           ~~~~~~~~~
+  586 |         for (auto cs : catalog_sales) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  587 |           if (!(((sr.sr_customer_sk == cs.cs_bill_customer_sk) &&
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  588 |                  (sr.sr_item_sk == cs.cs_item_sk))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  589 |             continue;
+      |             ~~~~~~~~~
+  590 |           for (auto d1 : date_dim) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  591 |             if (!((d1.d_date_sk == ss.ss_sold_date_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  592 |               continue;
+      |               ~~~~~~~~~
+  593 |             for (auto d2 : date_dim) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  594 |               if (!((d2.d_date_sk == sr.sr_returned_date_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  595 |                 continue;
+      |                 ~~~~~~~~~
+  596 |               for (auto d3 : date_dim) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  597 |                 if (!((d3.d_date_sk == cs.cs_sold_date_sk)))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  598 |                   continue;
+      |                   ~~~~~~~~~
+  599 |                 for (auto s : store) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~
+  600 |                   if (!((s.s_store_sk == ss.ss_store_sk)))
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  601 |                     continue;
+      |                     ~~~~~~~~~
+  602 |                   for (auto i : item) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~
+  603 |                     if (!((i.i_item_sk == ss.ss_item_sk)))
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  604 |                       continue;
+      |                       ~~~~~~~~~
+  605 |                     if (!(((((((d1.d_moy == 4) && (d1.d_year == 2000)) &&
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  606 |                               (d2.d_moy >= 4)) &&
+      |                               ~~~~~~~~~~~~~~~~~~~
+  607 |                              (d2.d_moy <= 10)) &&
+      |                              ~~~~~~~~~~~~~~~~~~~~
+  608 |                             (d3.d_moy >= 4)) &&
+      |                             ~~~~~~~~~~~~~~~~~~~
+  609 |                            (d3.d_moy <= 10))))
+      |                            ~~~~~~~~~~~~~~~~~~~
+  610 |                       continue;
+      |                       ~~~~~~~~~
+  611 |                     auto __key = Result{i.i_item_id, i.i_item_desc,
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  612 |                                         s.s_store_id, s.s_store_name};
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  613 |                     bool __found = false;
+      |                     ~~~~~~~~~~~~~~~~~~~~~
+  614 |                     for (auto &__g : __groups) {
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  615 |                       if (__g.key == __key) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~
+  616 |                         __g.items.push_back(
+      |                         ~~~~~~~~~~~~~~~~~~~~
+  617 |                             __struct8{ss, sr, cs, d1, d2, d3, s, i});
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  618 |                         __found = true;
+      |                         ~~~~~~~~~~~~~~~
+  619 |                         break;
+      |                         ~~~~~~
+  620 |                       }
+      |                       ~
+  621 |                     }
+      |                     ~
+  622 |                     if (!__found) {
+      |                     ~~~~~~~~~~~~~~~
+  623 |                       __groups.push_back(
+      |                       ~~~~~~~~~~~~~~~~~~~
+  624 |                           __struct9{__key, std::vector<__struct8>{__struct8{
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  625 |                                                ss, sr, cs, d1, d2, d3, s, i}}});
+      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  626 |                     }
+      |                     ~
+  627 |                   }
+      |                   ~
+  628 |                 }
+      |                 ~
+  629 |               }
+      |               ~
+  630 |             }
+      |             ~
+  631 |           }
+      |           ~
+  632 |         }
+      |         ~
+  633 |       }
+      |       ~
+  634 |     }
+      |     ~
+  635 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  636 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  637 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  638 |           g.key.item_id, g.key.item_desc, g.key.s_store_id, g.key.s_store_name,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  639 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  640 |               ([&]() {
+      |               ~~~~~~~~
+  641 |                 std::vector<decltype(std::declval<__struct8>().ss_net_profit)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  642 |                     __items;
+      |                     ~~~~~~~~
+  643 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  644 |                   __items.push_back(x.ss_net_profit);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  645 |                 }
+      |                 ~
+  646 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  647 |               })()),
+      |               ~~~~~~
+  648 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  649 |               ([&]() {
+      |               ~~~~~~~~
+  650 |                 std::vector<decltype(std::declval<__struct8>().sr_net_loss)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  651 |                     __items;
+      |                     ~~~~~~~~
+  652 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  653 |                   __items.push_back(x.sr_net_loss);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  654 |                 }
+      |                 ~
+  655 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  656 |               })()),
+      |               ~~~~~~
+  657 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  658 |               ([&]() {
+      |               ~~~~~~~~
+  659 |                 std::vector<decltype(std::declval<__struct8>().cs_net_profit)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  660 |                     __items;
+      |                     ~~~~~~~~
+  661 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  662 |                   __items.push_back(x.cs_net_profit);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  663 |                 }
+      |                 ~
+  664 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  665 |               })())});
+      |               ~~~~~~~~
+  666 |     }
+      |     ~
+  667 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  668 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q26.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q26.error
@@ -1,0 +1,709 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:82:8: error: redefinition of ‘struct CatalogSale’
+   82 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:53:8: note: previous definition of ‘struct CatalogSale’
+   53 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:98:8: error: redefinition of ‘struct DateDim’
+   98 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:69:8: note: previous definition of ‘struct DateDim’
+   69 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:102:8: error: redefinition of ‘struct Item’
+  102 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:73:8: note: previous definition of ‘struct Item’
+   73 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:106:8: error: redefinition of ‘struct Promotion’
+  106 | struct Promotion {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:77:8: note: previous definition of ‘struct Promotion’
+   77 | struct Promotion {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:112:12: error: ‘cs’ was not declared in this scope
+  112 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:112:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:113:12: error: ‘cd’ was not declared in this scope; did you mean ‘cs’?
+  113 |   decltype(cd) cd;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:113:12: error: ‘cd’ was not declared in this scope; did you mean ‘cs’?
+  113 |   decltype(cd) cd;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:114:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+  114 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:114:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+  114 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:115:12: error: ‘i’ was not declared in this scope
+  115 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:115:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:116:12: error: ‘p’ was not declared in this scope
+  116 |   decltype(p) p;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:116:12: error: ‘p’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:119:12: error: ‘i’ was not declared in this scope
+  119 |   decltype(i.i_item_id) key;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:119:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:282:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  282 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:137:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  137 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:327:13: error: redefinition of ‘void __json(const DateDim&)’
+  327 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:207:13: note: ‘void __json(const DateDim&)’ previously defined here
+  207 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:372:13: error: redefinition of ‘void __json(const Item&)’
+  372 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:222:13: note: ‘void __json(const Item&)’ previously defined here
+  222 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:387:13: error: redefinition of ‘void __json(const Promotion&)’
+  387 | inline void __json(const Promotion &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:237:13: note: ‘void __json(const Promotion&)’ previously defined here
+  237 | inline void __json(const Promotion &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:29: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  477 |                 if (__g.key == __key) {
+      |                     ~~~~~~~ ^~ ~~~~~
+      |                         |      |
+      |                         int    std::__cxx11::basic_string<char>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:2:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/string:48:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const _CharT*’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:5:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:477:32: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  477 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:478:46: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  478 |                   __g.items.push_back(Result{cs, cd, d, i, p});
+      |                                              ^~
+      |                                              |
+      |                                              CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:485:55: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  485 |                     __key, std::vector<Result>{Result{cs, cd, d, i, p}}});
+      |                                                       ^~
+      |                                                       |
+      |                                                       CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:485:71: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  485 |                     __key, std::vector<Result>{Result{cs, cd, d, i, p}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:496:57: error: ‘struct Result’ has no member named ‘cs_quantity’
+  496 |             std::vector<decltype(std::declval<Result>().cs_quantity)> __items;
+      |                                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:496:57: error: ‘struct Result’ has no member named ‘cs_quantity’
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:496:69: error: template argument 1 is invalid
+  496 |             std::vector<decltype(std::declval<Result>().cs_quantity)> __items;
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:496:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:498:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  498 |               __items.push_back(x.cs_quantity);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:498:35: error: ‘struct Result’ has no member named ‘cs_quantity’
+  498 |               __items.push_back(x.cs_quantity);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:495:23: error: no matching function for call to ‘__avg(int)’
+  495 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  496 |             std::vector<decltype(std::declval<Result>().cs_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  497 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |               __items.push_back(x.cs_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  499 |             }
+      |             ~          
+  500 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  501 |           })()),
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  122 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:495:23: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  495 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  496 |             std::vector<decltype(std::declval<Result>().cs_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  497 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |               __items.push_back(x.cs_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  499 |             }
+      |             ~          
+  500 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  501 |           })()),
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:503:57: error: ‘struct Result’ has no member named ‘cs_list_price’
+  503 |             std::vector<decltype(std::declval<Result>().cs_list_price)> __items;
+      |                                                         ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:503:57: error: ‘struct Result’ has no member named ‘cs_list_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:503:71: error: template argument 1 is invalid
+  503 |             std::vector<decltype(std::declval<Result>().cs_list_price)> __items;
+      |                                                                       ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:503:71: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:505:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  505 |               __items.push_back(x.cs_list_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:505:35: error: ‘struct Result’ has no member named ‘cs_list_price’
+  505 |               __items.push_back(x.cs_list_price);
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:502:16: error: no matching function for call to ‘__avg(int)’
+  502 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  503 |             std::vector<decltype(std::declval<Result>().cs_list_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |               __items.push_back(x.cs_list_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |             }
+      |             ~   
+  507 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  508 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  122 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:502:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  502 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  503 |             std::vector<decltype(std::declval<Result>().cs_list_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |               __items.push_back(x.cs_list_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |             }
+      |             ~   
+  507 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  508 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:510:57: error: ‘struct Result’ has no member named ‘cs_coupon_amt’
+  510 |             std::vector<decltype(std::declval<Result>().cs_coupon_amt)> __items;
+      |                                                         ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:510:57: error: ‘struct Result’ has no member named ‘cs_coupon_amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:510:71: error: template argument 1 is invalid
+  510 |             std::vector<decltype(std::declval<Result>().cs_coupon_amt)> __items;
+      |                                                                       ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:510:71: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:512:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  512 |               __items.push_back(x.cs_coupon_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:512:35: error: ‘struct Result’ has no member named ‘cs_coupon_amt’
+  512 |               __items.push_back(x.cs_coupon_amt);
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:509:16: error: no matching function for call to ‘__avg(int)’
+  509 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  510 |             std::vector<decltype(std::declval<Result>().cs_coupon_amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  511 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  512 |               __items.push_back(x.cs_coupon_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  513 |             }
+      |             ~   
+  514 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  515 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  122 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:509:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  509 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  510 |             std::vector<decltype(std::declval<Result>().cs_coupon_amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  511 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  512 |               __items.push_back(x.cs_coupon_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  513 |             }
+      |             ~   
+  514 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  515 |           })()),
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:517:57: error: ‘struct Result’ has no member named ‘cs_sales_price’
+  517 |             std::vector<decltype(std::declval<Result>().cs_sales_price)>
+      |                                                         ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:517:57: error: ‘struct Result’ has no member named ‘cs_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:517:72: error: template argument 1 is invalid
+  517 |             std::vector<decltype(std::declval<Result>().cs_sales_price)>
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:517:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:520:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  520 |               __items.push_back(x.cs_sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:520:35: error: ‘struct Result’ has no member named ‘cs_sales_price’
+  520 |               __items.push_back(x.cs_sales_price);
+      |                                   ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:516:16: error: no matching function for call to ‘__avg(int)’
+  516 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  517 |             std::vector<decltype(std::declval<Result>().cs_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  518 |                 __items;
+      |                 ~~~~~~~~
+  519 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  520 |               __items.push_back(x.cs_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |             }
+      |             ~   
+  522 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  523 |           })())});
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  122 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:122:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:516:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  516 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  517 |             std::vector<decltype(std::declval<Result>().cs_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  518 |                 __items;
+      |                 ~~~~~~~~
+  519 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  520 |               __items.push_back(x.cs_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |             }
+      |             ~   
+  522 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  523 |           })())});
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq263380415998/001/prog.cpp:526:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<Result>’ requested
+  452 |   std::vector<Result> result = ([&]() {
+      |                                ~~~~~~~~
+  453 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  455 |       for (auto cd : customer_demographics) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  456 |         if (!((cs.cs_bill_cdemo_sk == cd.cd_demo_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  457 |           continue;
+      |           ~~~~~~~~~
+  458 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  459 |           if (!((cs.cs_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  460 |             continue;
+      |             ~~~~~~~~~
+  461 |           for (auto i : item) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  462 |             if (!((cs.cs_item_sk == i.i_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  463 |               continue;
+      |               ~~~~~~~~~
+  464 |             for (auto p : promotion) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  465 |               if (!((cs.cs_promo_sk == p.p_promo_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  466 |                 continue;
+      |                 ~~~~~~~~~
+  467 |               if (!((((((cd.cd_gender == std::string("M")) &&
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  468 |                         (cd.cd_marital_status == std::string("S"))) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |                        (cd.cd_education_status == std::string("College"))) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  470 |                       (((p.p_channel_email == std::string("N")) ||
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |                         (p.p_channel_event == std::string("N"))))) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  472 |                      (d.d_year == 2000))))
+      |                      ~~~~~~~~~~~~~~~~~~~~~
+  473 |                 continue;
+      |                 ~~~~~~~~~
+  474 |               auto __key = i.i_item_id;
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  475 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  476 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  477 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  478 |                   __g.items.push_back(Result{cs, cd, d, i, p});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  479 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  480 |                   break;
+      |                   ~~~~~~
+  481 |                 }
+      |                 ~
+  482 |               }
+      |               ~
+  483 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  484 |                 __groups.push_back(__struct7{
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |                     __key, std::vector<Result>{Result{cs, cd, d, i, p}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  486 |               }
+      |               ~
+  487 |             }
+      |             ~
+  488 |           }
+      |           ~
+  489 |         }
+      |         ~
+  490 |       }
+      |       ~
+  491 |     }
+      |     ~
+  492 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  493 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  494 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  495 |           g.key, __avg(([&]() {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  496 |             std::vector<decltype(std::declval<Result>().cs_quantity)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  497 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |               __items.push_back(x.cs_quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  499 |             }
+      |             ~
+  500 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  501 |           })()),
+      |           ~~~~~~
+  502 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  503 |             std::vector<decltype(std::declval<Result>().cs_list_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |               __items.push_back(x.cs_list_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |             }
+      |             ~
+  507 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  508 |           })()),
+      |           ~~~~~~
+  509 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  510 |             std::vector<decltype(std::declval<Result>().cs_coupon_amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  511 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  512 |               __items.push_back(x.cs_coupon_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  513 |             }
+      |             ~
+  514 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  515 |           })()),
+      |           ~~~~~~
+  516 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  517 |             std::vector<decltype(std::declval<Result>().cs_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  518 |                 __items;
+      |                 ~~~~~~~~
+  519 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  520 |               __items.push_back(x.cs_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |             }
+      |             ~
+  522 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  523 |           })())});
+      |           ~~~~~~~~
+  524 |     }
+      |     ~
+  525 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  526 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q27.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q27.error
@@ -1,0 +1,630 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:83:8: error: redefinition of ‘struct StoreSale’
+   83 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:55:8: note: previous definition of ‘struct StoreSale’
+   55 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:99:8: error: redefinition of ‘struct DateDim’
+   99 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:71:8: note: previous definition of ‘struct DateDim’
+   71 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:103:8: error: redefinition of ‘struct Store’
+  103 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:75:8: note: previous definition of ‘struct Store’
+   75 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:107:8: error: redefinition of ‘struct Item’
+  107 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:79:8: note: previous definition of ‘struct Item’
+   79 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:112:12: error: ‘i’ was not declared in this scope
+  112 |   decltype(i.i_item_id) item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:112:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:113:12: error: ‘s’ was not declared in this scope
+  113 |   decltype(s.s_state) state;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:113:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:116:12: error: ‘ss’ was not declared in this scope
+  116 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:116:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:117:12: error: ‘cd’ was not declared in this scope
+  117 |   decltype(cd) cd;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:117:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:118:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+  118 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:118:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+  118 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:119:12: error: ‘s’ was not declared in this scope
+  119 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:119:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:120:12: error: ‘i’ was not declared in this scope
+  120 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:120:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:301:13: error: redefinition of ‘void __json(const DateDim&)’
+  301 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:171:13: note: ‘void __json(const DateDim&)’ previously defined here
+  171 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:351:13: error: redefinition of ‘void __json(const Item&)’
+  351 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:186:13: note: ‘void __json(const Item&)’ previously defined here
+  186 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:381:13: error: redefinition of ‘void __json(const Store&)’
+  381 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:201:13: note: ‘void __json(const Store&)’ previously defined here
+  201 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:396:13: error: redefinition of ‘void __json(const StoreSale&)’
+  396 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:216:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  216 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:509:37: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  509 |               auto __key = Result{i.i_item_id, s.s_state};
+      |                                   ~~^~~~~~~~~
+      |                                     |
+      |                                     std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:513:49: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  513 |                   __g.items.push_back(__struct7{ss, cd, d, s, i});
+      |                                                 ^~
+      |                                                 |
+      |                                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:520:61: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  520 |                     __key, std::vector<__struct7>{__struct7{ss, cd, d, s, i}}});
+      |                                                             ^~
+      |                                                             |
+      |                                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:520:77: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  520 |                     __key, std::vector<__struct7>{__struct7{ss, cd, d, s, i}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:533:65: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                                                                 ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:533:65: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:533:77: error: template argument 1 is invalid
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:533:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:536:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  536 |                    __items.push_back(x.ss_quantity);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:536:40: error: ‘struct __struct7’ has no member named ‘ss_quantity’
+  536 |                    __items.push_back(x.ss_quantity);
+      |                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:532:49: error: no matching function for call to ‘__avg(int)’
+  532 |                g.key.item_id, g.key.state, __avg(([&]() {
+      |                                            ~~~~~^~~~~~~~~
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  534 |                      __items;
+      |                      ~~~~~~~~                    
+  535 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~        
+  536 |                    __items.push_back(x.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  537 |                  }
+      |                  ~                               
+  538 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~                 
+  539 |                })()),
+      |                ~~~~~                             
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  126 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:532:49: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  532 |                g.key.item_id, g.key.state, __avg(([&]() {
+      |                                            ~~~~~^~~~~~~~~
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  534 |                      __items;
+      |                      ~~~~~~~~                    
+  535 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~        
+  536 |                    __items.push_back(x.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  537 |                  }
+      |                  ~                               
+  538 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~                 
+  539 |                })()),
+      |                ~~~~~                             
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:541:65: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:541:65: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:541:79: error: template argument 1 is invalid
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:541:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:544:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  544 |                    __items.push_back(x.ss_list_price);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:544:40: error: ‘struct __struct7’ has no member named ‘ss_list_price’
+  544 |                    __items.push_back(x.ss_list_price);
+      |                                        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:540:21: error: no matching function for call to ‘__avg(int)’
+  540 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  542 |                      __items;
+      |                      ~~~~~~~~
+  543 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  544 |                    __items.push_back(x.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  545 |                  }
+      |                  ~   
+  546 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  547 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  126 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:540:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  540 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  542 |                      __items;
+      |                      ~~~~~~~~
+  543 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  544 |                    __items.push_back(x.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  545 |                  }
+      |                  ~   
+  546 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  547 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:549:65: error: ‘struct __struct7’ has no member named ‘ss_coupon_amt’
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:549:65: error: ‘struct __struct7’ has no member named ‘ss_coupon_amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:549:79: error: template argument 1 is invalid
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:549:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:552:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:552:40: error: ‘struct __struct7’ has no member named ‘ss_coupon_amt’
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                                        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:548:21: error: no matching function for call to ‘__avg(int)’
+  548 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  550 |                      __items;
+      |                      ~~~~~~~~
+  551 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  553 |                  }
+      |                  ~   
+  554 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  555 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  126 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:548:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  548 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  550 |                      __items;
+      |                      ~~~~~~~~
+  551 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  553 |                  }
+      |                  ~   
+  554 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  555 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:557:65: error: ‘struct __struct7’ has no member named ‘ss_sales_price’
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                                                                 ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:557:65: error: ‘struct __struct7’ has no member named ‘ss_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:557:80: error: template argument 1 is invalid
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:557:80: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:560:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:560:40: error: ‘struct __struct7’ has no member named ‘ss_sales_price’
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                                        ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:556:21: error: no matching function for call to ‘__avg(int)’
+  556 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  558 |                      __items;
+      |                      ~~~~~~~~
+  559 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  561 |                  }
+      |                  ~   
+  562 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  563 |                })())}});
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  126 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:126:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:556:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  556 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  558 |                      __items;
+      |                      ~~~~~~~~
+  559 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  561 |                  }
+      |                  ~   
+  562 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  563 |                })())}});
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:529:24: error: no matching function for call to ‘std::vector<std::pair<__struct10, __struct9> >::push_back(<brace-enclosed initializer list>)’
+  529 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  530 |           {__struct10{g.key.item_id, g.key.state},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  531 |            __struct9{
+      |            ~~~~~~~~~~   
+  532 |                g.key.item_id, g.key.state, __avg(([&]() {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  534 |                      __items;
+      |                      ~~~~~~~~
+  535 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  536 |                    __items.push_back(x.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  537 |                  }
+      |                  ~      
+  538 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  539 |                })()),
+      |                ~~~~~~   
+  540 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  542 |                      __items;
+      |                      ~~~~~~~~
+  543 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  544 |                    __items.push_back(x.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  545 |                  }
+      |                  ~      
+  546 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  547 |                })()),
+      |                ~~~~~~   
+  548 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  550 |                      __items;
+      |                      ~~~~~~~~
+  551 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  553 |                  }
+      |                  ~      
+  554 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  555 |                })()),
+      |                ~~~~~~   
+  556 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  558 |                      __items;
+      |                      ~~~~~~~~
+  559 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  561 |                  }
+      |                  ~      
+  562 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  563 |                })())}});
+      |                ~~~~~~~~ 
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<__struct10, __struct9>; _Alloc = std::allocator<std::pair<__struct10, __struct9> >; value_type = std::pair<__struct10, __struct9>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<__struct10, __struct9> >::value_type&’ {aka ‘const std::pair<__struct10, __struct9>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<__struct10, __struct9>; _Alloc = std::allocator<std::pair<__struct10, __struct9> >; value_type = std::pair<__struct10, __struct9>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<__struct10, __struct9> >::value_type&&’ {aka ‘std::pair<__struct10, __struct9>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq27212138119/001/prog.cpp:573:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  484 |   std::vector<__struct7> result = ([&]() {
+      |                                   ~~~~~~~~
+  485 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  486 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  487 |       for (auto cd : customer_demographics) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |         if (!((ss.ss_cdemo_sk == cd.cd_demo_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  489 |           continue;
+      |           ~~~~~~~~~
+  490 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  491 |           if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  492 |             continue;
+      |             ~~~~~~~~~
+  493 |           for (auto s : store) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~
+  494 |             if (!((ss.ss_store_sk == s.s_store_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  495 |               continue;
+      |               ~~~~~~~~~
+  496 |             for (auto i : item) {
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  497 |               if (!((ss.ss_item_sk == i.i_item_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |                 continue;
+      |                 ~~~~~~~~~
+  499 |               if (!((((((cd.cd_gender == std::string("F")) &&
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  500 |                         (cd.cd_marital_status == std::string("M"))) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  501 |                        (cd.cd_education_status == std::string("College"))) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  502 |                       (d.d_year == 2000)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~
+  503 |                      (std::find(
+      |                      ~~~~~~~~~~~
+  504 |                           std::vector<std::string>{std::string("CA")}.begin(),
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  505 |                           std::vector<std::string>{std::string("CA")}.end(),
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |                           s.s_state) !=
+      |                           ~~~~~~~~~~~~~
+  507 |                       std::vector<std::string>{std::string("CA")}.end()))))
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |                 continue;
+      |                 ~~~~~~~~~
+  509 |               auto __key = Result{i.i_item_id, s.s_state};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  510 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  511 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  512 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  513 |                   __g.items.push_back(__struct7{ss, cd, d, s, i});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  514 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  515 |                   break;
+      |                   ~~~~~~
+  516 |                 }
+      |                 ~
+  517 |               }
+      |               ~
+  518 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  519 |                 __groups.push_back(__struct8{
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  520 |                     __key, std::vector<__struct7>{__struct7{ss, cd, d, s, i}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |               }
+      |               ~
+  522 |             }
+      |             ~
+  523 |           }
+      |           ~
+  524 |         }
+      |         ~
+  525 |       }
+      |       ~
+  526 |     }
+      |     ~
+  527 |     std::vector<std::pair<__struct10, __struct9>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  528 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  529 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  530 |           {__struct10{g.key.item_id, g.key.state},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  531 |            __struct9{
+      |            ~~~~~~~~~~
+  532 |                g.key.item_id, g.key.state, __avg(([&]() {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  533 |                  std::vector<decltype(std::declval<__struct7>().ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  534 |                      __items;
+      |                      ~~~~~~~~
+  535 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  536 |                    __items.push_back(x.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  537 |                  }
+      |                  ~
+  538 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  539 |                })()),
+      |                ~~~~~~
+  540 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  541 |                  std::vector<decltype(std::declval<__struct7>().ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  542 |                      __items;
+      |                      ~~~~~~~~
+  543 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  544 |                    __items.push_back(x.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  545 |                  }
+      |                  ~
+  546 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  547 |                })()),
+      |                ~~~~~~
+  548 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  549 |                  std::vector<decltype(std::declval<__struct7>().ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  550 |                      __items;
+      |                      ~~~~~~~~
+  551 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  552 |                    __items.push_back(x.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  553 |                  }
+      |                  ~
+  554 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  555 |                })()),
+      |                ~~~~~~
+  556 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  557 |                  std::vector<decltype(std::declval<__struct7>().ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  558 |                      __items;
+      |                      ~~~~~~~~
+  559 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  560 |                    __items.push_back(x.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  561 |                  }
+      |                  ~
+  562 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  563 |                })())}});
+      |                ~~~~~~~~~
+  564 |     }
+      |     ~
+  565 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  566 |       return std::tie(a.first.f0, a.first.f1) <
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  567 |              std::tie(b.first.f0, b.first.f1);
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  568 |     });
+      |     ~~~
+  569 |     std::vector<__struct9> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  570 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  571 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  572 |     return __res;
+      |     ~~~~~~~~~~~~~
+  573 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q28.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q28.error
@@ -1,0 +1,319 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:58:8: error: redefinition of ‘struct StoreSale’
+   58 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:52:8: note: previous definition of ‘struct StoreSale’
+   52 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:73:12: error: ‘x’ was not declared in this scope
+   73 |   decltype(x) x;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:73:12: error: ‘x’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:76:35: error: ‘struct Result’ has no member named ‘ss_list_price’
+   76 |   decltype(std::declval<Result>().ss_list_price) key;
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:76:35: error: ‘struct Result’ has no member named ‘ss_list_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:79:8: error: redefinition of ‘struct Result’
+   79 | struct Result {
+      |        ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:72:8: note: previous definition of ‘struct Result’
+   72 | struct Result {
+      |        ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:83:35: error: ‘struct Result’ has no member named ‘ss_list_price’
+   83 |   decltype(std::declval<Result>().ss_list_price) key;
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:83:35: error: ‘struct Result’ has no member named ‘ss_list_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:154:13: error: redefinition of ‘void __json(const StoreSale&)’
+  154 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:129:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  129 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:194:26: error: ‘ss’ was not declared in this scope
+  194 |     std::vector<decltype(ss)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:194:29: error: template argument 1 is invalid
+  194 |     std::vector<decltype(ss)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:194:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:202:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  202 |       __items.push_back(ss);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:207:26: error: ‘ss’ was not declared in this scope
+  207 |     std::vector<decltype(ss)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:207:29: error: template argument 1 is invalid
+  207 |     std::vector<decltype(ss)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:207:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:215:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  215 |       __items.push_back(ss);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:221:40: error: ‘x’ was not declared in this scope
+  221 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:221:56: error: template argument 1 is invalid
+  221 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:221:56: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:222:33: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  222 |                   for (auto x : bucket1) {
+      |                                 ^~~~~~~
+      |                                 std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:222:33: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  222 |                   for (auto x : bucket1) {
+      |                                 ^~~~~~~
+      |                                 std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:223:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  223 |                     __items.push_back(x.ss_list_price);
+      |                             ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:220:22: error: no matching function for call to ‘__avg(int)’
+  220 |       __struct5{__avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+  221 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  222 |                   for (auto x : bucket1) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  223 |                     __items.push_back(x.ss_list_price);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  224 |                   }
+      |                   ~   
+  225 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  226 |                 })()),
+      |                 ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:64:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   64 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:64:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:220:22: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  220 |       __struct5{__avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+  221 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  222 |                   for (auto x : bucket1) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  223 |                     __items.push_back(x.ss_list_price);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  224 |                   }
+      |                   ~   
+  225 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  226 |                 })()),
+      |                 ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:227:31: error: request for member ‘size’ in ‘bucket1’, which is of non-class type ‘int’
+  227 |                 ((int)bucket1.size()),
+      |                               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:230:34: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  230 |                    for (auto x : bucket1) {
+      |                                  ^~~~~~~
+      |                                  std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:230:34: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  230 |                    for (auto x : bucket1) {
+      |                                  ^~~~~~~
+      |                                  std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:242:74: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  242 |                            __struct3{__key, std::vector<Result>{Result{x}}});
+      |                                                                          ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:5:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:253:40: error: ‘x’ was not declared in this scope
+  253 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:253:56: error: template argument 1 is invalid
+  253 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:253:56: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:254:33: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  254 |                   for (auto x : bucket2) {
+      |                                 ^~~~~~~
+      |                                 std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:254:33: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  254 |                   for (auto x : bucket2) {
+      |                                 ^~~~~~~
+      |                                 std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:255:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  255 |                     __items.push_back(x.ss_list_price);
+      |                             ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:252:22: error: no matching function for call to ‘__avg(int)’
+  252 |                 __avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+  253 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  254 |                   for (auto x : bucket2) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |                     __items.push_back(x.ss_list_price);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |                   }
+      |                   ~   
+  257 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  258 |                 })()),
+      |                 ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:64:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   64 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:64:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:252:22: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  252 |                 __avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+  253 |                   std::vector<decltype(x.ss_list_price)> __items;
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  254 |                   for (auto x : bucket2) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |                     __items.push_back(x.ss_list_price);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |                   }
+      |                   ~   
+  257 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  258 |                 })()),
+      |                 ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:259:31: error: request for member ‘size’ in ‘bucket2’, which is of non-class type ‘int’
+  259 |                 ((int)bucket2.size()),
+      |                               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:262:34: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  262 |                    for (auto x : bucket2) {
+      |                                  ^~~~~~~
+      |                                  std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:262:34: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  262 |                    for (auto x : bucket2) {
+      |                                  ^~~~~~~
+      |                                  std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq283960735320/001/prog.cpp:274:74: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  274 |                            __struct4{__key, std::vector<Result>{Result{x}}});
+      |                                                                          ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided

--- a/tests/dataset/tpc-ds/compiler/cpp/q29.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q29.error
@@ -1,0 +1,212 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:91:8: error: redefinition of ‘struct StoreSale’
+   91 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:55:8: note: previous definition of ‘struct StoreSale’
+   55 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:99:8: error: redefinition of ‘struct StoreReturn’
+   99 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:63:8: note: previous definition of ‘struct StoreReturn’
+   63 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:106:8: error: redefinition of ‘struct CatalogSale’
+  106 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:70:8: note: previous definition of ‘struct CatalogSale’
+   70 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:112:8: error: redefinition of ‘struct DateDim’
+  112 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:76:8: note: previous definition of ‘struct DateDim’
+   76 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:117:8: error: redefinition of ‘struct Store’
+  117 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:81:8: note: previous definition of ‘struct Store’
+   81 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:122:8: error: redefinition of ‘struct Item’
+  122 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:86:8: note: previous definition of ‘struct Item’
+   86 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:128:12: error: ‘ss’ was not declared in this scope
+  128 |   decltype(ss.ss_quantity) ss_quantity;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:128:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:129:12: error: ‘sr’ was not declared in this scope
+  129 |   decltype(sr.sr_return_quantity) sr_return_quantity;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:129:12: error: ‘sr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:130:12: error: ‘cs’ was not declared in this scope
+  130 |   decltype(cs.cs_quantity) cs_quantity;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:130:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:131:12: error: ‘i’ was not declared in this scope
+  131 |   decltype(i.i_item_id) i_item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:131:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:132:12: error: ‘i’ was not declared in this scope
+  132 |   decltype(i.i_item_desc) i_item_desc;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:132:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:133:12: error: ‘s’ was not declared in this scope
+  133 |   decltype(s.s_store_id) s_store_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:133:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:134:12: error: ‘s’ was not declared in this scope
+  134 |   decltype(s.s_store_name) s_store_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:134:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:305:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  305 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:155:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  155 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:330:13: error: redefinition of ‘void __json(const DateDim&)’
+  330 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:180:13: note: ‘void __json(const DateDim&)’ previously defined here
+  180 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:390:13: error: redefinition of ‘void __json(const Item&)’
+  390 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:200:13: note: ‘void __json(const Item&)’ previously defined here
+  200 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:435:13: error: redefinition of ‘void __json(const Store&)’
+  435 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:220:13: note: ‘void __json(const Store&)’ previously defined here
+  220 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:455:13: error: redefinition of ‘void __json(const StoreReturn&)’
+  455 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:240:13: note: ‘void __json(const StoreReturn&)’ previously defined here
+  240 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:525:13: error: redefinition of ‘void __json(const StoreSale&)’
+  525 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:270:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  270 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:607:48: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  607 |                              cs.cs_quantity, i.i_item_id, i.i_item_desc,
+      |                                              ~~^~~~~~~~~
+      |                                                |
+      |                                                std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:626:21: error: no match for ‘operator==’ (operand types are ‘Result’ and ‘Result’)
+  626 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Result Result
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq293081803124/001/prog.cpp:667:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<Base>’ requested
+  619 |   std::vector<Base> result = ([&]() {
+      |                              ~~~~~~~~
+  620 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  621 |     for (auto b : base) {
+      |     ~~~~~~~~~~~~~~~~~~~~~
+  622 |       auto __key =
+      |       ~~~~~~~~~~~~
+  623 |           Result{b.i_item_id, b.i_item_desc, b.s_store_id, b.s_store_name};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  624 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  625 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  626 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  627 |           __g.items.push_back(Base{b});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  628 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  629 |           break;
+      |           ~~~~~~
+  630 |         }
+      |         ~
+  631 |       }
+      |       ~
+  632 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  633 |         __groups.push_back(__struct9{__key, std::vector<Base>{Base{b}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  634 |       }
+      |       ~
+  635 |     }
+      |     ~
+  636 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  637 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  638 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  639 |           g.key.item_id, g.key.item_desc, g.key.s_store_id, g.key.s_store_name,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  640 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  641 |               ([&]() {
+      |               ~~~~~~~~
+  642 |                 std::vector<decltype(std::declval<Base>().ss_quantity)> __items;
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  643 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  644 |                   __items.push_back(x.ss_quantity);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  645 |                 }
+      |                 ~
+  646 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  647 |               })()),
+      |               ~~~~~~
+  648 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  649 |               ([&]() {
+      |               ~~~~~~~~
+  650 |                 std::vector<decltype(std::declval<Base>().sr_return_quantity)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  651 |                     __items;
+      |                     ~~~~~~~~
+  652 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  653 |                   __items.push_back(x.sr_return_quantity);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  654 |                 }
+      |                 ~
+  655 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  656 |               })()),
+      |               ~~~~~~
+  657 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  658 |               ([&]() {
+      |               ~~~~~~~~
+  659 |                 std::vector<decltype(std::declval<Base>().cs_quantity)> __items;
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  660 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  661 |                   __items.push_back(x.cs_quantity);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  662 |                 }
+      |                 ~
+  663 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  664 |               })())});
+      |               ~~~~~~~~
+  665 |     }
+      |     ~
+  666 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  667 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q3.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q3.error
@@ -1,0 +1,329 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:73:12: error: ‘dt’ was not declared in this scope
+   73 |   decltype(dt.d_year) d_year;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:73:12: error: ‘dt’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:74:12: error: ‘i’ was not declared in this scope
+   74 |   decltype(i.i_brand_id) brand_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:74:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+   75 |   decltype(i.i_brand) brand;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:78:12: error: ‘dt’ was not declared in this scope
+   78 |   decltype(dt) dt;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:78:12: error: ‘dt’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:79:12: error: ‘ss’ was not declared in this scope
+   79 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:79:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:80:12: error: ‘i’ was not declared in this scope
+   80 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:80:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:264:58: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  264 |           auto __key = Result{dt.d_year, i.i_brand_id, i.i_brand};
+      |                                                        ~~^~~~~~~
+      |                                                          |
+      |                                                          std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:268:45: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  268 |               __g.items.push_back(__struct5{dt, ss, i});
+      |                                             ^~
+      |                                             |
+      |                                             DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:275:67: error: cannot convert ‘DateDim’ to ‘int’ in initialization
+  275 |                 __struct6{__key, std::vector<__struct5>{__struct5{dt, ss, i}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   DateDim
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:275:77: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  275 |                 __struct6{__key, std::vector<__struct5>{__struct5{dt, ss, i}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:287:50: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+  287 |                                                 .ss_ext_sales_price)>
+      |                                                  ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:287:50: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:287:69: error: template argument 1 is invalid
+  287 |                                                 .ss_ext_sales_price)>
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:287:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:290:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  290 |                          __items.push_back(x.ss_ext_sales_price);
+      |                                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:290:46: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+  290 |                          __items.push_back(x.ss_ext_sales_price);
+      |                                              ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:285:24:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:284:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  284 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:284:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  284 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                          ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:299:50: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+  299 |                                                 .ss_ext_sales_price)>
+      |                                                  ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:299:50: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:299:69: error: template argument 1 is invalid
+  299 |                                                 .ss_ext_sales_price)>
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:299:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:302:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  302 |                          __items.push_back(x.ss_ext_sales_price);
+      |                                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:302:46: error: ‘struct __struct5’ has no member named ‘ss_ext_sales_price’
+  302 |                          __items.push_back(x.ss_ext_sales_price);
+      |                                              ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:297:24:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:296:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  296 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:296:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  296 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                          ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:282:24: error: no matching function for call to ‘std::vector<std::pair<__struct8, __struct7> >::push_back(<brace-enclosed initializer list>)’
+  282 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  283 |           {__struct8{g.key.d_year, (-([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  284 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  286 |                        std::vector<decltype(std::declval<__struct5>()
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  287 |                                                 .ss_ext_sales_price)>
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  288 |                            __items;
+      |                            ~~~~~~~~
+  289 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |                          __items.push_back(x.ss_ext_sales_price);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  291 |                        }
+      |                        ~
+  292 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  293 |                      })())),
+      |                      ~~~~~~~
+  294 |                      g.key.brand_id},
+      |                      ~~~~~~~~~~~~~~~~
+  295 |            __struct7{g.key.d_year, g.key.brand_id, g.key.brand, ([&](auto v) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  296 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  297 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  298 |                        std::vector<decltype(std::declval<__struct5>()
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  299 |                                                 .ss_ext_sales_price)>
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  300 |                            __items;
+      |                            ~~~~~~~~
+  301 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |                          __items.push_back(x.ss_ext_sales_price);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |                        }
+      |                        ~
+  304 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  305 |                      })())}});
+      |                      ~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<__struct8, __struct7>; _Alloc = std::allocator<std::pair<__struct8, __struct7> >; value_type = std::pair<__struct8, __struct7>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<__struct8, __struct7> >::value_type&’ {aka ‘const std::pair<__struct8, __struct7>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<__struct8, __struct7>; _Alloc = std::allocator<std::pair<__struct8, __struct7> >; value_type = std::pair<__struct8, __struct7>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<__struct8, __struct7> >::value_type&&’ {aka ‘std::pair<__struct8, __struct7>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq33156202184/001/prog.cpp:315:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  253 |   std::vector<__struct5> result = ([&]() {
+      |                                   ~~~~~~~~
+  254 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |     for (auto dt : date_dim) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |       for (auto ss : store_sales) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |         if (!((dt.d_date_sk == ss.ss_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |           continue;
+      |           ~~~~~~~~~
+  259 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  260 |           if (!((ss.ss_item_sk == i.i_item_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |             continue;
+      |             ~~~~~~~~~
+  262 |           if (!(((i.i_manufact_id == 100) && (dt.d_moy == 12))))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |             continue;
+      |             ~~~~~~~~~
+  264 |           auto __key = Result{dt.d_year, i.i_brand_id, i.i_brand};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  266 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  267 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  268 |               __g.items.push_back(__struct5{dt, ss, i});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  269 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  270 |               break;
+      |               ~~~~~~
+  271 |             }
+      |             ~
+  272 |           }
+      |           ~
+  273 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  274 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  275 |                 __struct6{__key, std::vector<__struct5>{__struct5{dt, ss, i}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |           }
+      |           ~
+  277 |         }
+      |         ~
+  278 |       }
+      |       ~
+  279 |     }
+      |     ~
+  280 |     std::vector<std::pair<__struct8, __struct7>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  281 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  282 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  283 |           {__struct8{g.key.d_year, (-([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  284 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  286 |                        std::vector<decltype(std::declval<__struct5>()
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  287 |                                                 .ss_ext_sales_price)>
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  288 |                            __items;
+      |                            ~~~~~~~~
+  289 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |                          __items.push_back(x.ss_ext_sales_price);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  291 |                        }
+      |                        ~
+  292 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  293 |                      })())),
+      |                      ~~~~~~~
+  294 |                      g.key.brand_id},
+      |                      ~~~~~~~~~~~~~~~~
+  295 |            __struct7{g.key.d_year, g.key.brand_id, g.key.brand, ([&](auto v) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  296 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  297 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  298 |                        std::vector<decltype(std::declval<__struct5>()
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  299 |                                                 .ss_ext_sales_price)>
+      |                                                 ~~~~~~~~~~~~~~~~~~~~~
+  300 |                            __items;
+      |                            ~~~~~~~~
+  301 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |                          __items.push_back(x.ss_ext_sales_price);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |                        }
+      |                        ~
+  304 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  305 |                      })())}});
+      |                      ~~~~~~~~~
+  306 |     }
+      |     ~
+  307 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  308 |       return std::tie(a.first.f0, a.first.f1, a.first.f2) <
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |              std::tie(b.first.f0, b.first.f1, b.first.f2);
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |     });
+      |     ~~~
+  311 |     std::vector<__struct7> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  313 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  314 |     return __res;
+      |     ~~~~~~~~~~~~~
+  315 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q30.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q30.error
@@ -1,0 +1,363 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:76:12: error: ‘wr’ was not declared in this scope
+   76 |   decltype(wr.wr_returning_customer_sk) cust;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:76:12: error: ‘wr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:77:12: error: ‘ca’ was not declared in this scope
+   77 |   decltype(ca.ca_state) state;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:77:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:80:12: error: ‘wr’ was not declared in this scope
+   80 |   decltype(wr) wr;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:80:12: error: ‘wr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:81:12: error: ‘d’ was not declared in this scope
+   81 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:81:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:82:12: error: ‘ca’ was not declared in this scope
+   82 |   decltype(ca) ca;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:82:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:94:38: error: ‘struct __struct6’ has no member named ‘ctr_state’
+   94 |   decltype(std::declval<__struct6>().ctr_state) key;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:94:38: error: ‘struct __struct6’ has no member named ‘ctr_state’
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:110:12: error: ‘c’ was not declared in this scope
+  110 |   decltype(c.c_customer_id) c_customer_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:110:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:111:12: error: ‘c’ was not declared in this scope
+  111 |   decltype(c.c_first_name) c_first_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:111:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:112:12: error: ‘c’ was not declared in this scope
+  112 |   decltype(c.c_last_name) c_last_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:112:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:113:38: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  113 |   decltype(std::declval<__struct6>().ctr_total_return) ctr_total_return;
+      |                                      ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:113:38: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:319:67: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  319 |               CustomerTotalReturn{wr.wr_returning_customer_sk, ca.ca_state};
+      |                                                                ~~~^~~~~~~~
+      |                                                                   |
+      |                                                                   std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:323:45: error: cannot convert ‘WebReturn’ to ‘int’ in initialization
+  323 |               __g.items.push_back(__struct6{wr, d, ca});
+      |                                             ^~
+      |                                             |
+      |                                             WebReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:330:67: error: cannot convert ‘WebReturn’ to ‘int’ in initialization
+  330 |                 __struct7{__key, std::vector<__struct6>{__struct6{wr, d, ca}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   WebReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:330:77: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  330 |                 __struct7{__key, std::vector<__struct6>{__struct6{wr, d, ca}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:341:60: error: ‘struct __struct6’ has no member named ‘wr_return_amt’
+  341 |             std::vector<decltype(std::declval<__struct6>().wr_return_amt)>
+      |                                                            ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:341:60: error: ‘struct __struct6’ has no member named ‘wr_return_amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:341:74: error: template argument 1 is invalid
+  341 |             std::vector<decltype(std::declval<__struct6>().wr_return_amt)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:341:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:344:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  344 |               __items.push_back(x.wr_return_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:344:35: error: ‘struct __struct6’ has no member named ‘wr_return_amt’
+  344 |               __items.push_back(x.wr_return_amt);
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:340:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:339:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  339 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:339:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  339 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:350:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  307 |   std::vector<__struct6> customer_total_return = ([&]() {
+      |                                                  ~~~~~~~~
+  308 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |     for (auto wr : web_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  311 |         if (!((wr.wr_returned_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |           continue;
+      |           ~~~~~~~~~
+  313 |         for (auto ca : customer_address) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  314 |           if (!((wr.wr_returning_addr_sk == ca.ca_address_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  315 |             continue;
+      |             ~~~~~~~~~
+  316 |           if (!(((d.d_year == 2000) && (ca.ca_state == std::string("CA")))))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  317 |             continue;
+      |             ~~~~~~~~~
+  318 |           auto __key =
+      |           ~~~~~~~~~~~~
+  319 |               CustomerTotalReturn{wr.wr_returning_customer_sk, ca.ca_state};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  320 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  321 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  322 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  323 |               __g.items.push_back(__struct6{wr, d, ca});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  324 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  325 |               break;
+      |               ~~~~~~
+  326 |             }
+      |             ~
+  327 |           }
+      |           ~
+  328 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  329 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  330 |                 __struct7{__key, std::vector<__struct6>{__struct6{wr, d, ca}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  331 |           }
+      |           ~
+  332 |         }
+      |         ~
+  333 |       }
+      |       ~
+  334 |     }
+      |     ~
+  335 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  336 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  337 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  338 |           g.key.cust, g.key.state, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  340 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  341 |             std::vector<decltype(std::declval<__struct6>().wr_return_amt)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |                 __items;
+      |                 ~~~~~~~~
+  343 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |               __items.push_back(x.wr_return_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |             }
+      |             ~
+  346 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  347 |           })())});
+      |           ~~~~~~~~
+  348 |     }
+      |     ~
+  349 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  350 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:354:24: error: ‘struct __struct6’ has no member named ‘ctr_state’
+  354 |       auto __key = ctr.ctr_state;
+      |                        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:372:60: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  372 |             std::vector<decltype(std::declval<__struct6>().ctr_total_return)>
+      |                                                            ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:372:60: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:372:77: error: template argument 1 is invalid
+  372 |             std::vector<decltype(std::declval<__struct6>().ctr_total_return)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:372:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:375:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  375 |               __items.push_back(x.ctr_total_return);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:375:35: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  375 |               __items.push_back(x.ctr_total_return);
+      |                                   ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:371:23: error: no matching function for call to ‘__avg(int)’
+  371 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  372 |             std::vector<decltype(std::declval<__struct6>().ctr_total_return)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |                 __items;
+      |                 ~~~~~~~~
+  374 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |               __items.push_back(x.ctr_total_return);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |             }
+      |             ~          
+  377 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  378 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:97:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   97 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:97:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:371:23: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  371 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  372 |             std::vector<decltype(std::declval<__struct6>().ctr_total_return)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |                 __items;
+      |                 ~~~~~~~~
+  374 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |               __items.push_back(x.ctr_total_return);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |             }
+      |             ~          
+  377 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  378 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:381:5: error: conversion from ‘vector<AvgByState>’ to non-scalar type ‘vector<__struct6>’ requested
+  351 |   std::vector<__struct6> avg_by_state = ([&]() {
+      |                                         ~~~~~~~~
+  352 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |     for (auto ctr : customer_total_return) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |       auto __key = ctr.ctr_state;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  355 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  356 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  357 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  358 |           __g.items.push_back(__struct6{ctr});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  360 |           break;
+      |           ~~~~~~
+  361 |         }
+      |         ~
+  362 |       }
+      |       ~
+  363 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  364 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  365 |             __struct9{__key, std::vector<__struct6>{__struct6{ctr}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |       }
+      |       ~
+  367 |     }
+      |     ~
+  368 |     std::vector<AvgByState> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |       __items.push_back(AvgByState{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |           g.key, __avg(([&]() {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  372 |             std::vector<decltype(std::declval<__struct6>().ctr_total_return)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |                 __items;
+      |                 ~~~~~~~~
+  374 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |               __items.push_back(x.ctr_total_return);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |             }
+      |             ~
+  377 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  378 |           })())});
+      |           ~~~~~~~~
+  379 |     }
+      |     ~
+  380 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  381 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:386:20: error: ‘struct __struct6’ has no member named ‘ctr_state’
+  386 |         if (!((ctr.ctr_state == avg.state)))
+      |                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:386:37: error: ‘struct __struct6’ has no member named ‘state’
+  386 |         if (!((ctr.ctr_state == avg.state)))
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:389:22: error: ‘struct __struct6’ has no member named ‘ctr_customer_sk’
+  389 |           if (!((ctr.ctr_customer_sk == c.c_customer_sk)))
+      |                      ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:391:22: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  391 |           if (!((ctr.ctr_total_return > (avg.avg_return * 1.2))))
+      |                      ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:391:46: error: ‘struct __struct6’ has no member named ‘avg_return’
+  391 |           if (!((ctr.ctr_total_return > (avg.avg_return * 1.2))))
+      |                                              ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq301515924810/001/prog.cpp:394:55: error: ‘struct __struct6’ has no member named ‘ctr_total_return’
+  394 |                                    c.c_last_name, ctr.ctr_total_return});
+      |                                                       ^~~~~~~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q31.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q31.error
@@ -1,0 +1,134 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:67:12: error: ‘county’ was not declared in this scope
+   67 |   decltype(county) ca_county;
+      |            ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:67:12: error: ‘county’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:69:12: error: ‘web_g1’ was not declared in this scope
+   69 |   decltype(web_g1) web_q1_q2_increase;
+      |            ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:69:12: error: ‘web_g1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:70:12: error: ‘store_g1’ was not declared in this scope
+   70 |   decltype(store_g1) store_q1_q2_increase;
+      |            ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:70:12: error: ‘store_g1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:71:12: error: ‘web_g2’ was not declared in this scope
+   71 |   decltype(web_g2) web_q2_q3_increase;
+      |            ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:71:12: error: ‘web_g2’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:72:12: error: ‘store_g2’ was not declared in this scope
+   72 |   decltype(store_g2) store_q2_q3_increase;
+      |            ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:72:12: error: ‘store_g2’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:179:28: error: ‘s’ was not declared in this scope
+  179 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:179:49: error: template argument 1 is invalid
+  179 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:179:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:183:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  183 |         __items.push_back(s.ss_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:178:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:177:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  177 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:177:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  177 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:190:28: error: ‘s’ was not declared in this scope
+  190 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:190:49: error: template argument 1 is invalid
+  190 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:190:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:194:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  194 |         __items.push_back(s.ss_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:189:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:188:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  188 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:188:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  188 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:201:28: error: ‘s’ was not declared in this scope
+  201 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:201:49: error: template argument 1 is invalid
+  201 |       std::vector<decltype(s.ss_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:201:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:205:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  205 |         __items.push_back(s.ss_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:200:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:199:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  199 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:199:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  199 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:212:28: error: ‘w’ was not declared in this scope
+  212 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:212:49: error: template argument 1 is invalid
+  212 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:212:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:216:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  216 |         __items.push_back(w.ws_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:211:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:210:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  210 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:210:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  210 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:223:28: error: ‘w’ was not declared in this scope
+  223 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:223:49: error: template argument 1 is invalid
+  223 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:223:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:227:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  227 |         __items.push_back(w.ws_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:222:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:221:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  221 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:221:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  221 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:234:28: error: ‘w’ was not declared in this scope
+  234 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:234:49: error: template argument 1 is invalid
+  234 |       std::vector<decltype(w.ws_ext_sales_price)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:234:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:238:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  238 |         __items.push_back(w.ws_ext_sales_price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:6)> [with auto:6 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:233:7:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:232:32: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  232 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq312232213289/001/prog.cpp:232:43: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  232 |       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q32.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q32.error
@@ -1,0 +1,62 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:131:26: error: ‘cs’ was not declared in this scope
+  131 |     std::vector<decltype(cs.cs_ext_discount_amt)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:131:49: error: template argument 1 is invalid
+  131 |     std::vector<decltype(cs.cs_ext_discount_amt)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:131:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:141:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  141 |           __items.push_back(cs.cs_ext_discount_amt);
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:147:28: error: no matching function for call to ‘__avg(int&)’
+  147 |   auto avg_discount = __avg(filtered);
+      |                       ~~~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:66:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   66 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:66:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:147:28: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  147 |   auto avg_discount = __avg(filtered);
+      |                       ~~~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:151:26: error: ‘x’ was not declared in this scope
+  151 |     std::vector<decltype(x)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:151:28: error: template argument 1 is invalid
+  151 |     std::vector<decltype(x)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:151:28: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:152:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  152 |     for (auto x : filtered) {
+      |                   ^~~~~~~~
+      |                   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:152:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  152 |     for (auto x : filtered) {
+      |                   ^~~~~~~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:155:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  155 |       __items.push_back(x);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:150:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:149:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  149 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq324058117265/001/prog.cpp:149:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  149 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q33.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q33.error
@@ -1,0 +1,106 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:89:12: error: ‘i’ was not declared in this scope
+   89 |   decltype(i.i_manufact_id) manu;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:89:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:90:12: error: ‘ss’ was not declared in this scope
+   90 |   decltype(ss.ss_ext_sales_price) price;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:90:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:273:7: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  273 |       concat(([&]() {
+      |       ^~~~~~
+      |       wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq33638932158/001/prog.cpp:393:5: error: conversion from ‘vector<Result>’ to non-scalar type ‘vector<UnionSale>’ requested
+  348 |   std::vector<UnionSale> result = ([&]() {
+      |                                   ~~~~~~~~
+  349 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |     for (auto s : union_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |       auto __key = s.manu;
+      |       ~~~~~~~~~~~~~~~~~~~~
+  352 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  353 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  355 |           __g.items.push_back(UnionSale{s});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  356 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  357 |           break;
+      |           ~~~~~~
+  358 |         }
+      |         ~
+  359 |       }
+      |       ~
+  360 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  361 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  362 |             __struct8{__key, std::vector<UnionSale>{UnionSale{s}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |       }
+      |       ~
+  364 |     }
+      |     ~
+  365 |     std::vector<std::pair<double, Result>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  368 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                ([&]() {
+      |                ~~~~~~~~
+  370 |                  std::vector<decltype(std::declval<UnionSale>().price)> __items;
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |                    __items.push_back(x.price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |                  }
+      |                  ~
+  374 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  375 |                })())),
+      |                ~~~~~~~
+  376 |            Result{
+      |            ~~~~~~~
+  377 |                g.key, ([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  378 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  379 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  380 |                  std::vector<decltype(std::declval<UnionSale>().price)> __items;
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  381 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |                    __items.push_back(x.price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  383 |                  }
+      |                  ~
+  384 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  385 |                })())}});
+      |                ~~~~~~~~~
+  386 |     }
+      |     ~
+  387 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |     std::vector<Result> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  391 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  392 |     return __res;
+      |     ~~~~~~~~~~~~~
+  393 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q34.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q34.error
@@ -1,0 +1,265 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+   85 |   decltype(ss.ss_ticket_number) ticket;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+   86 |   decltype(ss.ss_customer_sk) cust;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+   89 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:90:12: error: ‘d’ was not declared in this scope
+   90 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:90:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+   91 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:92:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   92 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:92:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   92 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:104:12: error: ‘c’ was not declared in this scope
+  104 |   decltype(c.c_last_name) c_last_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:104:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:105:12: error: ‘c’ was not declared in this scope
+  105 |   decltype(c.c_first_name) c_first_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:105:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+  106 |   decltype(c.c_salutation) c_salutation;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:107:12: error: ‘c’ was not declared in this scope
+  107 |   decltype(c.c_preferred_cust_flag) c_preferred_cust_flag;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:107:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘ss_ticket_number’
+  108 |   decltype(std::declval<__struct7>().ss_ticket_number) ss_ticket_number;
+      |                                      ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘ss_ticket_number’
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:109:38: error: ‘struct __struct7’ has no member named ‘cnt’
+  109 |   decltype(std::declval<__struct7>().cnt) cnt;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:109:38: error: ‘struct __struct7’ has no member named ‘cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:373:27: error: no match for ‘operator==’ (operand types are ‘Dn’ and ‘Dn’)
+  373 |               if (__g.key == __key) {
+      |                   ~~~~~~~ ^~ ~~~~~
+      |                       |      |
+      |                       Dn     Dn
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:374:47: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  374 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                                               ^~
+      |                                               |
+      |                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:381:59: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  381 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:381:72: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  381 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:393:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  351 |   std::vector<__struct7> dn = ([&]() {
+      |                               ~~~~~~~~
+  352 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  355 |         if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  356 |           continue;
+      |           ~~~~~~~~~
+  357 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  358 |           if (!((ss.ss_store_sk == s.s_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |             continue;
+      |             ~~~~~~~~~
+  360 |           for (auto hd : household_demographics) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |             if (!((ss.ss_hdemo_sk == hd.hd_demo_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  362 |               continue;
+      |               ~~~~~~~~~
+  363 |             if (!(((((((((d.d_dom >= 1) && (d.d_dom <= 3))) &&
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |                        (hd.hd_buy_potential == std::string(">10000"))) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                       (hd.hd_vehicle_count > 0)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |                      (((hd.hd_dep_count / hd.hd_vehicle_count)) > 1.2)) &&
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |                     (d.d_year == 2000)) &&
+      |                     ~~~~~~~~~~~~~~~~~~~~~~
+  368 |                    (s.s_county == std::string("A")))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |               continue;
+      |               ~~~~~~~~~
+  370 |             auto __key = Dn{ss.ss_ticket_number, ss.ss_customer_sk};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  372 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  374 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  376 |                 break;
+      |                 ~~~~~~
+  377 |               }
+      |               ~
+  378 |             }
+      |             ~
+  379 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  380 |               __groups.push_back(__struct8{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  381 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |             }
+      |             ~
+  383 |           }
+      |           ~
+  384 |         }
+      |         ~
+  385 |       }
+      |       ~
+  386 |     }
+      |     ~
+  387 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  390 |           __struct9{g.key.ticket, g.key.cust, ((int)g.items.size())});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  391 |     }
+      |     ~
+  392 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  393 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:395:36: error: ‘c’ was not declared in this scope
+  395 |     std::vector<std::pair<decltype(c.c_last_name), Result>> __items;
+      |                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:395:52: error: template argument 1 is invalid
+  395 |     std::vector<std::pair<decltype(c.c_last_name), Result>> __items;
+      |                                                    ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:395:58: error: template argument 1 is invalid
+  395 |     std::vector<std::pair<decltype(c.c_last_name), Result>> __items;
+      |                                                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:395:58: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:398:20: error: ‘struct __struct7’ has no member named ‘ss_customer_sk’
+  398 |         if (!((dn1.ss_customer_sk == c.c_customer_sk)))
+      |                    ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:400:21: error: ‘struct __struct7’ has no member named ‘cnt’
+  400 |         if (!(((dn1.cnt >= 15) && (dn1.cnt <= 20))))
+      |                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:400:40: error: ‘struct __struct7’ has no member named ‘cnt’
+  400 |         if (!(((dn1.cnt >= 15) && (dn1.cnt <= 20))))
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:402:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  402 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:405:50: error: ‘struct __struct7’ has no member named ‘ss_ticket_number’
+  405 |                     c.c_preferred_cust_flag, dn1.ss_ticket_number, dn1.cnt}});
+      |                                                  ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:405:72: error: ‘struct __struct7’ has no member named ‘cnt’
+  405 |                     c.c_preferred_cust_flag, dn1.ss_ticket_number, dn1.cnt}});
+      |                                                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:408:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  408 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:408:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  408 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:411:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  411 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq342411866166/001/prog.cpp:411:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  411 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q35.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q35.error
@@ -1,0 +1,217 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:81:12: error: ‘ca’ was not declared in this scope
+   81 |   decltype(ca.ca_state) state;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:81:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:82:12: error: ‘cd’ was not declared in this scope
+   82 |   decltype(cd.cd_gender) gender;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:82:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:83:12: error: ‘cd’ was not declared in this scope
+   83 |   decltype(cd.cd_marital_status) marital;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:83:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:84:12: error: ‘cd’ was not declared in this scope
+   84 |   decltype(cd.cd_dep_count) dep;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:84:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:85:12: error: ‘cd’ was not declared in this scope
+   85 |   decltype(cd.cd_dep_employed_count) emp;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:85:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:86:12: error: ‘cd’ was not declared in this scope
+   86 |   decltype(cd.cd_dep_college_count) col;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:86:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:89:12: error: ‘c’ was not declared in this scope
+   89 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:89:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:90:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   90 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:90:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   90 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:91:12: error: ‘cd’ was not declared in this scope; did you mean ‘ca’?
+   91 |   decltype(cd) cd;
+      |            ^~
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:91:12: error: ‘cd’ was not declared in this scope; did you mean ‘ca’?
+   91 |   decltype(cd) cd;
+      |            ^~
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:317:26: error: ‘ss’ was not declared in this scope
+  317 |     std::vector<decltype(ss.ss_customer_sk)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:317:44: error: template argument 1 is invalid
+  317 |     std::vector<decltype(ss.ss_customer_sk)> __items;
+      |                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:317:44: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:324:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  324 |         __items.push_back(ss.ss_customer_sk);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:338:38: error: request for member ‘begin’ in ‘purchased’, which is of non-class type ‘int’
+  338 |           if (!((std::find(purchased.begin(), purchased.end(),
+      |                                      ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:338:57: error: request for member ‘end’ in ‘purchased’, which is of non-class type ‘int’
+  338 |           if (!((std::find(purchased.begin(), purchased.end(),
+      |                                                         ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:339:58: error: request for member ‘end’ in ‘purchased’, which is of non-class type ‘int’
+  339 |                            c.c_customer_sk) != purchased.end())))
+      |                                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:341:33: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  341 |           auto __key = Group{ca.ca_state,
+      |                              ~~~^~~~~~~~
+      |                                 |
+      |                                 std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:350:45: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  350 |               __g.items.push_back(__struct7{c, ca, cd});
+      |                                             ^
+      |                                             |
+      |                                             Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:357:67: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  357 |                 __struct8{__key, std::vector<__struct7>{__struct7{c, ca, cd}}});
+      |                                                                   ^
+      |                                                                   |
+      |                                                                   Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:357:77: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  357 |                 __struct8{__key, std::vector<__struct7>{__struct7{c, ca, cd}}});
+      |                                                                             ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq353804131198/001/prog.cpp:369:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  329 |   std::vector<__struct7> groups = ([&]() {
+      |                                   ~~~~~~~~
+  330 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  331 |     for (auto c : customer) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |       for (auto ca : customer_address) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  333 |         if (!((c.c_current_addr_sk == ca.ca_address_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |           continue;
+      |           ~~~~~~~~~
+  335 |         for (auto cd : customer_demographics) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  336 |           if (!((c.c_current_cdemo_sk == cd.cd_demo_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  337 |             continue;
+      |             ~~~~~~~~~
+  338 |           if (!((std::find(purchased.begin(), purchased.end(),
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |                            c.c_customer_sk) != purchased.end())))
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  340 |             continue;
+      |             ~~~~~~~~~
+  341 |           auto __key = Group{ca.ca_state,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |                              cd.cd_gender,
+      |                              ~~~~~~~~~~~~~
+  343 |                              cd.cd_marital_status,
+      |                              ~~~~~~~~~~~~~~~~~~~~~
+  344 |                              cd.cd_dep_count,
+      |                              ~~~~~~~~~~~~~~~~
+  345 |                              cd.cd_dep_employed_count,
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |                              cd.cd_dep_college_count};
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~
+  347 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  348 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  350 |               __g.items.push_back(__struct7{c, ca, cd});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  352 |               break;
+      |               ~~~~~~
+  353 |             }
+      |             ~
+  354 |           }
+      |           ~
+  355 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  356 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  357 |                 __struct8{__key, std::vector<__struct7>{__struct7{c, ca, cd}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |           }
+      |           ~
+  359 |         }
+      |         ~
+  360 |       }
+      |       ~
+  361 |     }
+      |     ~
+  362 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |       __items.push_back(__struct9{g.key.state, g.key.gender, g.key.marital,
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                                   g.key.dep, g.key.emp, g.key.col,
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |                                   ((int)g.items.size())});
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |     }
+      |     ~
+  368 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  369 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q36.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q36.error
@@ -1,0 +1,295 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
+   77 |   decltype(i.i_category) category;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:78:12: error: ‘i’ was not declared in this scope
+   78 |   decltype(i.i_class) class;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:78:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:78:28: error: expected identifier before ‘;’ token
+   78 |   decltype(i.i_class) class;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:78:3: error: multiple types in one declaration
+   78 |   decltype(i.i_class) class;
+      |   ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:81:12: error: ‘ss’ was not declared in this scope
+   81 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:81:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+   82 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:83:12: error: ‘i’ was not declared in this scope
+   83 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:83:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:84:12: error: ‘s’ was not declared in this scope
+   84 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:84:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:92:42: error: expected unqualified-id before ‘class’
+   92 |   decltype(std::declval<__struct7>().key.class) i_class;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:96:42: error: ‘struct Result’ has no member named ‘catestd’
+   96 |   decltype(std::declval<__struct7>().key.catestd::declval<__struct7>() ory) f0;
+      |                                          ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:96:42: error: ‘Result::catestd’ has not been declared
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:96:68: error: expected primary-expression before ‘>’ token
+   96 |   decltype(std::declval<__struct7>().key.catestd::declval<__struct7>() ory) f0;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:96:70: error: expected primary-expression before ‘)’ token
+   96 |   decltype(std::declval<__struct7>().key.catestd::declval<__struct7>() ory) f0;
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:97:42: error: expected unqualified-id before ‘class’
+   97 |   decltype(std::declval<__struct7>().key.class) f1;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp: In function ‘void __json(const Result&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:126:12: error: expected unqualified-id before ‘class’
+  126 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:280:56: error: too many initializers for ‘Result’
+  280 |             auto __key = Result{i.i_category, i.i_class};
+      |                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:284:47: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  284 |                 __g.items.push_back(__struct6{ss, d, i, s});
+      |                                               ^~
+      |                                               |
+      |                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:291:59: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  291 |                   __key, std::vector<__struct6>{__struct6{ss, d, i, s}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:291:71: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  291 |                   __key, std::vector<__struct6>{__struct6{ss, d, i, s}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:300:21: error: expected primary-expression before ‘{’ token
+  300 |           {__struct9{g.key.category, g.key.class},
+      |                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:300:21: error: expected ‘}’ before ‘{’ token
+  300 |           {__struct9{g.key.category, g.key.class},
+      |           ~         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:300:21: error: expected ‘)’ before ‘{’ token
+  300 |           {__struct9{g.key.category, g.key.class},
+      |                     ^
+      |                     )
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:299:24: note: to match this ‘(’
+  299 |       __items.push_back(
+      |                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:301:21: error: expected primary-expression before ‘{’ token
+  301 |            __struct8{
+      |                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:323:25: error: expected primary-expression before ‘)’ token
+  323 |                 })()))}});
+      |                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:324:6: error: expected ‘)’ before ‘std’
+  324 |     }
+      |      ^
+      |      )
+  325 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:265:35: note: to match this ‘(’
+  265 |   std::vector<__struct6> result = ([&]() {
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:265:36: error: conversion from ‘main()::<lambda()>’ to non-scalar type ‘std::vector<__struct6>’ requested
+  265 |   std::vector<__struct6> result = ([&]() {
+      |                                   ~^~~~~~~
+  266 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  267 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
+  268 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~     
+  269 |         if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |           continue;
+      |           ~~~~~~~~~                 
+  271 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~       
+  272 |           if (!((ss.ss_item_sk == i.i_item_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  273 |             continue;
+      |             ~~~~~~~~~               
+  274 |           for (auto s : store) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~    
+  275 |             if (!((ss.ss_store_sk == s.s_store_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |               continue;
+      |               ~~~~~~~~~             
+  277 |             if (!(((d.d_year == 2000) && (((s.s_state == std::string("A")) ||
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  278 |                                            (s.s_state == std::string("B")))))))
+      |                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  279 |               continue;
+      |               ~~~~~~~~~             
+  280 |             auto __key = Result{i.i_category, i.i_class};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  281 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~   
+  282 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  283 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  284 |                 __g.items.push_back(__struct6{ss, d, i, s});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~     
+  286 |                 break;
+      |                 ~~~~~~              
+  287 |               }
+      |               ~                     
+  288 |             }
+      |             ~                       
+  289 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~         
+  290 |               __groups.push_back(__struct7{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  291 |                   __key, std::vector<__struct6>{__struct6{ss, d, i, s}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  292 |             }
+      |             ~                       
+  293 |           }
+      |           ~                         
+  294 |         }
+      |         ~                           
+  295 |       }
+      |       ~                             
+  296 |     }
+      |     ~                               
+  297 |     std::vector<std::pair<__struct9, __struct8>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  298 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~      
+  299 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~            
+  300 |           {__struct9{g.key.category, g.key.class},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  301 |            __struct8{
+      |            ~~~~~~~~~~               
+  302 |                g.key.category, g.key.class,
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |                (([&](auto v) {
+      |                ~~~~~~~~~~~~~~~      
+  304 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  305 |                 })(([&]() {
+      |                 ~~~~~~~~~~~         
+  306 |                   std::vector<decltype(std::declval<__struct6>().ss_net_profit)>
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  307 |                       __items;
+      |                       ~~~~~~~~      
+  308 |                   for (auto x : g.items) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |                     __items.push_back(x.ss_net_profit);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |                   }
+      |                   ~                 
+  311 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~   
+  312 |                 })()) /
+      |                 ~~~~~~~             
+  313 |                 ([&](auto v) {
+      |                 ~~~~~~~~~~~~~~      
+  314 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  315 |                 })(([&]() {
+      |                 ~~~~~~~~~~~         
+  316 |                   std::vector<
+      |                   ~~~~~~~~~~~~      
+  317 |                       decltype(std::declval<__struct6>().ss_ext_sales_price)>
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  318 |                       __items;
+      |                       ~~~~~~~~      
+  319 |                   for (auto x : g.items) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  320 |                     __items.push_back(x.ss_ext_sales_price);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |                   }
+      |                   ~                 
+  322 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~   
+  323 |                 })()))}});
+      |                 ~~~~~~~~~~          
+  324 |     }
+      |     ~                               
+  325 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~                             
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:328:6: error: expected ‘,’ or ‘;’ before ‘)’ token
+  328 |     });
+      |      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:330:20: error: ‘__items’ was not declared in this scope; did you mean ‘__res’?
+  330 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    __res
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:332:12: error: cannot convert ‘std::vector<__struct8>’ to ‘int’ in return
+  332 |     return __res;
+      |            ^~~~~
+      |            |
+      |            std::vector<__struct8>
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:333:4: error: expected unqualified-id before ‘)’ token
+  333 |   })();
+      |    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:334:10: error: expected ‘)’ before ‘(’ token
+  334 |   (__json(result));
+      |   ~      ^
+      |          )
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:336:3: error: expected unqualified-id before ‘return’
+  336 |   return 0;
+      |   ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq362833932405/001/prog.cpp:337:1: error: expected declaration before ‘}’ token
+  337 | }
+      | ^

--- a/tests/dataset/tpc-ds/compiler/cpp/q37.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q37.error
@@ -1,0 +1,211 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
+   77 |   decltype(i.i_item_id) id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:78:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   78 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:78:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   78 |   decltype(i.i_item_desc) desc;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:79:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   79 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:79:12: error: ‘i’ was not declared in this scope; did you mean ‘id’?
+   79 |   decltype(i.i_current_price) price;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:82:12: error: ‘i’ was not declared in this scope
+   82 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:82:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:83:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   83 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:83:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   83 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:84:12: error: ‘d’ was not declared in this scope
+   84 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:84:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:85:12: error: ‘cs’ was not declared in this scope
+   85 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:85:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:273:35: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  273 |             auto __key = Result{i.i_item_id, i.i_item_desc, i.i_current_price};
+      |                                 ~~^~~~~~~~~
+      |                                   |
+      |                                   std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:277:47: error: cannot convert ‘Item’ to ‘int’ in initialization
+  277 |                 __g.items.push_back(__struct6{i, inv, d, cs});
+      |                                               ^
+      |                                               |
+      |                                               Item
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:284:59: error: cannot convert ‘Item’ to ‘int’ in initialization
+  284 |                   __key, std::vector<__struct6>{__struct6{i, inv, d, cs}}});
+      |                                                           ^
+      |                                                           |
+      |                                                           Item
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:284:73: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  284 |                   __key, std::vector<__struct6>{__struct6{i, inv, d, cs}}});
+      |                                                                         ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq371356632478/001/prog.cpp:303:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  254 |   std::vector<__struct6> result = ([&]() {
+      |                                   ~~~~~~~~
+  255 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |     for (auto i : item) {
+      |     ~~~~~~~~~~~~~~~~~~~~~
+  257 |       for (auto inv : inventory) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |         if (!((i.i_item_sk == inv.inv_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  259 |           continue;
+      |           ~~~~~~~~~
+  260 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |           if (!((inv.inv_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |             continue;
+      |             ~~~~~~~~~
+  263 |           for (auto cs : catalog_sales) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |             if (!((cs.cs_item_sk == i.i_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |               continue;
+      |               ~~~~~~~~~
+  266 |             if (!(((((((i.i_current_price >= 20) &&
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  267 |                        (i.i_current_price <= 50)) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  268 |                       (i.i_manufact_id >= 800)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  269 |                      (i.i_manufact_id <= 803)) &&
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |                     (inv.inv_quantity_on_hand >= 100)) &&
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  271 |                    (inv.inv_quantity_on_hand <= 500))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |               continue;
+      |               ~~~~~~~~~
+  273 |             auto __key = Result{i.i_item_id, i.i_item_desc, i.i_current_price};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  275 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  277 |                 __g.items.push_back(__struct6{i, inv, d, cs});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  278 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  279 |                 break;
+      |                 ~~~~~~
+  280 |               }
+      |               ~
+  281 |             }
+      |             ~
+  282 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  283 |               __groups.push_back(__struct7{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  284 |                   __key, std::vector<__struct6>{__struct6{i, inv, d, cs}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  285 |             }
+      |             ~
+  286 |           }
+      |           ~
+  287 |         }
+      |         ~
+  288 |       }
+      |       ~
+  289 |     }
+      |     ~
+  290 |     std::vector<
+      |     ~~~~~~~~~~~~
+  291 |         std::pair<decltype(std::declval<__struct7>().key.id), __struct8>>
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  292 |         __items;
+      |         ~~~~~~~~
+  293 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  294 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  295 |           {g.key.id, __struct8{g.key.id, g.key.desc, g.key.price}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  296 |     }
+      |     ~
+  297 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  298 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  299 |     std::vector<__struct8> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  300 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  301 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |     return __res;
+      |     ~~~~~~~~~~~~~
+  303 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q38.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q38.error
@@ -1,0 +1,62 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:143:15: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  143 | auto distinct(auto xs) {
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:155:26: error: ‘s’ was not declared in this scope
+  155 |     std::vector<decltype(s.ss_customer_sk)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:155:43: error: template argument 1 is invalid
+  155 |     std::vector<decltype(s.ss_customer_sk)> __items;
+      |                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:155:43: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:159:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  159 |       __items.push_back(s.ss_customer_sk);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp: In instantiation of ‘auto distinct(auto:1) [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:154:28:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:145:3: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  145 |   for (auto x : xs) {
+      |   ^~~
+      |   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:145:3: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  145 |   for (auto x : xs) {
+      |   ^~~
+      |   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:146:19: error: ‘contains’ was not declared in this scope
+  146 |     if ((!contains(out, x))) {
+      |           ~~~~~~~~^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:164:26: error: ‘c’ was not declared in this scope
+  164 |     std::vector<decltype(c.cs_bill_customer_sk)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:164:48: error: template argument 1 is invalid
+  164 |     std::vector<decltype(c.cs_bill_customer_sk)> __items;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:164:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:168:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  168 |       __items.push_back(c.cs_bill_customer_sk);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:173:26: error: ‘w’ was not declared in this scope
+  173 |     std::vector<decltype(w.ws_bill_customer_sk)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:173:48: error: template argument 1 is invalid
+  173 |     std::vector<decltype(w.ws_bill_customer_sk)> __items;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:173:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq381350353663/001/prog.cpp:177:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  177 |       __items.push_back(w.ws_bill_customer_sk);
+      |               ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q39.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q39.error
@@ -1,0 +1,358 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:80:12: error: ‘w’ was not declared in this scope
+   80 |   decltype(w.w_warehouse_sk) w;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:80:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+   81 |   decltype(i.i_item_sk) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+   82 |   decltype(d.d_moy) month;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:85:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   85 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:85:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   85 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:86:12: error: ‘d’ was not declared in this scope
+   86 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:86:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:88:12: error: ‘w’ was not declared in this scope
+   88 |   decltype(w) w;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:88:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:110:12: error: ‘g’ was not declared in this scope
+  110 |   decltype(g.w) w;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:110:12: error: ‘g’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:111:12: error: ‘g’ was not declared in this scope
+  111 |   decltype(g.i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:111:12: error: ‘g’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:112:21: error: ‘g’ was not declared in this scope
+  112 |   decltype(__append(g.qtys, std::declval<__struct5>().qty)) qtys;
+      |                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:112:55: error: ‘struct __struct5’ has no member named ‘qty’
+  112 |   decltype(__append(g.qtys, std::declval<__struct5>().qty)) qtys;
+      |                                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:112:21: error: ‘g’ was not declared in this scope
+  112 |   decltype(__append(g.qtys, std::declval<__struct5>().qty)) qtys;
+      |                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:112:55: error: ‘struct __struct5’ has no member named ‘qty’
+  112 |   decltype(__append(g.qtys, std::declval<__struct5>().qty)) qtys;
+      |                                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:123:12: error: ‘g’ was not declared in this scope
+  123 |   decltype(g.w) w_warehouse_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:123:12: error: ‘g’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:124:12: error: ‘g’ was not declared in this scope
+  124 |   decltype(g.i) i_item_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:124:12: error: ‘g’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:125:12: error: ‘cov’ was not declared in this scope; did you mean ‘cos’?
+  125 |   decltype(cov) cov;
+      |            ^~~
+      |            cos
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:125:12: error: ‘cov’ was not declared in this scope; did you mean ‘cos’?
+  125 |   decltype(cov) cov;
+      |            ^~~
+      |            cos
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:311:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  311 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |           {std::string("i_item_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  313 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  314 |               {std::string("i_item_sk"), 1}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:325:39: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘i_item_sk’
+  325 |           if (!((inv.inv_item_sk == i.i_item_sk)))
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:332:54: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘i_item_sk’
+  332 |             auto __key = Monthly{w.w_warehouse_sk, i.i_item_sk, d.d_moy};
+      |                                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:336:47: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  336 |                 __g.items.push_back(__struct5{inv, d, i, w});
+      |                                               ^~~
+      |                                               |
+      |                                               Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:343:59: error: cannot convert ‘Inventory’ to ‘int’ in initialization
+  343 |                   __key, std::vector<__struct5>{__struct5{inv, d, i, w}}});
+      |                                                           ^~~
+      |                                                           |
+      |                                                           Inventory
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:343:72: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  343 |                   __key, std::vector<__struct5>{__struct5{inv, d, i, w}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:356:52: error: ‘struct __struct5’ has no member named ‘inv_quantity_on_hand’
+  356 |                 decltype(std::declval<__struct5>().inv_quantity_on_hand)>
+      |                                                    ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:356:52: error: ‘struct __struct5’ has no member named ‘inv_quantity_on_hand’
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:356:73: error: template argument 1 is invalid
+  356 |                 decltype(std::declval<__struct5>().inv_quantity_on_hand)>
+      |                                                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:356:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:359:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  359 |               __items.push_back(x.inv_quantity_on_hand);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:359:35: error: ‘struct __struct5’ has no member named ‘inv_quantity_on_hand’
+  359 |               __items.push_back(x.inv_quantity_on_hand);
+      |                                   ^~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:354:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:353:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  353 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:353:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  353 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:365:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  318 |   std::vector<__struct5> monthly = ([&]() {
+      |                                    ~~~~~~~~
+  319 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  320 |     for (auto inv : inventory) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  322 |         if (!((inv.inv_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |           continue;
+      |           ~~~~~~~~~
+  324 |         for (auto i : item) {
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  325 |           if (!((inv.inv_item_sk == i.i_item_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |             continue;
+      |             ~~~~~~~~~
+  327 |           for (auto w : warehouse) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  328 |             if (!((inv.inv_warehouse_sk == w.w_warehouse_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  329 |               continue;
+      |               ~~~~~~~~~
+  330 |             if (!((d.d_year == 2000)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  331 |               continue;
+      |               ~~~~~~~~~
+  332 |             auto __key = Monthly{w.w_warehouse_sk, i.i_item_sk, d.d_moy};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  333 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  334 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  335 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  336 |                 __g.items.push_back(__struct5{inv, d, i, w});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  337 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  338 |                 break;
+      |                 ~~~~~~
+  339 |               }
+      |               ~
+  340 |             }
+      |             ~
+  341 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  342 |               __groups.push_back(__struct6{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |                   __key, std::vector<__struct5>{__struct5{inv, d, i, w}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |             }
+      |             ~
+  345 |           }
+      |           ~
+  346 |         }
+      |         ~
+  347 |       }
+      |       ~
+  348 |     }
+      |     ~
+  349 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |           g.key.w, g.key.i, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  355 |             std::vector<
+      |             ~~~~~~~~~~~~
+  356 |                 decltype(std::declval<__struct5>().inv_quantity_on_hand)>
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  357 |                 __items;
+      |                 ~~~~~~~~
+  358 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |               __items.push_back(x.inv_quantity_on_hand);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |             }
+      |             ~
+  361 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  362 |           })())});
+      |           ~~~~~~~~
+  363 |     }
+      |     ~
+  364 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  365 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:368:30: error: no matching function for call to ‘to_string(Key)’
+  368 |     auto key = std::to_string(Key{m.w, m.i});
+      |                ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/string:54,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:3:
+/usr/include/c++/13/bits/basic_string.h:4162:3: note: candidate: ‘std::string std::__cxx11::to_string(int)’
+ 4162 |   to_string(int __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4162:17: note:   no known conversion for argument 1 from ‘Key’ to ‘int’
+ 4162 |   to_string(int __val)
+      |             ~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4177:3: note: candidate: ‘std::string std::__cxx11::to_string(unsigned int)’
+ 4177 |   to_string(unsigned __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4177:22: note:   no known conversion for argument 1 from ‘Key’ to ‘unsigned int’
+ 4177 |   to_string(unsigned __val)
+      |             ~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4189:3: note: candidate: ‘std::string std::__cxx11::to_string(long int)’
+ 4189 |   to_string(long __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4189:18: note:   no known conversion for argument 1 from ‘Key’ to ‘long int’
+ 4189 |   to_string(long __val)
+      |             ~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4204:3: note: candidate: ‘std::string std::__cxx11::to_string(long unsigned int)’
+ 4204 |   to_string(unsigned long __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4204:27: note:   no known conversion for argument 1 from ‘Key’ to ‘long unsigned int’
+ 4204 |   to_string(unsigned long __val)
+      |             ~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4216:3: note: candidate: ‘std::string std::__cxx11::to_string(long long int)’
+ 4216 |   to_string(long long __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4216:23: note:   no known conversion for argument 1 from ‘Key’ to ‘long long int’
+ 4216 |   to_string(long long __val)
+      |             ~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4229:3: note: candidate: ‘std::string std::__cxx11::to_string(long long unsigned int)’
+ 4229 |   to_string(unsigned long long __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4229:32: note:   no known conversion for argument 1 from ‘Key’ to ‘long long unsigned int’
+ 4229 |   to_string(unsigned long long __val)
+      |             ~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4241:3: note: candidate: ‘std::string std::__cxx11::to_string(float)’
+ 4241 |   to_string(float __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4241:19: note:   no known conversion for argument 1 from ‘Key’ to ‘float’
+ 4241 |   to_string(float __val)
+      |             ~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4251:3: note: candidate: ‘std::string std::__cxx11::to_string(double)’
+ 4251 |   to_string(double __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4251:20: note:   no known conversion for argument 1 from ‘Key’ to ‘double’
+ 4251 |   to_string(double __val)
+      |             ~~~~~~~^~~~~
+/usr/include/c++/13/bits/basic_string.h:4261:3: note: candidate: ‘std::string std::__cxx11::to_string(long double)’
+ 4261 |   to_string(long double __val)
+      |   ^~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:4261:25: note:   no known conversion for argument 1 from ‘Key’ to ‘long double’
+ 4261 |   to_string(long double __val)
+      |             ~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:371:61: error: ‘struct __struct5’ has no member named ‘qty’
+  371 |       grouped[key] = __struct9{g.w, g.i, __append(g.qtys, m.qty)};
+      |                                                             ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:373:65: error: ‘struct __struct5’ has no member named ‘qty’
+  373 |       grouped[key] = __struct9{m.w, m.i, std::vector<decltype(m.qty)>{m.qty}};
+      |                                                                 ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:373:65: error: ‘struct __struct5’ has no member named ‘qty’
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:373:69: error: template argument 1 is invalid
+  373 |       grouped[key] = __struct9{m.w, m.i, std::vector<decltype(m.qty)>{m.qty}};
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:373:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:373:73: error: ‘struct __struct5’ has no member named ‘qty’
+  373 |       grouped[key] = __struct9{m.w, m.i, std::vector<decltype(m.qty)>{m.qty}};
+      |                                                                         ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:383:25: error: request for member ‘qtys’ in ‘g’, which is of non-class type ‘int’
+  383 |     auto mean = __avg(g.qtys);
+      |                         ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:385:21: error: request for member ‘qtys’ in ‘g’, which is of non-class type ‘int’
+  385 |     for (auto q : g.qtys) {
+      |                     ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:388:34: error: request for member ‘qtys’ in ‘g’, which is of non-class type ‘int’
+  388 |     auto variance = (sumsq / ((g.qtys.size() - 1)));
+      |                                  ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:391:38: error: request for member ‘w’ in ‘g’, which is of non-class type ‘int’
+  391 |       summary.push_back(__struct10{g.w, g.i, cov});
+      |                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq392741454324/001/prog.cpp:391:43: error: request for member ‘i’ in ‘g’, which is of non-class type ‘int’
+  391 |       summary.push_back(__struct10{g.w, g.i, cov});
+      |                                           ^

--- a/tests/dataset/tpc-ds/compiler/cpp/q4.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q4.error
@@ -1,0 +1,1080 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:92:12: error: ‘c’ was not declared in this scope
+   92 |   decltype(c.c_customer_id) id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:92:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:93:12: error: ‘c’ was not declared in this scope
+   93 |   decltype(c.c_first_name) first;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:93:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:94:12: error: ‘c’ was not declared in this scope
+   94 |   decltype(c.c_last_name) last;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:94:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:95:12: error: ‘c’ was not declared in this scope
+   95 |   decltype(c.c_login) login;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:95:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:96:12: error: ‘d’ was not declared in this scope; did you mean ‘id’?
+   96 |   decltype(d.d_year) year;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:96:12: error: ‘d’ was not declared in this scope; did you mean ‘id’?
+   96 |   decltype(d.d_year) year;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:99:12: error: ‘c’ was not declared in this scope
+   99 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:99:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:100:12: error: ‘s’ was not declared in this scope
+  100 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:100:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:101:12: error: ‘d’ was not declared in this scope
+  101 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:101:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:117:12: error: ‘c’ was not declared in this scope
+  117 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:117:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:118:12: error: ‘cs’ was not declared in this scope; did you mean ‘c’?
+  118 |   decltype(cs) cs;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:118:12: error: ‘cs’ was not declared in this scope; did you mean ‘c’?
+  118 |   decltype(cs) cs;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:119:12: error: ‘d’ was not declared in this scope
+  119 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:119:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:126:12: error: ‘c’ was not declared in this scope
+  126 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:126:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:127:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  127 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:127:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  127 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:128:12: error: ‘d’ was not declared in this scope
+  128 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:128:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:135:38: error: ‘struct __struct7’ has no member named ‘customer_id’
+  135 |   decltype(std::declval<__struct7>().customer_id) customer_id;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:135:38: error: ‘struct __struct7’ has no member named ‘customer_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:136:38: error: ‘struct __struct7’ has no member named ‘customer_first_name’
+  136 |   decltype(std::declval<__struct7>().customer_first_name) customer_first_name;
+      |                                      ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:136:38: error: ‘struct __struct7’ has no member named ‘customer_first_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:137:38: error: ‘struct __struct7’ has no member named ‘customer_last_name’
+  137 |   decltype(std::declval<__struct7>().customer_last_name) customer_last_name;
+      |                                      ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:137:38: error: ‘struct __struct7’ has no member named ‘customer_last_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:138:38: error: ‘struct __struct7’ has no member named ‘customer_login’
+  138 |   decltype(std::declval<__struct7>().customer_login) customer_login;
+      |                                      ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:138:38: error: ‘struct __struct7’ has no member named ‘customer_login’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:475:42: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  475 |                 auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                                        ~~^~~~~~~~~~~~~
+      |                                          |
+      |                                          std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:480:51: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  480 |                     __g.items.push_back(__struct7{c, s, d});
+      |                                                   ^
+      |                                                   |
+      |                                                   Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:487:63: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  487 |                       __key, std::vector<__struct7>{__struct7{c, s, d}}});
+      |                                                               ^
+      |                                                               |
+      |                                                               Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:487:71: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  487 |                       __key, std::vector<__struct7>{__struct7{c, s, d}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:500:54: error: ‘struct __struct7’ has no member named ‘ss_ext_list_price’
+  500 |                       (((((std::declval<__struct7>().ss_ext_list_price -
+      |                                                      ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:501:54: error: ‘struct __struct7’ has no member named ‘ss_ext_wholesale_cost’
+  501 |                            std::declval<__struct7>().ss_ext_wholesale_cost) -
+      |                                                      ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:502:53: error: ‘struct __struct7’ has no member named ‘ss_ext_discount_amt’
+  502 |                           std::declval<__struct7>().ss_ext_discount_amt)) +
+      |                                                     ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:503:51: error: ‘struct __struct7’ has no member named ‘ss_ext_sales_price’
+  503 |                         std::declval<__struct7>().ss_ext_sales_price)) /
+      |                                                   ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:500:54: error: ‘struct __struct7’ has no member named ‘ss_ext_list_price’
+  500 |                       (((((std::declval<__struct7>().ss_ext_list_price -
+      |                                                      ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:501:54: error: ‘struct __struct7’ has no member named ‘ss_ext_wholesale_cost’
+  501 |                            std::declval<__struct7>().ss_ext_wholesale_cost) -
+      |                                                      ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:502:53: error: ‘struct __struct7’ has no member named ‘ss_ext_discount_amt’
+  502 |                           std::declval<__struct7>().ss_ext_discount_amt)) +
+      |                                                     ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:503:51: error: ‘struct __struct7’ has no member named ‘ss_ext_sales_price’
+  503 |                         std::declval<__struct7>().ss_ext_sales_price)) /
+      |                                                   ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:504:26: error: template argument 1 is invalid
+  504 |                       2))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:504:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:507:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  507 |                     __items.push_back(
+      |                             ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:508:33: error: ‘struct __struct7’ has no member named ‘ss_ext_list_price’
+  508 |                         ((((((x.ss_ext_list_price - x.ss_ext_wholesale_cost) -
+      |                                 ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:508:55: error: ‘struct __struct7’ has no member named ‘ss_ext_wholesale_cost’
+  508 |                         ((((((x.ss_ext_list_price - x.ss_ext_wholesale_cost) -
+      |                                                       ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:509:32: error: ‘struct __struct7’ has no member named ‘ss_ext_discount_amt’
+  509 |                              x.ss_ext_discount_amt)) +
+      |                                ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:510:30: error: ‘struct __struct7’ has no member named ‘ss_ext_sales_price’
+  510 |                            x.ss_ext_sales_price)) /
+      |                              ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:498:19:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:497:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  497 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                          ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:497:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  497 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                     ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:528:42: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  528 |                 auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                                        ~~^~~~~~~~~~~~~
+      |                                          |
+      |                                          std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:533:52: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  533 |                     __g.items.push_back(__struct10{c, cs, d});
+      |                                                    ^
+      |                                                    |
+      |                                                    Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:540:65: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  540 |                       __key, std::vector<__struct10>{__struct10{c, cs, d}}});
+      |                                                                 ^
+      |                                                                 |
+      |                                                                 Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:540:74: error: no matching function for call to ‘std::vector<__struct10>::vector(<brace-enclosed initializer list>)’
+  540 |                       __key, std::vector<__struct10>{__struct10{c, cs, d}}});
+      |                                                                          ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct10; _Alloc = std::allocator<__struct10>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; allocator_type = std::allocator<__struct10>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; std::__type_identity_t<_Alloc> = std::allocator<__struct10>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; allocator_type = std::allocator<__struct10>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; allocator_type = std::allocator<__struct10>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; std::__type_identity_t<_Alloc> = std::allocator<__struct10>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; size_type = long unsigned int; value_type = std::vector<__struct10>::value_type; allocator_type = std::allocator<__struct10>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; size_type = long unsigned int; allocator_type = std::allocator<__struct10>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct10; _Alloc = std::allocator<__struct10>; allocator_type = std::allocator<__struct10>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct10; _Alloc = std::allocator<__struct10>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:553:55: error: ‘struct __struct10’ has no member named ‘cs_ext_list_price’
+  553 |                       (((((std::declval<__struct10>().cs_ext_list_price -
+      |                                                       ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:554:55: error: ‘struct __struct10’ has no member named ‘cs_ext_wholesale_cost’
+  554 |                            std::declval<__struct10>().cs_ext_wholesale_cost) -
+      |                                                       ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:555:54: error: ‘struct __struct10’ has no member named ‘cs_ext_discount_amt’
+  555 |                           std::declval<__struct10>().cs_ext_discount_amt)) +
+      |                                                      ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:556:52: error: ‘struct __struct10’ has no member named ‘cs_ext_sales_price’
+  556 |                         std::declval<__struct10>().cs_ext_sales_price)) /
+      |                                                    ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:553:55: error: ‘struct __struct10’ has no member named ‘cs_ext_list_price’
+  553 |                       (((((std::declval<__struct10>().cs_ext_list_price -
+      |                                                       ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:554:55: error: ‘struct __struct10’ has no member named ‘cs_ext_wholesale_cost’
+  554 |                            std::declval<__struct10>().cs_ext_wholesale_cost) -
+      |                                                       ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:555:54: error: ‘struct __struct10’ has no member named ‘cs_ext_discount_amt’
+  555 |                           std::declval<__struct10>().cs_ext_discount_amt)) +
+      |                                                      ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:556:52: error: ‘struct __struct10’ has no member named ‘cs_ext_sales_price’
+  556 |                         std::declval<__struct10>().cs_ext_sales_price)) /
+      |                                                    ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:557:26: error: template argument 1 is invalid
+  557 |                       2))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:557:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:560:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  560 |                     __items.push_back(
+      |                             ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:561:33: error: ‘struct __struct10’ has no member named ‘cs_ext_list_price’
+  561 |                         ((((((x.cs_ext_list_price - x.cs_ext_wholesale_cost) -
+      |                                 ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:561:55: error: ‘struct __struct10’ has no member named ‘cs_ext_wholesale_cost’
+  561 |                         ((((((x.cs_ext_list_price - x.cs_ext_wholesale_cost) -
+      |                                                       ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:562:32: error: ‘struct __struct10’ has no member named ‘cs_ext_discount_amt’
+  562 |                              x.cs_ext_discount_amt)) +
+      |                                ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:563:30: error: ‘struct __struct10’ has no member named ‘cs_ext_sales_price’
+  563 |                            x.cs_ext_sales_price)) /
+      |                              ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:6)> [with auto:6 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:551:19:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:550:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  550 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                          ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:550:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  550 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                     ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:581:39: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  581 |              auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                                     ~~^~~~~~~~~~~~~
+      |                                       |
+      |                                       std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:586:49: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  586 |                  __g.items.push_back(__struct12{c, ws, d});
+      |                                                 ^
+      |                                                 |
+      |                                                 Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:593:62: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  593 |                    __key, std::vector<__struct12>{__struct12{c, ws, d}}});
+      |                                                              ^
+      |                                                              |
+      |                                                              Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:593:71: error: no matching function for call to ‘std::vector<__struct12>::vector(<brace-enclosed initializer list>)’
+  593 |                    __key, std::vector<__struct12>{__struct12{c, ws, d}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct12; _Alloc = std::allocator<__struct12>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; allocator_type = std::allocator<__struct12>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; std::__type_identity_t<_Alloc> = std::allocator<__struct12>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; allocator_type = std::allocator<__struct12>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; allocator_type = std::allocator<__struct12>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; std::__type_identity_t<_Alloc> = std::allocator<__struct12>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; size_type = long unsigned int; value_type = std::vector<__struct12>::value_type; allocator_type = std::allocator<__struct12>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; size_type = long unsigned int; allocator_type = std::allocator<__struct12>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct12; _Alloc = std::allocator<__struct12>; allocator_type = std::allocator<__struct12>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct12; _Alloc = std::allocator<__struct12>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:605:56: error: ‘struct __struct12’ has no member named ‘ws_ext_list_price’
+  605 |                        (((((std::declval<__struct12>().ws_ext_list_price -
+      |                                                        ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:606:56: error: ‘struct __struct12’ has no member named ‘ws_ext_wholesale_cost’
+  606 |                             std::declval<__struct12>().ws_ext_wholesale_cost) -
+      |                                                        ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:607:55: error: ‘struct __struct12’ has no member named ‘ws_ext_discount_amt’
+  607 |                            std::declval<__struct12>().ws_ext_discount_amt)) +
+      |                                                       ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:608:53: error: ‘struct __struct12’ has no member named ‘ws_ext_sales_price’
+  608 |                          std::declval<__struct12>().ws_ext_sales_price)) /
+      |                                                     ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:605:56: error: ‘struct __struct12’ has no member named ‘ws_ext_list_price’
+  605 |                        (((((std::declval<__struct12>().ws_ext_list_price -
+      |                                                        ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:606:56: error: ‘struct __struct12’ has no member named ‘ws_ext_wholesale_cost’
+  606 |                             std::declval<__struct12>().ws_ext_wholesale_cost) -
+      |                                                        ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:607:55: error: ‘struct __struct12’ has no member named ‘ws_ext_discount_amt’
+  607 |                            std::declval<__struct12>().ws_ext_discount_amt)) +
+      |                                                       ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:608:53: error: ‘struct __struct12’ has no member named ‘ws_ext_sales_price’
+  608 |                          std::declval<__struct12>().ws_ext_sales_price)) /
+      |                                                     ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:609:27: error: template argument 1 is invalid
+  609 |                        2))>
+      |                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:609:27: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:612:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  612 |                      __items.push_back(
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:613:34: error: ‘struct __struct12’ has no member named ‘ws_ext_list_price’
+  613 |                          ((((((x.ws_ext_list_price - x.ws_ext_wholesale_cost) -
+      |                                  ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:613:56: error: ‘struct __struct12’ has no member named ‘ws_ext_wholesale_cost’
+  613 |                          ((((((x.ws_ext_list_price - x.ws_ext_wholesale_cost) -
+      |                                                        ^~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:614:33: error: ‘struct __struct12’ has no member named ‘ws_ext_discount_amt’
+  614 |                               x.ws_ext_discount_amt)) +
+      |                                 ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:615:31: error: ‘struct __struct12’ has no member named ‘ws_ext_sales_price’
+  615 |                             x.ws_ext_sales_price)) /
+      |                               ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:7)> [with auto:7 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:602:80:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:602:54: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  602 |              ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:602:65: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  602 |              ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:461:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  456 |   std::vector<__struct7> year_total = ([&](auto a, auto b) {
+      |                                       ~~~~~~~~~~~~~~~~~~~~~~
+  457 |     a.insert(a.end(), b.begin(), b.end());
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  458 |     std::sort(a.begin(), a.end());
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  459 |     a.erase(std::unique(a.begin(), a.end()), a.end());
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  460 |     return a;
+      |     ~~~~~~~~~
+  461 |   })(([&](auto a, auto b) {
+      |   ~~^~~~~~~~~~~~~~~~~~~~~~~
+  462 |        a.insert(a.end(), b.begin(), b.end());
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  463 |        std::sort(a.begin(), a.end());
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  464 |        a.erase(std::unique(a.begin(), a.end()), a.end());
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  465 |        return a;
+      |        ~~~~~~~~~
+  466 |      })((([&]() {
+      |      ~~~~~~~~~~~~
+  467 |           std::vector<__struct8> __groups;
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  468 |           for (auto c : customer) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |             for (auto s : store_sales) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  470 |               if (!((c.c_customer_sk == s.ss_customer_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |                 continue;
+      |                 ~~~~~~~~~
+  472 |               for (auto d : date_dim) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  473 |                 if (!((s.ss_sold_date_sk == d.d_date_sk)))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  474 |                   continue;
+      |                   ~~~~~~~~~
+  475 |                 auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  476 |                                        c.c_last_name, c.c_login, d.d_year};
+      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  477 |                 bool __found = false;
+      |                 ~~~~~~~~~~~~~~~~~~~~~
+  478 |                 for (auto &__g : __groups) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  479 |                   if (__g.key == __key) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~
+  480 |                     __g.items.push_back(__struct7{c, s, d});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  481 |                     __found = true;
+      |                     ~~~~~~~~~~~~~~~
+  482 |                     break;
+      |                     ~~~~~~
+  483 |                   }
+      |                   ~
+  484 |                 }
+      |                 ~
+  485 |                 if (!__found) {
+      |                 ~~~~~~~~~~~~~~~
+  486 |                   __groups.push_back(__struct8{
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  487 |                       __key, std::vector<__struct7>{__struct7{c, s, d}}});
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |                 }
+      |                 ~
+  489 |               }
+      |               ~
+  490 |             }
+      |             ~
+  491 |           }
+      |           ~
+  492 |           std::vector<__struct9> __items;
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  493 |           for (auto &g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  494 |             __items.push_back(__struct9{
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  495 |                 g.key.id, g.key.first, g.key.last, g.key.login, g.key.year,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  496 |                 ([&](auto v) {
+      |                 ~~~~~~~~~~~~~~
+  497 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |                 })(([&]() {
+      |                 ~~~~~~~~~~~
+  499 |                   std::vector<decltype((
+      |                   ~~~~~~~~~~~~~~~~~~~~~~
+  500 |                       (((((std::declval<__struct7>().ss_ext_list_price -
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  501 |                            std::declval<__struct7>().ss_ext_wholesale_cost) -
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  502 |                           std::declval<__struct7>().ss_ext_discount_amt)) +
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  503 |                         std::declval<__struct7>().ss_ext_sales_price)) /
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |                       2))>
+      |                       ~~~~
+  505 |                       __items;
+      |                       ~~~~~~~~
+  506 |                   for (auto x : g.items) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  507 |                     __items.push_back(
+      |                     ~~~~~~~~~~~~~~~~~~
+  508 |                         ((((((x.ss_ext_list_price - x.ss_ext_wholesale_cost) -
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  509 |                              x.ss_ext_discount_amt)) +
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~
+  510 |                            x.ss_ext_sales_price)) /
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~
+  511 |                          2));
+      |                          ~~~~
+  512 |                   }
+      |                   ~
+  513 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  514 |                 })()),
+      |                 ~~~~~~
+  515 |                 std::string("s")});
+      |                 ~~~~~~~~~~~~~~~~~~~
+  516 |           }
+      |           ~
+  517 |           return __items;
+      |           ~~~~~~~~~~~~~~~
+  518 |         })()),
+      |         ~~~~~~
+  519 |         (([&]() {
+      |         ~~~~~~~~~
+  520 |           std::vector<__struct11> __groups;
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  521 |           for (auto c : customer) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+  522 |             for (auto cs : catalog_sales) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  523 |               if (!((c.c_customer_sk == cs.cs_bill_customer_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  524 |                 continue;
+      |                 ~~~~~~~~~
+  525 |               for (auto d : date_dim) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  526 |                 if (!((cs.cs_sold_date_sk == d.d_date_sk)))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  527 |                   continue;
+      |                   ~~~~~~~~~
+  528 |                 auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  529 |                                        c.c_last_name, c.c_login, d.d_year};
+      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  530 |                 bool __found = false;
+      |                 ~~~~~~~~~~~~~~~~~~~~~
+  531 |                 for (auto &__g : __groups) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  532 |                   if (__g.key == __key) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~
+  533 |                     __g.items.push_back(__struct10{c, cs, d});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  534 |                     __found = true;
+      |                     ~~~~~~~~~~~~~~~
+  535 |                     break;
+      |                     ~~~~~~
+  536 |                   }
+      |                   ~
+  537 |                 }
+      |                 ~
+  538 |                 if (!__found) {
+      |                 ~~~~~~~~~~~~~~~
+  539 |                   __groups.push_back(__struct11{
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  540 |                       __key, std::vector<__struct10>{__struct10{c, cs, d}}});
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  541 |                 }
+      |                 ~
+  542 |               }
+      |               ~
+  543 |             }
+      |             ~
+  544 |           }
+      |           ~
+  545 |           std::vector<__struct9> __items;
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  546 |           for (auto &g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  547 |             __items.push_back(__struct9{
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  548 |                 g.key.id, g.key.first, g.key.last, g.key.login, g.key.year,
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  549 |                 ([&](auto v) {
+      |                 ~~~~~~~~~~~~~~
+  550 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  551 |                 })(([&]() {
+      |                 ~~~~~~~~~~~
+  552 |                   std::vector<decltype((
+      |                   ~~~~~~~~~~~~~~~~~~~~~~
+  553 |                       (((((std::declval<__struct10>().cs_ext_list_price -
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  554 |                            std::declval<__struct10>().cs_ext_wholesale_cost) -
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  555 |                           std::declval<__struct10>().cs_ext_discount_amt)) +
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  556 |                         std::declval<__struct10>().cs_ext_sales_price)) /
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  557 |                       2))>
+      |                       ~~~~
+  558 |                       __items;
+      |                       ~~~~~~~~
+  559 |                   for (auto x : g.items) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  560 |                     __items.push_back(
+      |                     ~~~~~~~~~~~~~~~~~~
+  561 |                         ((((((x.cs_ext_list_price - x.cs_ext_wholesale_cost) -
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  562 |                              x.cs_ext_discount_amt)) +
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~
+  563 |                            x.cs_ext_sales_price)) /
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~
+  564 |                          2));
+      |                          ~~~~
+  565 |                   }
+      |                   ~
+  566 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  567 |                 })()),
+      |                 ~~~~~~
+  568 |                 std::string("c")});
+      |                 ~~~~~~~~~~~~~~~~~~~
+  569 |           }
+      |           ~
+  570 |           return __items;
+      |           ~~~~~~~~~~~~~~~
+  571 |         })())),
+      |         ~~~~~~~
+  572 |      (([&]() {
+      |      ~~~~~~~~~
+  573 |        std::vector<__struct13> __groups;
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  574 |        for (auto c : customer) {
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~
+  575 |          for (auto ws : web_sales) {
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  576 |            if (!((c.c_customer_sk == ws.ws_bill_customer_sk)))
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  577 |              continue;
+      |              ~~~~~~~~~
+  578 |            for (auto d : date_dim) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~
+  579 |              if (!((ws.ws_sold_date_sk == d.d_date_sk)))
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  580 |                continue;
+      |                ~~~~~~~~~
+  581 |              auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  582 |                                     c.c_last_name, c.c_login, d.d_year};
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  583 |              bool __found = false;
+      |              ~~~~~~~~~~~~~~~~~~~~~
+  584 |              for (auto &__g : __groups) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  585 |                if (__g.key == __key) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~
+  586 |                  __g.items.push_back(__struct12{c, ws, d});
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  587 |                  __found = true;
+      |                  ~~~~~~~~~~~~~~~
+  588 |                  break;
+      |                  ~~~~~~
+  589 |                }
+      |                ~
+  590 |              }
+      |              ~
+  591 |              if (!__found) {
+      |              ~~~~~~~~~~~~~~~
+  592 |                __groups.push_back(__struct13{
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  593 |                    __key, std::vector<__struct12>{__struct12{c, ws, d}}});
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  594 |              }
+      |              ~
+  595 |            }
+      |            ~
+  596 |          }
+      |          ~
+  597 |        }
+      |        ~
+  598 |        std::vector<__struct9> __items;
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  599 |        for (auto &g : __groups) {
+      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  600 |          __items.push_back(__struct9{
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  601 |              g.key.id, g.key.first, g.key.last, g.key.login, g.key.year,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  602 |              ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  603 |                  ([&]() {
+      |                  ~~~~~~~~
+  604 |                    std::vector<decltype((
+      |                    ~~~~~~~~~~~~~~~~~~~~~~
+  605 |                        (((((std::declval<__struct12>().ws_ext_list_price -
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  606 |                             std::declval<__struct12>().ws_ext_wholesale_cost) -
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  607 |                            std::declval<__struct12>().ws_ext_discount_amt)) +
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  608 |                          std::declval<__struct12>().ws_ext_sales_price)) /
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  609 |                        2))>
+      |                        ~~~~
+  610 |                        __items;
+      |                        ~~~~~~~~
+  611 |                    for (auto x : g.items) {
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~
+  612 |                      __items.push_back(
+      |                      ~~~~~~~~~~~~~~~~~~
+  613 |                          ((((((x.ws_ext_list_price - x.ws_ext_wholesale_cost) -
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  614 |                               x.ws_ext_discount_amt)) +
+      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  615 |                             x.ws_ext_sales_price)) /
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~
+  616 |                           2));
+      |                           ~~~~
+  617 |                    }
+      |                    ~
+  618 |                    return __items;
+      |                    ~~~~~~~~~~~~~~~
+  619 |                  })()),
+      |                  ~~~~~~
+  620 |              std::string("w")});
+      |              ~~~~~~~~~~~~~~~~~~~
+  621 |        }
+      |        ~
+  622 |        return __items;
+      |        ~~~~~~~~~~~~~~~
+  623 |      })()));
+      |      ~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:625:57: error: ‘s2’ was not declared in this scope
+  625 |     std::vector<std::pair<decltype(std::vector<decltype(s2.customer_id)>{
+      |                                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:625:72: error: template argument 1 is invalid
+  625 |     std::vector<std::pair<decltype(std::vector<decltype(s2.customer_id)>{
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:625:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:628:27: error: template argument 1 is invalid
+  628 |                           Result>>
+      |                           ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:628:33: error: template argument 1 is invalid
+  628 |                           Result>>
+      |                                 ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:628:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:632:19: error: ‘struct __struct7’ has no member named ‘customer_id’
+  632 |         if (!((s2.customer_id == s1.customer_id)))
+      |                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:632:37: error: ‘struct __struct7’ has no member named ‘customer_id’
+  632 |         if (!((s2.customer_id == s1.customer_id)))
+      |                                     ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:635:21: error: ‘struct __struct7’ has no member named ‘customer_id’
+  635 |           if (!((c1.customer_id == s1.customer_id)))
+      |                     ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:635:39: error: ‘struct __struct7’ has no member named ‘customer_id’
+  635 |           if (!((c1.customer_id == s1.customer_id)))
+      |                                       ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:638:23: error: ‘struct __struct7’ has no member named ‘customer_id’
+  638 |             if (!((c2.customer_id == s1.customer_id)))
+      |                       ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:638:41: error: ‘struct __struct7’ has no member named ‘customer_id’
+  638 |             if (!((c2.customer_id == s1.customer_id)))
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:641:25: error: ‘struct __struct7’ has no member named ‘customer_id’
+  641 |               if (!((w1.customer_id == s1.customer_id)))
+      |                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:641:43: error: ‘struct __struct7’ has no member named ‘customer_id’
+  641 |               if (!((w1.customer_id == s1.customer_id)))
+      |                                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:644:27: error: ‘struct __struct7’ has no member named ‘customer_id’
+  644 |                 if (!((w2.customer_id == s1.customer_id)))
+      |                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:644:45: error: ‘struct __struct7’ has no member named ‘customer_id’
+  644 |                 if (!((w2.customer_id == s1.customer_id)))
+      |                                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:646:43: error: ‘struct __struct7’ has no member named ‘sale_type’
+  646 |                 if (!((((((((((((((((((s1.sale_type == std::string("s")) &&
+      |                                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:647:43: error: ‘struct __struct7’ has no member named ‘sale_type’
+  647 |                                       (c1.sale_type == std::string("c"))) &&
+      |                                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:648:42: error: ‘struct __struct7’ has no member named ‘sale_type’
+  648 |                                      (w1.sale_type == std::string("w"))) &&
+      |                                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:649:41: error: ‘struct __struct7’ has no member named ‘sale_type’
+  649 |                                     (s2.sale_type == std::string("s"))) &&
+      |                                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:650:40: error: ‘struct __struct7’ has no member named ‘sale_type’
+  650 |                                    (c2.sale_type == std::string("c"))) &&
+      |                                        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:651:39: error: ‘struct __struct7’ has no member named ‘sale_type’
+  651 |                                   (w2.sale_type == std::string("w"))) &&
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:652:38: error: ‘struct __struct7’ has no member named ‘dyear’
+  652 |                                  (s1.dyear == 2001)) &&
+      |                                      ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:653:37: error: ‘struct __struct7’ has no member named ‘dyear’
+  653 |                                 (s2.dyear == 2002)) &&
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:654:36: error: ‘struct __struct7’ has no member named ‘dyear’
+  654 |                                (c1.dyear == 2001)) &&
+      |                                    ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:655:35: error: ‘struct __struct7’ has no member named ‘dyear’
+  655 |                               (c2.dyear == 2002)) &&
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:656:34: error: ‘struct __struct7’ has no member named ‘dyear’
+  656 |                              (w1.dyear == 2001)) &&
+      |                                  ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:657:33: error: ‘struct __struct7’ has no member named ‘dyear’
+  657 |                             (w2.dyear == 2002)) &&
+      |                                 ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:658:32: error: ‘struct __struct7’ has no member named ‘year_total’
+  658 |                            (s1.year_total > 0)) &&
+      |                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:659:31: error: ‘struct __struct7’ has no member named ‘year_total’
+  659 |                           (c1.year_total > 0)) &&
+      |                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:660:30: error: ‘struct __struct7’ has no member named ‘year_total’
+  660 |                          (w1.year_total > 0)) &&
+      |                              ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:661:32: error: ‘struct __struct7’ has no member named ‘year_total’
+  661 |                         ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:661:54: error: ‘struct __struct7’ has no member named ‘year_total’
+  661 |                         ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:661:70: error: ‘struct __struct7’ has no member named ‘year_total’
+  661 |                         ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:663:32: error: ‘struct __struct7’ has no member named ‘year_total’
+  663 |                          (((s1.year_total > 0) ? (s2.year_total / s1.year_total)
+      |                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:663:54: error: ‘struct __struct7’ has no member named ‘year_total’
+  663 |                          (((s1.year_total > 0) ? (s2.year_total / s1.year_total)
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:663:70: error: ‘struct __struct7’ has no member named ‘year_total’
+  663 |                          (((s1.year_total > 0) ? (s2.year_total / s1.year_total)
+      |                                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:665:31: error: ‘struct __struct7’ has no member named ‘year_total’
+  665 |                        ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:665:53: error: ‘struct __struct7’ has no member named ‘year_total’
+  665 |                        ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:665:69: error: ‘struct __struct7’ has no member named ‘year_total’
+  665 |                        ((((c1.year_total > 0) ? (c2.year_total / c1.year_total)
+      |                                                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:667:31: error: ‘struct __struct7’ has no member named ‘year_total’
+  667 |                         (((w1.year_total > 0) ? (w2.year_total / w1.year_total)
+      |                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:667:53: error: ‘struct __struct7’ has no member named ‘year_total’
+  667 |                         (((w1.year_total > 0) ? (w2.year_total / w1.year_total)
+      |                                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:667:69: error: ‘struct __struct7’ has no member named ‘year_total’
+  667 |                         (((w1.year_total > 0) ? (w2.year_total / w1.year_total)
+      |                                                                     ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:670:25: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  670 |                 __items.push_back(
+      |                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:671:46: error: ‘struct __struct7’ has no member named ‘customer_id’
+  671 |                     {std::vector<decltype(s2.customer_id)>{
+      |                                              ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:671:46: error: ‘struct __struct7’ has no member named ‘customer_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:671:58: error: template argument 1 is invalid
+  671 |                     {std::vector<decltype(s2.customer_id)>{
+      |                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:671:58: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:672:29: error: ‘struct __struct7’ has no member named ‘customer_id’
+  672 |                          s2.customer_id, s2.customer_first_name,
+      |                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:672:45: error: ‘struct __struct7’ has no member named ‘customer_first_name’
+  672 |                          s2.customer_id, s2.customer_first_name,
+      |                                             ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:673:29: error: ‘struct __struct7’ has no member named ‘customer_last_name’
+  673 |                          s2.customer_last_name, s2.customer_login},
+      |                             ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:673:52: error: ‘struct __struct7’ has no member named ‘customer_login’
+  673 |                          s2.customer_last_name, s2.customer_login},
+      |                                                    ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:674:32: error: ‘struct __struct7’ has no member named ‘customer_id’
+  674 |                      Result{s2.customer_id, s2.customer_first_name,
+      |                                ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:674:48: error: ‘struct __struct7’ has no member named ‘customer_first_name’
+  674 |                      Result{s2.customer_id, s2.customer_first_name,
+      |                                                ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:675:32: error: ‘struct __struct7’ has no member named ‘customer_last_name’
+  675 |                             s2.customer_last_name, s2.customer_login}});
+      |                                ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:675:55: error: ‘struct __struct7’ has no member named ‘customer_login’
+  675 |                             s2.customer_last_name, s2.customer_login}});
+      |                                                       ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:682:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  682 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:682:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  682 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:685:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  685 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:685:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  685 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:71,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:2:
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_equal_to_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >; _Iterator2 = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >]’:
+/usr/include/c++/13/bits/stl_algo.h:917:20:   required from ‘_ForwardIterator std::__unique(_ForwardIterator, _ForwardIterator, _BinaryPredicate) [with _ForwardIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _BinaryPredicate = __gnu_cxx::__ops::_Iter_equal_to_iter]’
+/usr/include/c++/13/bits/stl_algo.h:948:27:   required from ‘_FIter std::unique(_FIter, _FIter) [with _FIter = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:464:27:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<__struct9>; auto:4 = std::vector<__struct9>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:466:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:117:23: error: no match for ‘operator==’ (operand types are ‘__struct9’ and ‘__struct9’)
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1217 |     operator==(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1225 |     operator==(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘constexpr bool __gnu_cxx::__ops::_Iter_less_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >; _Iterator2 = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1819:14:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:463:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<__struct9>; auto:4 = std::vector<__struct9>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:466:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:45:23: error: no match for ‘operator<’ (operand types are ‘__struct9’ and ‘__struct9’)
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Val_less_iter::operator()(_Value&, _Iterator) const [with _Value = __struct9; _Iterator = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1799:20:   required from ‘void std::__unguarded_linear_insert(_RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Val_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1827:36:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:463:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<__struct9>; auto:4 = std::vector<__struct9>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:466:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:98:22: error: no match for ‘operator<’ (operand types are ‘__struct9’ and ‘__struct9’)
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_less_val::operator()(_Iterator, _Value&) const [with _Iterator = __gnu_cxx::__normal_iterator<__struct9*, std::vector<__struct9> >; _Value = __struct9]’:
+/usr/include/c++/13/bits/stl_heap.h:140:48:   required from ‘void std::__push_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Distance = long int; _Tp = __struct9; _Compare = __gnu_cxx::__ops::_Iter_less_val]’
+/usr/include/c++/13/bits/stl_heap.h:247:23:   required from ‘void std::__adjust_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Distance = long int; _Tp = __struct9; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_heap.h:356:22:   required from ‘void std::__make_heap(_RandomAccessIterator, _RandomAccessIterator, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1635:23:   required from ‘void std::__heap_select(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1910:25:   required from ‘void std::__partial_sort(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1926:27:   required from ‘void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Size = long int; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1947:25:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<__struct9*, vector<__struct9> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:463:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<__struct9>; auto:4 = std::vector<__struct9>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq4489728145/001/prog.cpp:466:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:69:22: error: no match for ‘operator<’ (operand types are ‘__struct9’ and ‘__struct9’)
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘__struct9’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q40.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q40.error
@@ -1,0 +1,860 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:80:12: error: ‘w’ was not declared in this scope
+   80 |   decltype(w.state) w_state;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:80:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+   81 |   decltype(i.item_id) i_item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+   82 |   decltype(d.date) sold_date;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:295:46: error: no match for ‘operator==’ (operand types are ‘CatalogReturn’ and ‘std::nullptr_t’)
+  295 |                            (cs.price - (((cr == nullptr) ? 0 : cr.refunded)))});
+      |                                           ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:315:46: error: no match for ‘operator==’ (operand types are ‘CatalogReturn’ and ‘std::nullptr_t’)
+  315 |                            (cs.price - (((cr == nullptr) ? 0 : cr.refunded)))});
+      |                                           ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:330:21: error: no match for ‘operator==’ (operand types are ‘Result’ and ‘Result’)
+  330 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Result Result
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:51: error: no match for ‘operator<’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
+In file included from /usr/include/c++/13/string:48,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  455 |     operator<(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  500 |     operator<(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1705 |     operator<(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1770 |     operator<(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:835:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator<(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  835 |     operator<(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:835:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:671:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  671 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:671:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/string_view:678:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  678 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/string_view:686:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  686 |     operator< (__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:686:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3829 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3843 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3856 |     operator<(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const _CharT*’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1961:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator<(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1961 |     operator<(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1961:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1551:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1551 |     operator<(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1551:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1172 |     operator<(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator<(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2079 |     operator<(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:324:3: note: candidate: ‘bool std::operator<(const error_code&, const error_code&)’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:324:31: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |             ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:507:3: note: candidate: ‘bool std::operator<(const error_condition&, const error_condition&)’
+  507 |   operator<(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:507:36: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  507 |   operator<(const error_condition& __lhs,
+      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:51: error: no match for ‘operator<’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  455 |     operator<(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  500 |     operator<(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1705 |     operator<(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1770 |     operator<(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:835:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator<(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  835 |     operator<(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:835:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/string_view:671:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  671 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:671:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/string_view:678:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  678 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/string_view:686:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  686 |     operator< (__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:686:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3829 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3843 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3856 |     operator<(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const _CharT*’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/tuple:1961:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator<(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1961 |     operator<(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1961:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1551:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1551 |     operator<(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1551:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1172 |     operator<(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator<(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2079 |     operator<(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:347:53: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                                                     ^~~~~~~~~~
+/usr/include/c++/13/system_error:324:3: note: candidate: ‘bool std::operator<(const error_code&, const error_code&)’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:324:31: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |             ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:507:3: note: candidate: ‘bool std::operator<(const error_condition&, const error_condition&)’
+  507 |   operator<(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:507:36: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  507 |   operator<(const error_condition& __lhs,
+      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:349:26: error: template argument 1 is invalid
+  349 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:349:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:47: error: no match for ‘operator<’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                   ~~~~~~~~~~~ ^ ~~~~~~~~~~
+      |                                     |           |
+      |                                     int         std::__cxx11::basic_string<char>
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  455 |     operator<(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:455:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  500 |     operator<(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:500:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1705 |     operator<(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1705:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator<(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1770 |     operator<(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1770:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:835:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator<(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  835 |     operator<(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:835:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/string_view:671:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  671 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:671:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/string_view:678:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  678 |     operator< (basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/string_view:686:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator<(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  686 |     operator< (__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:686:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3829 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3829:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3843 |     operator<(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3843:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator<(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3856 |     operator<(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3856:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const _CharT*’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/tuple:1961:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator<(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1961 |     operator<(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1961:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1551:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1551 |     operator<(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1551:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator<(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1172 |     operator<(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1172:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator<(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2079 |     operator<(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2079:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:352:49: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |                                                 ^~~~~~~~~~
+/usr/include/c++/13/system_error:324:3: note: candidate: ‘bool std::operator<(const error_code&, const error_code&)’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:324:31: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  324 |   operator<(const error_code& __lhs, const error_code& __rhs) noexcept
+      |             ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:507:3: note: candidate: ‘bool std::operator<(const error_condition&, const error_condition&)’
+  507 |   operator<(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:507:36: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  507 |   operator<(const error_condition& __lhs,
+      |             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:345:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:344:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  344 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:344:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  344 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:55: error: no match for ‘operator>=’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  483 |     operator>=(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  527 |     operator>=(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1735 |     operator>=(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1791 |     operator>=(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator>=(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  860 |     operator>=(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:737:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  737 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:737:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:744:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  744 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:744:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:752:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  752 |     operator>=(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:752:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3952 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3966 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3979 |     operator>=(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const _CharT*’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator>=(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1992 |     operator>=(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1579 |     operator>=(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1200 |     operator>=(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator>=(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2104 |     operator>=(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:55: error: no match for ‘operator>=’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  483 |     operator>=(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  527 |     operator>=(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1735 |     operator>=(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1791 |     operator>=(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator>=(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  860 |     operator>=(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:737:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  737 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:737:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:744:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  744 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:744:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/string_view:752:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  752 |     operator>=(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:752:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3952 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3966 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3979 |     operator>=(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const _CharT*’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator>=(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1992 |     operator>=(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1579 |     operator>=(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1200 |     operator>=(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator>=(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2104 |     operator>=(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:359:58: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                                                          ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:361:30: error: template argument 1 is invalid
+  361 |                         : 0))>
+      |                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:361:30: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:51: error: no match for ‘operator>=’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                       ~~~~~~~~~~~ ^~ ~~~~~~~~~~
+      |                                         |            |
+      |                                         int          std::__cxx11::basic_string<char>
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  483 |     operator>=(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:483:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  527 |     operator>=(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:527:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1735 |     operator>=(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1735:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator>=(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1791 |     operator>=(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1791:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator>=(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  860 |     operator>=(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:860:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/string_view:737:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  737 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:737:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/string_view:744:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  744 |     operator>=(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:744:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/string_view:752:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator>=(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  752 |     operator>=(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:752:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3952 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3952:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3966 |     operator>=(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3966:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator>=(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3979 |     operator>=(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3979:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const _CharT*’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator>=(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1992 |     operator>=(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1992:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1579 |     operator>=(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1579:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator>=(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1200 |     operator>=(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1200:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator>=(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2104 |     operator>=(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2104:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:364:54: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:356:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:356:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  356 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:356:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  356 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq40497414356/001/prog.cpp:370:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<Record>’ requested
+  324 |   std::vector<Record> result = ([&]() {
+      |                                ~~~~~~~~
+  325 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |     for (auto r : records) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  327 |       auto __key = Result{r.w_state, r.i_item_id};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  328 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  329 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  330 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  331 |           __g.items.push_back(Record{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  333 |           break;
+      |           ~~~~~~
+  334 |         }
+      |         ~
+  335 |       }
+      |       ~
+  336 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  337 |         __groups.push_back(__struct8{__key, std::vector<Record>{Record{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  338 |       }
+      |       ~
+  339 |     }
+      |     ~
+  340 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  341 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |       __items.push_back(__struct9{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |           g.key.w_state, g.key.i_item_id, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  346 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  347 |                 (std::declval<Record>().sold_date < sales_date)
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  348 |                     ? std::declval<Record>().net
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |                     : 0))>
+      |                     ~~~~~~
+  350 |                 __items;
+      |                 ~~~~~~~~
+  351 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |               __items.push_back(((x.sold_date < sales_date) ? x.net : 0));
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |             }
+      |             ~
+  354 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  355 |           })()),
+      |           ~~~~~~
+  356 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  357 |               ([&]() {
+      |               ~~~~~~~~
+  358 |                 std::vector<decltype((
+      |                 ~~~~~~~~~~~~~~~~~~~~~~
+  359 |                     (std::declval<Record>().sold_date >= sales_date)
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |                         ? std::declval<Record>().net
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                         : 0))>
+      |                         ~~~~~~
+  362 |                     __items;
+      |                     ~~~~~~~~
+  363 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |                   __items.push_back(((x.sold_date >= sales_date) ? x.net : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                 }
+      |                 ~
+  366 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  367 |               })())});
+      |               ~~~~~~~~
+  368 |     }
+      |     ~
+  369 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  370 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q41.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q41.error
@@ -1,0 +1,65 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:114:36: error: ‘i1’ was not declared in this scope
+  114 |     std::vector<std::pair<decltype(i1.product_name), decltype(i1.product_name)>>
+      |                                    ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:114:54: error: template argument 1 is invalid
+  114 |     std::vector<std::pair<decltype(i1.product_name), decltype(i1.product_name)>>
+      |                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:114:54: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:114:79: error: template argument 1 is invalid
+  114 |     std::vector<std::pair<decltype(i1.product_name), decltype(i1.product_name)>>
+      |                                                                               ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:114:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:119:39: error: ‘i2’ was not declared in this scope; did you mean ‘i1’?
+  119 |                  std::vector<decltype(i2)> __items;
+      |                                       ^~
+      |                                       i1
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:119:42: error: template argument 1 is invalid
+  119 |                  std::vector<decltype(i2)> __items;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:119:42: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:124:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  124 |                    __items.push_back(i2);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:128:21: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & item), i1}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  128 |                    .size()) > 1))))
+      |                     ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:130:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  130 |       __items.push_back({i1.product_name, i1.product_name});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:132:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  132 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:132:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  132 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:134:42: error: template argument 1 is invalid
+  134 |     std::vector<decltype(i1.product_name)> __res;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:134:42: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:135:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  135 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:135:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  135 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq41942487761/001/prog.cpp:136:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+  136 |       __res.push_back(p.second);
+      |             ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q42.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q42.error
@@ -1,0 +1,146 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:73:12: error: ‘dt’ was not declared in this scope
+   73 |   decltype(dt.d_year) d_year;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:73:12: error: ‘dt’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:74:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+   74 |   decltype(it.i_category_id) i_category_id;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:74:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+   74 |   decltype(it.i_category_id) i_category_id;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:75:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+   75 |   decltype(it.i_category) i_category;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:75:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
+   75 |   decltype(it.i_category) i_category;
+      |            ^~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:76:12: error: ‘ss’ was not declared in this scope
+   76 |   decltype(ss.ext_sales_price) price;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:76:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:248:68: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  248 |           __items.push_back(Record{dt.d_year, it.i_category_id, it.i_category,
+      |                                                                 ~~~^~~~~~~~~~
+      |                                                                    |
+      |                                                                    std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:261:21: error: no match for ‘operator==’ (operand types are ‘Grouped’ and ‘Grouped’)
+  261 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 |      Grouped
+      |                 Grouped
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:285:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<Record>’ requested
+  255 |   std::vector<Record> grouped = ([&]() {
+      |                                 ~~~~~~~~
+  256 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |     for (auto r : records) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |       auto __key = Grouped{r.d_year, r.i_category_id, r.i_category};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  259 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  260 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  262 |           __g.items.push_back(Record{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  264 |           break;
+      |           ~~~~~~
+  265 |         }
+      |         ~
+  266 |       }
+      |       ~
+  267 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  268 |         __groups.push_back(__struct6{__key, std::vector<Record>{Record{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  269 |       }
+      |       ~
+  270 |     }
+      |     ~
+  271 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  273 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |           g.key.d_year, g.key.i_category_id, g.key.i_category, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  275 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  277 |             std::vector<decltype(std::declval<Record>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  278 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  279 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  280 |             }
+      |             ~
+  281 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  282 |           })())});
+      |           ~~~~~~~~
+  283 |     }
+      |     ~
+  284 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  285 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:288:41: error: ‘struct Record’ has no member named ‘sum_ss_ext_sales_price’
+  288 |         decltype(std::declval<Record>().sum_ss_ext_sales_price), Record>>
+      |                                         ^~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:288:41: error: ‘struct Record’ has no member named ‘sum_ss_ext_sales_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:288:66: error: template argument 1 is invalid
+  288 |         decltype(std::declval<Record>().sum_ss_ext_sales_price), Record>>
+      |                                                                  ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:288:72: error: template argument 1 is invalid
+  288 |         decltype(std::declval<Record>().sum_ss_ext_sales_price), Record>>
+      |                                                                        ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:288:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:291:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  291 |       __items.push_back({(-g.sum_ss_ext_sales_price), g});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:291:30: error: ‘struct Record’ has no member named ‘sum_ss_ext_sales_price’
+  291 |       __items.push_back({(-g.sum_ss_ext_sales_price), g});
+      |                              ^~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:293:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  293 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:293:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  293 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:296:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  296 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq423590881961/001/prog.cpp:296:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  296 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q43.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q43.error
@@ -1,0 +1,4229 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:71:12: error: ‘d’ was not declared in this scope
+   71 |   decltype(d.d_day_name) d_day_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:71:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:72:12: error: ‘s’ was not declared in this scope
+   72 |   decltype(s.store_name) s_store_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:72:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:73:12: error: ‘s’ was not declared in this scope
+   73 |   decltype(s.store_id) s_store_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:73:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:74:12: error: ‘ss’ was not declared in this scope
+   74 |   decltype(ss.sales_price) price;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:74:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:278:24: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  278 |               Record{d.d_day_name, s.store_name, s.store_id, ss.sales_price});
+      |                      ~~^~~~~~~~~~
+      |                        |
+      |                        std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:290:21: error: no match for ‘operator==’ (operand types are ‘Base’ and ‘Base’)
+  290 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Base   Base
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:2:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/string:48:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const _CharT*’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:6:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const _CharT*’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:307:75: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                                                                           ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:309:26: error: template argument 1 is invalid
+  309 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:309:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:312:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  312 |               __items.push_back(
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:34: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                     ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                       |                  |
+      |                       int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const _CharT*’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:313:57: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                                                         ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:305:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:304:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  304 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:304:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  304 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:56: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                             |                  |
+      |                                             int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const _CharT*’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:56: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                             |                  |
+      |                                             int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const _CharT*’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:320:79: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:322:30: error: template argument 1 is invalid
+  322 |                         : 0))>
+      |                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:322:30: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:325:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  325 |                   __items.push_back(
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:38: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                         ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                           |                  |
+      |                           int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const _CharT*’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:326:61: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:317:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:317:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  317 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:317:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  317 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const _CharT*’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const _CharT*’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:334:76: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                                                                            ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:336:26: error: template argument 1 is invalid
+  336 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:336:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:339:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  339 |               __items.push_back(
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:34: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                     ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~
+      |                       |                  |
+      |                       int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const _CharT*’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:340:58: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                                                          ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:332:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:331:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  331 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:331:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  331 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const _CharT*’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const _CharT*’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:348:78: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                                                                              ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:350:26: error: template argument 1 is invalid
+  350 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:350:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:353:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  353 |               __items.push_back(
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:34: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                     ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~~
+      |                       |                  |
+      |                       int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const _CharT*’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:354:60: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                                                            ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:346:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:345:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  345 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:345:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  345 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const _CharT*’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const _CharT*’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:362:77: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:364:26: error: template argument 1 is invalid
+  364 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:364:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:367:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  367 |               __items.push_back(
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:34: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                     ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                       |                  |
+      |                       int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const _CharT*’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:368:59: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:360:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:359:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  359 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:359:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  359 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:56: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                             |                  |
+      |                                             int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const _CharT*’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:56: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                                             |                  |
+      |                                             int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const _CharT*’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:375:79: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                                                                               ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:377:30: error: template argument 1 is invalid
+  377 |                         : 0))>
+      |                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:377:30: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:380:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  380 |                   __items.push_back(
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:38: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                         ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~
+      |                           |                  |
+      |                           int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const _CharT*’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:381:61: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:6)> [with auto:6 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:372:77:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:372:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  372 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:372:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  372 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const _CharT*’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:52: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                                         |                  |
+      |                                         int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const _CharT*’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:389:77: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                                                                             ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:391:26: error: template argument 1 is invalid
+  391 |                     : 0))>
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:391:26: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:394:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  394 |               __items.push_back(
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:34: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’})
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                     ~~~~~~~~~~~~ ^~      ~~~~~~~~~~~~~~~~~~
+      |                       |                  |
+      |                       int                std::string {aka std::__cxx11::basic_string<char>}
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const _CharT*’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:395:59: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                                                           ^
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:7)> [with auto:7 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:387:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:386:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  386 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:386:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  386 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq43147692900/001/prog.cpp:401:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<Record>’ requested
+  284 |   std::vector<Record> base = ([&]() {
+      |                              ~~~~~~~~
+  285 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  286 |     for (auto r : records) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  287 |       auto __key = Base{r.s_store_name, r.s_store_id};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  288 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  289 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  291 |           __g.items.push_back(Record{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  292 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  293 |           break;
+      |           ~~~~~~
+  294 |         }
+      |         ~
+  295 |       }
+      |       ~
+  296 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  297 |         __groups.push_back(__struct6{__key, std::vector<Record>{Record{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  298 |       }
+      |       ~
+  299 |     }
+      |     ~
+  300 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  301 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |           g.key.name, g.key.id, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  304 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  305 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  306 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  307 |                 (std::declval<Record>().d_day_name == std::string("Sunday"))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  308 |                     ? std::declval<Record>().price
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |                     : 0))>
+      |                     ~~~~~~
+  310 |                 __items;
+      |                 ~~~~~~~~
+  311 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |               __items.push_back(
+      |               ~~~~~~~~~~~~~~~~~~
+  313 |                   ((x.d_day_name == std::string("Sunday")) ? x.price : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  314 |             }
+      |             ~
+  315 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  316 |           })()),
+      |           ~~~~~~
+  317 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  318 |               ([&]() {
+      |               ~~~~~~~~
+  319 |                 std::vector<decltype((
+      |                 ~~~~~~~~~~~~~~~~~~~~~~
+  320 |                     (std::declval<Record>().d_day_name == std::string("Monday"))
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |                         ? std::declval<Record>().price
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  322 |                         : 0))>
+      |                         ~~~~~~
+  323 |                     __items;
+      |                     ~~~~~~~~
+  324 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  325 |                   __items.push_back(
+      |                   ~~~~~~~~~~~~~~~~~~
+  326 |                       ((x.d_day_name == std::string("Monday")) ? x.price : 0));
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  327 |                 }
+      |                 ~
+  328 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  329 |               })()),
+      |               ~~~~~~
+  330 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  331 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  333 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  334 |                 (std::declval<Record>().d_day_name == std::string("Tuesday"))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  335 |                     ? std::declval<Record>().price
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  336 |                     : 0))>
+      |                     ~~~~~~
+  337 |                 __items;
+      |                 ~~~~~~~~
+  338 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |               __items.push_back(
+      |               ~~~~~~~~~~~~~~~~~~
+  340 |                   ((x.d_day_name == std::string("Tuesday")) ? x.price : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  341 |             }
+      |             ~
+  342 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  343 |           })()),
+      |           ~~~~~~
+  344 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  345 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  347 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  348 |                 (std::declval<Record>().d_day_name == std::string("Wednesday"))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |                     ? std::declval<Record>().price
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                     : 0))>
+      |                     ~~~~~~
+  351 |                 __items;
+      |                 ~~~~~~~~
+  352 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |               __items.push_back(
+      |               ~~~~~~~~~~~~~~~~~~
+  354 |                   ((x.d_day_name == std::string("Wednesday")) ? x.price : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  355 |             }
+      |             ~
+  356 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  357 |           })()),
+      |           ~~~~~~
+  358 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  359 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  361 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  362 |                 (std::declval<Record>().d_day_name == std::string("Thursday"))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |                     ? std::declval<Record>().price
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  364 |                     : 0))>
+      |                     ~~~~~~
+  365 |                 __items;
+      |                 ~~~~~~~~
+  366 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |               __items.push_back(
+      |               ~~~~~~~~~~~~~~~~~~
+  368 |                   ((x.d_day_name == std::string("Thursday")) ? x.price : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |             }
+      |             ~
+  370 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  371 |           })()),
+      |           ~~~~~~
+  372 |           ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |               ([&]() {
+      |               ~~~~~~~~
+  374 |                 std::vector<decltype((
+      |                 ~~~~~~~~~~~~~~~~~~~~~~
+  375 |                     (std::declval<Record>().d_day_name == std::string("Friday"))
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |                         ? std::declval<Record>().price
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                         : 0))>
+      |                         ~~~~~~
+  378 |                     __items;
+      |                     ~~~~~~~~
+  379 |                 for (auto x : g.items) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |                   __items.push_back(
+      |                   ~~~~~~~~~~~~~~~~~~
+  381 |                       ((x.d_day_name == std::string("Friday")) ? x.price : 0));
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |                 }
+      |                 ~
+  383 |                 return __items;
+      |                 ~~~~~~~~~~~~~~~
+  384 |               })()),
+      |               ~~~~~~
+  385 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  386 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  387 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  388 |             std::vector<decltype((
+      |             ~~~~~~~~~~~~~~~~~~~~~~
+  389 |                 (std::declval<Record>().d_day_name == std::string("Saturday"))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |                     ? std::declval<Record>().price
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  391 |                     : 0))>
+      |                     ~~~~~~
+  392 |                 __items;
+      |                 ~~~~~~~~
+  393 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |               __items.push_back(
+      |               ~~~~~~~~~~~~~~~~~~
+  395 |                   ((x.d_day_name == std::string("Saturday")) ? x.price : 0));
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |             }
+      |             ~
+  397 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  398 |           })())});
+      |           ~~~~~~~~
+  399 |     }
+      |     ~
+  400 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  401 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q44.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q44.error
@@ -1,0 +1,307 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:65:12: error: ‘ss’ was not declared in this scope
+   65 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:65:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:68:40: error: ‘struct GroupedBase’ has no member named ‘ss_item_sk’
+   68 |   decltype(std::declval<GroupedBase>().ss_item_sk) key;
+      |                                        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:68:40: error: ‘struct GroupedBase’ has no member named ‘ss_item_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:84:12: error: ‘best_name’ was not declared in this scope
+   84 |   decltype(best_name) best_performing;
+      |            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:84:12: error: ‘best_name’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:85:12: error: ‘worst_name’ was not declared in this scope
+   85 |   decltype(worst_name) worst_performing;
+      |            ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:85:12: error: ‘worst_name’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:174:43: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  174 |           __g.items.push_back(GroupedBase{ss});
+      |                                           ^~
+      |                                           |
+      |                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:181:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  181 |             __struct4{__key, std::vector<GroupedBase>{GroupedBase{ss}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:181:70: error: no matching function for call to ‘std::vector<GroupedBase>::vector(<brace-enclosed initializer list>)’
+  181 |             __struct4{__key, std::vector<GroupedBase>{GroupedBase{ss}}});
+      |                                                                      ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; allocator_type = std::allocator<GroupedBase>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; std::__type_identity_t<_Alloc> = std::allocator<GroupedBase>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; allocator_type = std::allocator<GroupedBase>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; allocator_type = std::allocator<GroupedBase>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; std::__type_identity_t<_Alloc> = std::allocator<GroupedBase>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; size_type = long unsigned int; value_type = GroupedBase; allocator_type = std::allocator<GroupedBase>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; size_type = long unsigned int; allocator_type = std::allocator<GroupedBase>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>; allocator_type = std::allocator<GroupedBase>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = GroupedBase; _Alloc = std::allocator<GroupedBase>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:188:62: error: ‘struct GroupedBase’ has no member named ‘ss_net_profit’
+  188 |             std::vector<decltype(std::declval<GroupedBase>().ss_net_profit)>
+      |                                                              ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:188:62: error: ‘struct GroupedBase’ has no member named ‘ss_net_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:188:76: error: template argument 1 is invalid
+  188 |             std::vector<decltype(std::declval<GroupedBase>().ss_net_profit)>
+      |                                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:188:76: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:191:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  191 |               __items.push_back(x.ss_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:191:35: error: ‘struct GroupedBase’ has no member named ‘ss_net_profit’
+  191 |               __items.push_back(x.ss_net_profit);
+      |                                   ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:187:23: error: no matching function for call to ‘__avg(int)’
+  187 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  188 |             std::vector<decltype(std::declval<GroupedBase>().ss_net_profit)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  189 |                 __items;
+      |                 ~~~~~~~~
+  190 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  191 |               __items.push_back(x.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  192 |             }
+      |             ~          
+  193 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  194 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:71:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   71 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:71:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:187:23: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  187 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  188 |             std::vector<decltype(std::declval<GroupedBase>().ss_net_profit)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  189 |                 __items;
+      |                 ~~~~~~~~
+  190 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  191 |               __items.push_back(x.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  192 |             }
+      |             ~          
+  193 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  194 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:197:5: error: conversion from ‘vector<__struct5>’ to non-scalar type ‘vector<GroupedBase>’ requested
+  167 |   std::vector<GroupedBase> grouped_base = (([&]() {
+      |                                           ~~~~~~~~~
+  168 |     std::vector<__struct4> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  169 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  170 |       auto __key = ss.ss_item_sk;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  171 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  172 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  173 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  174 |           __g.items.push_back(GroupedBase{ss});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  175 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  176 |           break;
+      |           ~~~~~~
+  177 |         }
+      |         ~
+  178 |       }
+      |       ~
+  179 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  180 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  181 |             __struct4{__key, std::vector<GroupedBase>{GroupedBase{ss}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  182 |       }
+      |       ~
+  183 |     }
+      |     ~
+  184 |     std::vector<__struct5> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  185 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  186 |       __items.push_back(__struct5{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  187 |           g.key, __avg(([&]() {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  188 |             std::vector<decltype(std::declval<GroupedBase>().ss_net_profit)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  189 |                 __items;
+      |                 ~~~~~~~~
+  190 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  191 |               __items.push_back(x.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  192 |             }
+      |             ~
+  193 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  194 |           })())});
+      |           ~~~~~~~~
+  195 |     }
+      |     ~
+  196 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  197 |   })());
+      |   ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:200:64: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+  200 |     std::vector<std::pair<decltype(std::declval<GroupedBase>().avg_profit),
+      |                                                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:200:64: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:201:27: error: template argument 1 is invalid
+  201 |                           GroupedBase>>
+      |                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:201:38: error: template argument 1 is invalid
+  201 |                           GroupedBase>>
+      |                                      ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:201:38: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:204:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  204 |       __items.push_back({(-x.avg_profit), x});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:204:30: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+  204 |       __items.push_back({(-x.avg_profit), x});
+      |                              ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:206:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  206 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:206:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  206 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:209:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  209 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:209:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  209 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:199:15: error: ‘first’ was not declared in this scope
+  199 |   auto best = first(([&]() {
+      |               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:214:64: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+  214 |     std::vector<std::pair<decltype(std::declval<GroupedBase>().avg_profit),
+      |                                                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:214:64: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:215:27: error: template argument 1 is invalid
+  215 |                           GroupedBase>>
+      |                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:215:38: error: template argument 1 is invalid
+  215 |                           GroupedBase>>
+      |                                      ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:215:38: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:218:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  218 |       __items.push_back({x.avg_profit, x});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:218:28: error: ‘struct GroupedBase’ has no member named ‘avg_profit’
+  218 |       __items.push_back({x.avg_profit, x});
+      |                            ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:220:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  220 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:220:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  220 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:223:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  223 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:223:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  223 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:228:26: error: ‘i’ was not declared in this scope
+  228 |     std::vector<decltype(i.i_product_name)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:228:43: error: template argument 1 is invalid
+  228 |     std::vector<decltype(i.i_product_name)> __items;
+      |                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:228:43: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:232:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  232 |       __items.push_back(i.i_product_name);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:237:26: error: ‘i’ was not declared in this scope
+  237 |     std::vector<decltype(i.i_product_name)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:237:43: error: template argument 1 is invalid
+  237 |     std::vector<decltype(i.i_product_name)> __items;
+      |                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:237:43: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq442139524863/001/prog.cpp:241:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  241 |       __items.push_back(i.i_product_name);
+      |               ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q45.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q45.error
@@ -1,0 +1,454 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:79:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   79 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:79:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   79 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:80:12: error: ‘c’ was not declared in this scope
+   80 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:80:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:81:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   81 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:81:12: error: ‘ca’ was not declared in this scope; did you mean ‘c’?
+   81 |   decltype(ca) ca;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:82:12: error: ‘i’ was not declared in this scope
+   82 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:82:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:83:12: error: ‘d’ was not declared in this scope
+   83 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:83:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:86:12: error: ‘ca’ was not declared in this scope
+   86 |   decltype(ca.ca_zip) key;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:86:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:260:36: error: ‘substr’ was not declared in this scope
+  260 |                                    substr(ca.ca_zip, 0, 5)) !=
+      |                                    ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:29: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  270 |                 if (__g.key == __key) {
+      |                     ~~~~~~~ ^~ ~~~~~
+      |                         |      |
+      |                         int    std::__cxx11::basic_string<char>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const _CharT*’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:7:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:270:32: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  270 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:271:44: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  271 |                   __g.items.push_back(Base{ws, c, ca, i, d});
+      |                                            ^~
+      |                                            |
+      |                                            WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:278:61: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  278 |                     __struct7{__key, std::vector<Base>{Base{ws, c, ca, i, d}}});
+      |                                                             ^~
+      |                                                             |
+      |                                                             WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:278:77: error: no matching function for call to ‘std::vector<Base>::vector(<brace-enclosed initializer list>)’
+  278 |                     __struct7{__key, std::vector<Base>{Base{ws, c, ca, i, d}}});
+      |                                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Base; _Alloc = std::allocator<Base>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Base; _Alloc = std::allocator<Base>; allocator_type = std::allocator<Base>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Base; _Alloc = std::allocator<Base>; std::__type_identity_t<_Alloc> = std::allocator<Base>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Base; _Alloc = std::allocator<Base>; allocator_type = std::allocator<Base>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Base; _Alloc = std::allocator<Base>; allocator_type = std::allocator<Base>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Base; _Alloc = std::allocator<Base>; std::__type_identity_t<_Alloc> = std::allocator<Base>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Base; _Alloc = std::allocator<Base>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Base; _Alloc = std::allocator<Base>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Base; _Alloc = std::allocator<Base>; size_type = long unsigned int; value_type = Base; allocator_type = std::allocator<Base>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Base; _Alloc = std::allocator<Base>; size_type = long unsigned int; allocator_type = std::allocator<Base>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Base; _Alloc = std::allocator<Base>; allocator_type = std::allocator<Base>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Base; _Alloc = std::allocator<Base>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:291:58: error: request for member ‘sales_price’ in ‘std::declval<Base>().Base::ws’, which is of non-class type ‘int’
+  291 |             std::vector<decltype(std::declval<Base>().ws.sales_price)> __items;
+      |                                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:291:58: error: request for member ‘sales_price’ in ‘std::declval<Base>().Base::ws’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:291:70: error: template argument 1 is invalid
+  291 |             std::vector<decltype(std::declval<Base>().ws.sales_price)> __items;
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:291:70: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:293:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  293 |               __items.push_back(x.ws.sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:293:38: error: request for member ‘sales_price’ in ‘x.Base::ws’, which is of non-class type ‘int’
+  293 |               __items.push_back(x.ws.sales_price);
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:290:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:289:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  289 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:289:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  289 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq45353923469/001/prog.cpp:299:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<Base>’ requested
+  244 |   std::vector<Base> base = ([&]() {
+      |                            ~~~~~~~~
+  245 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  246 |     for (auto ws : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  247 |       for (auto c : customer) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  248 |         if (!((ws.bill_customer_sk == c.c_customer_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |           continue;
+      |           ~~~~~~~~~
+  250 |         for (auto ca : customer_address) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |           if (!((c.c_current_addr_sk == ca.ca_address_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  252 |             continue;
+      |             ~~~~~~~~~
+  253 |           for (auto i : item) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  254 |             if (!((ws.item_sk == i.i_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |               continue;
+      |               ~~~~~~~~~
+  256 |             for (auto d : date_dim) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |               if (!((ws.sold_date_sk == d.d_date_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |                 continue;
+      |                 ~~~~~~~~~
+  259 |               if (!((((((std::find(zip_list.begin(), zip_list.end(),
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  260 |                                    substr(ca.ca_zip, 0, 5)) !=
+      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |                          zip_list.end()) ||
+      |                          ~~~~~~~~~~~~~~~~~~
+  262 |                         (std::find(item_ids.begin(), item_ids.end(),
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |                                    i.i_item_id) != item_ids.end()))) &&
+      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |                       (d.d_qoy == qoy)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~
+  265 |                      (d.d_year == year))))
+      |                      ~~~~~~~~~~~~~~~~~~~~~
+  266 |                 continue;
+      |                 ~~~~~~~~~
+  267 |               auto __key = ca.ca_zip;
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  268 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  269 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  271 |                   __g.items.push_back(Base{ws, c, ca, i, d});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  273 |                   break;
+      |                   ~~~~~~
+  274 |                 }
+      |                 ~
+  275 |               }
+      |               ~
+  276 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  277 |                 __groups.push_back(
+      |                 ~~~~~~~~~~~~~~~~~~~
+  278 |                     __struct7{__key, std::vector<Base>{Base{ws, c, ca, i, d}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  279 |               }
+      |               ~
+  280 |             }
+      |             ~
+  281 |           }
+      |           ~
+  282 |         }
+      |         ~
+  283 |       }
+      |       ~
+  284 |     }
+      |     ~
+  285 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  286 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  287 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  288 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  289 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  291 |             std::vector<decltype(std::declval<Base>().ws.sales_price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  292 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  293 |               __items.push_back(x.ws.sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  294 |             }
+      |             ~
+  295 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  296 |           })())});
+      |           ~~~~~~~~
+  297 |     }
+      |     ~
+  298 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  299 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q46.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q46.error
@@ -1,0 +1,443 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+   91 |   decltype(ss.ss_ticket_number) ss_ticket_number;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:92:12: error: ‘ss’ was not declared in this scope
+   92 |   decltype(ss.ss_customer_sk) ss_customer_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:92:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:93:12: error: ‘ca’ was not declared in this scope
+   93 |   decltype(ca.ca_city) ca_city;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:93:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:96:12: error: ‘ss’ was not declared in this scope
+   96 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:96:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:97:12: error: ‘d’ was not declared in this scope
+   97 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:97:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:98:12: error: ‘s’ was not declared in this scope
+   98 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:98:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:99:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   99 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:99:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   99 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:100:12: error: ‘ca’ was not declared in this scope
+  100 |   decltype(ca) ca;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:100:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:114:12: error: ‘c’ was not declared in this scope
+  114 |   decltype(c.c_last_name) c_last_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:114:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:115:12: error: ‘c’ was not declared in this scope
+  115 |   decltype(c.c_first_name) c_first_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:115:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:116:12: error: ‘current_addr’ was not declared in this scope
+  116 |   decltype(current_addr.ca_city) ca_city;
+      |            ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:116:12: error: ‘current_addr’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:117:38: error: ‘struct __struct8’ has no member named ‘bought_city’
+  117 |   decltype(std::declval<__struct8>().bought_city) bought_city;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:117:38: error: ‘struct __struct8’ has no member named ‘bought_city’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:118:38: error: ‘struct __struct8’ has no member named ‘ss_ticket_number’
+  118 |   decltype(std::declval<__struct8>().ss_ticket_number) ss_ticket_number;
+      |                                      ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:118:38: error: ‘struct __struct8’ has no member named ‘ss_ticket_number’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:119:38: error: ‘struct __struct8’ has no member named ‘amt’
+  119 |   decltype(std::declval<__struct8>().amt) amt;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:119:38: error: ‘struct __struct8’ has no member named ‘amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:120:38: error: ‘struct __struct8’ has no member named ‘profit’
+  120 |   decltype(std::declval<__struct8>().profit) profit;
+      |                                      ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:120:38: error: ‘struct __struct8’ has no member named ‘profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:422:65: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  422 |                   Dn{ss.ss_ticket_number, ss.ss_customer_sk, ca.ca_city};
+      |                                                              ~~~^~~~~~~
+      |                                                                 |
+      |                                                                 std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:426:49: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  426 |                   __g.items.push_back(__struct8{ss, d, s, hd, ca});
+      |                                                 ^~
+      |                                                 |
+      |                                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:434:54: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  434 |                     std::vector<__struct8>{__struct8{ss, d, s, hd, ca}}});
+      |                                                      ^~
+      |                                                      |
+      |                                                      StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:434:71: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  434 |                     std::vector<__struct8>{__struct8{ss, d, s, hd, ca}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:448:63: error: request for member ‘ss_coupon_amt’ in ‘std::declval<__struct8>().__struct8::ss’, which is of non-class type ‘int’
+  448 |             std::vector<decltype(std::declval<__struct8>().ss.ss_coupon_amt)>
+      |                                                               ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:448:63: error: request for member ‘ss_coupon_amt’ in ‘std::declval<__struct8>().__struct8::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:448:77: error: template argument 1 is invalid
+  448 |             std::vector<decltype(std::declval<__struct8>().ss.ss_coupon_amt)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:448:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:451:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  451 |               __items.push_back(x.ss.ss_coupon_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:451:38: error: request for member ‘ss_coupon_amt’ in ‘x.__struct8::ss’, which is of non-class type ‘int’
+  451 |               __items.push_back(x.ss.ss_coupon_amt);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:447:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:446:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  446 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:446:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  446 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:458:63: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct8>().__struct8::ss’, which is of non-class type ‘int’
+  458 |             std::vector<decltype(std::declval<__struct8>().ss.ss_net_profit)>
+      |                                                               ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:458:63: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct8>().__struct8::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:458:77: error: template argument 1 is invalid
+  458 |             std::vector<decltype(std::declval<__struct8>().ss.ss_net_profit)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:458:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:461:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  461 |               __items.push_back(x.ss.ss_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:461:38: error: request for member ‘ss_net_profit’ in ‘x.__struct8::ss’, which is of non-class type ‘int’
+  461 |               __items.push_back(x.ss.ss_net_profit);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:457:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:456:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  456 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:456:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  456 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:467:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  397 |   std::vector<__struct8> dn = ([&]() {
+      |                               ~~~~~~~~
+  398 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  399 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  400 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  401 |         if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  402 |           continue;
+      |           ~~~~~~~~~
+  403 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  404 |           if (!((ss.ss_store_sk == s.s_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  405 |             continue;
+      |             ~~~~~~~~~
+  406 |           for (auto hd : household_demographics) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  407 |             if (!((ss.ss_hdemo_sk == hd.hd_demo_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  408 |               continue;
+      |               ~~~~~~~~~
+  409 |             for (auto ca : customer_address) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  410 |               if (!((ss.ss_addr_sk == ca.ca_address_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  411 |                 continue;
+      |                 ~~~~~~~~~
+  412 |               if (!(((((((hd.hd_dep_count == depcnt) ||
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  413 |                          (hd.hd_vehicle_count == vehcnt))) &&
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  414 |                        (std::find(std::vector<int>{6, 0}.begin(),
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  415 |                                   std::vector<int>{6, 0}.end(),
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  416 |                                   d.d_dow) != std::vector<int>{6, 0}.end())) &&
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  417 |                       (d.d_year == year)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~
+  418 |                      (std::find(cities.begin(), cities.end(), s.s_city) !=
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  419 |                       cities.end()))))
+      |                       ~~~~~~~~~~~~~~~~
+  420 |                 continue;
+      |                 ~~~~~~~~~
+  421 |               auto __key =
+      |               ~~~~~~~~~~~~
+  422 |                   Dn{ss.ss_ticket_number, ss.ss_customer_sk, ca.ca_city};
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  423 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  424 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  425 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  426 |                   __g.items.push_back(__struct8{ss, d, s, hd, ca});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  427 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  428 |                   break;
+      |                   ~~~~~~
+  429 |                 }
+      |                 ~
+  430 |               }
+      |               ~
+  431 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  432 |                 __groups.push_back(__struct9{
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |                     __key,
+      |                     ~~~~~~
+  434 |                     std::vector<__struct8>{__struct8{ss, d, s, hd, ca}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  435 |               }
+      |               ~
+  436 |             }
+      |             ~
+  437 |           }
+      |           ~
+  438 |         }
+      |         ~
+  439 |       }
+      |       ~
+  440 |     }
+      |     ~
+  441 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  442 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  444 |           g.key.ss_ticket_number, g.key.ss_customer_sk, g.key.ca_city,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  445 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  446 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  447 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  448 |             std::vector<decltype(std::declval<__struct8>().ss.ss_coupon_amt)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  449 |                 __items;
+      |                 ~~~~~~~~
+  450 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  451 |               __items.push_back(x.ss.ss_coupon_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |             }
+      |             ~
+  453 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  454 |           })()),
+      |           ~~~~~~
+  455 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  456 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  457 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  458 |             std::vector<decltype(std::declval<__struct8>().ss.ss_net_profit)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  459 |                 __items;
+      |                 ~~~~~~~~
+  460 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  461 |               __items.push_back(x.ss.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  462 |             }
+      |             ~
+  463 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  464 |           })())});
+      |           ~~~~~~~~
+  465 |     }
+      |     ~
+  466 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  467 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:470:54: error: ‘struct __struct8’ has no member named ‘bought_city’
+  470 |         std::pair<decltype(std::declval<__struct8>().bought_city), Base>>
+      |                                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:470:54: error: ‘struct __struct8’ has no member named ‘bought_city’
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:470:68: error: template argument 1 is invalid
+  470 |         std::pair<decltype(std::declval<__struct8>().bought_city), Base>>
+      |                                                                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:470:72: error: template argument 1 is invalid
+  470 |         std::pair<decltype(std::declval<__struct8>().bought_city), Base>>
+      |                                                                        ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:470:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:474:22: error: ‘struct __struct8’ has no member named ‘ss_customer_sk’
+  474 |         if (!((dnrec.ss_customer_sk == c.c_customer_sk)))
+      |                      ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:479:48: error: ‘struct __struct8’ has no member named ‘bought_city’
+  479 |           if (!((current_addr.ca_city != dnrec.bought_city)))
+      |                                                ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:481:19: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  481 |           __items.push_back(
+      |                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:484:26: error: ‘struct __struct8’ has no member named ‘bought_city’
+  484 |                    dnrec.bought_city, dnrec.ss_ticket_number},
+      |                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:484:45: error: ‘struct __struct8’ has no member named ‘ss_ticket_number’
+  484 |                    dnrec.bought_city, dnrec.ss_ticket_number},
+      |                                             ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:484:61: error: no matching function for call to ‘std::vector<std::__cxx11::basic_string<char> >::vector(<brace-enclosed initializer list>)’
+  484 |                    dnrec.bought_city, dnrec.ss_ticket_number},
+      |                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:484:61: note:   candidate expects 3 arguments, 5 provided
+  484 |                    dnrec.bought_city, dnrec.ss_ticket_number},
+      |                                                             ^
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   candidate expects 2 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   candidate expects 1 argument, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   candidate expects 1 argument, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; value_type = std::__cxx11::basic_string<char>; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   candidate expects 2 arguments, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   candidate expects 1 argument, 5 provided
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 5 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:486:27: error: ‘struct __struct8’ has no member named ‘bought_city’
+  486 |                     dnrec.bought_city, dnrec.ss_ticket_number, dnrec.amt,
+      |                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:486:46: error: ‘struct __struct8’ has no member named ‘ss_ticket_number’
+  486 |                     dnrec.bought_city, dnrec.ss_ticket_number, dnrec.amt,
+      |                                              ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:486:70: error: ‘struct __struct8’ has no member named ‘amt’
+  486 |                     dnrec.bought_city, dnrec.ss_ticket_number, dnrec.amt,
+      |                                                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:487:27: error: ‘struct __struct8’ has no member named ‘profit’
+  487 |                     dnrec.profit}});
+      |                           ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:491:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  491 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:491:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  491 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:494:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  494 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq462047435609/001/prog.cpp:494:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  494 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q47.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q47.error
@@ -1,0 +1,112 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:103:40: error: ‘v’ was not declared in this scope; did you mean ‘v2’?
+  103 |         decltype(std::vector<decltype((v.sum_sales - v.avg_monthly_sales))>{
+      |                                        ^
+      |                                        v2
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:103:75: error: template argument 1 is invalid
+  103 |         decltype(std::vector<decltype((v.sum_sales - v.avg_monthly_sales))>{
+      |                                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:103:75: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:105:9: error: template argument 1 is invalid
+  105 |         V2>>
+      |         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:105:11: error: template argument 1 is invalid
+  105 |         V2>>
+      |           ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:105:11: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:113:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  113 |       __items.push_back(
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:115:59: error: no matching function for call to ‘std::vector<int>::vector(<brace-enclosed initializer list>)’
+  115 |                (v.sum_sales - v.avg_monthly_sales), v.item},
+      |                                                           ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = int; _Alloc = std::allocator<int>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:115:59: note:   deduced conflicting types for parameter ‘_InputIterator’ (‘int’ and ‘std::__cxx11::basic_string<char>’)
+  115 |                (v.sum_sales - v.avg_monthly_sales), v.item},
+      |                                                           ^
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>; allocator_type = std::allocator<int>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:43: note:   no known conversion for argument 1 from ‘int’ to ‘std::initializer_list<int>’
+  678 |       vector(initializer_list<value_type> __l,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = int; _Alloc = std::allocator<int>; std::__type_identity_t<_Alloc> = std::allocator<int>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:23: note:   no known conversion for argument 1 from ‘int’ to ‘std::vector<int>&&’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |              ~~~~~~~~~^~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = int; _Alloc = std::allocator<int>; allocator_type = std::allocator<int>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 2 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = int; _Alloc = std::allocator<int>; allocator_type = std::allocator<int>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 2 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = int; _Alloc = std::allocator<int>; std::__type_identity_t<_Alloc> = std::allocator<int>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:28: note:   no known conversion for argument 1 from ‘int’ to ‘const std::vector<int>&’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |              ~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = int; _Alloc = std::allocator<int>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   candidate expects 1 argument, 2 provided
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = int; _Alloc = std::allocator<int>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   candidate expects 1 argument, 2 provided
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>; size_type = long unsigned int; value_type = int; allocator_type = std::allocator<int>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:47: note:   no known conversion for argument 2 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::vector<int>::value_type&’ {aka ‘const int&’}
+  569 |       vector(size_type __n, const value_type& __value,
+      |                             ~~~~~~~~~~~~~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>; size_type = long unsigned int; allocator_type = std::allocator<int>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:51: note:   no known conversion for argument 2 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::vector<int>::allocator_type&’ {aka ‘const std::allocator<int>&’}
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |                             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>; allocator_type = std::allocator<int>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   candidate expects 1 argument, 2 provided
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = int; _Alloc = std::allocator<int>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 2 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:118:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  118 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:118:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  118 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:121:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  121 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4788796145/001/prog.cpp:121:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  121 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q48.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q48.error
@@ -1,0 +1,29 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:172:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  172 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  173 |           {std::string("s_store_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  174 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  175 |               {std::string("s_store_sk"), 1}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:190:26: error: ‘ss’ was not declared in this scope
+  190 |     std::vector<decltype(ss.quantity)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:190:38: error: template argument 1 is invalid
+  190 |     std::vector<decltype(ss.quantity)> __items;
+      |                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:190:38: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:227:21: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  227 |             __items.push_back(ss.quantity);
+      |                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:236:73:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:236:47: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  236 |       ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(qty);
+      |                                             ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq4898482275/001/prog.cpp:236:58: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  236 |       ([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(qty);
+      |                                                        ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q49.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q49.error
@@ -1,0 +1,115 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:64:12: error: ‘w’ was not declared in this scope
+   64 |   decltype(w.item) item;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:64:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:65:12: error: ‘w’ was not declared in this scope
+   65 |   decltype(w.return_ratio) return_ratio;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:65:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:66:12: error: ‘w’ was not declared in this scope
+   66 |   decltype(w.return_rank) return_rank;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:66:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:67:12: error: ‘w’ was not declared in this scope
+   67 |   decltype(w.currency_rank) currency_rank;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:67:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:140:55: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  140 |           __items.push_back(Tmp{std::string("web"), w.item, w.return_ratio,
+      |                                                     ~~^~~~
+      |                                                       |
+      |                                                       std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:150:59: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  150 |           __items.push_back(Tmp{std::string("catalog"), c.item, c.return_ratio,
+      |                                                         ~~^~~~
+      |                                                           |
+      |                                                           std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:160:57: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  160 |           __items.push_back(Tmp{std::string("store"), s.item, s.return_ratio,
+      |                                                       ~~^~~~
+      |                                                         |
+      |                                                         std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:134:27: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  134 |   std::vector<Tmp> tmp = (concat(
+      |                           ^~~~~~
+      |                           wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:169:79: error: no matching function for call to ‘std::vector<std::__cxx11::basic_string<char> >::vector(<brace-enclosed initializer list>)’
+  169 |                              r.channel, r.return_rank, r.currency_rank, r.item},
+      |                                                                               ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:169:79: note:   deduced conflicting types for parameter ‘_InputIterator’ (‘std::__cxx11::basic_string<char>’ and ‘int’)
+  169 |                              r.channel, r.return_rank, r.currency_rank, r.item},
+      |                                                                               ^
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; value_type = std::__cxx11::basic_string<char>; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 4 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq491746267682/001/prog.cpp:168:24: error: no matching function for call to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, Tmp> >::push_back(<brace-enclosed initializer list>)’
+  168 |       __items.push_back({std::vector<decltype(r.channel)>{
+      |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  169 |                              r.channel, r.return_rank, r.currency_rank, r.item},
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  170 |                          r});
+      |                          ~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, Tmp>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, Tmp> >; value_type = std::pair<std::__cxx11::basic_string<char>, Tmp>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<std::__cxx11::basic_string<char>, Tmp> >::value_type&’ {aka ‘const std::pair<std::__cxx11::basic_string<char>, Tmp>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, Tmp>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, Tmp> >; value_type = std::pair<std::__cxx11::basic_string<char>, Tmp>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, Tmp> >::value_type&&’ {aka ‘std::pair<std::__cxx11::basic_string<char>, Tmp>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q50.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q50.error
@@ -1,0 +1,180 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:85:12: error: ‘s’ was not declared in this scope
+   85 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:85:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:86:13: error: ‘sr’ was not declared in this scope; did you mean ‘s’?
+   86 |   decltype((sr.returned - ss.sold)) diff;
+      |             ^~
+      |             s
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:86:27: error: ‘ss’ was not declared in this scope; did you mean ‘s’?
+   86 |   decltype((sr.returned - ss.sold)) diff;
+      |                           ^~
+      |                           s
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:86:13: error: ‘sr’ was not declared in this scope; did you mean ‘s’?
+   86 |   decltype((sr.returned - ss.sold)) diff;
+      |             ^~
+      |             s
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:86:27: error: ‘ss’ was not declared in this scope; did you mean ‘s’?
+   86 |   decltype((sr.returned - ss.sold)) diff;
+      |                           ^~
+      |                           s
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:93:42: error: request for member ‘s_store_name’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+   93 |   decltype(std::declval<__struct6>().key.s_store_name) s_store_name;
+      |                                          ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:93:42: error: request for member ‘s_store_name’ in ‘std::declval<__struct6>().__struct6::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:320:40: error: cannot convert ‘Store’ to ‘int’ in initialization
+  320 |               __items.push_back(Joined{s, (sr.returned - ss.sold)});
+      |                                        ^
+      |                                        |
+      |                                        Store
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:346:38: error: request for member ‘s_store_name’ in ‘g.__struct6::key’, which is of non-class type ‘int’
+  346 |       __items.push_back(Result{g.key.s_store_name,
+      |                                      ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq501930065693/001/prog.cpp:399:5: error: conversion from ‘vector<Result>’ to non-scalar type ‘vector<Joined>’ requested
+  328 |   std::vector<Joined> result = ([&]() {
+      |                                ~~~~~~~~
+  329 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  330 |     for (auto j : joined) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  331 |       auto __key = j.s;
+      |       ~~~~~~~~~~~~~~~~~
+  332 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  333 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  335 |           __g.items.push_back(Joined{j});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  336 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  337 |           break;
+      |           ~~~~~~
+  338 |         }
+      |         ~
+  339 |       }
+      |       ~
+  340 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  341 |         __groups.push_back(__struct6{__key, std::vector<Joined>{Joined{j}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |       }
+      |       ~
+  343 |     }
+      |     ~
+  344 |     std::vector<Result> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |       __items.push_back(Result{g.key.s_store_name,
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  347 |                                ((int)([&]() {
+      |                                ~~~~~~~~~~~~~~
+  348 |                                   std::vector<decltype(1)> __items;
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |                                   for (auto x : g.items) {
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                                     if (!((x.diff <= 30)))
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~
+  351 |                                       continue;
+      |                                       ~~~~~~~~~
+  352 |                                     __items.push_back(1);
+      |                                     ~~~~~~~~~~~~~~~~~~~~~
+  353 |                                   }
+      |                                   ~
+  354 |                                   return __items;
+      |                                   ~~~~~~~~~~~~~~~
+  355 |                                 })()
+      |                                 ~~~~
+  356 |                                     .size()),
+      |                                     ~~~~~~~~~
+  357 |                                ((int)([&]() {
+      |                                ~~~~~~~~~~~~~~
+  358 |                                   std::vector<decltype(1)> __items;
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |                                   for (auto x : g.items) {
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |                                     if (!(((x.diff > 30) && (x.diff <= 60))))
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                                       continue;
+      |                                       ~~~~~~~~~
+  362 |                                     __items.push_back(1);
+      |                                     ~~~~~~~~~~~~~~~~~~~~~
+  363 |                                   }
+      |                                   ~
+  364 |                                   return __items;
+      |                                   ~~~~~~~~~~~~~~~
+  365 |                                 })()
+      |                                 ~~~~
+  366 |                                     .size()),
+      |                                     ~~~~~~~~~
+  367 |                                ((int)([&]() {
+      |                                ~~~~~~~~~~~~~~
+  368 |                                   std::vector<decltype(1)> __items;
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                                   for (auto x : g.items) {
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |                                     if (!(((x.diff > 60) && (x.diff <= 90))))
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |                                       continue;
+      |                                       ~~~~~~~~~
+  372 |                                     __items.push_back(1);
+      |                                     ~~~~~~~~~~~~~~~~~~~~~
+  373 |                                   }
+      |                                   ~
+  374 |                                   return __items;
+      |                                   ~~~~~~~~~~~~~~~
+  375 |                                 })()
+      |                                 ~~~~
+  376 |                                     .size()),
+      |                                     ~~~~~~~~~
+  377 |                                ((int)([&]() {
+      |                                ~~~~~~~~~~~~~~
+  378 |                                   std::vector<decltype(1)> __items;
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  379 |                                   for (auto x : g.items) {
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |                                     if (!(((x.diff > 90) && (x.diff <= 120))))
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  381 |                                       continue;
+      |                                       ~~~~~~~~~
+  382 |                                     __items.push_back(1);
+      |                                     ~~~~~~~~~~~~~~~~~~~~~
+  383 |                                   }
+      |                                   ~
+  384 |                                   return __items;
+      |                                   ~~~~~~~~~~~~~~~
+  385 |                                 })()
+      |                                 ~~~~
+  386 |                                     .size()),
+      |                                     ~~~~~~~~~
+  387 |                                ((int)([&]() {
+      |                                ~~~~~~~~~~~~~~
+  388 |                                   std::vector<decltype(1)> __items;
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |                                   for (auto x : g.items) {
+      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |                                     if (!((x.diff > 120)))
+      |                                     ~~~~~~~~~~~~~~~~~~~~~~
+  391 |                                       continue;
+      |                                       ~~~~~~~~~
+  392 |                                     __items.push_back(1);
+      |                                     ~~~~~~~~~~~~~~~~~~~~~
+  393 |                                   }
+      |                                   ~
+  394 |                                   return __items;
+      |                                   ~~~~~~~~~~~~~~~
+  395 |                                 })()
+      |                                 ~~~~
+  396 |                                     .size())});
+      |                                     ~~~~~~~~~~~
+  397 |     }
+      |     ~
+  398 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  399 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q51.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q51.error
@@ -1,0 +1,128 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:60:12: error: ‘x’ was not declared in this scope
+   60 |   decltype(x.date) date;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:60:12: error: ‘x’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:64:12: error: ‘w’ was not declared in this scope
+   64 |   decltype(w.date) date;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:64:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:65:12: error: ‘w’ was not declared in this scope
+   65 |   decltype(w.price) price;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:65:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:69:12: error: ‘w’ was not declared in this scope
+   69 |   decltype(w.date) d_date;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:69:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:140:17: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  140 | auto cumulative(auto xs) {
+      |                 ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp: In function ‘auto cumulative(auto:1)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:145:18: error: no matching function for call to ‘std::vector<int>::push_back(__struct2)’
+  145 |     out.push_back(__struct2{x.date, acc});
+      |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘__struct2’ to ‘const std::vector<int>::value_type&’ {aka ‘const int&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘__struct2’ to ‘std::vector<int>::value_type&&’ {aka ‘int&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:152:36: error: ‘w’ was not declared in this scope
+  152 |     std::vector<std::pair<decltype(w.date), WebCum>> __items;
+      |                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:152:45: error: template argument 1 is invalid
+  152 |     std::vector<std::pair<decltype(w.date), WebCum>> __items;
+      |                                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:152:51: error: template argument 1 is invalid
+  152 |     std::vector<std::pair<decltype(w.date), WebCum>> __items;
+      |                                                   ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:152:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:154:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  154 |       __items.push_back({w.date, WebCum{w.date, w.price}});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:156:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  156 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:156:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  156 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:159:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  159 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:159:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  159 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:164:36: error: ‘s’ was not declared in this scope
+  164 |     std::vector<std::pair<decltype(s.date), WebCum>> __items;
+      |                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:164:45: error: template argument 1 is invalid
+  164 |     std::vector<std::pair<decltype(s.date), WebCum>> __items;
+      |                                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:164:51: error: template argument 1 is invalid
+  164 |     std::vector<std::pair<decltype(s.date), WebCum>> __items;
+      |                                                   ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:164:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:166:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  166 |       __items.push_back({s.date, WebCum{s.date, s.price}});
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:168:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  168 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:168:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  168 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:171:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  171 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:171:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  171 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:179:18: error: request for member ‘date’ in ‘w’, which is of non-class type ‘int’
+  179 |         if (!((w.date == s.date)))
+      |                  ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:179:28: error: request for member ‘date’ in ‘s’, which is of non-class type ‘int’
+  179 |         if (!((w.date == s.date)))
+      |                            ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:181:18: error: request for member ‘cum’ in ‘w’, which is of non-class type ‘int’
+  181 |         if (!((w.cum > s.cum)))
+      |                  ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:181:26: error: request for member ‘cum’ in ‘s’, which is of non-class type ‘int’
+  181 |         if (!((w.cum > s.cum)))
+      |                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq51782556970/001/prog.cpp:183:39: error: request for member ‘date’ in ‘w’, which is of non-class type ‘int’
+  183 |         __items.push_back(Joined{1, w.date});
+      |                                       ^~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q52.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q52.error
@@ -1,0 +1,259 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:73:12: error: ‘d’ was not declared in this scope
+   73 |   decltype(d.d_year) year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:73:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:74:12: error: ‘i’ was not declared in this scope
+   74 |   decltype(i.i_brand_id) brand_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:74:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+   75 |   decltype(i.i_brand) brand;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:78:12: error: ‘ss’ was not declared in this scope
+   78 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:78:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:79:12: error: ‘i’ was not declared in this scope
+   79 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:79:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:80:12: error: ‘d’ was not declared in this scope
+   80 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:80:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:232:59: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  232 |           auto __key = Filtered{d.d_year, i.i_brand_id, i.i_brand};
+      |                                                         ~~^~~~~~~
+      |                                                           |
+      |                                                           std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:236:45: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  236 |               __g.items.push_back(__struct5{ss, i, d});
+      |                                             ^~
+      |                                             |
+      |                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:243:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  243 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:243:76: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  243 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:254:60: error: ‘struct __struct5’ has no member named ‘price’
+  254 |             std::vector<decltype(std::declval<__struct5>().price)> __items;
+      |                                                            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:254:60: error: ‘struct __struct5’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:254:66: error: template argument 1 is invalid
+  254 |             std::vector<decltype(std::declval<__struct5>().price)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:254:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:256:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  256 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:256:35: error: ‘struct __struct5’ has no member named ‘price’
+  256 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:253:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:252:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  252 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:252:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  252 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:262:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  222 |   std::vector<__struct5> filtered = ([&]() {
+      |                                     ~~~~~~~~
+  223 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  224 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  225 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  226 |         if (!(((ss.item == i.i_item_sk) && (i.i_manager_id == 1))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  227 |           continue;
+      |           ~~~~~~~~~
+  228 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  229 |           if (!((((ss.sold_date == d.d_date_sk) && (d.d_year == 2001)) &&
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  230 |                  (d.d_moy == 11))))
+      |                  ~~~~~~~~~~~~~~~~~~
+  231 |             continue;
+      |             ~~~~~~~~~
+  232 |           auto __key = Filtered{d.d_year, i.i_brand_id, i.i_brand};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  233 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  234 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  235 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  236 |               __g.items.push_back(__struct5{ss, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  237 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  238 |               break;
+      |               ~~~~~~
+  239 |             }
+      |             ~
+  240 |           }
+      |           ~
+  241 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  242 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  243 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  244 |           }
+      |           ~
+  245 |         }
+      |         ~
+  246 |       }
+      |       ~
+  247 |     }
+      |     ~
+  248 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |           g.key.year, g.key.brand_id, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  252 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  253 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  254 |             std::vector<decltype(std::declval<__struct5>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |             }
+      |             ~
+  258 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  259 |           })())});
+      |           ~~~~~~~~
+  260 |     }
+      |     ~
+  261 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  262 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:265:54: error: ‘struct __struct5’ has no member named ‘d_year’
+  265 |         std::pair<decltype(std::declval<__struct5>().d_year), __struct5>>
+      |                                                      ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:265:54: error: ‘struct __struct5’ has no member named ‘d_year’
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:265:63: error: template argument 1 is invalid
+  265 |         std::pair<decltype(std::declval<__struct5>().d_year), __struct5>>
+      |                                                               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:265:72: error: template argument 1 is invalid
+  265 |         std::pair<decltype(std::declval<__struct5>().d_year), __struct5>>
+      |                                                                        ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:265:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:268:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  268 |       __items.push_back({std::vector<decltype(r.d_year)>{
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:268:49: error: ‘struct __struct5’ has no member named ‘d_year’
+  268 |       __items.push_back({std::vector<decltype(r.d_year)>{
+      |                                                 ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:268:49: error: ‘struct __struct5’ has no member named ‘d_year’
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:268:56: error: template argument 1 is invalid
+  268 |       __items.push_back({std::vector<decltype(r.d_year)>{
+      |                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:268:56: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:269:32: error: ‘struct __struct5’ has no member named ‘d_year’
+  269 |                              r.d_year, (-r.ext_price), r.brand_id},
+      |                                ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:269:44: error: ‘struct __struct5’ has no member named ‘ext_price’
+  269 |                              r.d_year, (-r.ext_price), r.brand_id},
+      |                                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:269:58: error: ‘struct __struct5’ has no member named ‘brand_id’
+  269 |                              r.d_year, (-r.ext_price), r.brand_id},
+      |                                                          ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:272:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  272 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:272:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  272 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:275:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  275 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq521107151015/001/prog.cpp:275:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  275 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q53.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q53.error
@@ -1,0 +1,276 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:67:12: error: ‘ss’ was not declared in this scope
+   67 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:67:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:68:12: error: ‘i’ was not declared in this scope
+   68 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:68:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:69:12: error: ‘d’ was not declared in this scope
+   69 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:69:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:72:12: error: ‘i’ was not declared in this scope
+   72 |   decltype(i.i_manufact_id) key;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:72:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:89:36: error: ‘struct Grouped’ has no member named ‘manu’
+   89 |   decltype(std::declval<Grouped>().manu) i_manufact_id;
+      |                                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:89:36: error: ‘struct Grouped’ has no member named ‘manu’
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:90:36: error: ‘struct Grouped’ has no member named ‘sum_sales’
+   90 |   decltype(std::declval<Grouped>().sum_sales) sum_sales;
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:90:36: error: ‘struct Grouped’ has no member named ‘sum_sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:223:43: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  223 |               __g.items.push_back(Grouped{ss, i, d});
+      |                                           ^~
+      |                                           |
+      |                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:230:63: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  230 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                                                               ^~
+      |                                                               |
+      |                                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:230:72: error: no matching function for call to ‘std::vector<Grouped>::vector(<brace-enclosed initializer list>)’
+  230 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; std::__type_identity_t<_Alloc> = std::allocator<Grouped>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; std::__type_identity_t<_Alloc> = std::allocator<Grouped>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; size_type = long unsigned int; value_type = Grouped; allocator_type = std::allocator<Grouped>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; size_type = long unsigned int; allocator_type = std::allocator<Grouped>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:241:58: error: ‘struct Grouped’ has no member named ‘price’
+  241 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:241:58: error: ‘struct Grouped’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:241:64: error: template argument 1 is invalid
+  241 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:241:64: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:243:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  243 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:243:35: error: ‘struct Grouped’ has no member named ‘price’
+  243 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:240:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:239:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  239 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:239:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  239 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:248:58: error: ‘struct Grouped’ has no member named ‘price’
+  248 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:248:58: error: ‘struct Grouped’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:248:64: error: template argument 1 is invalid
+  248 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:248:64: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:250:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  250 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:250:35: error: ‘struct Grouped’ has no member named ‘price’
+  250 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:247:16: error: no matching function for call to ‘__avg(int)’
+  247 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  248 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |             }
+      |             ~   
+  252 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  253 |           })())});
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:75:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   75 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:75:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:247:16: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  247 |           __avg(([&]() {
+      |           ~~~~~^~~~~~~~~
+  248 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |             }
+      |             ~   
+  252 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  253 |           })())});
+      |           ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:256:5: error: conversion from ‘vector<__struct6>’ to non-scalar type ‘vector<Grouped>’ requested
+  210 |   std::vector<Grouped> grouped = ([&]() {
+      |                                  ~~~~~~~~
+  211 |     std::vector<__struct5> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  212 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  214 |         if (!((ss.item == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  215 |           continue;
+      |           ~~~~~~~~~
+  216 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  217 |           if (!((ss.date == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  218 |             continue;
+      |             ~~~~~~~~~
+  219 |           auto __key = i.i_manufact_id;
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  220 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  221 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  222 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  223 |               __g.items.push_back(Grouped{ss, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  224 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  225 |               break;
+      |               ~~~~~~
+  226 |             }
+      |             ~
+  227 |           }
+      |           ~
+  228 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  229 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  230 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  231 |           }
+      |           ~
+  232 |         }
+      |         ~
+  233 |       }
+      |       ~
+  234 |     }
+      |     ~
+  235 |     std::vector<__struct6> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  236 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  237 |       __items.push_back(__struct6{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  238 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  239 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  240 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  241 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  243 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  244 |             }
+      |             ~
+  245 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  246 |           })()),
+      |           ~~~~~~
+  247 |           __avg(([&]() {
+      |           ~~~~~~~~~~~~~~
+  248 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |             }
+      |             ~
+  252 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  253 |           })())});
+      |           ~~~~~~~~
+  254 |     }
+      |     ~
+  255 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  256 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:260:17: error: ‘struct Grouped’ has no member named ‘avg_sales’
+  260 |       if (!(((g.avg_sales > 0) &&
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:261:23: error: ‘struct Grouped’ has no member named ‘sum_sales’
+  261 |              ((abs((g.sum_sales - g.avg_sales)) / g.avg_sales) > 0.1))))
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:261:37: error: ‘struct Grouped’ has no member named ‘avg_sales’
+  261 |              ((abs((g.sum_sales - g.avg_sales)) / g.avg_sales) > 0.1))))
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:261:53: error: ‘struct Grouped’ has no member named ‘avg_sales’
+  261 |              ((abs((g.sum_sales - g.avg_sales)) / g.avg_sales) > 0.1))))
+      |                                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:263:34: error: ‘struct Grouped’ has no member named ‘manu’
+  263 |       __items.push_back(Result{g.manu, g.sum_sales});
+      |                                  ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq532438170783/001/prog.cpp:263:42: error: ‘struct Grouped’ has no member named ‘sum_sales’
+  263 |       __items.push_back(Result{g.manu, g.sum_sales});
+      |                                          ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q54.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q54.error
@@ -1,0 +1,182 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:78:12: error: ‘c’ was not declared in this scope
+   78 |   decltype(c.c_customer_sk) customer;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:78:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:79:12: error: ‘ss’ was not declared in this scope
+   79 |   decltype(ss.price) amt;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:79:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:91:63: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+   91 |            std::string, decltype(int((std::declval<Revenue>().revenue / 50)))>{
+      |                                                               ^~~~~~~
+      |                                                               Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:91:63: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+   91 |            std::string, decltype(int((std::declval<Revenue>().revenue / 50)))>{
+      |                                                               ^~~~~~~
+      |                                                               Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:91:78: error: template argument 2 is invalid
+   91 |            std::string, decltype(int((std::declval<Revenue>().revenue / 50)))>{
+      |                                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:91:78: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:92:57: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+   92 |       {std::string("seg"), int((std::declval<Revenue>().revenue / 50))}}) key;
+      |                                                         ^~~~~~~
+      |                                                         Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:92:57: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+   92 |       {std::string("seg"), int((std::declval<Revenue>().revenue / 50))}}) key;
+      |                                                         ^~~~~~~
+      |                                                         Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:96:42: error: request for member ‘seg’ in ‘std::declval<__struct9>().__struct9::key’, which is of non-class type ‘int’
+   96 |   decltype(std::declval<__struct9>().key.seg) segment;
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:96:42: error: request for member ‘seg’ in ‘std::declval<__struct9>().__struct9::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:98:43: error: request for member ‘seg’ in ‘std::declval<__struct9>().__struct9::key’, which is of non-class type ‘int’
+   98 |   decltype((std::declval<__struct9>().key.seg * 50)) segment_base;
+      |                                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:98:43: error: request for member ‘seg’ in ‘std::declval<__struct9>().__struct9::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:247:9: error: expected unqualified-id before ‘float’
+  247 | int int(float x) { return std::stoi(x); }
+      |         ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:247:9: error: expected ‘)’ before ‘float’
+  247 | int int(float x) { return std::stoi(x); }
+      |        ~^~~~~
+      |         )
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:306:5: error: conversion from ‘vector<ByCustomer>’ to non-scalar type ‘vector<Revenue>’ requested
+  276 |   std::vector<Revenue> by_customer = ([&]() {
+      |                                      ~~~~~~~~
+  277 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  278 |     for (auto r : revenue) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  279 |       auto __key = r.customer;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~
+  280 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  281 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  282 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  283 |           __g.items.push_back(Revenue{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  284 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  285 |           break;
+      |           ~~~~~~
+  286 |         }
+      |         ~
+  287 |       }
+      |       ~
+  288 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  289 |         __groups.push_back(__struct7{__key, std::vector<Revenue>{Revenue{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |       }
+      |       ~
+  291 |     }
+      |     ~
+  292 |     std::vector<ByCustomer> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  293 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  294 |       __items.push_back(ByCustomer{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  295 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  296 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  297 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  298 |             std::vector<decltype(std::declval<Revenue>().amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  299 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  300 |               __items.push_back(x.amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  301 |             }
+      |             ~
+  302 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  303 |           })())});
+      |           ~~~~~~~~
+  304 |     }
+      |     ~
+  305 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  306 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:311:59: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+  311 |           std::unordered_map<std::string, decltype(int((r.revenue / 50)))>{
+      |                                                           ^~~~~~~
+      |                                                           Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:311:59: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+  311 |           std::unordered_map<std::string, decltype(int((r.revenue / 50)))>{
+      |                                                           ^~~~~~~
+      |                                                           Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:311:74: error: template argument 2 is invalid
+  311 |           std::unordered_map<std::string, decltype(int((r.revenue / 50)))>{
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:311:74: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:312:43: error: ‘struct Revenue’ has no member named ‘revenue’; did you mean ‘Revenue’?
+  312 |               {std::string("seg"), int((r.revenue / 50))}};
+      |                                           ^~~~~~~
+      |                                           Revenue
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:328:25: error: request for member ‘seg’ in ‘g.__struct9::key’, which is of non-class type ‘int’
+  328 |           Segment{g.key.seg, ((int)g.items.size()), (g.key.seg * 50)});
+      |                         ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:328:60: error: request for member ‘seg’ in ‘g.__struct9::key’, which is of non-class type ‘int’
+  328 |           Segment{g.key.seg, ((int)g.items.size()), (g.key.seg * 50)});
+      |                                                            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq541723684716/001/prog.cpp:331:5: error: conversion from ‘vector<Segment>’ to non-scalar type ‘vector<Revenue>’ requested
+  307 |   std::vector<Revenue> segments = ([&]() {
+      |                                   ~~~~~~~~
+  308 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  309 |     for (auto r : by_customer) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |       auto __key =
+      |       ~~~~~~~~~~~~
+  311 |           std::unordered_map<std::string, decltype(int((r.revenue / 50)))>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |               {std::string("seg"), int((r.revenue / 50))}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  313 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  314 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  315 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  316 |           __g.items.push_back(Revenue{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  317 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  318 |           break;
+      |           ~~~~~~
+  319 |         }
+      |         ~
+  320 |       }
+      |       ~
+  321 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  322 |         __groups.push_back(__struct9{__key, std::vector<Revenue>{Revenue{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |       }
+      |       ~
+  324 |     }
+      |     ~
+  325 |     std::vector<Segment> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  327 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  328 |           Segment{g.key.seg, ((int)g.items.size()), (g.key.seg * 50)});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  329 |     }
+      |     ~
+  330 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  331 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q55.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q55.error
@@ -1,0 +1,475 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:72:12: error: ‘ss’ was not declared in this scope
+   72 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:72:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:73:12: error: ‘i’ was not declared in this scope
+   73 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:73:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:74:12: error: ‘d’ was not declared in this scope
+   74 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:74:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:77:53: error: ‘i’ was not declared in this scope
+   77 |   decltype(std::unordered_map<std::string, decltype(i.i_brand_id)>{
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:77:53: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:77:66: error: template argument 2 is invalid
+   77 |   decltype(std::unordered_map<std::string, decltype(i.i_brand_id)>{
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:77:66: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:78:33: error: ‘i’ was not declared in this scope
+   78 |       {std::string("brand_id"), i.i_brand_id}}) key;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:78:33: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:82:42: error: request for member ‘brand_id’ in ‘std::declval<__struct5>().__struct5::key’, which is of non-class type ‘int’
+   82 |   decltype(std::declval<__struct5>().key.brand_id) brand_id;
+      |                                          ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:82:42: error: request for member ‘brand_id’ in ‘std::declval<__struct5>().__struct5::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:25: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’)
+  198 |             if (__g.key == __key) {
+      |                 ~~~~~~~ ^~ ~~~~~
+      |                     |      |
+      |                     int    std::unordered_map<std::__cxx11::basic_string<char>, int>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:3:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, int> >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const _CharT*’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:7:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:198:28: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  198 |             if (__g.key == __key) {
+      |                            ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, int> >&, const allocator<pair<const __cxx11::basic_string<char>, int> >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, int> >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:199:43: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  199 |               __g.items.push_back(Grouped{ss, i, d});
+      |                                           ^~
+      |                                           |
+      |                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:206:63: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  206 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                                                               ^~
+      |                                                               |
+      |                                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:206:72: error: no matching function for call to ‘std::vector<Grouped>::vector(<brace-enclosed initializer list>)’
+  206 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                                                                        ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; std::__type_identity_t<_Alloc> = std::allocator<Grouped>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; std::__type_identity_t<_Alloc> = std::allocator<Grouped>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; size_type = long unsigned int; value_type = Grouped; allocator_type = std::allocator<Grouped>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; size_type = long unsigned int; allocator_type = std::allocator<Grouped>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Grouped; _Alloc = std::allocator<Grouped>; allocator_type = std::allocator<Grouped>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:214:17: error: request for member ‘brand_id’ in ‘g.__struct5::key’, which is of non-class type ‘int’
+  214 |           g.key.brand_id, ([&](auto v) {
+      |                 ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:217:58: error: ‘struct Grouped’ has no member named ‘price’
+  217 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:217:58: error: ‘struct Grouped’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:217:64: error: template argument 1 is invalid
+  217 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:217:64: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:219:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  219 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:219:35: error: ‘struct Grouped’ has no member named ‘price’
+  219 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:216:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:215:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  215 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:215:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  215 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:225:5: error: conversion from ‘vector<__struct6>’ to non-scalar type ‘vector<Grouped>’ requested
+  185 |   std::vector<Grouped> grouped = ([&]() {
+      |                                  ~~~~~~~~
+  186 |     std::vector<__struct5> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  187 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  188 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  189 |         if (!(((ss.item == i.i_item_sk) && (i.i_manager_id == 1))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  190 |           continue;
+      |           ~~~~~~~~~
+  191 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  192 |           if (!((ss.sold_date == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  193 |             continue;
+      |             ~~~~~~~~~
+  194 |           auto __key = std::unordered_map<std::string, decltype(i.i_brand_id)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  195 |               {std::string("brand_id"), i.i_brand_id}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  196 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  197 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  198 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  199 |               __g.items.push_back(Grouped{ss, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  200 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  201 |               break;
+      |               ~~~~~~
+  202 |             }
+      |             ~
+  203 |           }
+      |           ~
+  204 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  205 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  206 |                 __struct5{__key, std::vector<Grouped>{Grouped{ss, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  207 |           }
+      |           ~
+  208 |         }
+      |         ~
+  209 |       }
+      |       ~
+  210 |     }
+      |     ~
+  211 |     std::vector<__struct6> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  212 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |       __items.push_back(__struct6{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  214 |           g.key.brand_id, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  215 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  216 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  217 |             std::vector<decltype(std::declval<Grouped>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  218 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  219 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  220 |             }
+      |             ~
+  221 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  222 |           })())});
+      |           ~~~~~~~~
+  223 |     }
+      |     ~
+  224 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  225 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:227:60: error: ‘struct Grouped’ has no member named ‘ext_price’
+  227 |     std::vector<std::pair<decltype(std::declval<Grouped>().ext_price), Grouped>>
+      |                                                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:227:60: error: ‘struct Grouped’ has no member named ‘ext_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:227:72: error: template argument 1 is invalid
+  227 |     std::vector<std::pair<decltype(std::declval<Grouped>().ext_price), Grouped>>
+      |                                                                        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:227:79: error: template argument 1 is invalid
+  227 |     std::vector<std::pair<decltype(std::declval<Grouped>().ext_price), Grouped>>
+      |                                                                               ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:227:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:230:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  230 |       __items.push_back(
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:37: error: ‘struct Grouped’ has no member named ‘ext_price’
+  231 |           {std::vector<decltype((-g.ext_price))>{(-g.ext_price), g.brand_id},
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:37: error: ‘struct Grouped’ has no member named ‘ext_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:48: error: template argument 1 is invalid
+  231 |           {std::vector<decltype((-g.ext_price))>{(-g.ext_price), g.brand_id},
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:54: error: ‘struct Grouped’ has no member named ‘ext_price’
+  231 |           {std::vector<decltype((-g.ext_price))>{(-g.ext_price), g.brand_id},
+      |                                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:231:68: error: ‘struct Grouped’ has no member named ‘brand_id’
+  231 |           {std::vector<decltype((-g.ext_price))>{(-g.ext_price), g.brand_id},
+      |                                                                    ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:234:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  234 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:234:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  234 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:237:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  237 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq55681286063/001/prog.cpp:237:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  237 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q56.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q56.error
@@ -1,0 +1,586 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:58:12: error: ‘s’ was not declared in this scope
+   58 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:58:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:61:30: error: ‘struct S’ has no member named ‘item’
+   61 |   decltype(std::declval<S>().item) key;
+      |                              ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:61:30: error: ‘struct S’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:68:8: error: redefinition of ‘struct S’
+   68 | struct S {
+      |        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:57:8: note: previous definition of ‘struct S’
+   57 | struct S {
+      |        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:72:30: error: ‘struct S’ has no member named ‘item’
+   72 |   decltype(std::declval<S>().item) key;
+      |                              ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:72:30: error: ‘struct S’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:75:8: error: redefinition of ‘struct S’
+   75 | struct S {
+      |        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:57:8: note: previous definition of ‘struct S’
+   57 | struct S {
+      |        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:79:30: error: ‘struct S’ has no member named ‘item’
+   79 |   decltype(std::declval<S>().item) key;
+      |                              ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:79:30: error: ‘struct S’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:83:12: error: ‘u’ was not declared in this scope
+   83 |   decltype(u) u;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:83:12: error: ‘u’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:86:35: error: ‘struct Result’ has no member named ‘item’
+   86 |   decltype(std::declval<Result>().item) key;
+      |                                   ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:86:35: error: ‘struct Result’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:169:33: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  169 |           __g.items.push_back(S{s});
+      |                                 ^
+      |                                 |
+      |                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:175:62: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  175 |         __groups.push_back(__struct3{__key, std::vector<S>{S{s}}});
+      |                                                              ^
+      |                                                              |
+      |                                                              StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:175:64: error: no matching function for call to ‘std::vector<S>::vector(<brace-enclosed initializer list>)’
+  175 |         __groups.push_back(__struct3{__key, std::vector<S>{S{s}}});
+      |                                                                ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = S; _Alloc = std::allocator<S>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; value_type = S; allocator_type = std::allocator<S>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; allocator_type = std::allocator<S>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = S; _Alloc = std::allocator<S>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:184:62: error: ‘struct S’ has no member named ‘price’
+  184 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:184:62: error: ‘struct S’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:184:68: error: template argument 1 is invalid
+  184 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:184:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:186:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  186 |                         __items.push_back(x.price);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:186:45: error: ‘struct S’ has no member named ‘price’
+  186 |                         __items.push_back(x.price);
+      |                                             ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:183:23:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:182:48: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  182 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:182:59: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  182 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:192:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<S>’ requested
+  162 |   std::vector<S> ss = ([&]() {
+      |                       ~~~~~~~~
+  163 |     std::vector<__struct3> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  164 |     for (auto s : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  165 |       auto __key = s.item;
+      |       ~~~~~~~~~~~~~~~~~~~~
+  166 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  167 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  168 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  169 |           __g.items.push_back(S{s});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  170 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  171 |           break;
+      |           ~~~~~~
+  172 |         }
+      |         ~
+  173 |       }
+      |       ~
+  174 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  175 |         __groups.push_back(__struct3{__key, std::vector<S>{S{s}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  176 |       }
+      |       ~
+  177 |     }
+      |     ~
+  178 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  179 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  180 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  181 |           __struct4{g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  182 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  183 |                     })(([&]() {
+      |                     ~~~~~~~~~~~
+  184 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  185 |                       for (auto x : g.items) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  186 |                         __items.push_back(x.price);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  187 |                       }
+      |                       ~
+  188 |                       return __items;
+      |                       ~~~~~~~~~~~~~~~
+  189 |                     })())});
+      |                     ~~~~~~~~
+  190 |     }
+      |     ~
+  191 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  192 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:200:33: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  200 |           __g.items.push_back(S{s});
+      |                                 ^
+      |                                 |
+      |                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:206:62: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  206 |         __groups.push_back(__struct5{__key, std::vector<S>{S{s}}});
+      |                                                              ^
+      |                                                              |
+      |                                                              StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:206:64: error: no matching function for call to ‘std::vector<S>::vector(<brace-enclosed initializer list>)’
+  206 |         __groups.push_back(__struct5{__key, std::vector<S>{S{s}}});
+      |                                                                ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = S; _Alloc = std::allocator<S>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; value_type = S; allocator_type = std::allocator<S>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; allocator_type = std::allocator<S>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = S; _Alloc = std::allocator<S>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:215:62: error: ‘struct S’ has no member named ‘price’
+  215 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:215:62: error: ‘struct S’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:215:68: error: template argument 1 is invalid
+  215 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:215:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:217:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  217 |                         __items.push_back(x.price);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:217:45: error: ‘struct S’ has no member named ‘price’
+  217 |                         __items.push_back(x.price);
+      |                                             ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:214:23:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:213:48: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  213 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:213:59: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  213 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:223:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<S>’ requested
+  193 |   std::vector<S> cs = ([&]() {
+      |                       ~~~~~~~~
+  194 |     std::vector<__struct5> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  195 |     for (auto s : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  196 |       auto __key = s.item;
+      |       ~~~~~~~~~~~~~~~~~~~~
+  197 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  198 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  199 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  200 |           __g.items.push_back(S{s});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  201 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  202 |           break;
+      |           ~~~~~~
+  203 |         }
+      |         ~
+  204 |       }
+      |       ~
+  205 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  206 |         __groups.push_back(__struct5{__key, std::vector<S>{S{s}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  207 |       }
+      |       ~
+  208 |     }
+      |     ~
+  209 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  210 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  211 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  212 |           __struct4{g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  214 |                     })(([&]() {
+      |                     ~~~~~~~~~~~
+  215 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  216 |                       for (auto x : g.items) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  217 |                         __items.push_back(x.price);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  218 |                       }
+      |                       ~
+  219 |                       return __items;
+      |                       ~~~~~~~~~~~~~~~
+  220 |                     })())});
+      |                     ~~~~~~~~
+  221 |     }
+      |     ~
+  222 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  223 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:231:33: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  231 |           __g.items.push_back(S{s});
+      |                                 ^
+      |                                 |
+      |                                 StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:237:62: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  237 |         __groups.push_back(__struct6{__key, std::vector<S>{S{s}}});
+      |                                                              ^
+      |                                                              |
+      |                                                              StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:237:64: error: no matching function for call to ‘std::vector<S>::vector(<brace-enclosed initializer list>)’
+  237 |         __groups.push_back(__struct6{__key, std::vector<S>{S{s}}});
+      |                                                                ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = S; _Alloc = std::allocator<S>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; value_type = S; allocator_type = std::allocator<S>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; allocator_type = std::allocator<S>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = S; _Alloc = std::allocator<S>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:246:62: error: ‘struct S’ has no member named ‘price’
+  246 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:246:62: error: ‘struct S’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:246:68: error: template argument 1 is invalid
+  246 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:246:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:248:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  248 |                         __items.push_back(x.price);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:248:45: error: ‘struct S’ has no member named ‘price’
+  248 |                         __items.push_back(x.price);
+      |                                             ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:245:23:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:244:48: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  244 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                              ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:244:59: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  244 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                         ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:254:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<S>’ requested
+  224 |   std::vector<S> ws = ([&]() {
+      |                       ~~~~~~~~
+  225 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  226 |     for (auto s : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  227 |       auto __key = s.item;
+      |       ~~~~~~~~~~~~~~~~~~~~
+  228 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  229 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  230 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  231 |           __g.items.push_back(S{s});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  232 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  233 |           break;
+      |           ~~~~~~
+  234 |         }
+      |         ~
+  235 |       }
+      |       ~
+  236 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  237 |         __groups.push_back(__struct6{__key, std::vector<S>{S{s}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  238 |       }
+      |       ~
+  239 |     }
+      |     ~
+  240 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  241 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  243 |           __struct4{g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  244 |                       return std::accumulate(v.begin(), v.end(), 0.0);
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  245 |                     })(([&]() {
+      |                     ~~~~~~~~~~~
+  246 |                       std::vector<decltype(std::declval<S>().price)> __items;
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  247 |                       for (auto x : g.items) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  248 |                         __items.push_back(x.price);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |                       }
+      |                       ~
+  250 |                       return __items;
+      |                       ~~~~~~~~~~~~~~~
+  251 |                     })())});
+      |                     ~~~~~~~~
+  252 |     }
+      |     ~
+  253 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  254 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:255:3: error: expected primary-expression before ‘auto’
+  255 |   auto union = concat(ss, cs, ws);
+      |   ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:258:19: error: expected primary-expression before ‘union’
+  258 |     for (auto u : union) {
+      |                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:258:18: error: expected ‘)’ before ‘union’
+  258 |     for (auto u : union) {
+      |         ~        ^~~~~~
+      |                  )
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:258:19: error: expected primary-expression before ‘union’
+  258 |     for (auto u : union) {
+      |                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:278:57: error: ‘struct Result’ has no member named ‘total’
+  278 |             std::vector<decltype(std::declval<Result>().total)> __items;
+      |                                                         ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:278:57: error: ‘struct Result’ has no member named ‘total’
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:278:63: error: template argument 1 is invalid
+  278 |             std::vector<decltype(std::declval<Result>().total)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:278:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:280:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  280 |               __items.push_back(x.total);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:280:35: error: ‘struct Result’ has no member named ‘total’
+  280 |               __items.push_back(x.total);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:277:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:276:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  276 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:276:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  276 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq561627875285/001/prog.cpp:286:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<Result>’ requested
+  256 |   std::vector<Result> result = ([&]() {
+      |                                ~~~~~~~~
+  257 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |     for (auto u : union) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~
+  259 |       auto __key = u.item;
+      |       ~~~~~~~~~~~~~~~~~~~~
+  260 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  261 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  263 |           __g.items.push_back(Result{u});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  265 |           break;
+      |           ~~~~~~
+  266 |         }
+      |         ~
+  267 |       }
+      |       ~
+  268 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  269 |         __groups.push_back(__struct8{__key, std::vector<Result>{Result{u}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |       }
+      |       ~
+  271 |     }
+      |     ~
+  272 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  273 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |       __items.push_back(__struct9{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  275 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  276 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  277 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  278 |             std::vector<decltype(std::declval<Result>().total)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  279 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  280 |               __items.push_back(x.total);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  281 |             }
+      |             ~
+  282 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  283 |           })())});
+      |           ~~~~~~~~
+  284 |     }
+      |     ~
+  285 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  286 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q57.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q57.error
@@ -1,0 +1,383 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+   75 |   decltype(i.i_category) cat;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:75:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:76:12: error: ‘cc’ was not declared in this scope
+   76 |   decltype(cc.cc_name) call;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:76:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:77:12: error: ‘d’ was not declared in this scope
+   77 |   decltype(d.d_year) year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:77:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:80:12: error: ‘cs’ was not declared in this scope
+   80 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:80:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+   81 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:81:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+   82 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:83:12: error: ‘cc’ was not declared in this scope; did you mean ‘cs’?
+   83 |   decltype(cc) cc;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:83:12: error: ‘cc’ was not declared in this scope; did you mean ‘cs’?
+   83 |   decltype(cc) cc;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:96:38: error: ‘struct __struct6’ has no member named ‘cat’
+   96 |   decltype(std::declval<__struct6>().cat) cat;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:96:38: error: ‘struct __struct6’ has no member named ‘cat’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:97:38: error: ‘struct __struct6’ has no member named ‘call’
+   97 |   decltype(std::declval<__struct6>().call) call;
+      |                                      ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:97:38: error: ‘struct __struct6’ has no member named ‘call’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:117:38: error: ‘struct __struct6’ has no member named ‘cat’
+  117 |   decltype(std::declval<__struct6>().cat) i_category;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:117:38: error: ‘struct __struct6’ has no member named ‘cat’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:118:38: error: ‘struct __struct6’ has no member named ‘sum_sales’
+  118 |   decltype(std::declval<__struct6>().sum_sales) sum_sales;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:118:38: error: ‘struct __struct6’ has no member named ‘sum_sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:348:36: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  348 |             auto __key = Grouped{i.i_category, cc.cc_name, d.d_year};
+      |                                  ~~^~~~~~~~~~
+      |                                    |
+      |                                    std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:352:47: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  352 |                 __g.items.push_back(__struct6{cs, i, d, cc});
+      |                                               ^~
+      |                                               |
+      |                                               CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:359:59: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  359 |                   __key, std::vector<__struct6>{__struct6{cs, i, d, cc}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:359:72: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  359 |                   __key, std::vector<__struct6>{__struct6{cs, i, d, cc}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:371:60: error: ‘struct __struct6’ has no member named ‘price’
+  371 |             std::vector<decltype(std::declval<__struct6>().price)> __items;
+      |                                                            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:371:60: error: ‘struct __struct6’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:371:66: error: template argument 1 is invalid
+  371 |             std::vector<decltype(std::declval<__struct6>().price)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:371:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:373:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  373 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:373:35: error: ‘struct __struct6’ has no member named ‘price’
+  373 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:370:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:369:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  369 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:369:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  369 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:379:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  336 |   std::vector<__struct6> grouped = ([&]() {
+      |                                    ~~~~~~~~
+  337 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  338 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  340 |         if (!((cs.item == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  341 |           continue;
+      |           ~~~~~~~~~
+  342 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |           if (!((cs.date == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |             continue;
+      |             ~~~~~~~~~
+  345 |           for (auto cc : call_center) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |             if (!((cs.call == cc.cc_call_center_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  347 |               continue;
+      |               ~~~~~~~~~
+  348 |             auto __key = Grouped{i.i_category, cc.cc_name, d.d_year};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  350 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  352 |                 __g.items.push_back(__struct6{cs, i, d, cc});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  354 |                 break;
+      |                 ~~~~~~
+  355 |               }
+      |               ~
+  356 |             }
+      |             ~
+  357 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  358 |               __groups.push_back(__struct7{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |                   __key, std::vector<__struct6>{__struct6{cs, i, d, cc}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |             }
+      |             ~
+  361 |           }
+      |           ~
+  362 |         }
+      |         ~
+  363 |       }
+      |       ~
+  364 |     }
+      |     ~
+  365 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |           g.key.cat, g.key.call, g.key.year, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  371 |             std::vector<decltype(std::declval<__struct6>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  373 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |             }
+      |             ~
+  375 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  376 |           })())});
+      |           ~~~~~~~~
+  377 |     }
+      |     ~
+  378 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  379 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:383:32: error: ‘struct __struct6’ has no member named ‘cat’
+  383 |       auto __key = AvgByYear{g.cat, g.call};
+      |                                ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:383:39: error: ‘struct __struct6’ has no member named ‘call’
+  383 |       auto __key = AvgByYear{g.cat, g.call};
+      |                                       ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:401:60: error: ‘struct __struct6’ has no member named ‘sum_sales’
+  401 |             std::vector<decltype(std::declval<__struct6>().sum_sales)> __items;
+      |                                                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:401:60: error: ‘struct __struct6’ has no member named ‘sum_sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:401:70: error: template argument 1 is invalid
+  401 |             std::vector<decltype(std::declval<__struct6>().sum_sales)> __items;
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:401:70: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:403:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  403 |               __items.push_back(x.sum_sales);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:403:35: error: ‘struct __struct6’ has no member named ‘sum_sales’
+  403 |               __items.push_back(x.sum_sales);
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:400:41: error: no matching function for call to ‘__avg(int)’
+  400 |           gg.key.cat, gg.key.call, __avg(([&]() {
+      |                                    ~~~~~^~~~~~~~~
+  401 |             std::vector<decltype(std::declval<__struct6>().sum_sales)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  402 |             for (auto x : gg.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~    
+  403 |               __items.push_back(x.sum_sales);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  404 |             }
+      |             ~                            
+  405 |             return __items;
+      |             ~~~~~~~~~~~~~~~              
+  406 |           })())});
+      |           ~~~~~                          
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:103:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+  103 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:103:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:400:41: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  400 |           gg.key.cat, gg.key.call, __avg(([&]() {
+      |                                    ~~~~~^~~~~~~~~
+  401 |             std::vector<decltype(std::declval<__struct6>().sum_sales)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  402 |             for (auto x : gg.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~    
+  403 |               __items.push_back(x.sum_sales);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  404 |             }
+      |             ~                            
+  405 |             return __items;
+      |             ~~~~~~~~~~~~~~~              
+  406 |           })())});
+      |           ~~~~~                          
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:409:5: error: conversion from ‘vector<__struct11>’ to non-scalar type ‘vector<__struct6>’ requested
+  380 |   std::vector<__struct6> avg_by_year = ([&]() {
+      |                                        ~~~~~~~~
+  381 |     std::vector<__struct10> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |     for (auto g : grouped) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  383 |       auto __key = AvgByYear{g.cat, g.call};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  384 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  385 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  387 |           __g.items.push_back(__struct6{g});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  389 |           break;
+      |           ~~~~~~
+  390 |         }
+      |         ~
+  391 |       }
+      |       ~
+  392 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  393 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  394 |             __struct10{__key, std::vector<__struct6>{__struct6{g}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  395 |       }
+      |       ~
+  396 |     }
+      |     ~
+  397 |     std::vector<__struct11> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |     for (auto &gg : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  399 |       __items.push_back(__struct11{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  400 |           gg.key.cat, gg.key.call, __avg(([&]() {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  401 |             std::vector<decltype(std::declval<__struct6>().sum_sales)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  402 |             for (auto x : gg.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  403 |               __items.push_back(x.sum_sales);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  404 |             }
+      |             ~
+  405 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  406 |           })())});
+      |           ~~~~~~~~
+  407 |     }
+      |     ~
+  408 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  409 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:414:19: error: ‘struct __struct6’ has no member named ‘cat’
+  414 |         if (!(((g.cat == a.cat) && (g.call == a.call))))
+      |                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:414:28: error: ‘struct __struct6’ has no member named ‘cat’
+  414 |         if (!(((g.cat == a.cat) && (g.call == a.call))))
+      |                            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:414:39: error: ‘struct __struct6’ has no member named ‘call’
+  414 |         if (!(((g.cat == a.cat) && (g.call == a.call))))
+      |                                       ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:414:49: error: ‘struct __struct6’ has no member named ‘call’
+  414 |         if (!(((g.cat == a.cat) && (g.call == a.call))))
+      |                                                 ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:416:20: error: ‘struct __struct6’ has no member named ‘year’
+  416 |         if (!((((g.year == 2001) && (a.avg_sales > 0)) &&
+      |                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:416:40: error: ‘struct __struct6’ has no member named ‘avg_sales’
+  416 |         if (!((((g.year == 2001) && (a.avg_sales > 0)) &&
+      |                                        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:417:25: error: ‘struct __struct6’ has no member named ‘sum_sales’
+  417 |                ((abs((g.sum_sales - a.avg_sales)) / a.avg_sales) > 0.1))))
+      |                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:417:39: error: ‘struct __struct6’ has no member named ‘avg_sales’
+  417 |                ((abs((g.sum_sales - a.avg_sales)) / a.avg_sales) > 0.1))))
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:417:55: error: ‘struct __struct6’ has no member named ‘avg_sales’
+  417 |                ((abs((g.sum_sales - a.avg_sales)) / a.avg_sales) > 0.1))))
+      |                                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:419:36: error: ‘struct __struct6’ has no member named ‘cat’
+  419 |         __items.push_back(Result{g.cat, g.sum_sales});
+      |                                    ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq572873699264/001/prog.cpp:419:43: error: ‘struct __struct6’ has no member named ‘sum_sales’
+  419 |         __items.push_back(Result{g.cat, g.sum_sales});
+      |                                           ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q58.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q58.error
@@ -1,0 +1,12 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq58330515589/001/prog.cpp:65:12: error: ‘ss_items’ was not declared in this scope; did you mean ‘SsItem’?
+   65 |   decltype(ss_items.item_id) item_id;
+      |            ^~~~~~~~
+      |            SsItem
+/tmp/TestCPPCompiler_TPCDSQueriesq58330515589/001/prog.cpp:65:12: error: ‘ss_items’ was not declared in this scope; did you mean ‘SsItem’?
+   65 |   decltype(ss_items.item_id) item_id;
+      |            ^~~~~~~~
+      |            SsItem
+/tmp/TestCPPCompiler_TPCDSQueriesq58330515589/001/prog.cpp:66:12: error: ‘avg’ was not declared in this scope
+   66 |   decltype(avg) average;
+      |            ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq58330515589/001/prog.cpp:66:12: error: ‘avg’ was not declared in this scope

--- a/tests/dataset/tpc-ds/compiler/cpp/q59.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q59.error
@@ -1,0 +1,16 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:58:12: error: ‘y1’ was not declared in this scope
+   58 |   decltype(y1.store) s_store_id1;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:58:12: error: ‘y1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:59:13: error: ‘y2’ was not declared in this scope
+   59 |   decltype((y2.amount / y1.amount)) ratio;
+      |             ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:59:25: error: ‘y1’ was not declared in this scope
+   59 |   decltype((y2.amount / y1.amount)) ratio;
+      |                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:59:13: error: ‘y2’ was not declared in this scope
+   59 |   decltype((y2.amount / y1.amount)) ratio;
+      |             ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq593451684786/001/prog.cpp:59:25: error: ‘y1’ was not declared in this scope
+   59 |   decltype((y2.amount / y1.amount)) ratio;
+      |                         ^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q6.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q6.error
@@ -1,0 +1,381 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:89:12: error: ‘a’ was not declared in this scope
+   89 |   decltype(a) a;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:89:12: error: ‘a’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:90:12: error: ‘c’ was not declared in this scope
+   90 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:90:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+   91 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:92:12: error: ‘d’ was not declared in this scope
+   92 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:92:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+   93 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:96:35: error: ‘struct Result’ has no member named ‘ca_state’
+   96 |   decltype(std::declval<Result>().ca_state) key;
+      |                                   ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:96:35: error: ‘struct Result’ has no member named ‘ca_state’
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:281:49: error: ‘d’ was not declared in this scope
+  281 |                            std::vector<decltype(d.d_month_seq)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:281:63: error: template argument 1 is invalid
+  281 |                            std::vector<decltype(d.d_month_seq)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:281:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:285:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  285 |                              __items.push_back(d.d_month_seq);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:289:31: error: request for member ‘begin’ in ‘<lambda closure object>main()::<lambda()>{date_dim}.main()::<lambda()>()’, which is of non-class type ‘int’
+  289 |                              .begin(),
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:291:49: error: ‘d’ was not declared in this scope
+  291 |                            std::vector<decltype(d.d_month_seq)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:291:63: error: template argument 1 is invalid
+  291 |                            std::vector<decltype(d.d_month_seq)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:291:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:295:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  295 |                              __items.push_back(d.d_month_seq);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:299:31: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>{date_dim}.main()::<lambda()>()’, which is of non-class type ‘int’
+  299 |                              .end()));
+      |                               ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:318:47: error: ‘j’ was not declared in this scope
+  318 |                          std::vector<decltype(j.i_current_price)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:318:65: error: template argument 1 is invalid
+  318 |                          std::vector<decltype(j.i_current_price)> __items;
+      |                                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:318:65: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:322:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  322 |                            __items.push_back(j.i_current_price);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:317:35: error: no matching function for call to ‘__avg(int)’
+  317 |                       (1.2 * __avg(([&]() {
+      |                              ~~~~~^~~~~~~~~
+  318 |                          std::vector<decltype(j.i_current_price)> __items;
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  319 |                          for (auto j : item) {
+      |                          ~~~~~~~~~~~~~~~~~~~~~
+  320 |                            if (!((j.i_category == i.i_category)))
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |                              continue;
+      |                              ~~~~~~~~~
+  322 |                            __items.push_back(j.i_current_price);
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |                          }
+      |                          ~         
+  324 |                          return __items;
+      |                          ~~~~~~~~~~~~~~~
+  325 |                        })()))))))
+      |                        ~~~~~       
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:80:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   80 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:80:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:317:35: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  317 |                       (1.2 * __avg(([&]() {
+      |                              ~~~~~^~~~~~~~~
+  318 |                          std::vector<decltype(j.i_current_price)> __items;
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  319 |                          for (auto j : item) {
+      |                          ~~~~~~~~~~~~~~~~~~~~~
+  320 |                            if (!((j.i_category == i.i_category)))
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |                              continue;
+      |                              ~~~~~~~~~
+  322 |                            __items.push_back(j.i_current_price);
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |                          }
+      |                          ~         
+  324 |                          return __items;
+      |                          ~~~~~~~~~~~~~~~
+  325 |                        })()))))))
+      |                        ~~~~~       
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:29: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  330 |                 if (__g.key == __key) {
+      |                     ~~~~~~~ ^~ ~~~~~
+      |                         |      |
+      |                         int    std::__cxx11::basic_string<char>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:3:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const _CharT*’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:6:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:330:32: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  330 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:331:46: error: cannot convert ‘CustomerAddres’ to ‘int’ in initialization
+  331 |                   __g.items.push_back(Result{a, c, s, d, i});
+      |                                              ^
+      |                                              |
+      |                                              CustomerAddres
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:338:55: error: cannot convert ‘CustomerAddres’ to ‘int’ in initialization
+  338 |                     __key, std::vector<Result>{Result{a, c, s, d, i}}});
+      |                                                       ^
+      |                                                       |
+      |                                                       CustomerAddres
+/tmp/TestCPPCompiler_TPCDSQueriesq62097814211/001/prog.cpp:338:69: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  338 |                     __key, std::vector<Result>{Result{a, c, s, d, i}}});
+      |                                                                     ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided

--- a/tests/dataset/tpc-ds/compiler/cpp/q60.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q60.error
@@ -1,0 +1,122 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:92:26: error: ‘s’ was not declared in this scope
+   92 |     std::vector<decltype(s.price)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:92:34: error: template argument 1 is invalid
+   92 |     std::vector<decltype(s.price)> __items;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:92:34: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:94:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   94 |       __items.push_back(s.price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:91:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:90:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   90 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:90:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   90 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:71,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:2:
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_equal_to_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >; _Iterator2 = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >]’:
+/usr/include/c++/13/bits/stl_algo.h:917:20:   required from ‘_ForwardIterator std::__unique(_ForwardIterator, _ForwardIterator, _BinaryPredicate) [with _ForwardIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _BinaryPredicate = __gnu_cxx::__ops::_Iter_equal_to_iter]’
+/usr/include/c++/13/bits/stl_algo.h:948:27:   required from ‘_FIter std::unique(_FIter, _FIter) [with _FIter = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:85:27:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<StoreSale>; auto:4 = std::vector<StoreSale>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:87:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:117:23: error: no match for ‘operator==’ (operand types are ‘StoreSale’ and ‘StoreSale’)
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1217 |     operator==(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1217:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator==(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1225 |     operator==(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1225:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:117:23: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+  117 |       { return *__it1 == *__it2; }
+      |                ~~~~~~~^~~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘constexpr bool __gnu_cxx::__ops::_Iter_less_iter::operator()(_Iterator1, _Iterator2) const [with _Iterator1 = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >; _Iterator2 = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1819:14:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:84:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<StoreSale>; auto:4 = std::vector<StoreSale>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:87:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:45:23: error: no match for ‘operator<’ (operand types are ‘StoreSale’ and ‘StoreSale’)
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:45:23: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   45 |       { return *__it1 < *__it2; }
+      |                ~~~~~~~^~~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Val_less_iter::operator()(_Value&, _Iterator) const [with _Value = StoreSale; _Iterator = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >]’:
+/usr/include/c++/13/bits/stl_algo.h:1799:20:   required from ‘void std::__unguarded_linear_insert(_RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Val_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1827:36:   required from ‘void std::__insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1859:25:   required from ‘void std::__final_insertion_sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1950:31:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:84:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<StoreSale>; auto:4 = std::vector<StoreSale>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:87:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:98:22: error: no match for ‘operator<’ (operand types are ‘StoreSale’ and ‘StoreSale’)
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:98:22: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   98 |       { return __val < *__it; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/predefined_ops.h: In instantiation of ‘bool __gnu_cxx::__ops::_Iter_less_val::operator()(_Iterator, _Value&) const [with _Iterator = __gnu_cxx::__normal_iterator<StoreSale*, std::vector<StoreSale> >; _Value = StoreSale]’:
+/usr/include/c++/13/bits/stl_heap.h:140:48:   required from ‘void std::__push_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Distance = long int; _Tp = StoreSale; _Compare = __gnu_cxx::__ops::_Iter_less_val]’
+/usr/include/c++/13/bits/stl_heap.h:247:23:   required from ‘void std::__adjust_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Distance = long int; _Tp = StoreSale; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_heap.h:356:22:   required from ‘void std::__make_heap(_RandomAccessIterator, _RandomAccessIterator, _Compare&) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1635:23:   required from ‘void std::__heap_select(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1910:25:   required from ‘void std::__partial_sort(_RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1926:27:   required from ‘void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Size = long int; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:1947:25:   required from ‘void std::__sort(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’
+/usr/include/c++/13/bits/stl_algo.h:4861:18:   required from ‘void std::sort(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<StoreSale*, vector<StoreSale> >]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:84:17:   required from ‘main()::<lambda(auto:3, auto:4)> [with auto:3 = std::vector<StoreSale>; auto:4 = std::vector<StoreSale>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq602280930360/001/prog.cpp:87:8:   required from here
+/usr/include/c++/13/bits/predefined_ops.h:69:22: error: no match for ‘operator<’ (operand types are ‘StoreSale’ and ‘StoreSale’)
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note: candidate: ‘template<class _IteratorL, class _IteratorR, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_IteratorL, _Container>&, const __normal_iterator<_IteratorR, _Container>&)’
+ 1250 |     operator<(const __normal_iterator<_IteratorL, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1250:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_IteratorL, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note: candidate: ‘template<class _Iterator, class _Container> bool __gnu_cxx::operator<(const __normal_iterator<_Iterator, _Container>&, const __normal_iterator<_Iterator, _Container>&)’
+ 1258 |     operator<(const __normal_iterator<_Iterator, _Container>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1258:5: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/predefined_ops.h:69:22: note:   ‘StoreSale’ is not derived from ‘const __gnu_cxx::__normal_iterator<_Iterator, _Container>’
+   69 |       { return *__it < __val; }
+      |                ~~~~~~^~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q61.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q61.error
@@ -1,0 +1,38 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:77:26: error: ‘s’ was not declared in this scope
+   77 |     std::vector<decltype(s.price)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:77:34: error: template argument 1 is invalid
+   77 |     std::vector<decltype(s.price)> __items;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:77:34: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:81:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   81 |       __items.push_back(s.price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:76:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:75:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   75 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:75:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   75 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:88:26: error: ‘s’ was not declared in this scope
+   88 |     std::vector<decltype(s.price)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:88:34: error: template argument 1 is invalid
+   88 |     std::vector<decltype(s.price)> __items;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:88:34: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:90:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   90 |       __items.push_back(s.price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:87:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:86:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   86 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq611231607452/001/prog.cpp:86:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   86 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q62.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q62.error
@@ -1,0 +1,26 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq622811188022/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq622811188022/001/prog.cpp:55:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   55 |       std::vector<decltype(std::unordered_map<std::string, decltype(10)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   56 |           {std::string("days"), 10}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   57 |           std::unordered_map<std::string, decltype(10)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   58 |               {std::string("days"), 10}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   59 |           std::unordered_map<std::string, decltype(40)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   60 |               {std::string("days"), 40}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   61 |           std::unordered_map<std::string, decltype(70)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   62 |               {std::string("days"), 70}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   63 |           std::unordered_map<std::string, decltype(100)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   64 |               {std::string("days"), 100}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   65 |           std::unordered_map<std::string, decltype(130)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   66 |               {std::string("days"), 130}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q63.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q63.error
@@ -1,0 +1,421 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:59:12: error: ‘s’ was not declared in this scope
+   59 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:59:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:62:75: error: ‘struct ByMgr’ has no member named ‘mgr’
+   62 |   decltype(std::unordered_map<std::string, decltype(std::declval<ByMgr>().mgr)>{
+      |                                                                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:62:75: error: ‘struct ByMgr’ has no member named ‘mgr’
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:62:79: error: template argument 2 is invalid
+   62 |   decltype(std::unordered_map<std::string, decltype(std::declval<ByMgr>().mgr)>{
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:62:79: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:63:50: error: ‘struct ByMgr’ has no member named ‘mgr’
+   63 |       {std::string("mgr"), std::declval<ByMgr>().mgr}}) key;
+      |                                                  ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:63:50: error: ‘struct ByMgr’ has no member named ‘mgr’
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:67:42: error: request for member ‘mgr’ in ‘std::declval<__struct3>().__struct3::key’, which is of non-class type ‘int’
+   67 |   decltype(std::declval<__struct3>().key.mgr) mgr;
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:67:42: error: request for member ‘mgr’ in ‘std::declval<__struct3>().__struct3::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’)
+  119 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 int    std::unordered_map<std::__cxx11::basic_string<char>, int>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:2:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, int> >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/string:48:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:6:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:119:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  119 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, int> >&, const allocator<pair<const __cxx11::basic_string<char>, int> >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, int> >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:120:37: error: cannot convert ‘Sale’ to ‘int’ in initialization
+  120 |           __g.items.push_back(ByMgr{s});
+      |                                     ^
+      |                                     |
+      |                                     Sale
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:126:70: error: cannot convert ‘Sale’ to ‘int’ in initialization
+  126 |         __groups.push_back(__struct3{__key, std::vector<ByMgr>{ByMgr{s}}});
+      |                                                                      ^
+      |                                                                      |
+      |                                                                      Sale
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:126:72: error: no matching function for call to ‘std::vector<ByMgr>::vector(<brace-enclosed initializer list>)’
+  126 |         __groups.push_back(__struct3{__key, std::vector<ByMgr>{ByMgr{s}}});
+      |                                                                        ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = ByMgr; _Alloc = std::allocator<ByMgr>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; allocator_type = std::allocator<ByMgr>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; std::__type_identity_t<_Alloc> = std::allocator<ByMgr>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; allocator_type = std::allocator<ByMgr>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; allocator_type = std::allocator<ByMgr>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; std::__type_identity_t<_Alloc> = std::allocator<ByMgr>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; size_type = long unsigned int; value_type = ByMgr; allocator_type = std::allocator<ByMgr>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; size_type = long unsigned int; allocator_type = std::allocator<ByMgr>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>; allocator_type = std::allocator<ByMgr>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = ByMgr; _Alloc = std::allocator<ByMgr>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:132:17: error: request for member ‘mgr’ in ‘g.__struct3::key’, which is of non-class type ‘int’
+  132 |           g.key.mgr, ([&](auto v) {
+      |                 ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:135:56: error: ‘struct ByMgr’ has no member named ‘amount’
+  135 |             std::vector<decltype(std::declval<ByMgr>().amount)> __items;
+      |                                                        ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:135:56: error: ‘struct ByMgr’ has no member named ‘amount’
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:135:63: error: template argument 1 is invalid
+  135 |             std::vector<decltype(std::declval<ByMgr>().amount)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:135:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:137:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  137 |               __items.push_back(x.amount);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:137:35: error: ‘struct ByMgr’ has no member named ‘amount’
+  137 |               __items.push_back(x.amount);
+      |                                   ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:134:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:133:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  133 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:133:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  133 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:143:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<ByMgr>’ requested
+  112 |   std::vector<ByMgr> by_mgr = ([&]() {
+      |                               ~~~~~~~~
+  113 |     std::vector<__struct3> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  114 |     for (auto s : sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~
+  115 |       auto __key = std::unordered_map<std::string, decltype(s.mgr)>{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  116 |           {std::string("mgr"), s.mgr}};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  117 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  118 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  119 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  120 |           __g.items.push_back(ByMgr{s});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  121 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  122 |           break;
+      |           ~~~~~~
+  123 |         }
+      |         ~
+  124 |       }
+      |       ~
+  125 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  126 |         __groups.push_back(__struct3{__key, std::vector<ByMgr>{ByMgr{s}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  127 |       }
+      |       ~
+  128 |     }
+      |     ~
+  129 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  130 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  131 |       __items.push_back(__struct4{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  132 |           g.key.mgr, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~
+  133 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  134 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  135 |             std::vector<decltype(std::declval<ByMgr>().amount)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  136 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  137 |               __items.push_back(x.amount);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  138 |             }
+      |             ~
+  139 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  140 |           })())});
+      |           ~~~~~~~~
+  141 |     }
+      |     ~
+  142 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  143 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:147:48: error: ‘struct ByMgr’ has no member named ‘sum_sales’
+  147 |     std::vector<decltype(std::declval<ByMgr>().sum_sales)> __items;
+      |                                                ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:147:48: error: ‘struct ByMgr’ has no member named ‘sum_sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:147:58: error: template argument 1 is invalid
+  147 |     std::vector<decltype(std::declval<ByMgr>().sum_sales)> __items;
+      |                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:147:58: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:149:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  149 |       __items.push_back(x.sum_sales);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:149:27: error: ‘struct ByMgr’ has no member named ‘sum_sales’
+  149 |       __items.push_back(x.sum_sales);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:146:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:145:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  145 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq63487171643/001/prog.cpp:145:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  145 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q65.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q65.error
@@ -1,0 +1,467 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:60:12: error: ‘ss’ was not declared in this scope
+   60 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:60:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:64:68: error: ‘struct ItemRevenue’ has no member named ‘item’
+   64 |                               decltype(std::declval<ItemRevenue>().item)>{
+      |                                                                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:64:68: error: ‘struct ItemRevenue’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:64:73: error: template argument 2 is invalid
+   64 |                               decltype(std::declval<ItemRevenue>().item)>{
+      |                                                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:64:73: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:65:57: error: ‘struct ItemRevenue’ has no member named ‘item’
+   65 |       {std::string("item"), std::declval<ItemRevenue>().item}}) key;
+      |                                                         ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:65:57: error: ‘struct ItemRevenue’ has no member named ‘item’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:69:42: error: request for member ‘item’ in ‘std::declval<__struct3>().__struct3::key’, which is of non-class type ‘int’
+   69 |   decltype(std::declval<__struct3>().key.item) item;
+      |                                          ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:69:42: error: request for member ‘item’ in ‘std::declval<__struct3>().__struct3::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:120:15: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  120 | float average(auto xs) {
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’)
+  139 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 int    std::unordered_map<std::__cxx11::basic_string<char>, int>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:2:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, int> >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/string:48:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, int>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:6:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:139:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  139 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, int> >&, const allocator<pair<const __cxx11::basic_string<char>, int> >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, int> >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:140:43: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  140 |           __g.items.push_back(ItemRevenue{ss});
+      |                                           ^~
+      |                                           |
+      |                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:147:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  147 |             __struct3{__key, std::vector<ItemRevenue>{ItemRevenue{ss}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:147:70: error: no matching function for call to ‘std::vector<ItemRevenue>::vector(<brace-enclosed initializer list>)’
+  147 |             __struct3{__key, std::vector<ItemRevenue>{ItemRevenue{ss}}});
+      |                                                                      ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; allocator_type = std::allocator<ItemRevenue>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; std::__type_identity_t<_Alloc> = std::allocator<ItemRevenue>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; allocator_type = std::allocator<ItemRevenue>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; allocator_type = std::allocator<ItemRevenue>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; std::__type_identity_t<_Alloc> = std::allocator<ItemRevenue>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; size_type = long unsigned int; value_type = ItemRevenue; allocator_type = std::allocator<ItemRevenue>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; size_type = long unsigned int; allocator_type = std::allocator<ItemRevenue>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>; allocator_type = std::allocator<ItemRevenue>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = ItemRevenue; _Alloc = std::allocator<ItemRevenue>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:153:17: error: request for member ‘item’ in ‘g.__struct3::key’, which is of non-class type ‘int’
+  153 |           g.key.item, ([&](auto v) {
+      |                 ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:156:62: error: ‘struct ItemRevenue’ has no member named ‘price’
+  156 |             std::vector<decltype(std::declval<ItemRevenue>().price)> __items;
+      |                                                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:156:62: error: ‘struct ItemRevenue’ has no member named ‘price’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:156:68: error: template argument 1 is invalid
+  156 |             std::vector<decltype(std::declval<ItemRevenue>().price)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:156:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:158:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  158 |               __items.push_back(x.price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:158:35: error: ‘struct ItemRevenue’ has no member named ‘price’
+  158 |               __items.push_back(x.price);
+      |                                   ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:155:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:154:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  154 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:154:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  154 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:164:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<ItemRevenue>’ requested
+  132 |   std::vector<ItemRevenue> item_revenue = ([&]() {
+      |                                           ~~~~~~~~
+  133 |     std::vector<__struct3> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  134 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  135 |       auto __key = std::unordered_map<std::string, decltype(ss.item)>{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  136 |           {std::string("item"), ss.item}};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  137 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  138 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  139 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  140 |           __g.items.push_back(ItemRevenue{ss});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  141 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  142 |           break;
+      |           ~~~~~~
+  143 |         }
+      |         ~
+  144 |       }
+      |       ~
+  145 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  146 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  147 |             __struct3{__key, std::vector<ItemRevenue>{ItemRevenue{ss}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  148 |       }
+      |       ~
+  149 |     }
+      |     ~
+  150 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  151 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  152 |       __items.push_back(__struct4{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  153 |           g.key.item, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  154 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  155 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  156 |             std::vector<decltype(std::declval<ItemRevenue>().price)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  157 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  158 |               __items.push_back(x.price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  159 |             }
+      |             ~
+  160 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  161 |           })())});
+      |           ~~~~~~~~
+  162 |     }
+      |     ~
+  163 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  164 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:166:54: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+  166 |     std::vector<decltype(std::declval<ItemRevenue>().revenue)> __items;
+      |                                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:166:54: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:166:62: error: template argument 1 is invalid
+  166 |     std::vector<decltype(std::declval<ItemRevenue>().revenue)> __items;
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:166:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:168:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  168 |       __items.push_back(ir.revenue);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:168:28: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+  168 |       __items.push_back(ir.revenue);
+      |                            ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:173:54: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+  173 |     std::vector<decltype(std::declval<ItemRevenue>().revenue)> __items;
+      |                                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:173:54: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:173:62: error: template argument 1 is invalid
+  173 |     std::vector<decltype(std::declval<ItemRevenue>().revenue)> __items;
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:173:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:175:17: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+  175 |       if (!((ir.revenue <= (0.1 * avg_rev))))
+      |                 ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:177:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  177 |       __items.push_back(ir.revenue);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:177:28: error: ‘struct ItemRevenue’ has no member named ‘revenue’
+  177 |       __items.push_back(ir.revenue);
+      |                            ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:183:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:182:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  182 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:182:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  182 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp: In instantiation of ‘float average(auto:1) [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:165:25:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:121:11: error: request for member ‘size’ in ‘xs’, which is of non-class type ‘int’
+  121 |   if ((xs.size() == 0)) {
+      |        ~~~^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:125:3: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  125 |   for (auto x : xs) {
+      |   ^~~
+      |   std::begin
+In file included from /usr/include/c++/13/string:53:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:125:3: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  125 |   for (auto x : xs) {
+      |   ^~~
+      |   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq652690381697/001/prog.cpp:128:21: error: request for member ‘size’ in ‘xs’, which is of non-class type ‘int’
+  128 |   return (sum / (xs.size()));
+      |                  ~~~^~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q66.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q66.error
@@ -1,0 +1,63 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:56:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   56 |       std::vector<decltype(std::unordered_map<std::string, decltype(30)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   57 |           {std::string("net"), 30}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   58 |           std::unordered_map<std::string, decltype(30)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   59 |               {std::string("net"), 30}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:61:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   61 |       std::vector<decltype(std::unordered_map<std::string, decltype(36)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   62 |           {std::string("net"), 36}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   63 |           std::unordered_map<std::string, decltype(36)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   64 |               {std::string("net"), 36}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:68:41: error: ‘w’ was not declared in this scope
+   68 |                    std::vector<decltype(w.net)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:68:47: error: template argument 1 is invalid
+   68 |                    std::vector<decltype(w.net)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:68:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:70:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   70 |                      __items.push_back(w.net);
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:70:42: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘net’
+   70 |                      __items.push_back(w.net);
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:67:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:66:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   66 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:66:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   66 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:77:41: error: ‘c’ was not declared in this scope
+   77 |                    std::vector<decltype(c.net)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:77:47: error: template argument 1 is invalid
+   77 |                    std::vector<decltype(c.net)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:77:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:79:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   79 |                      __items.push_back(c.net);
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:79:42: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘net’
+   79 |                      __items.push_back(c.net);
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:76:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:75:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   75 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq662116732538/001/prog.cpp:75:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   75 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q67.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q67.error
@@ -1,0 +1,19 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:100:26: error: ‘ss’ was not declared in this scope
+  100 |     std::vector<decltype(ss.price)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:100:35: error: template argument 1 is invalid
+  100 |     std::vector<decltype(ss.price)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:100:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:116:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  116 |         __items.push_back(ss.price);
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:99:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:98:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   98 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq673111448586/001/prog.cpp:98:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   98 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q68.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q68.error
@@ -1,0 +1,38 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:79:42: error: ‘c’ was not declared in this scope
+   79 |                     std::vector<decltype(c.profit)> __items;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:79:51: error: template argument 1 is invalid
+   79 |                     std::vector<decltype(c.profit)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:79:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:81:31: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   81 |                       __items.push_back(c.profit);
+      |                               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:78:21:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:77:46: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   77 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:77:57: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   77 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:88:42: error: ‘s’ was not declared in this scope
+   88 |                     std::vector<decltype(s.profit)> __items;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:88:51: error: template argument 1 is invalid
+   88 |                     std::vector<decltype(s.profit)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:88:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:90:31: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   90 |                       __items.push_back(s.profit);
+      |                               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:87:21:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:86:46: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   86 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq681473386006/001/prog.cpp:86:57: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   86 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q69.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q69.error
@@ -1,0 +1,63 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:56:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   56 |       std::vector<decltype(std::unordered_map<std::string, decltype(34)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   57 |           {std::string("amount"), 34}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   58 |           std::unordered_map<std::string, decltype(34)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   59 |               {std::string("amount"), 34}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:61:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   61 |       std::vector<decltype(std::unordered_map<std::string, decltype(35)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   62 |           {std::string("amount"), 35}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   63 |           std::unordered_map<std::string, decltype(35)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   64 |               {std::string("amount"), 35}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:68:41: error: ‘w’ was not declared in this scope
+   68 |                    std::vector<decltype(w.amount)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:68:50: error: template argument 1 is invalid
+   68 |                    std::vector<decltype(w.amount)> __items;
+      |                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:68:50: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:70:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   70 |                      __items.push_back(w.amount);
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:70:42: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘amount’
+   70 |                      __items.push_back(w.amount);
+      |                                          ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:67:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:66:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   66 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:66:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   66 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:77:41: error: ‘s’ was not declared in this scope
+   77 |                    std::vector<decltype(s.amount)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:77:50: error: template argument 1 is invalid
+   77 |                    std::vector<decltype(s.amount)> __items;
+      |                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:77:50: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:79:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   79 |                      __items.push_back(s.amount);
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:79:42: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘amount’
+   79 |                      __items.push_back(s.amount);
+      |                                          ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:76:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:75:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   75 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq692335818597/001/prog.cpp:75:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   75 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q7.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q7.error
@@ -1,0 +1,764 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+   85 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:86:12: error: ‘cd’ was not declared in this scope
+   86 |   decltype(cd) cd;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:86:12: error: ‘cd’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:87:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+   87 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:87:12: error: ‘d’ was not declared in this scope; did you mean ‘cd’?
+   87 |   decltype(d) d;
+      |            ^
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+   88 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:89:12: error: ‘p’ was not declared in this scope
+   89 |   decltype(p) p;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:89:12: error: ‘p’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:92:53: error: ‘i’ was not declared in this scope
+   92 |   decltype(std::unordered_map<std::string, decltype(i.i_item_id)>{
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:92:53: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:92:65: error: template argument 2 is invalid
+   92 |   decltype(std::unordered_map<std::string, decltype(i.i_item_id)>{
+      |                                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:92:65: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:93:34: error: ‘i’ was not declared in this scope
+   93 |       {std::string("i_item_id"), i.i_item_id}}) key;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:93:34: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:105:42: error: request for member ‘i_item_id’ in ‘std::declval<__struct7>().__struct7::key’, which is of non-class type ‘int’
+  105 |   decltype(std::declval<__struct7>().key.i_item_id) i_item_id;
+      |                                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:105:42: error: request for member ‘i_item_id’ in ‘std::declval<__struct7>().__struct7::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:29: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’)
+  326 |                 if (__g.key == __key) {
+      |                     ~~~~~~~ ^~ ~~~~~
+      |                         |      |
+      |                         int    std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:3:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘const std::__new_allocator<_Tp>’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘const std::__new_allocator<_Tp>’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:2:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const _CharT*’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:6:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:326:32: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  326 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&, const allocator<pair<const __cxx11::basic_string<char>, __cxx11::basic_string<char> > >&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:327:46: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  327 |                   __g.items.push_back(Result{ss, cd, d, i, p});
+      |                                              ^~
+      |                                              |
+      |                                              StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:334:55: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  334 |                     __key, std::vector<Result>{Result{ss, cd, d, i, p}}});
+      |                                                       ^~
+      |                                                       |
+      |                                                       StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:334:71: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  334 |                     __key, std::vector<Result>{Result{ss, cd, d, i, p}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:342:58: error: request for member ‘i_item_id’ in ‘std::declval<__struct7>().__struct7::key’, which is of non-class type ‘int’
+  342 |         std::pair<decltype(std::declval<__struct7>().key.i_item_id), __struct8>>
+      |                                                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:342:58: error: request for member ‘i_item_id’ in ‘std::declval<__struct7>().__struct7::key’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:342:70: error: template argument 1 is invalid
+  342 |         std::pair<decltype(std::declval<__struct7>().key.i_item_id), __struct8>>
+      |                                                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:342:79: error: template argument 1 is invalid
+  342 |         std::pair<decltype(std::declval<__struct7>().key.i_item_id), __struct8>>
+      |                                                                               ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:342:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:345:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  345 |       __items.push_back(
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:346:18: error: request for member ‘i_item_id’ in ‘g.__struct7::key’, which is of non-class type ‘int’
+  346 |           {g.key.i_item_id,
+      |                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:348:22: error: request for member ‘i_item_id’ in ‘g.__struct7::key’, which is of non-class type ‘int’
+  348 |                g.key.i_item_id, __avg(([&]() {
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:349:65: error: request for member ‘ss_quantity’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+  349 |                  std::vector<decltype(std::declval<Result>().ss.ss_quantity)>
+      |                                                                 ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:349:65: error: request for member ‘ss_quantity’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:349:77: error: template argument 1 is invalid
+  349 |                  std::vector<decltype(std::declval<Result>().ss.ss_quantity)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:349:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:352:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  352 |                    __items.push_back(x.ss.ss_quantity);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:352:43: error: request for member ‘ss_quantity’ in ‘x.Result::ss’, which is of non-class type ‘int’
+  352 |                    __items.push_back(x.ss.ss_quantity);
+      |                                           ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:348:38: error: no matching function for call to ‘__avg(int)’
+  348 |                g.key.i_item_id, __avg(([&]() {
+      |                                 ~~~~~^~~~~~~~~
+  349 |                  std::vector<decltype(std::declval<Result>().ss.ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                      __items;
+      |                      ~~~~~~~~         
+  351 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |                    __items.push_back(x.ss.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |                  }
+      |                  ~                    
+  354 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~      
+  355 |                })()),
+      |                ~~~~~                  
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   96 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:348:38: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  348 |                g.key.i_item_id, __avg(([&]() {
+      |                                 ~~~~~^~~~~~~~~
+  349 |                  std::vector<decltype(std::declval<Result>().ss.ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                      __items;
+      |                      ~~~~~~~~         
+  351 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |                    __items.push_back(x.ss.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |                  }
+      |                  ~                    
+  354 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~      
+  355 |                })()),
+      |                ~~~~~                  
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:357:65: error: request for member ‘ss_list_price’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+  357 |                  std::vector<decltype(std::declval<Result>().ss.ss_list_price)>
+      |                                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:357:65: error: request for member ‘ss_list_price’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:357:79: error: template argument 1 is invalid
+  357 |                  std::vector<decltype(std::declval<Result>().ss.ss_list_price)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:357:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:360:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  360 |                    __items.push_back(x.ss.ss_list_price);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:360:43: error: request for member ‘ss_list_price’ in ‘x.Result::ss’, which is of non-class type ‘int’
+  360 |                    __items.push_back(x.ss.ss_list_price);
+      |                                           ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:356:21: error: no matching function for call to ‘__avg(int)’
+  356 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  357 |                  std::vector<decltype(std::declval<Result>().ss.ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |                      __items;
+      |                      ~~~~~~~~
+  359 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |                    __items.push_back(x.ss.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                  }
+      |                  ~   
+  362 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  363 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   96 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:356:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  356 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  357 |                  std::vector<decltype(std::declval<Result>().ss.ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |                      __items;
+      |                      ~~~~~~~~
+  359 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |                    __items.push_back(x.ss.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                  }
+      |                  ~   
+  362 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  363 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:365:65: error: request for member ‘ss_coupon_amt’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+  365 |                  std::vector<decltype(std::declval<Result>().ss.ss_coupon_amt)>
+      |                                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:365:65: error: request for member ‘ss_coupon_amt’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:365:79: error: template argument 1 is invalid
+  365 |                  std::vector<decltype(std::declval<Result>().ss.ss_coupon_amt)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:365:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:368:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  368 |                    __items.push_back(x.ss.ss_coupon_amt);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:368:43: error: request for member ‘ss_coupon_amt’ in ‘x.Result::ss’, which is of non-class type ‘int’
+  368 |                    __items.push_back(x.ss.ss_coupon_amt);
+      |                                           ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:364:21: error: no matching function for call to ‘__avg(int)’
+  364 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  365 |                  std::vector<decltype(std::declval<Result>().ss.ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |                      __items;
+      |                      ~~~~~~~~
+  367 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |                    __items.push_back(x.ss.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                  }
+      |                  ~   
+  370 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  371 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   96 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:364:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  364 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  365 |                  std::vector<decltype(std::declval<Result>().ss.ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |                      __items;
+      |                      ~~~~~~~~
+  367 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |                    __items.push_back(x.ss.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                  }
+      |                  ~   
+  370 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  371 |                })()),
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:373:65: error: request for member ‘ss_sales_price’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+  373 |                  std::vector<decltype(std::declval<Result>().ss.ss_sales_price)>
+      |                                                                 ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:373:65: error: request for member ‘ss_sales_price’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:373:80: error: template argument 1 is invalid
+  373 |                  std::vector<decltype(std::declval<Result>().ss.ss_sales_price)>
+      |                                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:373:80: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:376:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  376 |                    __items.push_back(x.ss.ss_sales_price);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:376:43: error: request for member ‘ss_sales_price’ in ‘x.Result::ss’, which is of non-class type ‘int’
+  376 |                    __items.push_back(x.ss.ss_sales_price);
+      |                                           ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:372:21: error: no matching function for call to ‘__avg(int)’
+  372 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  373 |                  std::vector<decltype(std::declval<Result>().ss.ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |                      __items;
+      |                      ~~~~~~~~
+  375 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |                    __items.push_back(x.ss.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                  }
+      |                  ~   
+  378 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  379 |                })())}});
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   96 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:96:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:372:21: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  372 |                __avg(([&]() {
+      |                ~~~~~^~~~~~~~~
+  373 |                  std::vector<decltype(std::declval<Result>().ss.ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |                      __items;
+      |                      ~~~~~~~~
+  375 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |                    __items.push_back(x.ss.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                  }
+      |                  ~   
+  378 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  379 |                })())}});
+      |                ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:381:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  381 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:381:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  381 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:384:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  384 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:384:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  384 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq72861879966/001/prog.cpp:387:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<Result>’ requested
+  299 |   std::vector<Result> result = ([&]() {
+      |                                ~~~~~~~~
+  300 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  301 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |       for (auto cd : customer_demographics) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |         if (!((ss.ss_cdemo_sk == cd.cd_demo_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  304 |           continue;
+      |           ~~~~~~~~~
+  305 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  306 |           if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  307 |             continue;
+      |             ~~~~~~~~~
+  308 |           for (auto i : item) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  309 |             if (!((ss.ss_item_sk == i.i_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |               continue;
+      |               ~~~~~~~~~
+  311 |             for (auto p : promotion) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |               if (!((ss.ss_promo_sk == p.p_promo_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  313 |                 continue;
+      |                 ~~~~~~~~~
+  314 |               if (!((((((cd.cd_gender == std::string("M")) &&
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  315 |                         (cd.cd_marital_status == std::string("S"))) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  316 |                        (cd.cd_education_status == std::string("College"))) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  317 |                       (((p.p_channel_email == std::string("N")) ||
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  318 |                         (p.p_channel_event == std::string("N"))))) &&
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  319 |                      (d.d_year == 1998))))
+      |                      ~~~~~~~~~~~~~~~~~~~~~
+  320 |                 continue;
+      |                 ~~~~~~~~~
+  321 |               auto __key =
+      |               ~~~~~~~~~~~~
+  322 |                   std::unordered_map<std::string, decltype(i.i_item_id)>{
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |                       {std::string("i_item_id"), i.i_item_id}};
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  324 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  325 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  326 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  327 |                   __g.items.push_back(Result{ss, cd, d, i, p});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  328 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  329 |                   break;
+      |                   ~~~~~~
+  330 |                 }
+      |                 ~
+  331 |               }
+      |               ~
+  332 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  333 |                 __groups.push_back(__struct7{
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |                     __key, std::vector<Result>{Result{ss, cd, d, i, p}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  335 |               }
+      |               ~
+  336 |             }
+      |             ~
+  337 |           }
+      |           ~
+  338 |         }
+      |         ~
+  339 |       }
+      |       ~
+  340 |     }
+      |     ~
+  341 |     std::vector<
+      |     ~~~~~~~~~~~~
+  342 |         std::pair<decltype(std::declval<__struct7>().key.i_item_id), __struct8>>
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |         __items;
+      |         ~~~~~~~~
+  344 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  346 |           {g.key.i_item_id,
+      |           ~~~~~~~~~~~~~~~~~
+  347 |            __struct8{
+      |            ~~~~~~~~~~
+  348 |                g.key.i_item_id, __avg(([&]() {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |                  std::vector<decltype(std::declval<Result>().ss.ss_quantity)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  350 |                      __items;
+      |                      ~~~~~~~~
+  351 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |                    __items.push_back(x.ss.ss_quantity);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |                  }
+      |                  ~
+  354 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  355 |                })()),
+      |                ~~~~~~
+  356 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  357 |                  std::vector<decltype(std::declval<Result>().ss.ss_list_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |                      __items;
+      |                      ~~~~~~~~
+  359 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  360 |                    __items.push_back(x.ss.ss_list_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                  }
+      |                  ~
+  362 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  363 |                })()),
+      |                ~~~~~~
+  364 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  365 |                  std::vector<decltype(std::declval<Result>().ss.ss_coupon_amt)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |                      __items;
+      |                      ~~~~~~~~
+  367 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |                    __items.push_back(x.ss.ss_coupon_amt);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |                  }
+      |                  ~
+  370 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  371 |                })()),
+      |                ~~~~~~
+  372 |                __avg(([&]() {
+      |                ~~~~~~~~~~~~~~
+  373 |                  std::vector<decltype(std::declval<Result>().ss.ss_sales_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |                      __items;
+      |                      ~~~~~~~~
+  375 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |                    __items.push_back(x.ss.ss_sales_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                  }
+      |                  ~
+  378 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  379 |                })())}});
+      |                ~~~~~~~~~
+  380 |     }
+      |     ~
+  381 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  383 |     std::vector<__struct8> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  384 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  385 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |     return __res;
+      |     ~~~~~~~~~~~~~
+  387 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q70.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q70.error
@@ -1,0 +1,258 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:71:12: error: ‘s’ was not declared in this scope
+   71 |   decltype(s.s_state) state;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:71:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:72:12: error: ‘s’ was not declared in this scope
+   72 |   decltype(s.s_county) county;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:72:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:75:12: error: ‘ss’ was not declared in this scope
+   75 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:75:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:76:12: error: ‘d’ was not declared in this scope
+   76 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:76:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:77:12: error: ‘s’ was not declared in this scope
+   77 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:77:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:237:33: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  237 |           auto __key = Result{s.s_state, s.s_county};
+      |                               ~~^~~~~~~
+      |                                 |
+      |                                 std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:241:45: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  241 |               __g.items.push_back(__struct5{ss, d, s});
+      |                                             ^~
+      |                                             |
+      |                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:248:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  248 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, d, s}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:248:76: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  248 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, d, s}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:261:66: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct5>().__struct5::ss’, which is of non-class type ‘int’
+  261 |                            decltype(std::declval<__struct5>().ss.ss_net_profit)>
+      |                                                                  ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:261:66: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct5>().__struct5::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:261:80: error: template argument 1 is invalid
+  261 |                            decltype(std::declval<__struct5>().ss.ss_net_profit)>
+      |                                                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:261:80: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:264:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  264 |                          __items.push_back(x.ss.ss_net_profit);
+      |                                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:264:49: error: request for member ‘ss_net_profit’ in ‘x.__struct5::ss’, which is of non-class type ‘int’
+  264 |                          __items.push_back(x.ss.ss_net_profit);
+      |                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:259:24:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:258:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  258 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:258:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  258 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                          ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:255:24: error: no matching function for call to ‘std::vector<std::pair<__struct8, __struct7> >::push_back(<brace-enclosed initializer list>)’
+  255 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  256 |           {__struct8{g.key.state, g.key.county},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |            __struct7{g.key.state, g.key.county, ([&](auto v) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  259 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  260 |                        std::vector<
+      |                        ~~~~~~~~~~~~
+  261 |                            decltype(std::declval<__struct5>().ss.ss_net_profit)>
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |                            __items;
+      |                            ~~~~~~~~
+  263 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |                          __items.push_back(x.ss.ss_net_profit);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |                        }
+      |                        ~
+  266 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  267 |                      })())}});
+      |                      ~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<__struct8, __struct7>; _Alloc = std::allocator<std::pair<__struct8, __struct7> >; value_type = std::pair<__struct8, __struct7>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<__struct8, __struct7> >::value_type&’ {aka ‘const std::pair<__struct8, __struct7>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<__struct8, __struct7>; _Alloc = std::allocator<std::pair<__struct8, __struct7> >; value_type = std::pair<__struct8, __struct7>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<__struct8, __struct7> >::value_type&&’ {aka ‘std::pair<__struct8, __struct7>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq702749909962/001/prog.cpp:277:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  226 |   std::vector<__struct5> result = ([&]() {
+      |                                   ~~~~~~~~
+  227 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  228 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  229 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  230 |         if (!((d.d_date_sk == ss.ss_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  231 |           continue;
+      |           ~~~~~~~~~
+  232 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  233 |           if (!((s.s_store_sk == ss.ss_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  234 |             continue;
+      |             ~~~~~~~~~
+  235 |           if (!(((d.d_month_seq >= dms) && (d.d_month_seq <= (dms + 11)))))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  236 |             continue;
+      |             ~~~~~~~~~
+  237 |           auto __key = Result{s.s_state, s.s_county};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  238 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  239 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  240 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  241 |               __g.items.push_back(__struct5{ss, d, s});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  243 |               break;
+      |               ~~~~~~
+  244 |             }
+      |             ~
+  245 |           }
+      |           ~
+  246 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  247 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  248 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, d, s}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |           }
+      |           ~
+  250 |         }
+      |         ~
+  251 |       }
+      |       ~
+  252 |     }
+      |     ~
+  253 |     std::vector<std::pair<__struct8, __struct7>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  254 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  255 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  256 |           {__struct8{g.key.state, g.key.county},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |            __struct7{g.key.state, g.key.county, ([&](auto v) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |                        return std::accumulate(v.begin(), v.end(), 0.0);
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  259 |                      })(([&]() {
+      |                      ~~~~~~~~~~~
+  260 |                        std::vector<
+      |                        ~~~~~~~~~~~~
+  261 |                            decltype(std::declval<__struct5>().ss.ss_net_profit)>
+      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |                            __items;
+      |                            ~~~~~~~~
+  263 |                        for (auto x : g.items) {
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |                          __items.push_back(x.ss.ss_net_profit);
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |                        }
+      |                        ~
+  266 |                        return __items;
+      |                        ~~~~~~~~~~~~~~~
+  267 |                      })())}});
+      |                      ~~~~~~~~~
+  268 |     }
+      |     ~
+  269 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |       return std::tie(a.first.f0, a.first.f1) <
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  271 |              std::tie(b.first.f0, b.first.f1);
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |     });
+      |     ~~~
+  273 |     std::vector<__struct7> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  275 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |     return __res;
+      |     ~~~~~~~~~~~~~
+  277 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q71.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q71.error
@@ -1,0 +1,289 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:92:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   92 |   decltype(ws.ws_ext_sales_price) ext_price;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:92:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   92 |   decltype(ws.ws_ext_sales_price) ext_price;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:93:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   93 |   decltype(ws.ws_item_sk) item_sk;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:93:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   93 |   decltype(ws.ws_item_sk) item_sk;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:94:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   94 |   decltype(ws.ws_sold_time_sk) time_sk;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:94:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   94 |   decltype(ws.ws_sold_time_sk) time_sk;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:97:12: error: ‘i’ was not declared in this scope
+   97 |   decltype(i.i_brand_id) brand_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:97:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:98:12: error: ‘i’ was not declared in this scope
+   98 |   decltype(i.i_brand) brand;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:98:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:99:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+   99 |   decltype(t.t_hour) t_hour;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:99:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+   99 |   decltype(t.t_hour) t_hour;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:100:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+  100 |   decltype(t.t_minute) t_minute;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:100:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+  100 |   decltype(t.t_minute) t_minute;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:103:12: error: ‘i’ was not declared in this scope
+  103 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:103:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:105:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+  105 |   decltype(t) t;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:105:12: error: ‘t’ was not declared in this scope; did you mean ‘tm’?
+  105 |   decltype(t) t;
+      |            ^
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:389:40: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  389 |   std::vector<UnionSale> union_sales = concat(
+      |                                        ^~~~~~
+      |                                        wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:445:47: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  445 |           auto __key = Result{i.i_brand_id, i.i_brand, t.t_hour, t.t_minute};
+      |                                             ~~^~~~~~~
+      |                                               |
+      |                                               std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:449:45: error: cannot convert ‘Item’ to ‘int’ in initialization
+  449 |               __g.items.push_back(__struct9{i, s, t});
+      |                                             ^
+      |                                             |
+      |                                             Item
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:456:68: error: cannot convert ‘Item’ to ‘int’ in initialization
+  456 |                 __struct10{__key, std::vector<__struct9>{__struct9{i, s, t}}});
+      |                                                                    ^
+      |                                                                    |
+      |                                                                    Item
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:456:76: error: no matching function for call to ‘std::vector<__struct9>::vector(<brace-enclosed initializer list>)’
+  456 |                 __struct10{__key, std::vector<__struct9>{__struct9{i, s, t}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; value_type = std::vector<__struct9>::value_type; allocator_type = std::allocator<__struct9>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; allocator_type = std::allocator<__struct9>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq711884955520/001/prog.cpp:497:5: error: conversion from ‘vector<__struct11>’ to non-scalar type ‘vector<__struct9>’ requested
+  432 |   std::vector<__struct9> result = ([&]() {
+      |                                   ~~~~~~~~
+  433 |     std::vector<__struct10> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |     for (auto i : item) {
+      |     ~~~~~~~~~~~~~~~~~~~~~
+  435 |       for (auto s : union_sales) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  436 |         if (!((s.item_sk == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |           continue;
+      |           ~~~~~~~~~
+  438 |         for (auto t : time_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  439 |           if (!((t.t_time_sk == s.time_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  440 |             continue;
+      |             ~~~~~~~~~
+  441 |           if (!(((i.i_manager_id == 1) &&
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  442 |                  (((t.t_meal_time == std::string("breakfast")) ||
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |                    (t.t_meal_time == std::string("dinner")))))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  444 |             continue;
+      |             ~~~~~~~~~
+  445 |           auto __key = Result{i.i_brand_id, i.i_brand, t.t_hour, t.t_minute};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  446 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  447 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  448 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  449 |               __g.items.push_back(__struct9{i, s, t});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  451 |               break;
+      |               ~~~~~~
+  452 |             }
+      |             ~
+  453 |           }
+      |           ~
+  454 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  455 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  456 |                 __struct10{__key, std::vector<__struct9>{__struct9{i, s, t}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  457 |           }
+      |           ~
+  458 |         }
+      |         ~
+  459 |       }
+      |       ~
+  460 |     }
+      |     ~
+  461 |     std::vector<std::pair<__struct12, __struct11>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  462 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  463 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  464 |           {__struct12{
+      |           ~~~~~~~~~~~~
+  465 |                (-([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~
+  466 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  467 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  468 |                  std::vector<decltype(std::declval<__struct9>().s.ext_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |                      __items;
+      |                      ~~~~~~~~
+  470 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |                    __items.push_back(x.s.ext_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  472 |                  }
+      |                  ~
+  473 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  474 |                })())),
+      |                ~~~~~~~
+  475 |                g.key.brand_id},
+      |                ~~~~~~~~~~~~~~~~
+  476 |            __struct11{
+      |            ~~~~~~~~~~~
+  477 |                g.key.brand_id, g.key.brand, g.key.t_hour, g.key.t_minute,
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  478 |                ([&](auto v) {
+      |                ~~~~~~~~~~~~~~
+  479 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  480 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  481 |                  std::vector<decltype(std::declval<__struct9>().s.ext_price)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  482 |                      __items;
+      |                      ~~~~~~~~
+  483 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  484 |                    __items.push_back(x.s.ext_price);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |                  }
+      |                  ~
+  486 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  487 |                })())}});
+      |                ~~~~~~~~~
+  488 |     }
+      |     ~
+  489 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  490 |       return std::tie(a.first.f0, a.first.f1) <
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  491 |              std::tie(b.first.f0, b.first.f1);
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  492 |     });
+      |     ~~~
+  493 |     std::vector<__struct11> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  494 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  495 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  496 |     return __res;
+      |     ~~~~~~~~~~~~~
+  497 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q72.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q72.error
@@ -1,0 +1,323 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+   92 |   decltype(i.i_item_desc) item_desc;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:93:12: error: ‘w’ was not declared in this scope
+   93 |   decltype(w.w_warehouse_name) warehouse;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:93:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:94:12: error: ‘d1’ was not declared in this scope
+   94 |   decltype(d1.d_week_seq) week_seq;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:94:12: error: ‘d1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:97:12: error: ‘cs’ was not declared in this scope
+   97 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:97:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:98:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   98 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:98:12: error: ‘inv’ was not declared in this scope; did you mean ‘int’?
+   98 |   decltype(inv) inv;
+      |            ^~~
+      |            int
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:99:12: error: ‘w’ was not declared in this scope
+   99 |   decltype(w) w;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:99:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:100:12: error: ‘i’ was not declared in this scope
+  100 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:100:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:101:12: error: ‘cd’ was not declared in this scope; did you mean ‘cs’?
+  101 |   decltype(cd) cd;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:101:12: error: ‘cd’ was not declared in this scope; did you mean ‘cs’?
+  101 |   decltype(cd) cd;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:102:12: error: ‘hd’ was not declared in this scope; did you mean ‘cd’?
+  102 |   decltype(hd) hd;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:102:12: error: ‘hd’ was not declared in this scope; did you mean ‘cd’?
+  102 |   decltype(hd) hd;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:103:12: error: ‘d1’ was not declared in this scope
+  103 |   decltype(d1) d1;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:103:12: error: ‘d1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:104:12: error: ‘d2’ was not declared in this scope; did you mean ‘d1’?
+  104 |   decltype(d2) d2;
+      |            ^~
+      |            d1
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:104:12: error: ‘d2’ was not declared in this scope; did you mean ‘d1’?
+  104 |   decltype(d2) d2;
+      |            ^~
+      |            d1
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:105:12: error: ‘d3’ was not declared in this scope; did you mean ‘d2’?
+  105 |   decltype(d3) d3;
+      |            ^~
+      |            d2
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:105:12: error: ‘d3’ was not declared in this scope; did you mean ‘d2’?
+  105 |   decltype(d3) d3;
+      |            ^~
+      |            d2
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:427:45: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  427 |                       auto __key = Result{i.i_item_desc, w.w_warehouse_name,
+      |                                           ~~^~~~~~~~~~~
+      |                                             |
+      |                                             std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:433:41: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  433 |                               __struct9{cs, inv, w, i, cd, hd, d1, d2, d3});
+      |                                         ^~
+      |                                         |
+      |                                         CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:441:40: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  441 |                                        cs, inv, w, i, cd, hd, d1, d2, d3}}});
+      |                                        ^~
+      |                                        |
+      |                                        CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:441:74: error: no matching function for call to ‘std::vector<__struct9>::vector(<brace-enclosed initializer list>)’
+  441 |                                        cs, inv, w, i, cd, hd, d1, d2, d3}}});
+      |                                                                          ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; value_type = std::vector<__struct9>::value_type; allocator_type = std::allocator<__struct9>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; allocator_type = std::allocator<__struct9>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:459:50: error: ‘struct __struct9’ has no member named ‘cs_promo_sk’
+  459 |                                         if (!((x.cs_promo_sk == nullptr)))
+      |                                                  ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:469:50: error: ‘struct __struct9’ has no member named ‘cs_promo_sk’
+  469 |                                         if (!((x.cs_promo_sk != nullptr)))
+      |                                                  ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq72273986548/001/prog.cpp:479:5: error: conversion from ‘vector<__struct11>’ to non-scalar type ‘vector<__struct9>’ requested
+  392 |   std::vector<__struct9> result = ([&]() {
+      |                                   ~~~~~~~~
+  393 |     std::vector<__struct10> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  395 |       for (auto inv : inventory) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |         if (!((inv.inv_item_sk == cs.cs_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |           continue;
+      |           ~~~~~~~~~
+  398 |         for (auto w : warehouse) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  399 |           if (!((w.w_warehouse_sk == inv.inv_warehouse_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  400 |             continue;
+      |             ~~~~~~~~~
+  401 |           for (auto i : item) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  402 |             if (!((i.i_item_sk == cs.cs_item_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  403 |               continue;
+      |               ~~~~~~~~~
+  404 |             for (auto cd : customer_demographics) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  405 |               if (!((cd.cd_demo_sk == cs.cs_bill_cdemo_sk)))
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  406 |                 continue;
+      |                 ~~~~~~~~~
+  407 |               for (auto hd : household_demographics) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  408 |                 if (!((hd.hd_demo_sk == cs.cs_bill_hdemo_sk)))
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  409 |                   continue;
+      |                   ~~~~~~~~~
+  410 |                 for (auto d1 : date_dim) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  411 |                   if (!((d1.d_date_sk == cs.cs_sold_date_sk)))
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  412 |                     continue;
+      |                     ~~~~~~~~~
+  413 |                   for (auto d2 : date_dim) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  414 |                     if (!((d2.d_date_sk == inv.inv_date_sk)))
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  415 |                       continue;
+      |                       ~~~~~~~~~
+  416 |                     for (auto d3 : date_dim) {
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  417 |                       if (!((d3.d_date_sk == cs.cs_ship_date_sk)))
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  418 |                         continue;
+      |                         ~~~~~~~~~
+  419 |                       if (!(((((((d1.d_week_seq == d2.d_week_seq) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  420 |                                  (inv.inv_quantity_on_hand < cs.cs_quantity)) &&
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  421 |                                 (d3.d_date > (d1.d_date + 5))) &&
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  422 |                                (hd.hd_buy_potential ==
+      |                                ~~~~~~~~~~~~~~~~~~~~~~~
+  423 |                                 std::string("5001-10000"))) &&
+      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  424 |                               (d1.d_year == 2000)) &&
+      |                               ~~~~~~~~~~~~~~~~~~~~~~~
+  425 |                              (cd.cd_marital_status == std::string("M")))))
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  426 |                         continue;
+      |                         ~~~~~~~~~
+  427 |                       auto __key = Result{i.i_item_desc, w.w_warehouse_name,
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |                                           d1.d_week_seq};
+      |                                           ~~~~~~~~~~~~~~~
+  429 |                       bool __found = false;
+      |                       ~~~~~~~~~~~~~~~~~~~~~
+  430 |                       for (auto &__g : __groups) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |                         if (__g.key == __key) {
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~
+  432 |                           __g.items.push_back(
+      |                           ~~~~~~~~~~~~~~~~~~~~
+  433 |                               __struct9{cs, inv, w, i, cd, hd, d1, d2, d3});
+      |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |                           __found = true;
+      |                           ~~~~~~~~~~~~~~~
+  435 |                           break;
+      |                           ~~~~~~
+  436 |                         }
+      |                         ~
+  437 |                       }
+      |                       ~
+  438 |                       if (!__found) {
+      |                       ~~~~~~~~~~~~~~~
+  439 |                         __groups.push_back(__struct10{
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  440 |                             __key, std::vector<__struct9>{__struct9{
+      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  441 |                                        cs, inv, w, i, cd, hd, d1, d2, d3}}});
+      |                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  442 |                       }
+      |                       ~
+  443 |                     }
+      |                     ~
+  444 |                   }
+      |                   ~
+  445 |                 }
+      |                 ~
+  446 |               }
+      |               ~
+  447 |             }
+      |             ~
+  448 |           }
+      |           ~
+  449 |         }
+      |         ~
+  450 |       }
+      |       ~
+  451 |     }
+      |     ~
+  452 |     std::vector<__struct11> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  453 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  454 |       __items.push_back(__struct11{g.key.item_desc, g.key.warehouse,
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  455 |                                    g.key.week_seq,
+      |                                    ~~~~~~~~~~~~~~~
+  456 |                                    ((int)([&]() {
+      |                                    ~~~~~~~~~~~~~~
+  457 |                                       std::vector<__struct9> __items;
+      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  458 |                                       for (auto x : g.items) {
+      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  459 |                                         if (!((x.cs_promo_sk == nullptr)))
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  460 |                                           continue;
+      |                                           ~~~~~~~~~
+  461 |                                         __items.push_back(x);
+      |                                         ~~~~~~~~~~~~~~~~~~~~~
+  462 |                                       }
+      |                                       ~
+  463 |                                       return __items;
+      |                                       ~~~~~~~~~~~~~~~
+  464 |                                     })()
+      |                                     ~~~~
+  465 |                                         .size()),
+      |                                         ~~~~~~~~~
+  466 |                                    ((int)([&]() {
+      |                                    ~~~~~~~~~~~~~~
+  467 |                                       std::vector<__struct9> __items;
+      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  468 |                                       for (auto x : g.items) {
+      |                                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |                                         if (!((x.cs_promo_sk != nullptr)))
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  470 |                                           continue;
+      |                                           ~~~~~~~~~
+  471 |                                         __items.push_back(x);
+      |                                         ~~~~~~~~~~~~~~~~~~~~~
+  472 |                                       }
+      |                                       ~
+  473 |                                       return __items;
+      |                                       ~~~~~~~~~~~~~~~
+  474 |                                     })()
+      |                                     ~~~~
+  475 |                                         .size()),
+      |                                         ~~~~~~~~~
+  476 |                                    ((int)g.items.size())});
+      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~
+  477 |     }
+      |     ~
+  478 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  479 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q73.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q73.error
@@ -1,0 +1,279 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+   85 |   decltype(ss.ss_ticket_number) ticket;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+   86 |   decltype(ss.ss_customer_sk) cust;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+   89 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:90:12: error: ‘d’ was not declared in this scope
+   90 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:90:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+   91 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:91:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:92:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   92 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:92:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   92 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:103:12: error: ‘c’ was not declared in this scope
+  103 |   decltype(c.c_last_name) c_last_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:103:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:104:12: error: ‘c’ was not declared in this scope
+  104 |   decltype(c.c_first_name) c_first_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:104:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:105:12: error: ‘c’ was not declared in this scope
+  105 |   decltype(c.c_salutation) c_salutation;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:105:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+  106 |   decltype(c.c_preferred_cust_flag) c_preferred_cust_flag;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:107:38: error: ‘struct __struct7’ has no member named ‘key’
+  107 |   decltype(std::declval<__struct7>().key.ticket) ss_ticket_number;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:107:38: error: ‘struct __struct7’ has no member named ‘key’
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘cnt’
+  108 |   decltype(std::declval<__struct7>().cnt) cnt;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:353:27: error: no match for ‘operator==’ (operand types are ‘Group’ and ‘Group’)
+  353 |               if (__g.key == __key) {
+      |                   ~~~~~~~ ^~ ~~~~~
+      |                       |      |
+      |                       Group  Group
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:354:47: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  354 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                                               ^~
+      |                                               |
+      |                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:361:59: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  361 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:361:72: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  361 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:8:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:372:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  329 |   std::vector<__struct7> groups = ([&]() {
+      |                                   ~~~~~~~~
+  330 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  331 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  332 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  333 |         if (!((d.d_date_sk == ss.ss_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  334 |           continue;
+      |           ~~~~~~~~~
+  335 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  336 |           if (!((s.s_store_sk == ss.ss_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  337 |             continue;
+      |             ~~~~~~~~~
+  338 |           for (auto hd : household_demographics) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  339 |             if (!((hd.hd_demo_sk == ss.ss_hdemo_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  340 |               continue;
+      |               ~~~~~~~~~
+  341 |             if (!((((((((d.d_dom >= 1) && (d.d_dom <= 2)) &&
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  342 |                        (((hd.hd_buy_potential == std::string("1001-5000")) ||
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |                          (hd.hd_buy_potential == std::string("0-500"))))) &&
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |                       (hd.hd_vehicle_count > 0)) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |                      ((hd.hd_dep_count / hd.hd_vehicle_count) > 1)) &&
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |                     ((((d.d_year == 1998) || (d.d_year == 1999)) ||
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  347 |                       (d.d_year == 2000)))) &&
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~
+  348 |                    (s.s_county == std::string("A")))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |               continue;
+      |               ~~~~~~~~~
+  350 |             auto __key = Group{ss.ss_ticket_number, ss.ss_customer_sk};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  352 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  353 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  354 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  355 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  356 |                 break;
+      |                 ~~~~~~
+  357 |               }
+      |               ~
+  358 |             }
+      |             ~
+  359 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  360 |               __groups.push_back(__struct8{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  362 |             }
+      |             ~
+  363 |           }
+      |           ~
+  364 |         }
+      |         ~
+  365 |       }
+      |       ~
+  366 |     }
+      |     ~
+  367 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |       __items.push_back(__struct9{g.key, ((int)g.items.size())});
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  370 |     }
+      |     ~
+  371 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  372 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:374:62: error: ‘struct __struct7’ has no member named ‘cnt’
+  374 |     std::vector<std::pair<decltype(std::declval<__struct7>().cnt), Result>>
+      |                                                              ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:374:62: error: ‘struct __struct7’ has no member named ‘cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:374:68: error: template argument 1 is invalid
+  374 |     std::vector<std::pair<decltype(std::declval<__struct7>().cnt), Result>>
+      |                                                                    ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:374:74: error: template argument 1 is invalid
+  374 |     std::vector<std::pair<decltype(std::declval<__struct7>().cnt), Result>>
+      |                                                                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:374:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:378:37: error: ‘struct __struct7’ has no member named ‘key’
+  378 |         if (!((c.c_customer_sk == g.key.cust)))
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:380:19: error: ‘struct __struct7’ has no member named ‘cnt’
+  380 |         if (!(((g.cnt >= 1) && (g.cnt <= 5))))
+      |                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:380:35: error: ‘struct __struct7’ has no member named ‘cnt’
+  380 |         if (!(((g.cnt >= 1) && (g.cnt <= 5))))
+      |                                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:382:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  382 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:383:39: error: ‘struct __struct7’ has no member named ‘cnt’
+  383 |             {std::vector<decltype((-g.cnt))>{(-g.cnt), c.c_last_name},
+      |                                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:383:39: error: ‘struct __struct7’ has no member named ‘cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:383:44: error: template argument 1 is invalid
+  383 |             {std::vector<decltype((-g.cnt))>{(-g.cnt), c.c_last_name},
+      |                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:383:44: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:383:50: error: ‘struct __struct7’ has no member named ‘cnt’
+  383 |             {std::vector<decltype((-g.cnt))>{(-g.cnt), c.c_last_name},
+      |                                                  ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:385:48: error: ‘struct __struct7’ has no member named ‘key’
+  385 |                     c.c_preferred_cust_flag, g.key.ticket, g.cnt}});
+      |                                                ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:385:62: error: ‘struct __struct7’ has no member named ‘cnt’
+  385 |                     c.c_preferred_cust_flag, g.key.ticket, g.cnt}});
+      |                                                              ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:388:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  388 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:388:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  388 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:391:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  391 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq73995005988/001/prog.cpp:391:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  391 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q74.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q74.error
@@ -1,0 +1,340 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:75:12: error: ‘c’ was not declared in this scope
+   75 |   decltype(c.c_customer_id) id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:75:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:76:12: error: ‘c’ was not declared in this scope
+   76 |   decltype(c.c_first_name) first;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:76:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:77:12: error: ‘c’ was not declared in this scope
+   77 |   decltype(c.c_last_name) last;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:77:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:78:12: error: ‘d’ was not declared in this scope; did you mean ‘id’?
+   78 |   decltype(d.d_year) year;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:78:12: error: ‘d’ was not declared in this scope; did you mean ‘id’?
+   78 |   decltype(d.d_year) year;
+      |            ^
+      |            id
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:81:12: error: ‘c’ was not declared in this scope
+   81 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:81:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:82:12: error: ‘ss’ was not declared in this scope
+   82 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:82:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:83:12: error: ‘d’ was not declared in this scope
+   83 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:83:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:98:12: error: ‘c’ was not declared in this scope
+   98 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:98:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:99:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   99 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:2:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:99:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   99 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+  100 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:107:38: error: ‘struct __struct6’ has no member named ‘customer_id’
+  107 |   decltype(std::declval<__struct6>().customer_id) customer_id;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:107:38: error: ‘struct __struct6’ has no member named ‘customer_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:108:38: error: ‘struct __struct6’ has no member named ‘customer_first_name’
+  108 |   decltype(std::declval<__struct6>().customer_first_name) customer_first_name;
+      |                                      ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:108:38: error: ‘struct __struct6’ has no member named ‘customer_first_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:109:38: error: ‘struct __struct6’ has no member named ‘customer_last_name’
+  109 |   decltype(std::declval<__struct6>().customer_last_name) customer_last_name;
+      |                                      ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:109:38: error: ‘struct __struct6’ has no member named ‘customer_last_name’
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:330:57: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  330 |               auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                                                       ~~^~~~~~~~~~~~
+      |                                                         |
+      |                                                         std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:335:49: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  335 |                   __g.items.push_back(__struct6{c, ss, d});
+      |                                                 ^
+      |                                                 |
+      |                                                 Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:342:61: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  342 |                     __key, std::vector<__struct6>{__struct6{c, ss, d}}});
+      |                                                             ^
+      |                                                             |
+      |                                                             Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:342:70: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  342 |                     __key, std::vector<__struct6>{__struct6{c, ss, d}}});
+      |                                                                      ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:353:67: error: request for member ‘ss_net_paid’ in ‘std::declval<__struct6>().__struct6::ss’, which is of non-class type ‘int’
+  353 |                 std::vector<decltype(std::declval<__struct6>().ss.ss_net_paid)>
+      |                                                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:353:67: error: request for member ‘ss_net_paid’ in ‘std::declval<__struct6>().__struct6::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:353:79: error: template argument 1 is invalid
+  353 |                 std::vector<decltype(std::declval<__struct6>().ss.ss_net_paid)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:353:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:356:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  356 |                   __items.push_back(x.ss.ss_net_paid);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:356:42: error: request for member ‘ss_net_paid’ in ‘x.__struct6::ss’, which is of non-class type ‘int’
+  356 |                   __items.push_back(x.ss.ss_net_paid);
+      |                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:352:17:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:351:42: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  351 |                 return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                        ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:351:53: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  351 |                 return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                   ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:375:57: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  375 |               auto __key = YearTotal{c.c_customer_id, c.c_first_name,
+      |                                                       ~~^~~~~~~~~~~~
+      |                                                         |
+      |                                                         std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:380:49: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  380 |                   __g.items.push_back(__struct9{c, ws, d});
+      |                                                 ^
+      |                                                 |
+      |                                                 Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:387:61: error: cannot convert ‘Customer’ to ‘int’ in initialization
+  387 |                     __key, std::vector<__struct9>{__struct9{c, ws, d}}});
+      |                                                             ^
+      |                                                             |
+      |                                                             Customer
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:387:70: error: no matching function for call to ‘std::vector<__struct9>::vector(<brace-enclosed initializer list>)’
+  387 |                     __key, std::vector<__struct9>{__struct9{c, ws, d}}});
+      |                                                                      ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; value_type = std::vector<__struct9>::value_type; allocator_type = std::allocator<__struct9>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; allocator_type = std::allocator<__struct9>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:398:67: error: request for member ‘ws_net_paid’ in ‘std::declval<__struct9>().__struct9::ws’, which is of non-class type ‘int’
+  398 |                 std::vector<decltype(std::declval<__struct9>().ws.ws_net_paid)>
+      |                                                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:398:67: error: request for member ‘ws_net_paid’ in ‘std::declval<__struct9>().__struct9::ws’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:398:79: error: template argument 1 is invalid
+  398 |                 std::vector<decltype(std::declval<__struct9>().ws.ws_net_paid)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:398:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:401:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  401 |                   __items.push_back(x.ws.ws_net_paid);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:401:42: error: request for member ‘ws_net_paid’ in ‘x.__struct9::ws’, which is of non-class type ‘int’
+  401 |                   __items.push_back(x.ws.ws_net_paid);
+      |                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:397:17:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:396:42: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  396 |                 return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                        ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:396:53: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  396 |                 return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                   ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:318:39: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  318 |   std::vector<__struct6> year_total = concat(
+      |                                       ^~~~~~
+      |                                       wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:412:17: error: ‘struct __struct6’ has no member named ‘sale_type’
+  412 |       if (!(((y.sale_type == std::string("s")) && (y.year == 1998))))
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:412:54: error: ‘struct __struct6’ has no member named ‘year’
+  412 |       if (!(((y.sale_type == std::string("s")) && (y.year == 1998))))
+      |                                                      ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:409:22: error: ‘first’ was not declared in this scope
+  409 |   auto s_firstyear = first(([&]() {
+      |                      ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:421:17: error: ‘struct __struct6’ has no member named ‘sale_type’
+  421 |       if (!(((y.sale_type == std::string("s")) && (y.year == 1999))))
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:421:54: error: ‘struct __struct6’ has no member named ‘year’
+  421 |       if (!(((y.sale_type == std::string("s")) && (y.year == 1999))))
+      |                                                      ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:430:17: error: ‘struct __struct6’ has no member named ‘sale_type’
+  430 |       if (!(((y.sale_type == std::string("w")) && (y.year == 1998))))
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:430:54: error: ‘struct __struct6’ has no member named ‘year’
+  430 |       if (!(((y.sale_type == std::string("w")) && (y.year == 1998))))
+      |                                                      ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:439:17: error: ‘struct __struct6’ has no member named ‘sale_type’
+  439 |       if (!(((y.sale_type == std::string("w")) && (y.year == 1999))))
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:439:54: error: ‘struct __struct6’ has no member named ‘year’
+  439 |       if (!(((y.sale_type == std::string("w")) && (y.year == 1999))))
+      |                                                      ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq742062244990/001/prog.cpp:451:70: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  451 |                                         s_secyear.customer_last_name}}
+      |                                                                      ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided

--- a/tests/dataset/tpc-ds/compiler/cpp/q75.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q75.error
@@ -1,0 +1,333 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:85:12: error: ‘d’ was not declared in this scope
+   85 |   decltype(d.d_year) d_year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:85:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+   86 |   decltype(ss.ss_item_sk) i_item_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:87:12: error: ‘ss’ was not declared in this scope
+   87 |   decltype(ss.ss_quantity) quantity;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:87:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:88:12: error: ‘ss’ was not declared in this scope
+   88 |   decltype(ss.ss_sales_price) amount;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:88:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+   92 |   decltype(i.i_brand_id) brand_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+   93 |   decltype(i.i_class_id) class_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+   94 |   decltype(i.i_category_id) category_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope
+   95 |   decltype(i.i_manufact_id) manuf_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+   99 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:115:38: error: ‘struct __struct8’ has no member named ‘d_year’
+  115 |   decltype(std::declval<__struct8>().d_year) prev_year;
+      |                                      ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:115:38: error: ‘struct __struct8’ has no member named ‘d_year’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:116:38: error: ‘struct __struct8’ has no member named ‘d_year’
+  116 |   decltype(std::declval<__struct8>().d_year) year;
+      |                                      ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:116:38: error: ‘struct __struct8’ has no member named ‘d_year’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:117:38: error: ‘struct __struct8’ has no member named ‘i_brand_id’
+  117 |   decltype(std::declval<__struct8>().i_brand_id) i_brand_id;
+      |                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:117:38: error: ‘struct __struct8’ has no member named ‘i_brand_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:118:38: error: ‘struct __struct8’ has no member named ‘i_class_id’
+  118 |   decltype(std::declval<__struct8>().i_class_id) i_class_id;
+      |                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:118:38: error: ‘struct __struct8’ has no member named ‘i_class_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:119:38: error: ‘struct __struct8’ has no member named ‘i_category_id’
+  119 |   decltype(std::declval<__struct8>().i_category_id) i_category_id;
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:119:38: error: ‘struct __struct8’ has no member named ‘i_category_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:120:38: error: ‘struct __struct8’ has no member named ‘i_manufact_id’
+  120 |   decltype(std::declval<__struct8>().i_manufact_id) i_manufact_id;
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:120:38: error: ‘struct __struct8’ has no member named ‘i_manufact_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:121:38: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  121 |   decltype(std::declval<__struct8>().sales_cnt) prev_yr_cnt;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:121:38: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:122:38: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  122 |   decltype(std::declval<__struct8>().sales_cnt) curr_yr_cnt;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:122:38: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:123:39: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  123 |   decltype((std::declval<__struct8>().sales_cnt -
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:124:39: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  124 |             std::declval<__struct8>().sales_cnt)) sales_cnt_diff;
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:123:39: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  123 |   decltype((std::declval<__struct8>().sales_cnt -
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:124:39: error: ‘struct __struct8’ has no member named ‘sales_cnt’
+  124 |             std::declval<__struct8>().sales_cnt)) sales_cnt_diff;
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:125:39: error: ‘struct __struct8’ has no member named ‘sales_amt’
+  125 |   decltype((std::declval<__struct8>().sales_amt -
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:126:39: error: ‘struct __struct8’ has no member named ‘sales_amt’
+  126 |             std::declval<__struct8>().sales_amt)) sales_amt_diff;
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:125:39: error: ‘struct __struct8’ has no member named ‘sales_amt’
+  125 |   decltype((std::declval<__struct8>().sales_amt -
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:126:39: error: ‘struct __struct8’ has no member named ‘sales_amt’
+  126 |             std::declval<__struct8>().sales_amt)) sales_amt_diff;
+      |                                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:427:43: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  427 |   std::vector<SalesDetail> sales_detail = concat(
+      |                                           ^~~~~~
+      |                                           wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:476:23: error: no match for ‘operator==’ (operand types are ‘AllSale’ and ‘AllSale’)
+  476 |           if (__g.key == __key) {
+      |               ~~~~~~~ ^~ ~~~~~
+      |                   |      |
+      |                   |      AllSale
+      |                   AllSale
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:477:47: error: cannot convert ‘Item’ to ‘int’ in initialization
+  477 |             __g.items.push_back(__struct8{sd, i});
+      |                                               ^
+      |                                               |
+      |                                               Item
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:484:69: error: cannot convert ‘Item’ to ‘int’ in initialization
+  484 |               __struct9{__key, std::vector<__struct8>{__struct8{sd, i}}});
+      |                                                                     ^
+      |                                                                     |
+      |                                                                     Item
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:484:71: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  484 |               __struct9{__key, std::vector<__struct8>{__struct8{sd, i}}});
+      |                                                                       ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:513:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  464 |   std::vector<__struct8> all_sales = ([&]() {
+      |                                      ~~~~~~~~
+  465 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  466 |     for (auto sd : sales_detail) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  467 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  468 |         if (!((i.i_item_sk == sd.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  469 |           continue;
+      |           ~~~~~~~~~
+  470 |         if (!((i.i_category == std::string("Electronics"))))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  471 |           continue;
+      |           ~~~~~~~~~
+  472 |         auto __key = AllSale{sd.d_year, i.i_brand_id, i.i_class_id,
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  473 |                              i.i_category_id, i.i_manufact_id};
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  474 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  475 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  476 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  477 |             __g.items.push_back(__struct8{sd, i});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  478 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  479 |             break;
+      |             ~~~~~~
+  480 |           }
+      |           ~
+  481 |         }
+      |         ~
+  482 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  483 |           __groups.push_back(
+      |           ~~~~~~~~~~~~~~~~~~~
+  484 |               __struct9{__key, std::vector<__struct8>{__struct8{sd, i}}});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |         }
+      |         ~
+  486 |       }
+      |       ~
+  487 |     }
+      |     ~
+  488 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  489 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  490 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  491 |           g.key.year, g.key.brand_id, g.key.class_id, g.key.category_id,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  492 |           g.key.manuf_id, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  493 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  494 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  495 |             std::vector<decltype(std::declval<__struct8>().sd.quantity)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  496 |                 __items;
+      |                 ~~~~~~~~
+  497 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  498 |               __items.push_back(x.sd.quantity);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  499 |             }
+      |             ~
+  500 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  501 |           })()),
+      |           ~~~~~~
+  502 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  503 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  504 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  505 |             std::vector<decltype(std::declval<__struct8>().sd.amount)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  506 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  507 |               __items.push_back(x.sd.amount);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  508 |             }
+      |             ~
+  509 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  510 |           })())});
+      |           ~~~~~~~~
+  511 |     }
+      |     ~
+  512 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  513 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:517:16: error: ‘struct __struct8’ has no member named ‘d_year’
+  517 |       if (!((a.d_year == 2000)))
+      |                ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:514:18: error: ‘first’ was not declared in this scope
+  514 |   auto prev_yr = first(([&]() {
+      |                  ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:526:16: error: ‘struct __struct8’ has no member named ‘d_year’
+  526 |       if (!((a.d_year == 2001)))
+      |                ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq751020294350/001/prog.cpp:539:58: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  539 |                  (curr_yr.sales_amt - prev_yr.sales_amt)}}
+      |                                                          ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided

--- a/tests/dataset/tpc-ds/compiler/cpp/q76.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q76.error
@@ -1,0 +1,276 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+   85 |   decltype(ss.ss_customer_sk) col_name;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:85:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:86:12: error: ‘d’ was not declared in this scope
+   86 |   decltype(d.d_year) d_year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:86:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:87:12: error: ‘d’ was not declared in this scope
+   87 |   decltype(d.d_qoy) d_qoy;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:87:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+   88 |   decltype(i.i_category) i_category;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:88:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+   89 |   decltype(ss.ss_ext_sales_price) ext_sales_price;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:89:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:92:12: error: ‘r’ was not declared in this scope
+   92 |   decltype(r.channel) channel;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:92:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:93:12: error: ‘r’ was not declared in this scope
+   93 |   decltype(r.col_name) col_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:93:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:94:12: error: ‘r’ was not declared in this scope
+   94 |   decltype(r.d_year) d_year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:94:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:95:12: error: ‘r’ was not declared in this scope
+   95 |   decltype(r.d_qoy) d_qoy;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:95:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:96:12: error: ‘r’ was not declared in this scope
+   96 |   decltype(r.i_category) i_category;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:96:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:99:12: error: ‘r’ was not declared in this scope
+   99 |   decltype(r) r;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:99:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:358:64: error: cannot convert ‘std::nullptr_t’ to ‘int’ in initialization
+  358 |           __items.push_back(StorePart{std::string("store"), ss.ss_customer_sk,
+      |                                                             ~~~^~~~~~~~~~~~~~
+      |                                                                |
+      |                                                                std::nullptr_t
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:378:42: error: cannot convert ‘std::nullptr_t’ to ‘int’ in initialization
+  378 |                                       ws.ws_bill_customer_sk, d.d_year, d.d_qoy,
+      |                                       ~~~^~~~~~~~~~~~~~~~~~~
+      |                                          |
+      |                                          std::nullptr_t
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:397:42: error: cannot convert ‘std::nullptr_t’ to ‘int’ in initialization
+  397 |                                       cs.cs_bill_customer_sk, d.d_year, d.d_qoy,
+      |                                       ~~~^~~~~~~~~~~~~~~~~~~
+      |                                          |
+      |                                          std::nullptr_t
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:404:19: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  404 |   auto all_rows = concat(store_part, web_part, catalog_part);
+      |                   ^~~~~~
+      |                   wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:420:65: error: no matching function for call to ‘std::vector<__struct8>::vector(<brace-enclosed initializer list>)’
+  420 |             __struct9{__key, std::vector<__struct8>{__struct8{r}}});
+      |                                                                 ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; std::__type_identity_t<_Alloc> = std::allocator<__struct8>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; value_type = std::vector<__struct8>::value_type; allocator_type = std::allocator<__struct8>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; size_type = long unsigned int; allocator_type = std::allocator<__struct8>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct8; _Alloc = std::allocator<__struct8>; allocator_type = std::allocator<__struct8>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct8; _Alloc = std::allocator<__struct8>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:434:53: error: request for member ‘ext_sales_price’ in ‘std::declval<__struct8>().__struct8::r’, which is of non-class type ‘int’
+  434 |                                                  .r.ext_sales_price)>
+      |                                                     ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:434:53: error: request for member ‘ext_sales_price’ in ‘std::declval<__struct8>().__struct8::r’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:434:69: error: template argument 1 is invalid
+  434 |                                                  .r.ext_sales_price)>
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:434:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:437:35: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  437 |                           __items.push_back(x.r.ext_sales_price);
+      |                                   ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:437:49: error: request for member ‘ext_sales_price’ in ‘x.__struct8::r’, which is of non-class type ‘int’
+  437 |                           __items.push_back(x.r.ext_sales_price);
+      |                                                 ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:432:25:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:431:50: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  431 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:431:61: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  431 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                           ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:427:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct10> >::push_back(<brace-enclosed initializer list>)’
+  427 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  428 |           {g.key.channel,
+      |           ~~~~~~~~~~~~~~~
+  429 |            __struct10{g.key.channel, g.key.col_name, g.key.d_year, g.key.d_qoy,
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |                       g.key.i_category, ((int)g.items.size()), ([&](auto v) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |                       })(([&]() {
+      |                       ~~~~~~~~~~~
+  433 |                         std::vector<decltype(std::declval<__struct8>()
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |                                                  .r.ext_sales_price)>
+      |                                                  ~~~~~~~~~~~~~~~~~~~~
+  435 |                             __items;
+      |                             ~~~~~~~~
+  436 |                         for (auto x : g.items) {
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |                           __items.push_back(x.r.ext_sales_price);
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  438 |                         }
+      |                         ~
+  439 |                         return __items;
+      |                         ~~~~~~~~~~~~~~~
+  440 |                       })())}});
+      |                       ~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<int, __struct10>; _Alloc = std::allocator<std::pair<int, __struct10> >; value_type = std::pair<int, __struct10>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<int, __struct10> >::value_type&’ {aka ‘const std::pair<int, __struct10>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<int, __struct10>; _Alloc = std::allocator<std::pair<int, __struct10> >; value_type = std::pair<int, __struct10>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<int, __struct10> >::value_type&&’ {aka ‘std::pair<int, __struct10>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq762624354851/001/prog.cpp:448:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<__struct8>’ requested
+  405 |   std::vector<__struct8> result = ([&]() {
+      |                                   ~~~~~~~~
+  406 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  407 |     for (auto r : all_rows) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~
+  408 |       auto __key =
+      |       ~~~~~~~~~~~~
+  409 |           Result{r.channel, r.col_name, r.d_year, r.d_qoy, r.i_category};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  410 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  411 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  412 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  413 |           __g.items.push_back(__struct8{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  414 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  415 |           break;
+      |           ~~~~~~
+  416 |         }
+      |         ~
+  417 |       }
+      |       ~
+  418 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  419 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  420 |             __struct9{__key, std::vector<__struct8>{__struct8{r}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  421 |       }
+      |       ~
+  422 |     }
+      |     ~
+  423 |     std::vector<
+      |     ~~~~~~~~~~~~
+  424 |         std::pair<decltype(std::declval<__struct9>().key.channel), __struct10>>
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  425 |         __items;
+      |         ~~~~~~~~
+  426 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  427 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  428 |           {g.key.channel,
+      |           ~~~~~~~~~~~~~~~
+  429 |            __struct10{g.key.channel, g.key.col_name, g.key.d_year, g.key.d_qoy,
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  430 |                       g.key.i_category, ((int)g.items.size()), ([&](auto v) {
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |                         return std::accumulate(v.begin(), v.end(), 0.0);
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |                       })(([&]() {
+      |                       ~~~~~~~~~~~
+  433 |                         std::vector<decltype(std::declval<__struct8>()
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |                                                  .r.ext_sales_price)>
+      |                                                  ~~~~~~~~~~~~~~~~~~~~
+  435 |                             __items;
+      |                             ~~~~~~~~
+  436 |                         for (auto x : g.items) {
+      |                         ~~~~~~~~~~~~~~~~~~~~~~~~
+  437 |                           __items.push_back(x.r.ext_sales_price);
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  438 |                         }
+      |                         ~
+  439 |                         return __items;
+      |                         ~~~~~~~~~~~~~~~
+  440 |                       })())}});
+      |                       ~~~~~~~~~
+  441 |     }
+      |     ~
+  442 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  444 |     std::vector<__struct10> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  445 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  446 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  447 |     return __res;
+      |     ~~~~~~~~~~~~~
+  448 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q77.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q77.error
@@ -1,0 +1,1583 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:97:12: error: ‘ss’ was not declared in this scope
+   97 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:97:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+   98 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:98:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:101:30: error: ‘struct S’ has no member named ‘s_store_sk’
+  101 |   decltype(std::declval<S>().s_store_sk) key;
+      |                              ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:101:30: error: ‘struct S’ has no member named ‘s_store_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:110:12: error: ‘sr’ was not declared in this scope; did you mean ‘Sr’?
+  110 |   decltype(sr) sr;
+      |            ^~
+      |            Sr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:110:12: error: ‘sr’ was not declared in this scope; did you mean ‘Sr’?
+  110 |   decltype(sr) sr;
+      |            ^~
+      |            Sr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:111:12: error: ‘d’ was not declared in this scope
+  111 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:111:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:114:31: error: ‘struct Sr’ has no member named ‘s_store_sk’
+  114 |   decltype(std::declval<Sr>().s_store_sk) key;
+      |                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:114:31: error: ‘struct Sr’ has no member named ‘s_store_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:123:12: error: ‘cs’ was not declared in this scope
+  123 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:123:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:124:12: error: ‘d’ was not declared in this scope
+  124 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:124:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:127:30: error: ‘struct C’ has no member named ‘cs_call_center_sk’
+  127 |   decltype(std::declval<C>().cs_call_center_sk) key;
+      |                              ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:127:30: error: ‘struct C’ has no member named ‘cs_call_center_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:136:12: error: ‘cr’ was not declared in this scope; did you mean ‘Cr’?
+  136 |   decltype(cr) cr;
+      |            ^~
+      |            Cr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:136:12: error: ‘cr’ was not declared in this scope; did you mean ‘Cr’?
+  136 |   decltype(cr) cr;
+      |            ^~
+      |            Cr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:137:12: error: ‘d’ was not declared in this scope
+  137 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:137:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:140:31: error: ‘struct Cr’ has no member named ‘cr_call_center_sk’
+  140 |   decltype(std::declval<Cr>().cr_call_center_sk) key;
+      |                               ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:140:31: error: ‘struct Cr’ has no member named ‘cr_call_center_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:149:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  149 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:149:12: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  149 |   decltype(ws) ws;
+      |            ^~
+      |            std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:150:12: error: ‘d’ was not declared in this scope
+  150 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:150:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:153:30: error: ‘struct W’ has no member named ‘ws_web_page_sk’
+  153 |   decltype(std::declval<W>().ws_web_page_sk) key;
+      |                              ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:153:30: error: ‘struct W’ has no member named ‘ws_web_page_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:162:12: error: ‘wr’ was not declared in this scope; did you mean ‘Wr’?
+  162 |   decltype(wr) wr;
+      |            ^~
+      |            Wr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:162:12: error: ‘wr’ was not declared in this scope; did you mean ‘Wr’?
+  162 |   decltype(wr) wr;
+      |            ^~
+      |            Wr
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:163:12: error: ‘d’ was not declared in this scope
+  163 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:163:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:166:31: error: ‘struct Wr’ has no member named ‘wr_web_page_sk’
+  166 |   decltype(std::declval<Wr>().wr_web_page_sk) key;
+      |                               ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:166:31: error: ‘struct Wr’ has no member named ‘wr_web_page_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:176:30: error: ‘struct S’ has no member named ‘s_store_sk’
+  176 |   decltype(std::declval<S>().s_store_sk) id;
+      |                              ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:176:30: error: ‘struct S’ has no member named ‘s_store_sk’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:177:30: error: ‘struct S’ has no member named ‘sales’
+  177 |   decltype(std::declval<S>().sales) sales;
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:177:30: error: ‘struct S’ has no member named ‘sales’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:627:35: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  627 |             __g.items.push_back(S{ss, d});
+      |                                   ^~
+      |                                   |
+      |                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:633:64: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  633 |           __groups.push_back(__struct9{__key, std::vector<S>{S{ss, d}}});
+      |                                                                ^~
+      |                                                                |
+      |                                                                StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:633:70: error: no matching function for call to ‘std::vector<S>::vector(<brace-enclosed initializer list>)’
+  633 |           __groups.push_back(__struct9{__key, std::vector<S>{S{ss, d}}});
+      |                                                                      ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = S; _Alloc = std::allocator<S>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>; std::__type_identity_t<_Alloc> = std::allocator<S>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S; _Alloc = std::allocator<S>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; value_type = S; allocator_type = std::allocator<S>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; size_type = long unsigned int; allocator_type = std::allocator<S>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = S; _Alloc = std::allocator<S>; allocator_type = std::allocator<S>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = S; _Alloc = std::allocator<S>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:643:55: error: request for member ‘ss_ext_sales_price’ in ‘std::declval<S>().S::ss’, which is of non-class type ‘int’
+  643 |             std::vector<decltype(std::declval<S>().ss.ss_ext_sales_price)>
+      |                                                       ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:643:55: error: request for member ‘ss_ext_sales_price’ in ‘std::declval<S>().S::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:643:74: error: template argument 1 is invalid
+  643 |             std::vector<decltype(std::declval<S>().ss.ss_ext_sales_price)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:643:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:646:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  646 |               __items.push_back(x.ss.ss_ext_sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:646:38: error: request for member ‘ss_ext_sales_price’ in ‘x.S::ss’, which is of non-class type ‘int’
+  646 |               __items.push_back(x.ss.ss_ext_sales_price);
+      |                                      ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:642:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:641:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  641 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:641:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  641 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:653:55: error: request for member ‘ss_net_profit’ in ‘std::declval<S>().S::ss’, which is of non-class type ‘int’
+  653 |             std::vector<decltype(std::declval<S>().ss.ss_net_profit)> __items;
+      |                                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:653:55: error: request for member ‘ss_net_profit’ in ‘std::declval<S>().S::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:653:69: error: template argument 1 is invalid
+  653 |             std::vector<decltype(std::declval<S>().ss.ss_net_profit)> __items;
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:653:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:655:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  655 |               __items.push_back(x.ss.ss_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:655:38: error: request for member ‘ss_net_profit’ in ‘x.S::ss’, which is of non-class type ‘int’
+  655 |               __items.push_back(x.ss.ss_net_profit);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:652:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:651:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  651 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:651:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  651 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:661:5: error: conversion from ‘vector<__struct10>’ to non-scalar type ‘vector<S>’ requested
+  617 |   std::vector<S> ss = ([&]() {
+      |                       ~~~~~~~~
+  618 |     std::vector<__struct9> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  619 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  620 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  621 |         if (!((d.d_date_sk == ss.ss_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  622 |           continue;
+      |           ~~~~~~~~~
+  623 |         auto __key = ss.s_store_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  624 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  625 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  626 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  627 |             __g.items.push_back(S{ss, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  628 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  629 |             break;
+      |             ~~~~~~
+  630 |           }
+      |           ~
+  631 |         }
+      |         ~
+  632 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  633 |           __groups.push_back(__struct9{__key, std::vector<S>{S{ss, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  634 |         }
+      |         ~
+  635 |       }
+      |       ~
+  636 |     }
+      |     ~
+  637 |     std::vector<__struct10> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  638 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  639 |       __items.push_back(__struct10{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  640 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  641 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  642 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  643 |             std::vector<decltype(std::declval<S>().ss.ss_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  644 |                 __items;
+      |                 ~~~~~~~~
+  645 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  646 |               __items.push_back(x.ss.ss_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  647 |             }
+      |             ~
+  648 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  649 |           })()),
+      |           ~~~~~~
+  650 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  651 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  652 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  653 |             std::vector<decltype(std::declval<S>().ss.ss_net_profit)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  654 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  655 |               __items.push_back(x.ss.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  656 |             }
+      |             ~
+  657 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  658 |           })())});
+      |           ~~~~~~~~
+  659 |     }
+      |     ~
+  660 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  661 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:672:36: error: cannot convert ‘StoreReturn’ to ‘int’ in initialization
+  672 |             __g.items.push_back(Sr{sr, d});
+      |                                    ^~
+      |                                    |
+      |                                    StoreReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:678:67: error: cannot convert ‘StoreReturn’ to ‘int’ in initialization
+  678 |           __groups.push_back(__struct12{__key, std::vector<Sr>{Sr{sr, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:678:73: error: no matching function for call to ‘std::vector<Sr>::vector(<brace-enclosed initializer list>)’
+  678 |           __groups.push_back(__struct12{__key, std::vector<Sr>{Sr{sr, d}}});
+      |                                                                         ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Sr; _Alloc = std::allocator<Sr>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; allocator_type = std::allocator<Sr>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; std::__type_identity_t<_Alloc> = std::allocator<Sr>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Sr; _Alloc = std::allocator<Sr>; allocator_type = std::allocator<Sr>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Sr; _Alloc = std::allocator<Sr>; allocator_type = std::allocator<Sr>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; std::__type_identity_t<_Alloc> = std::allocator<Sr>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Sr; _Alloc = std::allocator<Sr>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Sr; _Alloc = std::allocator<Sr>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; size_type = long unsigned int; value_type = Sr; allocator_type = std::allocator<Sr>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; size_type = long unsigned int; allocator_type = std::allocator<Sr>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Sr; _Alloc = std::allocator<Sr>; allocator_type = std::allocator<Sr>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Sr; _Alloc = std::allocator<Sr>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:688:56: error: request for member ‘sr_return_amt’ in ‘std::declval<Sr>().Sr::sr’, which is of non-class type ‘int’
+  688 |             std::vector<decltype(std::declval<Sr>().sr.sr_return_amt)> __items;
+      |                                                        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:688:56: error: request for member ‘sr_return_amt’ in ‘std::declval<Sr>().Sr::sr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:688:70: error: template argument 1 is invalid
+  688 |             std::vector<decltype(std::declval<Sr>().sr.sr_return_amt)> __items;
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:688:70: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:690:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  690 |               __items.push_back(x.sr.sr_return_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:690:38: error: request for member ‘sr_return_amt’ in ‘x.Sr::sr’, which is of non-class type ‘int’
+  690 |               __items.push_back(x.sr.sr_return_amt);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:687:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:686:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  686 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:686:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  686 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:697:56: error: request for member ‘sr_net_loss’ in ‘std::declval<Sr>().Sr::sr’, which is of non-class type ‘int’
+  697 |             std::vector<decltype(std::declval<Sr>().sr.sr_net_loss)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:697:56: error: request for member ‘sr_net_loss’ in ‘std::declval<Sr>().Sr::sr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:697:68: error: template argument 1 is invalid
+  697 |             std::vector<decltype(std::declval<Sr>().sr.sr_net_loss)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:697:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:699:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  699 |               __items.push_back(x.sr.sr_net_loss);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:699:38: error: request for member ‘sr_net_loss’ in ‘x.Sr::sr’, which is of non-class type ‘int’
+  699 |               __items.push_back(x.sr.sr_net_loss);
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:696:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:695:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  695 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:695:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  695 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:705:5: error: conversion from ‘vector<__struct13>’ to non-scalar type ‘vector<Sr>’ requested
+  662 |   std::vector<Sr> sr = ([&]() {
+      |                        ~~~~~~~~
+  663 |     std::vector<__struct12> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  664 |     for (auto sr : store_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  665 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  666 |         if (!((d.d_date_sk == sr.sr_returned_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  667 |           continue;
+      |           ~~~~~~~~~
+  668 |         auto __key = sr.s_store_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  669 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  670 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  671 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  672 |             __g.items.push_back(Sr{sr, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  673 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  674 |             break;
+      |             ~~~~~~
+  675 |           }
+      |           ~
+  676 |         }
+      |         ~
+  677 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  678 |           __groups.push_back(__struct12{__key, std::vector<Sr>{Sr{sr, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  679 |         }
+      |         ~
+  680 |       }
+      |       ~
+  681 |     }
+      |     ~
+  682 |     std::vector<__struct13> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  683 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  684 |       __items.push_back(__struct13{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  685 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  686 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  687 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  688 |             std::vector<decltype(std::declval<Sr>().sr.sr_return_amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  689 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  690 |               __items.push_back(x.sr.sr_return_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  691 |             }
+      |             ~
+  692 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  693 |           })()),
+      |           ~~~~~~
+  694 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  695 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  696 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  697 |             std::vector<decltype(std::declval<Sr>().sr.sr_net_loss)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  698 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  699 |               __items.push_back(x.sr.sr_net_loss);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  700 |             }
+      |             ~
+  701 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  702 |           })())});
+      |           ~~~~~~~~
+  703 |     }
+      |     ~
+  704 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  705 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:716:35: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  716 |             __g.items.push_back(C{cs, d});
+      |                                   ^~
+      |                                   |
+      |                                   CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:722:65: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  722 |           __groups.push_back(__struct15{__key, std::vector<C>{C{cs, d}}});
+      |                                                                 ^~
+      |                                                                 |
+      |                                                                 CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:722:71: error: no matching function for call to ‘std::vector<C>::vector(<brace-enclosed initializer list>)’
+  722 |           __groups.push_back(__struct15{__key, std::vector<C>{C{cs, d}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = C; _Alloc = std::allocator<C>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = C; _Alloc = std::allocator<C>; allocator_type = std::allocator<C>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = C; _Alloc = std::allocator<C>; std::__type_identity_t<_Alloc> = std::allocator<C>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = C; _Alloc = std::allocator<C>; allocator_type = std::allocator<C>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = C; _Alloc = std::allocator<C>; allocator_type = std::allocator<C>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = C; _Alloc = std::allocator<C>; std::__type_identity_t<_Alloc> = std::allocator<C>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = C; _Alloc = std::allocator<C>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = C; _Alloc = std::allocator<C>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = C; _Alloc = std::allocator<C>; size_type = long unsigned int; value_type = C; allocator_type = std::allocator<C>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = C; _Alloc = std::allocator<C>; size_type = long unsigned int; allocator_type = std::allocator<C>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = C; _Alloc = std::allocator<C>; allocator_type = std::allocator<C>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = C; _Alloc = std::allocator<C>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:732:55: error: request for member ‘cs_ext_sales_price’ in ‘std::declval<C>().C::cs’, which is of non-class type ‘int’
+  732 |             std::vector<decltype(std::declval<C>().cs.cs_ext_sales_price)>
+      |                                                       ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:732:55: error: request for member ‘cs_ext_sales_price’ in ‘std::declval<C>().C::cs’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:732:74: error: template argument 1 is invalid
+  732 |             std::vector<decltype(std::declval<C>().cs.cs_ext_sales_price)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:732:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:735:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  735 |               __items.push_back(x.cs.cs_ext_sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:735:38: error: request for member ‘cs_ext_sales_price’ in ‘x.C::cs’, which is of non-class type ‘int’
+  735 |               __items.push_back(x.cs.cs_ext_sales_price);
+      |                                      ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:731:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:730:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  730 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:730:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  730 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:742:55: error: request for member ‘cs_net_profit’ in ‘std::declval<C>().C::cs’, which is of non-class type ‘int’
+  742 |             std::vector<decltype(std::declval<C>().cs.cs_net_profit)> __items;
+      |                                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:742:55: error: request for member ‘cs_net_profit’ in ‘std::declval<C>().C::cs’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:742:69: error: template argument 1 is invalid
+  742 |             std::vector<decltype(std::declval<C>().cs.cs_net_profit)> __items;
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:742:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:744:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  744 |               __items.push_back(x.cs.cs_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:744:38: error: request for member ‘cs_net_profit’ in ‘x.C::cs’, which is of non-class type ‘int’
+  744 |               __items.push_back(x.cs.cs_net_profit);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:6)> [with auto:6 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:741:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:740:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  740 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:740:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  740 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:750:5: error: conversion from ‘vector<__struct16>’ to non-scalar type ‘vector<C>’ requested
+  706 |   std::vector<C> cs = ([&]() {
+      |                       ~~~~~~~~
+  707 |     std::vector<__struct15> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  708 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  709 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  710 |         if (!((d.d_date_sk == cs.cs_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  711 |           continue;
+      |           ~~~~~~~~~
+  712 |         auto __key = cs.cs_call_center_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  713 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  714 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  715 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  716 |             __g.items.push_back(C{cs, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  717 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  718 |             break;
+      |             ~~~~~~
+  719 |           }
+      |           ~
+  720 |         }
+      |         ~
+  721 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  722 |           __groups.push_back(__struct15{__key, std::vector<C>{C{cs, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  723 |         }
+      |         ~
+  724 |       }
+      |       ~
+  725 |     }
+      |     ~
+  726 |     std::vector<__struct16> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  727 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  728 |       __items.push_back(__struct16{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  729 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  730 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  731 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  732 |             std::vector<decltype(std::declval<C>().cs.cs_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  733 |                 __items;
+      |                 ~~~~~~~~
+  734 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  735 |               __items.push_back(x.cs.cs_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  736 |             }
+      |             ~
+  737 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  738 |           })()),
+      |           ~~~~~~
+  739 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  740 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  741 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  742 |             std::vector<decltype(std::declval<C>().cs.cs_net_profit)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  743 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  744 |               __items.push_back(x.cs.cs_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  745 |             }
+      |             ~
+  746 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  747 |           })())});
+      |           ~~~~~~~~
+  748 |     }
+      |     ~
+  749 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  750 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:761:36: error: cannot convert ‘CatalogReturn’ to ‘int’ in initialization
+  761 |             __g.items.push_back(Cr{cr, d});
+      |                                    ^~
+      |                                    |
+      |                                    CatalogReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:767:67: error: cannot convert ‘CatalogReturn’ to ‘int’ in initialization
+  767 |           __groups.push_back(__struct18{__key, std::vector<Cr>{Cr{cr, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   CatalogReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:767:73: error: no matching function for call to ‘std::vector<Cr>::vector(<brace-enclosed initializer list>)’
+  767 |           __groups.push_back(__struct18{__key, std::vector<Cr>{Cr{cr, d}}});
+      |                                                                         ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Cr; _Alloc = std::allocator<Cr>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; allocator_type = std::allocator<Cr>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; std::__type_identity_t<_Alloc> = std::allocator<Cr>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Cr; _Alloc = std::allocator<Cr>; allocator_type = std::allocator<Cr>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Cr; _Alloc = std::allocator<Cr>; allocator_type = std::allocator<Cr>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; std::__type_identity_t<_Alloc> = std::allocator<Cr>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Cr; _Alloc = std::allocator<Cr>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Cr; _Alloc = std::allocator<Cr>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; size_type = long unsigned int; value_type = Cr; allocator_type = std::allocator<Cr>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; size_type = long unsigned int; allocator_type = std::allocator<Cr>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Cr; _Alloc = std::allocator<Cr>; allocator_type = std::allocator<Cr>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Cr; _Alloc = std::allocator<Cr>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:777:56: error: request for member ‘cr_return_amount’ in ‘std::declval<Cr>().Cr::cr’, which is of non-class type ‘int’
+  777 |             std::vector<decltype(std::declval<Cr>().cr.cr_return_amount)>
+      |                                                        ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:777:56: error: request for member ‘cr_return_amount’ in ‘std::declval<Cr>().Cr::cr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:777:73: error: template argument 1 is invalid
+  777 |             std::vector<decltype(std::declval<Cr>().cr.cr_return_amount)>
+      |                                                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:777:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:780:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  780 |               __items.push_back(x.cr.cr_return_amount);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:780:38: error: request for member ‘cr_return_amount’ in ‘x.Cr::cr’, which is of non-class type ‘int’
+  780 |               __items.push_back(x.cr.cr_return_amount);
+      |                                      ^~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:7)> [with auto:7 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:776:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:775:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  775 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:775:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  775 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:787:56: error: request for member ‘cr_net_loss’ in ‘std::declval<Cr>().Cr::cr’, which is of non-class type ‘int’
+  787 |             std::vector<decltype(std::declval<Cr>().cr.cr_net_loss)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:787:56: error: request for member ‘cr_net_loss’ in ‘std::declval<Cr>().Cr::cr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:787:68: error: template argument 1 is invalid
+  787 |             std::vector<decltype(std::declval<Cr>().cr.cr_net_loss)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:787:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:789:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  789 |               __items.push_back(x.cr.cr_net_loss);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:789:38: error: request for member ‘cr_net_loss’ in ‘x.Cr::cr’, which is of non-class type ‘int’
+  789 |               __items.push_back(x.cr.cr_net_loss);
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:8)> [with auto:8 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:786:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:785:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  785 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:785:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  785 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:795:5: error: conversion from ‘vector<__struct19>’ to non-scalar type ‘vector<Cr>’ requested
+  751 |   std::vector<Cr> cr = ([&]() {
+      |                        ~~~~~~~~
+  752 |     std::vector<__struct18> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  753 |     for (auto cr : catalog_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  754 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  755 |         if (!((d.d_date_sk == cr.cr_returned_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  756 |           continue;
+      |           ~~~~~~~~~
+  757 |         auto __key = cr.cr_call_center_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  758 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  759 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  760 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  761 |             __g.items.push_back(Cr{cr, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  762 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  763 |             break;
+      |             ~~~~~~
+  764 |           }
+      |           ~
+  765 |         }
+      |         ~
+  766 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  767 |           __groups.push_back(__struct18{__key, std::vector<Cr>{Cr{cr, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  768 |         }
+      |         ~
+  769 |       }
+      |       ~
+  770 |     }
+      |     ~
+  771 |     std::vector<__struct19> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  772 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  773 |       __items.push_back(__struct19{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  774 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  775 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  776 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  777 |             std::vector<decltype(std::declval<Cr>().cr.cr_return_amount)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  778 |                 __items;
+      |                 ~~~~~~~~
+  779 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  780 |               __items.push_back(x.cr.cr_return_amount);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  781 |             }
+      |             ~
+  782 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  783 |           })()),
+      |           ~~~~~~
+  784 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  785 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  786 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  787 |             std::vector<decltype(std::declval<Cr>().cr.cr_net_loss)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  788 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  789 |               __items.push_back(x.cr.cr_net_loss);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  790 |             }
+      |             ~
+  791 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  792 |           })())});
+      |           ~~~~~~~~
+  793 |     }
+      |     ~
+  794 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  795 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:806:35: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  806 |             __g.items.push_back(W{ws, d});
+      |                                   ^~
+      |                                   |
+      |                                   WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:812:65: error: cannot convert ‘WebSale’ to ‘int’ in initialization
+  812 |           __groups.push_back(__struct21{__key, std::vector<W>{W{ws, d}}});
+      |                                                                 ^~
+      |                                                                 |
+      |                                                                 WebSale
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:812:71: error: no matching function for call to ‘std::vector<W>::vector(<brace-enclosed initializer list>)’
+  812 |           __groups.push_back(__struct21{__key, std::vector<W>{W{ws, d}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = W; _Alloc = std::allocator<W>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = W; _Alloc = std::allocator<W>; allocator_type = std::allocator<W>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = W; _Alloc = std::allocator<W>; std::__type_identity_t<_Alloc> = std::allocator<W>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = W; _Alloc = std::allocator<W>; allocator_type = std::allocator<W>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = W; _Alloc = std::allocator<W>; allocator_type = std::allocator<W>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = W; _Alloc = std::allocator<W>; std::__type_identity_t<_Alloc> = std::allocator<W>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = W; _Alloc = std::allocator<W>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = W; _Alloc = std::allocator<W>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = W; _Alloc = std::allocator<W>; size_type = long unsigned int; value_type = W; allocator_type = std::allocator<W>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = W; _Alloc = std::allocator<W>; size_type = long unsigned int; allocator_type = std::allocator<W>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = W; _Alloc = std::allocator<W>; allocator_type = std::allocator<W>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = W; _Alloc = std::allocator<W>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:822:55: error: request for member ‘ws_ext_sales_price’ in ‘std::declval<W>().W::ws’, which is of non-class type ‘int’
+  822 |             std::vector<decltype(std::declval<W>().ws.ws_ext_sales_price)>
+      |                                                       ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:822:55: error: request for member ‘ws_ext_sales_price’ in ‘std::declval<W>().W::ws’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:822:74: error: template argument 1 is invalid
+  822 |             std::vector<decltype(std::declval<W>().ws.ws_ext_sales_price)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:822:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:825:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  825 |               __items.push_back(x.ws.ws_ext_sales_price);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:825:38: error: request for member ‘ws_ext_sales_price’ in ‘x.W::ws’, which is of non-class type ‘int’
+  825 |               __items.push_back(x.ws.ws_ext_sales_price);
+      |                                      ^~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:9)> [with auto:9 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:821:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:820:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  820 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:820:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  820 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:832:55: error: request for member ‘ws_net_profit’ in ‘std::declval<W>().W::ws’, which is of non-class type ‘int’
+  832 |             std::vector<decltype(std::declval<W>().ws.ws_net_profit)> __items;
+      |                                                       ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:832:55: error: request for member ‘ws_net_profit’ in ‘std::declval<W>().W::ws’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:832:69: error: template argument 1 is invalid
+  832 |             std::vector<decltype(std::declval<W>().ws.ws_net_profit)> __items;
+      |                                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:832:69: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:834:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  834 |               __items.push_back(x.ws.ws_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:834:38: error: request for member ‘ws_net_profit’ in ‘x.W::ws’, which is of non-class type ‘int’
+  834 |               __items.push_back(x.ws.ws_net_profit);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:10)> [with auto:10 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:831:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:830:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  830 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:830:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  830 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:840:5: error: conversion from ‘vector<__struct22>’ to non-scalar type ‘vector<W>’ requested
+  796 |   std::vector<W> ws = ([&]() {
+      |                       ~~~~~~~~
+  797 |     std::vector<__struct21> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  798 |     for (auto ws : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  799 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  800 |         if (!((d.d_date_sk == ws.ws_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  801 |           continue;
+      |           ~~~~~~~~~
+  802 |         auto __key = ws.ws_web_page_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  803 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  804 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  805 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  806 |             __g.items.push_back(W{ws, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  807 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  808 |             break;
+      |             ~~~~~~
+  809 |           }
+      |           ~
+  810 |         }
+      |         ~
+  811 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  812 |           __groups.push_back(__struct21{__key, std::vector<W>{W{ws, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  813 |         }
+      |         ~
+  814 |       }
+      |       ~
+  815 |     }
+      |     ~
+  816 |     std::vector<__struct22> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  817 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  818 |       __items.push_back(__struct22{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  819 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  820 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  821 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  822 |             std::vector<decltype(std::declval<W>().ws.ws_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  823 |                 __items;
+      |                 ~~~~~~~~
+  824 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  825 |               __items.push_back(x.ws.ws_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  826 |             }
+      |             ~
+  827 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  828 |           })()),
+      |           ~~~~~~
+  829 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  830 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  831 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  832 |             std::vector<decltype(std::declval<W>().ws.ws_net_profit)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  833 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  834 |               __items.push_back(x.ws.ws_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  835 |             }
+      |             ~
+  836 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  837 |           })())});
+      |           ~~~~~~~~
+  838 |     }
+      |     ~
+  839 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  840 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:851:36: error: cannot convert ‘WebReturn’ to ‘int’ in initialization
+  851 |             __g.items.push_back(Wr{wr, d});
+      |                                    ^~
+      |                                    |
+      |                                    WebReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:857:67: error: cannot convert ‘WebReturn’ to ‘int’ in initialization
+  857 |           __groups.push_back(__struct24{__key, std::vector<Wr>{Wr{wr, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   WebReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:857:73: error: no matching function for call to ‘std::vector<Wr>::vector(<brace-enclosed initializer list>)’
+  857 |           __groups.push_back(__struct24{__key, std::vector<Wr>{Wr{wr, d}}});
+      |                                                                         ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Wr; _Alloc = std::allocator<Wr>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; allocator_type = std::allocator<Wr>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; std::__type_identity_t<_Alloc> = std::allocator<Wr>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Wr; _Alloc = std::allocator<Wr>; allocator_type = std::allocator<Wr>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Wr; _Alloc = std::allocator<Wr>; allocator_type = std::allocator<Wr>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; std::__type_identity_t<_Alloc> = std::allocator<Wr>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Wr; _Alloc = std::allocator<Wr>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Wr; _Alloc = std::allocator<Wr>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; size_type = long unsigned int; value_type = Wr; allocator_type = std::allocator<Wr>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; size_type = long unsigned int; allocator_type = std::allocator<Wr>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Wr; _Alloc = std::allocator<Wr>; allocator_type = std::allocator<Wr>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Wr; _Alloc = std::allocator<Wr>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:867:56: error: request for member ‘wr_return_amt’ in ‘std::declval<Wr>().Wr::wr’, which is of non-class type ‘int’
+  867 |             std::vector<decltype(std::declval<Wr>().wr.wr_return_amt)> __items;
+      |                                                        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:867:56: error: request for member ‘wr_return_amt’ in ‘std::declval<Wr>().Wr::wr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:867:70: error: template argument 1 is invalid
+  867 |             std::vector<decltype(std::declval<Wr>().wr.wr_return_amt)> __items;
+      |                                                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:867:70: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:869:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  869 |               __items.push_back(x.wr.wr_return_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:869:38: error: request for member ‘wr_return_amt’ in ‘x.Wr::wr’, which is of non-class type ‘int’
+  869 |               __items.push_back(x.wr.wr_return_amt);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:11)> [with auto:11 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:866:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:865:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  865 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:865:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  865 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:876:56: error: request for member ‘wr_net_loss’ in ‘std::declval<Wr>().Wr::wr’, which is of non-class type ‘int’
+  876 |             std::vector<decltype(std::declval<Wr>().wr.wr_net_loss)> __items;
+      |                                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:876:56: error: request for member ‘wr_net_loss’ in ‘std::declval<Wr>().Wr::wr’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:876:68: error: template argument 1 is invalid
+  876 |             std::vector<decltype(std::declval<Wr>().wr.wr_net_loss)> __items;
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:876:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:878:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  878 |               __items.push_back(x.wr.wr_net_loss);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:878:38: error: request for member ‘wr_net_loss’ in ‘x.Wr::wr’, which is of non-class type ‘int’
+  878 |               __items.push_back(x.wr.wr_net_loss);
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:12)> [with auto:12 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:875:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:874:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  874 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:874:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  874 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:884:5: error: conversion from ‘vector<__struct25>’ to non-scalar type ‘vector<Wr>’ requested
+  841 |   std::vector<Wr> wr = ([&]() {
+      |                        ~~~~~~~~
+  842 |     std::vector<__struct24> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  843 |     for (auto wr : web_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  844 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  845 |         if (!((d.d_date_sk == wr.wr_returned_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  846 |           continue;
+      |           ~~~~~~~~~
+  847 |         auto __key = wr.wr_web_page_sk;
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  848 |         bool __found = false;
+      |         ~~~~~~~~~~~~~~~~~~~~~
+  849 |         for (auto &__g : __groups) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  850 |           if (__g.key == __key) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~
+  851 |             __g.items.push_back(Wr{wr, d});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  852 |             __found = true;
+      |             ~~~~~~~~~~~~~~~
+  853 |             break;
+      |             ~~~~~~
+  854 |           }
+      |           ~
+  855 |         }
+      |         ~
+  856 |         if (!__found) {
+      |         ~~~~~~~~~~~~~~~
+  857 |           __groups.push_back(__struct24{__key, std::vector<Wr>{Wr{wr, d}}});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  858 |         }
+      |         ~
+  859 |       }
+      |       ~
+  860 |     }
+      |     ~
+  861 |     std::vector<__struct25> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  862 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  863 |       __items.push_back(__struct25{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  864 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  865 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  866 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  867 |             std::vector<decltype(std::declval<Wr>().wr.wr_return_amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  868 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  869 |               __items.push_back(x.wr.wr_return_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  870 |             }
+      |             ~
+  871 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  872 |           })()),
+      |           ~~~~~~
+  873 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  874 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  875 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  876 |             std::vector<decltype(std::declval<Wr>().wr.wr_net_loss)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  877 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  878 |               __items.push_back(x.wr.wr_net_loss);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  879 |             }
+      |             ~
+  880 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  881 |           })())});
+      |           ~~~~~~~~
+  882 |     }
+      |     ~
+  883 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  884 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:892:31: error: ‘struct S’ has no member named ‘s_store_sk’
+  892 |                      if (!((s.s_store_sk == r.s_store_sk)))
+      |                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:892:47: error: ‘struct Sr’ has no member named ‘s_store_sk’
+  892 |                      if (!((s.s_store_sk == r.s_store_sk)))
+      |                                               ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:896:58: error: ‘struct S’ has no member named ‘s_store_sk’
+  896 |                          std::string("store channel"), s.s_store_sk, s.sales,
+      |                                                          ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:896:72: error: ‘struct S’ has no member named ‘sales’
+  896 |                          std::string("store channel"), s.s_store_sk, s.sales,
+      |                                                                        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:897:30: error: no match for ‘operator==’ (operand types are ‘Sr’ and ‘std::nullptr_t’)
+  897 |                          ((r == nullptr) ? 0 : r.returns),
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:897:50: error: ‘struct Sr’ has no member named ‘returns’
+  897 |                          ((r == nullptr) ? 0 : r.returns),
+      |                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:898:29: error: ‘struct S’ has no member named ‘profit’
+  898 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:898:43: error: no match for ‘operator==’ (operand types are ‘Sr’ and ‘std::nullptr_t’)
+  898 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                         ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:898:63: error: ‘struct Sr’ has no member named ‘profit_loss’
+  898 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                                               ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:903:58: error: ‘struct S’ has no member named ‘s_store_sk’
+  903 |                          std::string("store channel"), s.s_store_sk, s.sales,
+      |                                                          ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:903:72: error: ‘struct S’ has no member named ‘sales’
+  903 |                          std::string("store channel"), s.s_store_sk, s.sales,
+      |                                                                        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:904:30: error: no match for ‘operator==’ (operand types are ‘Sr’ and ‘std::nullptr_t’)
+  904 |                          ((r == nullptr) ? 0 : r.returns),
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:904:50: error: ‘struct Sr’ has no member named ‘returns’
+  904 |                          ((r == nullptr) ? 0 : r.returns),
+      |                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:905:29: error: ‘struct S’ has no member named ‘profit’
+  905 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:905:43: error: no match for ‘operator==’ (operand types are ‘Sr’ and ‘std::nullptr_t’)
+  905 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                         ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:905:63: error: ‘struct Sr’ has no member named ‘profit_loss’
+  905 |                          (s.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                                               ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:915:29: error: ‘struct C’ has no member named ‘cs_call_center_sk’
+  915 |                    if (!((c.cs_call_center_sk == r.cr_call_center_sk)))
+      |                             ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:915:52: error: ‘struct Cr’ has no member named ‘cr_call_center_sk’
+  915 |                    if (!((c.cs_call_center_sk == r.cr_call_center_sk)))
+      |                                                    ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:918:58: error: ‘struct C’ has no member named ‘cs_call_center_sk’
+  918 |                        std::string("catalog channel"), c.cs_call_center_sk,
+      |                                                          ^~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:919:26: error: ‘struct C’ has no member named ‘sales’
+  919 |                        c.sales, r.returns, (c.profit - r.profit_loss)});
+      |                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:919:35: error: ‘struct Cr’ has no member named ‘returns’
+  919 |                        c.sales, r.returns, (c.profit - r.profit_loss)});
+      |                                   ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:919:47: error: ‘struct C’ has no member named ‘profit’
+  919 |                        c.sales, r.returns, (c.profit - r.profit_loss)});
+      |                                               ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:919:58: error: ‘struct Cr’ has no member named ‘profit_loss’
+  919 |                        c.sales, r.returns, (c.profit - r.profit_loss)});
+      |                                                          ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:930:31: error: ‘struct W’ has no member named ‘wp_web_page_sk’
+  930 |                      if (!((w.wp_web_page_sk == r.wp_web_page_sk)))
+      |                               ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:930:51: error: ‘struct Wr’ has no member named ‘wp_web_page_sk’
+  930 |                      if (!((w.wp_web_page_sk == r.wp_web_page_sk)))
+      |                                                   ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:934:56: error: ‘struct W’ has no member named ‘wp_web_page_sk’
+  934 |                          std::string("web channel"), w.wp_web_page_sk, w.sales,
+      |                                                        ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:934:74: error: ‘struct W’ has no member named ‘sales’
+  934 |                          std::string("web channel"), w.wp_web_page_sk, w.sales,
+      |                                                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:935:30: error: no match for ‘operator==’ (operand types are ‘Wr’ and ‘std::nullptr_t’)
+  935 |                          ((r == nullptr) ? 0 : r.returns),
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:935:50: error: ‘struct Wr’ has no member named ‘returns’
+  935 |                          ((r == nullptr) ? 0 : r.returns),
+      |                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:936:29: error: ‘struct W’ has no member named ‘profit’
+  936 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:936:43: error: no match for ‘operator==’ (operand types are ‘Wr’ and ‘std::nullptr_t’)
+  936 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                         ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:936:63: error: ‘struct Wr’ has no member named ‘profit_loss’
+  936 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                                               ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:941:56: error: ‘struct W’ has no member named ‘wp_web_page_sk’
+  941 |                          std::string("web channel"), w.wp_web_page_sk, w.sales,
+      |                                                        ^~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:941:74: error: ‘struct W’ has no member named ‘sales’
+  941 |                          std::string("web channel"), w.wp_web_page_sk, w.sales,
+      |                                                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:942:30: error: no match for ‘operator==’ (operand types are ‘Wr’ and ‘std::nullptr_t’)
+  942 |                          ((r == nullptr) ? 0 : r.returns),
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:942:50: error: ‘struct Wr’ has no member named ‘returns’
+  942 |                          ((r == nullptr) ? 0 : r.returns),
+      |                                                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:943:29: error: ‘struct W’ has no member named ‘profit’
+  943 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:943:43: error: no match for ‘operator==’ (operand types are ‘Wr’ and ‘std::nullptr_t’)
+  943 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                         ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:943:63: error: ‘struct Wr’ has no member named ‘profit_loss’
+  943 |                          (w.profit - (((r == nullptr) ? 0 : r.profit_loss)))});
+      |                                                               ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:886:7: error: ‘concat’ was not declared in this scope; did you mean ‘wcsncat’?
+  886 |       concat(([&]() {
+      |       ^~~~~~
+      |       wcsncat
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:955:21: error: no match for ‘operator==’ (operand types are ‘Result’ and ‘Result’)
+  955 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Result Result
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:976:66: error: ‘struct PerChannel’ has no member named ‘p’
+  976 |                  std::vector<decltype(std::declval<PerChannel>().p.sales)>
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:976:66: error: ‘struct PerChannel’ has no member named ‘p’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:976:74: error: template argument 1 is invalid
+  976 |                  std::vector<decltype(std::declval<PerChannel>().p.sales)>
+      |                                                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:976:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:979:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  979 |                    __items.push_back(x.p.sales);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:979:40: error: ‘struct PerChannel’ has no member named ‘p’
+  979 |                    __items.push_back(x.p.sales);
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:13)> [with auto:13 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:975:18:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:974:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  974 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:974:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  974 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                    ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:986:66: error: ‘struct PerChannel’ has no member named ‘p’
+  986 |                  std::vector<decltype(std::declval<PerChannel>().p.returns)>
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:986:66: error: ‘struct PerChannel’ has no member named ‘p’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:986:76: error: template argument 1 is invalid
+  986 |                  std::vector<decltype(std::declval<PerChannel>().p.returns)>
+      |                                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:986:76: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:989:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  989 |                    __items.push_back(x.p.returns);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:989:40: error: ‘struct PerChannel’ has no member named ‘p’
+  989 |                    __items.push_back(x.p.returns);
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:14)> [with auto:14 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:985:18:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:984:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  984 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:984:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  984 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                    ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:996:66: error: ‘struct PerChannel’ has no member named ‘p’
+  996 |                  std::vector<decltype(std::declval<PerChannel>().p.profit)>
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:996:66: error: ‘struct PerChannel’ has no member named ‘p’
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:996:75: error: template argument 1 is invalid
+  996 |                  std::vector<decltype(std::declval<PerChannel>().p.profit)>
+      |                                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:996:75: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:999:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  999 |                    __items.push_back(x.p.profit);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:999:40: error: ‘struct PerChannel’ has no member named ‘p’
+  999 |                    __items.push_back(x.p.profit);
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:15)> [with auto:15 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:995:18:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:994:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  994 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:994:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  994 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                    ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq772109394433/001/prog.cpp:970:24: error: no matching function for call to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, PerChannel> >::push_back(<brace-enclosed initializer list>)’
+  970 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  971 |           {g.key.channel,
+      |           ~~~~~~~~~~~~~~~
+  972 |            PerChannel{
+      |            ~~~~~~~~~~~  
+  973 |                g.key.channel, g.key.id, ([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  974 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  975 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  976 |                  std::vector<decltype(std::declval<PerChannel>().p.sales)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  977 |                      __items;
+      |                      ~~~~~~~~
+  978 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  979 |                    __items.push_back(x.p.sales);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  980 |                  }
+      |                  ~      
+  981 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  982 |                })()),
+      |                ~~~~~~   
+  983 |                ([&](auto v) {
+      |                ~~~~~~~~~~~~~~
+  984 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  985 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  986 |                  std::vector<decltype(std::declval<PerChannel>().p.returns)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  987 |                      __items;
+      |                      ~~~~~~~~
+  988 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  989 |                    __items.push_back(x.p.returns);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  990 |                  }
+      |                  ~      
+  991 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  992 |                })()),
+      |                ~~~~~~   
+  993 |                ([&](auto v) {
+      |                ~~~~~~~~~~~~~~
+  994 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  995 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  996 |                  std::vector<decltype(std::declval<PerChannel>().p.profit)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  997 |                      __items;
+      |                      ~~~~~~~~
+  998 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  999 |                    __items.push_back(x.p.profit);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ 1000 |                  }
+      |                  ~      
+ 1001 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+ 1002 |                })())}});
+      |                ~~~~~~~~ 
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, PerChannel>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, PerChannel> >; value_type = std::pair<std::__cxx11::basic_string<char>, PerChannel>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<std::__cxx11::basic_string<char>, PerChannel> >::value_type&’ {aka ‘const std::pair<std::__cxx11::basic_string<char>, PerChannel>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<std::__cxx11::basic_string<char>, PerChannel>; _Alloc = std::allocator<std::pair<std::__cxx11::basic_string<char>, PerChannel> >; value_type = std::pair<std::__cxx11::basic_string<char>, PerChannel>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<std::__cxx11::basic_string<char>, PerChannel> >::value_type&&’ {aka ‘std::pair<std::__cxx11::basic_string<char>, PerChannel>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q78.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q78.error
@@ -1,0 +1,145 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:77:12: error: ‘s’ was not declared in this scope
+   77 |   decltype(s.ss_sold_year) ss_sold_year;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:77:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:78:12: error: ‘s’ was not declared in this scope
+   78 |   decltype(s.ss_item_sk) ss_item_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:78:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:79:12: error: ‘s’ was not declared in this scope
+   79 |   decltype(s.ss_customer_sk) ss_customer_sk;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:79:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:81:12: error: ‘s’ was not declared in this scope
+   81 |   decltype(s.ss_qty) store_qty;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:81:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:82:12: error: ‘s’ was not declared in this scope
+   82 |   decltype(s.ss_wc) store_wholesale_cost;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:82:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:83:12: error: ‘s’ was not declared in this scope
+   83 |   decltype(s.ss_sp) store_sales_price;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:83:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:271:30: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  271 |               if (!((((((((w == nullptr) ? 0 : w.ws_qty)) > 0) ||
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:272:30: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  272 |                        ((((c == nullptr) ? 0 : c.cs_qty)) > 0))) &&
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:277:45: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  277 |                          (s.ss_qty / (((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:278:45: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  278 |                                        (((c == nullptr) ? 0 : c.cs_qty))))),
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:280:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  280 |                          ((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:281:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  281 |                           (((c == nullptr) ? 0 : c.cs_qty))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:282:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  282 |                          ((((w == nullptr) ? 0 : w.ws_wc)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:283:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  283 |                           (((c == nullptr) ? 0 : c.cs_wc))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:284:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  284 |                          ((((w == nullptr) ? 0 : w.ws_sp)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:285:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  285 |                           (((c == nullptr) ? 0 : c.cs_sp)))});
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:289:30: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  289 |               if (!((((((((w == nullptr) ? 0 : w.ws_qty)) > 0) ||
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:290:30: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  290 |                        ((((c == nullptr) ? 0 : c.cs_qty)) > 0))) &&
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:295:45: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  295 |                          (s.ss_qty / (((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:296:45: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  296 |                                        (((c == nullptr) ? 0 : c.cs_qty))))),
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:298:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  298 |                          ((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:299:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  299 |                           (((c == nullptr) ? 0 : c.cs_qty))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:300:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  300 |                          ((((w == nullptr) ? 0 : w.ws_wc)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:301:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  301 |                           (((c == nullptr) ? 0 : c.cs_wc))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:302:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  302 |                          ((((w == nullptr) ? 0 : w.ws_sp)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:303:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  303 |                           (((c == nullptr) ? 0 : c.cs_sp)))});
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:317:30: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  317 |               if (!((((((((w == nullptr) ? 0 : w.ws_qty)) > 0) ||
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:318:30: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  318 |                        ((((c == nullptr) ? 0 : c.cs_qty)) > 0))) &&
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:323:45: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  323 |                          (s.ss_qty / (((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:324:45: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  324 |                                        (((c == nullptr) ? 0 : c.cs_qty))))),
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:326:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  326 |                          ((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:327:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  327 |                           (((c == nullptr) ? 0 : c.cs_qty))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:328:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  328 |                          ((((w == nullptr) ? 0 : w.ws_wc)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:329:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  329 |                           (((c == nullptr) ? 0 : c.cs_wc))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:330:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  330 |                          ((((w == nullptr) ? 0 : w.ws_sp)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:331:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  331 |                           (((c == nullptr) ? 0 : c.cs_sp)))});
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:335:30: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  335 |               if (!((((((((w == nullptr) ? 0 : w.ws_qty)) > 0) ||
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:336:30: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  336 |                        ((((c == nullptr) ? 0 : c.cs_qty)) > 0))) &&
+      |                            ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:341:45: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  341 |                          (s.ss_qty / (((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:342:45: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  342 |                                        (((c == nullptr) ? 0 : c.cs_qty))))),
+      |                                           ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:344:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  344 |                          ((((w == nullptr) ? 0 : w.ws_qty)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:345:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  345 |                           (((c == nullptr) ? 0 : c.cs_qty))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:346:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  346 |                          ((((w == nullptr) ? 0 : w.ws_wc)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:347:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  347 |                           (((c == nullptr) ? 0 : c.cs_wc))),
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:348:32: error: no match for ‘operator==’ (operand types are ‘W’ and ‘std::nullptr_t’)
+  348 |                          ((((w == nullptr) ? 0 : w.ws_sp)) +
+      |                              ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq78761924668/001/prog.cpp:349:32: error: no match for ‘operator==’ (operand types are ‘C’ and ‘std::nullptr_t’)
+  349 |                           (((c == nullptr) ? 0 : c.cs_sp)))});
+      |                              ~~^~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q79.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q79.error
@@ -1,0 +1,411 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+   86 |   decltype(ss.ss_ticket_number) ticket;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:86:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:87:12: error: ‘ss’ was not declared in this scope
+   87 |   decltype(ss.ss_customer_sk) customer_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:87:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:88:12: error: ‘s’ was not declared in this scope
+   88 |   decltype(s.s_city) city;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:88:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+   91 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:92:12: error: ‘d’ was not declared in this scope
+   92 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:92:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:93:12: error: ‘s’ was not declared in this scope
+   93 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:93:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:94:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   94 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:94:12: error: ‘hd’ was not declared in this scope; did you mean ‘d’?
+   94 |   decltype(hd) hd;
+      |            ^~
+      |            d
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+  106 |   decltype(c.c_last_name) c_last_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:106:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:107:12: error: ‘c’ was not declared in this scope
+  107 |   decltype(c.c_first_name) c_first_name;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:107:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘key’
+  108 |   decltype(std::declval<__struct7>().key.city) s_city;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:108:38: error: ‘struct __struct7’ has no member named ‘key’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:109:38: error: ‘struct __struct7’ has no member named ‘key’
+  109 |   decltype(std::declval<__struct7>().key.ticket) ss_ticket_number;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:109:38: error: ‘struct __struct7’ has no member named ‘key’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:110:38: error: ‘struct __struct7’ has no member named ‘amt’
+  110 |   decltype(std::declval<__struct7>().amt) amt;
+      |                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:110:38: error: ‘struct __struct7’ has no member named ‘amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:111:38: error: ‘struct __struct7’ has no member named ‘profit’
+  111 |   decltype(std::declval<__struct7>().profit) profit;
+      |                                      ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:111:38: error: ‘struct __struct7’ has no member named ‘profit’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:360:72: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  360 |             auto __key = Agg{ss.ss_ticket_number, ss.ss_customer_sk, s.s_city};
+      |                                                                      ~~^~~~~~
+      |                                                                        |
+      |                                                                        std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:364:47: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  364 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                                               ^~
+      |                                               |
+      |                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:371:59: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  371 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:371:72: error: no matching function for call to ‘std::vector<__struct7>::vector(<brace-enclosed initializer list>)’
+  371 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; std::__type_identity_t<_Alloc> = std::allocator<__struct7>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; value_type = std::vector<__struct7>::value_type; allocator_type = std::allocator<__struct7>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; size_type = long unsigned int; allocator_type = std::allocator<__struct7>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct7; _Alloc = std::allocator<__struct7>; allocator_type = std::allocator<__struct7>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct7; _Alloc = std::allocator<__struct7>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:383:63: error: request for member ‘ss_coupon_amt’ in ‘std::declval<__struct7>().__struct7::ss’, which is of non-class type ‘int’
+  383 |             std::vector<decltype(std::declval<__struct7>().ss.ss_coupon_amt)>
+      |                                                               ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:383:63: error: request for member ‘ss_coupon_amt’ in ‘std::declval<__struct7>().__struct7::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:383:77: error: template argument 1 is invalid
+  383 |             std::vector<decltype(std::declval<__struct7>().ss.ss_coupon_amt)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:383:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:386:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  386 |               __items.push_back(x.ss.ss_coupon_amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:386:38: error: request for member ‘ss_coupon_amt’ in ‘x.__struct7::ss’, which is of non-class type ‘int’
+  386 |               __items.push_back(x.ss.ss_coupon_amt);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:382:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:381:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  381 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:381:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  381 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:393:63: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct7>().__struct7::ss’, which is of non-class type ‘int’
+  393 |             std::vector<decltype(std::declval<__struct7>().ss.ss_net_profit)>
+      |                                                               ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:393:63: error: request for member ‘ss_net_profit’ in ‘std::declval<__struct7>().__struct7::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:393:77: error: template argument 1 is invalid
+  393 |             std::vector<decltype(std::declval<__struct7>().ss.ss_net_profit)>
+      |                                                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:393:77: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:396:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  396 |               __items.push_back(x.ss.ss_net_profit);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:396:38: error: request for member ‘ss_net_profit’ in ‘x.__struct7::ss’, which is of non-class type ‘int’
+  396 |               __items.push_back(x.ss.ss_net_profit);
+      |                                      ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:392:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:391:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  391 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:391:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  391 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:402:5: error: conversion from ‘vector<__struct9>’ to non-scalar type ‘vector<__struct7>’ requested
+  341 |   std::vector<__struct7> agg = ([&]() {
+      |                                ~~~~~~~~
+  342 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  343 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  344 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  345 |         if (!((d.d_date_sk == ss.ss_sold_date_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  346 |           continue;
+      |           ~~~~~~~~~
+  347 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  348 |           if (!((s.s_store_sk == ss.ss_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  349 |             continue;
+      |             ~~~~~~~~~
+  350 |           for (auto hd : household_demographics) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  351 |             if (!((hd.hd_demo_sk == ss.ss_hdemo_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  352 |               continue;
+      |               ~~~~~~~~~
+  353 |             if (!((((((((hd.hd_dep_count == 2) || (hd.hd_vehicle_count > 1))) &&
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  354 |                       (d.d_dow == 1)) &&
+      |                       ~~~~~~~~~~~~~~~~~~
+  355 |                      ((((d.d_year == 1998) || (d.d_year == 1999)) ||
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  356 |                        (d.d_year == 2000)))) &&
+      |                        ~~~~~~~~~~~~~~~~~~~~~~~~
+  357 |                     (s.s_number_employees >= 200)) &&
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  358 |                    (s.s_number_employees <= 295))))
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  359 |               continue;
+      |               ~~~~~~~~~
+  360 |             auto __key = Agg{ss.ss_ticket_number, ss.ss_customer_sk, s.s_city};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  361 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  362 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  363 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  364 |                 __g.items.push_back(__struct7{ss, d, s, hd});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  365 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  366 |                 break;
+      |                 ~~~~~~
+  367 |               }
+      |               ~
+  368 |             }
+      |             ~
+  369 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  370 |               __groups.push_back(__struct8{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |                   __key, std::vector<__struct7>{__struct7{ss, d, s, hd}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |             }
+      |             ~
+  373 |           }
+      |           ~
+  374 |         }
+      |         ~
+  375 |       }
+      |       ~
+  376 |     }
+      |     ~
+  377 |     std::vector<__struct9> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  378 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  379 |       __items.push_back(__struct9{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |           g.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  381 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  383 |             std::vector<decltype(std::declval<__struct7>().ss.ss_coupon_amt)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  384 |                 __items;
+      |                 ~~~~~~~~
+  385 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |               __items.push_back(x.ss.ss_coupon_amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  387 |             }
+      |             ~
+  388 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  389 |           })()),
+      |           ~~~~~~
+  390 |           ([&](auto v) {
+      |           ~~~~~~~~~~~~~~
+  391 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  392 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  393 |             std::vector<decltype(std::declval<__struct7>().ss.ss_net_profit)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |                 __items;
+      |                 ~~~~~~~~
+  395 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |               __items.push_back(x.ss.ss_net_profit);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |             }
+      |             ~
+  398 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  399 |           })())});
+      |           ~~~~~~~~
+  400 |     }
+      |     ~
+  401 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  402 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:404:62: error: ‘struct __struct7’ has no member named ‘key’
+  404 |     std::vector<std::pair<decltype(std::declval<__struct7>().key), Result>>
+      |                                                              ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:404:62: error: ‘struct __struct7’ has no member named ‘key’
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:404:68: error: template argument 1 is invalid
+  404 |     std::vector<std::pair<decltype(std::declval<__struct7>().key), Result>>
+      |                                                                    ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:404:74: error: template argument 1 is invalid
+  404 |     std::vector<std::pair<decltype(std::declval<__struct7>().key), Result>>
+      |                                                                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:404:74: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:408:37: error: ‘struct __struct7’ has no member named ‘key’
+  408 |         if (!((c.c_customer_sk == a.key.customer_sk)))
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:410:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  410 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:412:53: error: ‘struct __struct7’ has no member named ‘key’
+  412 |                                                   a.key.city, a.profit},
+      |                                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:412:65: error: ‘struct __struct7’ has no member named ‘profit’
+  412 |                                                   a.key.city, a.profit},
+      |                                                                 ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:412:71: error: no matching function for call to ‘std::vector<std::__cxx11::basic_string<char> >::vector(<brace-enclosed initializer list>)’
+  412 |                                                   a.key.city, a.profit},
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; std::__type_identity_t<_Alloc> = std::allocator<std::__cxx11::basic_string<char> >]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; value_type = std::__cxx11::basic_string<char>; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; size_type = long unsigned int; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   candidate expects 2 arguments, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >; allocator_type = std::allocator<std::__cxx11::basic_string<char> >]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   candidate expects 1 argument, 4 provided
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = std::__cxx11::basic_string<char>; _Alloc = std::allocator<std::__cxx11::basic_string<char> >]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 4 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:413:54: error: ‘struct __struct7’ has no member named ‘key’
+  413 |              Result{c.c_last_name, c.c_first_name, a.key.city, a.key.ticket,
+      |                                                      ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:413:66: error: ‘struct __struct7’ has no member named ‘key’
+  413 |              Result{c.c_last_name, c.c_first_name, a.key.city, a.key.ticket,
+      |                                                                  ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:414:23: error: ‘struct __struct7’ has no member named ‘amt’
+  414 |                     a.amt, a.profit}});
+      |                       ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:414:30: error: ‘struct __struct7’ has no member named ‘profit’
+  414 |                     a.amt, a.profit}});
+      |                              ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:417:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  417 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:417:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  417 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:420:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  420 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq791900115007/001/prog.cpp:420:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  420 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q8.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q8.error
@@ -1,0 +1,503 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:81:12: error: ‘ss’ was not declared in this scope
+   81 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:81:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+   82 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:82:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:83:12: error: ‘s’ was not declared in this scope
+   83 |   decltype(s) s;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:83:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:84:12: error: ‘ca’ was not declared in this scope
+   84 |   decltype(ca) ca;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:84:12: error: ‘ca’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:85:12: error: ‘c’ was not declared in this scope; did you mean ‘ca’?
+   85 |   decltype(c) c;
+      |            ^
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:85:12: error: ‘c’ was not declared in this scope; did you mean ‘ca’?
+   85 |   decltype(c) c;
+      |            ^
+      |            ca
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:88:12: error: ‘s’ was not declared in this scope
+   88 |   decltype(s.s_store_name) key;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:88:12: error: ‘s’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:243:11: error: ‘substr’ was not declared in this scope
+  243 |   reverse(substr(std::string("zip"), 0, 2));
+      |           ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:243:3: error: ‘reverse’ was not declared in this scope; did you mean ‘std::reverse’?
+  243 |   reverse(substr(std::string("zip"), 0, 2));
+      |   ^~~~~~~
+      |   std::reverse
+In file included from /usr/include/c++/13/algorithm:73,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:2:
+/usr/include/c++/13/pstl/glue_algorithm_defs.h:249:1: note: ‘std::reverse’ declared here
+  249 | reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last);
+      | ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:29: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  268 |                 if (__g.key == __key) {
+      |                     ~~~~~~~ ^~ ~~~~~
+      |                         |      |
+      |                         int    std::__cxx11::basic_string<char>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:3:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/algorithm:60:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const _CharT*’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:4:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:7:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:268:32: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  268 |                 if (__g.key == __key) {
+      |                                ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:269:46: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  269 |                   __g.items.push_back(Result{ss, d, s, ca, c});
+      |                                              ^~
+      |                                              |
+      |                                              StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:276:55: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  276 |                     __key, std::vector<Result>{Result{ss, d, s, ca, c}}});
+      |                                                       ^~
+      |                                                       |
+      |                                                       StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:276:71: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+  276 |                     __key, std::vector<Result>{Result{ss, d, s, ca, c}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>; std::__type_identity_t<_Alloc> = std::allocator<Result>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; value_type = Result; allocator_type = std::allocator<Result>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; size_type = long unsigned int; allocator_type = std::allocator<Result>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Result; _Alloc = std::allocator<Result>; allocator_type = std::allocator<Result>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Result; _Alloc = std::allocator<Result>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:292:65: error: request for member ‘ss_net_profit’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+  292 |                  std::vector<decltype(std::declval<Result>().ss.ss_net_profit)>
+      |                                                                 ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:292:65: error: request for member ‘ss_net_profit’ in ‘std::declval<Result>().Result::ss’, which is of non-class type ‘int’
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:292:79: error: template argument 1 is invalid
+  292 |                  std::vector<decltype(std::declval<Result>().ss.ss_net_profit)>
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:292:79: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:295:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  295 |                    __items.push_back(x.ss.ss_net_profit);
+      |                            ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:295:43: error: request for member ‘ss_net_profit’ in ‘x.Result::ss’, which is of non-class type ‘int’
+  295 |                    __items.push_back(x.ss.ss_net_profit);
+      |                                           ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:291:18:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:290:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  290 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                         ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:290:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  290 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                    ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:286:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct8> >::push_back(<brace-enclosed initializer list>)’
+  286 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~^
+  287 |           {g.key,
+      |           ~~~~~~~       
+  288 |            __struct8{
+      |            ~~~~~~~~~~   
+  289 |                g.key, ([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  290 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  291 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  292 |                  std::vector<decltype(std::declval<Result>().ss.ss_net_profit)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  293 |                      __items;
+      |                      ~~~~~~~~
+  294 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  295 |                    __items.push_back(x.ss.ss_net_profit);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  296 |                  }
+      |                  ~      
+  297 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  298 |                })())}});
+      |                ~~~~~~~~ 
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<int, __struct8>; _Alloc = std::allocator<std::pair<int, __struct8> >; value_type = std::pair<int, __struct8>]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<std::pair<int, __struct8> >::value_type&’ {aka ‘const std::pair<int, __struct8>&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = std::pair<int, __struct8>; _Alloc = std::allocator<std::pair<int, __struct8> >; value_type = std::pair<int, __struct8>]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<int, __struct8> >::value_type&&’ {aka ‘std::pair<int, __struct8>&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq83462107540/001/prog.cpp:306:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<Result>’ requested
+  245 |   std::vector<Result> result = ([&]() {
+      |                                ~~~~~~~~
+  246 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  247 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  248 |       for (auto d : date_dim) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+  249 |         if (!((((ss.ss_sold_date_sk == d.d_date_sk) && (d.d_qoy == 1)) &&
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  250 |                (d.d_year == 1998))))
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  251 |           continue;
+      |           ~~~~~~~~~
+  252 |         for (auto s : store) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~
+  253 |           if (!((ss.ss_store_sk == s.s_store_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  254 |             continue;
+      |             ~~~~~~~~~
+  255 |           for (auto ca : customer_address) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  256 |             if (!((substr(s.s_zip, 0, 2) == substr(ca.ca_zip, 0, 2))))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  257 |               continue;
+      |               ~~~~~~~~~
+  258 |             for (auto c : customer) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~
+  259 |               if (!(((ca.ca_address_sk == c.c_current_addr_sk) &&
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  260 |                      (c.c_preferred_cust_flag == std::string("Y")))))
+      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |                 continue;
+      |                 ~~~~~~~~~
+  262 |               if (!((std::find(zip_list.begin(), zip_list.end(),
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |                                substr(ca.ca_zip, 0, 5)) != zip_list.end())))
+      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  264 |                 continue;
+      |                 ~~~~~~~~~
+  265 |               auto __key = s.s_store_name;
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  266 |               bool __found = false;
+      |               ~~~~~~~~~~~~~~~~~~~~~
+  267 |               for (auto &__g : __groups) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  268 |                 if (__g.key == __key) {
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~
+  269 |                   __g.items.push_back(Result{ss, d, s, ca, c});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |                   __found = true;
+      |                   ~~~~~~~~~~~~~~~
+  271 |                   break;
+      |                   ~~~~~~
+  272 |                 }
+      |                 ~
+  273 |               }
+      |               ~
+  274 |               if (!__found) {
+      |               ~~~~~~~~~~~~~~~
+  275 |                 __groups.push_back(__struct7{
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |                     __key, std::vector<Result>{Result{ss, d, s, ca, c}}});
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  277 |               }
+      |               ~
+  278 |             }
+      |             ~
+  279 |           }
+      |           ~
+  280 |         }
+      |         ~
+  281 |       }
+      |       ~
+  282 |     }
+      |     ~
+  283 |     std::vector<std::pair<decltype(std::declval<__struct7>().key), __struct8>>
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  284 |         __items;
+      |         ~~~~~~~~
+  285 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  286 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  287 |           {g.key,
+      |           ~~~~~~~
+  288 |            __struct8{
+      |            ~~~~~~~~~~
+  289 |                g.key, ([&](auto v) {
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  290 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  291 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  292 |                  std::vector<decltype(std::declval<Result>().ss.ss_net_profit)>
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  293 |                      __items;
+      |                      ~~~~~~~~
+  294 |                  for (auto x : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  295 |                    __items.push_back(x.ss.ss_net_profit);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  296 |                  }
+      |                  ~
+  297 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  298 |                })())}});
+      |                ~~~~~~~~~
+  299 |     }
+      |     ~
+  300 |     std::sort(__items.begin(), __items.end(),
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  301 |               [](auto &a, auto &b) { return a.first < b.first; });
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  302 |     std::vector<__struct8> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  303 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  304 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  305 |     return __res;
+      |     ~~~~~~~~~~~~~
+  306 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q80.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q80.error
@@ -1,0 +1,57 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:81:49: error: ‘s’ was not declared in this scope
+   81 |                           std::vector<decltype((s.price - s.ret))> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:81:66: error: template argument 1 is invalid
+   81 |                           std::vector<decltype((s.price - s.ret))> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:81:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:83:37: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   83 |                             __items.push_back((s.price - s.ret));
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:80:27:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:79:52: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   79 |                           return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                  ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:79:63: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   79 |                           return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                             ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:90:49: error: ‘c’ was not declared in this scope
+   90 |                           std::vector<decltype((c.price - c.ret))> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:90:66: error: template argument 1 is invalid
+   90 |                           std::vector<decltype((c.price - c.ret))> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:90:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:92:37: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   92 |                             __items.push_back((c.price - c.ret));
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:89:27:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:88:52: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   88 |                           return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                  ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:88:63: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   88 |                           return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                             ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:99:48: error: ‘w’ was not declared in this scope
+   99 |                          std::vector<decltype((w.price - w.ret))> __items;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:99:65: error: template argument 1 is invalid
+   99 |                          std::vector<decltype((w.price - w.ret))> __items;
+      |                                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:99:65: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:101:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  101 |                            __items.push_back((w.price - w.ret));
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:98:26:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:97:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   97 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq801099439893/001/prog.cpp:97:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   97 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                            ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q81.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q81.error
@@ -1,0 +1,410 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:59:12: error: ‘r’ was not declared in this scope
+   59 |   decltype(r) r;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:59:12: error: ‘r’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:62:36: error: ‘struct AvgList’ has no member named ‘state’
+   62 |   decltype(std::declval<AvgList>().state) key;
+      |                                    ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:62:36: error: ‘struct AvgList’ has no member named ‘state’
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+  135 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 int    std::__cxx11::basic_string<char>
+In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:33,
+                 from /usr/include/c++/13/bits/allocator.h:46,
+                 from /usr/include/c++/13/string:43,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:2:
+/usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
+  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
+      |         ^~~~~~~~
+/usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/iosfwd:42,
+                 from /usr/include/c++/13/ios:40:
+/usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
+  192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
+  237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/string:48:
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
+  448 |     operator==(const reverse_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
+  493 |     operator==(const reverse_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
+ 1678 |     operator==(const move_iterator<_IteratorL>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
+ 1748 |     operator==(const move_iterator<_Iterator>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
+                 from /usr/include/c++/13/string:51:
+/usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
+  812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/basic_string.h:47,
+                 from /usr/include/c++/13/string:54:
+/usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
+  609 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
+  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
+  642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3774 |     operator==(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/memory_resource.h:47,
+                 from /usr/include/c++/13/string:58:
+/usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
+ 1919 |     operator==(const tuple<_TElements...>& __t,
+      |     ^~~~~~~~
+/usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/bits/locale_facets.h:48,
+                 from /usr/include/c++/13/bits/basic_ios.h:37,
+                 from /usr/include/c++/13/ios:46:
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
+  234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:63,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:3:
+/usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
+ 1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/map:64:
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const multimap<_Key, _Tp, _Compare, _Allocator>&, const multimap<_Key, _Tp, _Compare, _Allocator>&)’
+ 1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/unordered_map:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:5:
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
+ 2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
+ 2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:135:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+  135 |         if (__g.key == __key) {
+      |                        ^~~~~
+/usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |       ^~~~~~~~
+/usr/include/c++/13/bits/allocator.h:216:18: note:   no known conversion for argument 1 from ‘int’ to ‘const std::allocator<char>&’
+  216 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
+      |                  ^~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/bits/ios_base.h:46:
+/usr/include/c++/13/system_error:449:3: note: candidate: ‘bool std::operator==(const error_code&, const error_code&)’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:449:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  449 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:465:3: note: candidate: ‘bool std::operator==(const error_code&, const error_condition&)’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:465:32: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_code&’
+  465 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:480:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_condition&)’
+  480 |   operator==(const error_condition& __lhs,
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:480:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  480 |   operator==(const error_condition& __lhs,
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/usr/include/c++/13/system_error:517:3: note: candidate: ‘bool std::operator==(const error_condition&, const error_code&)’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |   ^~~~~~~~
+/usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
+  517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
+      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:136:39: error: cannot convert ‘CatalogReturn’ to ‘int’ in initialization
+  136 |           __g.items.push_back(AvgList{r});
+      |                                       ^
+      |                                       |
+      |                                       CatalogReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:142:74: error: cannot convert ‘CatalogReturn’ to ‘int’ in initialization
+  142 |         __groups.push_back(__struct3{__key, std::vector<AvgList>{AvgList{r}}});
+      |                                                                          ^
+      |                                                                          |
+      |                                                                          CatalogReturn
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:142:76: error: no matching function for call to ‘std::vector<AvgList>::vector(<brace-enclosed initializer list>)’
+  142 |         __groups.push_back(__struct3{__key, std::vector<AvgList>{AvgList{r}}});
+      |                                                                            ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = AvgList; _Alloc = std::allocator<AvgList>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; allocator_type = std::allocator<AvgList>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; std::__type_identity_t<_Alloc> = std::allocator<AvgList>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; allocator_type = std::allocator<AvgList>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; allocator_type = std::allocator<AvgList>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; std::__type_identity_t<_Alloc> = std::allocator<AvgList>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; size_type = long unsigned int; value_type = AvgList; allocator_type = std::allocator<AvgList>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; size_type = long unsigned int; allocator_type = std::allocator<AvgList>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = AvgList; _Alloc = std::allocator<AvgList>; allocator_type = std::allocator<AvgList>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = AvgList; _Alloc = std::allocator<AvgList>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:149:58: error: ‘struct AvgList’ has no member named ‘amt’
+  149 |             std::vector<decltype(std::declval<AvgList>().amt)> __items;
+      |                                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:149:58: error: ‘struct AvgList’ has no member named ‘amt’
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:149:62: error: template argument 1 is invalid
+  149 |             std::vector<decltype(std::declval<AvgList>().amt)> __items;
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:149:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:151:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  151 |               __items.push_back(x.amt);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:151:35: error: ‘struct AvgList’ has no member named ‘amt’
+  151 |               __items.push_back(x.amt);
+      |                                   ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:148:23: error: no matching function for call to ‘__avg(int)’
+  148 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  149 |             std::vector<decltype(std::declval<AvgList>().amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  150 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  151 |               __items.push_back(x.amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  152 |             }
+      |             ~          
+  153 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  154 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:65:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   65 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:65:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:148:23: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  148 |           g.key, __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  149 |             std::vector<decltype(std::declval<AvgList>().amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  150 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  151 |               __items.push_back(x.amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  152 |             }
+      |             ~          
+  153 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  154 |           })())});
+      |           ~~~~~        
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:157:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<AvgList>’ requested
+  129 |   std::vector<AvgList> avg_list = ([&]() {
+      |                                   ~~~~~~~~
+  130 |     std::vector<__struct3> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  131 |     for (auto r : catalog_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  132 |       auto __key = r.state;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  133 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  134 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  135 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  136 |           __g.items.push_back(AvgList{r});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  137 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  138 |           break;
+      |           ~~~~~~
+  139 |         }
+      |         ~
+  140 |       }
+      |       ~
+  141 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  142 |         __groups.push_back(__struct3{__key, std::vector<AvgList>{AvgList{r}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  143 |       }
+      |       ~
+  144 |     }
+      |     ~
+  145 |     std::vector<__struct4> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  146 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  147 |       __items.push_back(__struct4{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  148 |           g.key, __avg(([&]() {
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  149 |             std::vector<decltype(std::declval<AvgList>().amt)> __items;
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  150 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  151 |               __items.push_back(x.amt);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+  152 |             }
+      |             ~
+  153 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  154 |           })())});
+      |           ~~~~~~~~
+  155 |     }
+      |     ~
+  156 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  157 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:161:16: error: ‘struct AvgList’ has no member named ‘state’
+  161 |       if (!((a.state == std::string("CA"))))
+      |                ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:158:20: error: ‘first’ was not declared in this scope
+  158 |   auto avg_state = first(([&]() {
+      |                    ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:168:26: error: ‘r’ was not declared in this scope
+  168 |     std::vector<decltype(r.amt)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:168:32: error: template argument 1 is invalid
+  168 |     std::vector<decltype(r.amt)> __items;
+      |                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:168:32: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq811279005367/001/prog.cpp:173:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  173 |       __items.push_back(r.amt);
+      |               ^~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q82.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q82.error
@@ -1,0 +1,28 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq821024191759/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq821024191759/001/prog.cpp:74:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   74 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   75 |           {std::string("id"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   76 |           std::unordered_map<std::string, decltype(1)>{{std::string("id"), 1}},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   77 |           std::unordered_map<std::string, decltype(2)>{{std::string("id"), 2}},
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   78 |           std::unordered_map<std::string, decltype(3)>{{std::string("id"), 3}}};
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq821024191759/001/prog.cpp:83:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   83 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   84 |           {std::string("item"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   85 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   86 |               {std::string("item"), 1}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   87 |           std::unordered_map<std::string, decltype(2)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   88 |               {std::string("item"), 2}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq821024191759/001/prog.cpp:92:26: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘item’
+   92 |       if ((inv.item == s.item)) {
+      |                          ^~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q83.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q83.error
@@ -1,0 +1,106 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:56:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   56 |       std::vector<decltype(std::unordered_map<std::string, decltype(10)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   57 |           {std::string("qty"), 10}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   58 |           std::unordered_map<std::string, decltype(10)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   59 |               {std::string("qty"), 10}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   60 |           std::unordered_map<std::string, decltype(5)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   61 |               {std::string("qty"), 5}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:63:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   63 |       std::vector<decltype(std::unordered_map<std::string, decltype(25)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   64 |           {std::string("qty"), 25}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   65 |           std::unordered_map<std::string, decltype(25)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   66 |               {std::string("qty"), 25}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   67 |           std::unordered_map<std::string, decltype(20)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   68 |               {std::string("qty"), 20}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:70:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   70 |       std::vector<decltype(std::unordered_map<std::string, decltype(10)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   71 |           {std::string("qty"), 10}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   72 |           std::unordered_map<std::string, decltype(10)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   73 |               {std::string("qty"), 10}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+   74 |           std::unordered_map<std::string, decltype(13)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   75 |               {std::string("qty"), 13}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:79:42: error: ‘x’ was not declared in this scope
+   79 |                     std::vector<decltype(x.qty)> __items;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:79:48: error: template argument 1 is invalid
+   79 |                     std::vector<decltype(x.qty)> __items;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:79:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:81:31: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   81 |                       __items.push_back(x.qty);
+      |                               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:81:43: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘qty’
+   81 |                       __items.push_back(x.qty);
+      |                                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:78:21:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:77:46: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   77 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:77:57: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   77 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:88:42: error: ‘x’ was not declared in this scope
+   88 |                     std::vector<decltype(x.qty)> __items;
+      |                                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:88:48: error: template argument 1 is invalid
+   88 |                     std::vector<decltype(x.qty)> __items;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:88:48: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:90:31: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   90 |                       __items.push_back(x.qty);
+      |                               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:90:43: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘qty’
+   90 |                       __items.push_back(x.qty);
+      |                                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:87:21:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:86:46: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   86 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:86:57: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   86 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:97:41: error: ‘x’ was not declared in this scope
+   97 |                    std::vector<decltype(x.qty)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:97:47: error: template argument 1 is invalid
+   97 |                    std::vector<decltype(x.qty)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:97:47: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:99:30: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   99 |                      __items.push_back(x.qty);
+      |                              ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:99:42: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘qty’
+   99 |                      __items.push_back(x.qty);
+      |                                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:96:20:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:95:45: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   95 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                           ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq831466913293/001/prog.cpp:95:56: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   95 |                    return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                      ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q84.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q84.error
@@ -1,0 +1,47 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:173:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  173 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  174 |           {std::string("cd_demo_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  175 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  176 |               {std::string("cd_demo_sk"), 1}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  177 |           std::unordered_map<std::string, decltype(2)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  178 |               {std::string("cd_demo_sk"), 2}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  179 |           std::unordered_map<std::string, decltype(3)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  180 |               {std::string("cd_demo_sk"), 3}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  181 |           std::unordered_map<std::string, decltype(4)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  182 |               {std::string("cd_demo_sk"), 4}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:192:26: error: ‘sr’ was not declared in this scope
+  192 |     std::vector<decltype(sr.amt)> __items;
+      |                          ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:192:33: error: template argument 1 is invalid
+  192 |     std::vector<decltype(sr.amt)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:192:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:199:32: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘cd_demo_sk’
+  199 |           if (!((c.cdemo == cd.cd_demo_sk)))
+      |                                ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:202:23: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘cd_demo_sk’
+  202 |             if (!((cd.cd_demo_sk == sr.sr_cdemo_sk)))
+      |                       ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:210:25: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  210 |                 __items.push_back(sr.amt);
+      |                         ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:191:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:190:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  190 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq842311390743/001/prog.cpp:190:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  190 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q85.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q85.error
@@ -1,0 +1,46 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:89:26: error: ‘r’ was not declared in this scope
+   89 |     std::vector<decltype(r.qty)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:89:32: error: template argument 1 is invalid
+   89 |     std::vector<decltype(r.qty)> __items;
+      |                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:89:32: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:91:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   91 |       __items.push_back(r.qty);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:88:22: error: no matching function for call to ‘__avg(int)’
+   88 |   auto result = __avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+   89 |     std::vector<decltype(r.qty)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   90 |     for (auto r : web_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   91 |       __items.push_back(r.qty);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+   92 |     }
+      |     ~                 
+   93 |     return __items;
+      |     ~~~~~~~~~~~~~~~   
+   94 |   })());
+      |   ~~~~~               
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:57:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   57 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:57:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq854161813206/001/prog.cpp:88:22: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+   88 |   auto result = __avg(([&]() {
+      |                 ~~~~~^~~~~~~~~
+   89 |     std::vector<decltype(r.qty)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   90 |     for (auto r : web_returns) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   91 |       __items.push_back(r.qty);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~
+   92 |     }
+      |     ~                 
+   93 |     return __items;
+      |     ~~~~~~~~~~~~~~~   
+   94 |   })());
+      |   ~~~~~               

--- a/tests/dataset/tpc-ds/compiler/cpp/q86.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q86.error
@@ -1,0 +1,82 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:56:35: error: expected identifier before ‘;’ token
+   56 |   decltype(std::string("B")) class;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:56:3: error: multiple types in one declaration
+   56 |   decltype(std::string("B")) class;
+      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp: In function ‘void __json(const WebSale&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:71:12: error: expected unqualified-id before ‘class’
+   71 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:81:53: error: too many initializers for ‘WebSale’
+   81 |       WebSale{std::string("A"), std::string("B"), 40},
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:82:53: error: too many initializers for ‘WebSale’
+   82 |       WebSale{std::string("A"), std::string("B"), 46},
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:83:53: error: too many initializers for ‘WebSale’
+   83 |       WebSale{std::string("A"), std::string("C"), 10},
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:84:53: error: too many initializers for ‘WebSale’
+   84 |       WebSale{std::string("B"), std::string("B"), 20}};
+      |                                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:84:54: error: could not convert ‘{<expression error>, <expression error>, <expression error>, <expression error>}’ from ‘<brace-enclosed initializer list>’ to ‘std::vector<WebSale>’
+   84 |       WebSale{std::string("B"), std::string("B"), 20}};
+      |                                                      ^
+      |                                                      |
+      |                                                      <brace-enclosed initializer list>
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:88:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+   88 |     std::vector<decltype(ws.net)> __items;
+      |                          ^~
+      |                          std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:2:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:88:33: error: template argument 1 is invalid
+   88 |     std::vector<decltype(ws.net)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:88:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:90:50: error: expected unqualified-id before ‘class’
+   90 |       if (!(((ws.cat == std::string("A")) && (ws.class == std::string("B")))))
+      |                                                  ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:90:50: error: expected ‘)’ before ‘class’
+   90 |       if (!(((ws.cat == std::string("A")) && (ws.class == std::string("B")))))
+      |                                              ~   ^~~~~
+      |                                                  )
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:91:17: error: expected ‘)’ before ‘;’ token
+   91 |         continue;
+      |                 ^
+      |                 )
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:90:13: note: to match this ‘(’
+   90 |       if (!(((ws.cat == std::string("A")) && (ws.class == std::string("B")))))
+      |             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:91:17: error: expected ‘)’ before ‘;’ token
+   91 |         continue;
+      |                 ^
+      |                 )
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:90:12: note: to match this ‘(’
+   90 |       if (!(((ws.cat == std::string("A")) && (ws.class == std::string("B")))))
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:91:17: error: expected ‘)’ before ‘;’ token
+   91 |         continue;
+      |                 ^
+      |                 )
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:90:10: note: to match this ‘(’
+   90 |       if (!(((ws.cat == std::string("A")) && (ws.class == std::string("B")))))
+      |          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:92:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   92 |       __items.push_back(ws.net);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:87:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:86:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   86 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq86904573061/001/prog.cpp:86:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   86 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q87.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q87.error
@@ -1,0 +1,187 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:78:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   78 |       std::vector<decltype(std::unordered_map<std::string, std::string>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   79 |           {std::string("cust"), std::string("A")}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   80 |           std::unordered_map<std::string, std::string>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   81 |               {std::string("cust"), std::string("A")}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:84:26: error: ‘s’ was not declared in this scope
+   84 |     std::vector<decltype(s.cust)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:84:33: error: template argument 1 is invalid
+   84 |     std::vector<decltype(s.cust)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:84:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:86:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   86 |       __items.push_back(s.cust);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:91:26: error: ‘s’ was not declared in this scope
+   91 |     std::vector<decltype(s.cust)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:91:33: error: template argument 1 is invalid
+   91 |     std::vector<decltype(s.cust)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:91:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:93:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   93 |       __items.push_back(s.cust);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:93:27: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘cust’
+   93 |       __items.push_back(s.cust);
+      |                           ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:98:26: error: ‘s’ was not declared in this scope
+   98 |     std::vector<decltype(s.cust)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:98:33: error: template argument 1 is invalid
+   98 |     std::vector<decltype(s.cust)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:98:33: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:100:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  100 |       __items.push_back(s.cust);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:100:27: error: request for member ‘cust’ in ‘s’, which is of non-class type ‘int’
+  100 |       __items.push_back(s.cust);
+      |                           ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:105:26: error: ‘c’ was not declared in this scope
+  105 |     std::vector<decltype(c)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:105:28: error: template argument 1 is invalid
+  105 |     std::vector<decltype(c)> __items;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:105:28: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:106:19: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  106 |     for (auto c : store_customers) {
+      |                   ^~~~~~~~~~~~~~~
+      |                   std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:2:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:106:19: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  106 |     for (auto c : store_customers) {
+      |                   ^~~~~~~~~~~~~~~
+      |                   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:108:38: error: ‘x’ was not declared in this scope
+  108 |                 std::vector<decltype(x)> __items;
+      |                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:108:40: error: template argument 1 is invalid
+  108 |                 std::vector<decltype(x)> __items;
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:108:40: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:109:31: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  109 |                 for (auto x : catalog_customers) {
+      |                               ^~~~~~~~~~~~~~~~~
+      |                               std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:109:31: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  109 |                 for (auto x : catalog_customers) {
+      |                               ^~~~~~~~~~~~~~~~~
+      |                               std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:112:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  112 |                   __items.push_back(x);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:116:20: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & catalog_customers)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  116 |                   .size() == 0) &&
+      |                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:118:38: error: ‘x’ was not declared in this scope
+  118 |                 std::vector<decltype(x)> __items;
+      |                                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:118:40: error: template argument 1 is invalid
+  118 |                 std::vector<decltype(x)> __items;
+      |                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:118:40: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:119:31: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  119 |                 for (auto x : web_customers) {
+      |                               ^~~~~~~~~~~~~
+      |                               std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:119:31: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  119 |                 for (auto x : web_customers) {
+      |                               ^~~~~~~~~~~~~
+      |                               std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:122:27: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  122 |                   __items.push_back(x);
+      |                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:126:20: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & web_customers)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  126 |                   .size() == 0))))
+      |                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:128:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  128 |       __items.push_back(c);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:135:26: error: ‘s’ was not declared in this scope
+  135 |     std::vector<decltype(s.price)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:135:34: error: template argument 1 is invalid
+  135 |     std::vector<decltype(s.price)> __items;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:135:34: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:138:37: error: ‘x’ was not declared in this scope
+  138 |                std::vector<decltype(x)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:138:39: error: template argument 1 is invalid
+  138 |                std::vector<decltype(x)> __items;
+      |                                       ^
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:138:39: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:139:30: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  139 |                for (auto x : store_only) {
+      |                              ^~~~~~~~~~
+      |                              std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:139:30: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  139 |                for (auto x : store_only) {
+      |                              ^~~~~~~~~~
+      |                              std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:142:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  142 |                  __items.push_back(x);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:146:19: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & store_only), s}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  146 |                  .size() > 0)))
+      |                   ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:148:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  148 |       __items.push_back(s.price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:134:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:133:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  133 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq871110983219/001/prog.cpp:133:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  133 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q88.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q88.error
@@ -1,0 +1,9 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq88977314822/001/prog.cpp:165:19: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  165 | float count_range(auto ssales, auto tdim, int hour, int start_min,
+      |                   ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq88977314822/001/prog.cpp:165:32: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  165 | float count_range(auto ssales, auto tdim, int hour, int start_min,
+      |                                ^~~~
+/usr/bin/ld: /tmp/ccfb6pGI.o: in function `main':
+prog.cpp:(.text+0x3a9): undefined reference to `void __json<float>(float const&)'
+collect2: error: ld returned 1 exit status

--- a/tests/dataset/tpc-ds/compiler/cpp/q89.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q89.error
@@ -1,0 +1,40 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:56:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+   56 |       std::vector<decltype(std::unordered_map<std::string, decltype(40)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   57 |           {std::string("price"), 40}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   58 |           std::unordered_map<std::string, decltype(40)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   59 |               {std::string("price"), 40}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   60 |           std::unordered_map<std::string, decltype(30)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   61 |               {std::string("price"), 30}},
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   62 |           std::unordered_map<std::string, decltype(19)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   63 |               {std::string("price"), 19}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:67:26: error: ‘s’ was not declared in this scope
+   67 |     std::vector<decltype(s.price)> __items;
+      |                          ^
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:67:34: error: template argument 1 is invalid
+   67 |     std::vector<decltype(s.price)> __items;
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:67:34: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:69:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+   69 |       __items.push_back(s.price);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:69:27: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘price’
+   69 |       __items.push_back(s.price);
+      |                           ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:66:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:65:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+   65 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq892010743432/001/prog.cpp:65:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+   65 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q9.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q9.error
@@ -1,0 +1,665 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:67:12: error: ‘bucket1’ was not declared in this scope
+   67 |   decltype(bucket1) bucket1;
+      |            ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:67:12: error: ‘bucket1’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:68:12: error: ‘bucket2’ was not declared in this scope; did you mean ‘bucket1’?
+   68 |   decltype(bucket2) bucket2;
+      |            ^~~~~~~
+      |            bucket1
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:68:12: error: ‘bucket2’ was not declared in this scope; did you mean ‘bucket1’?
+   68 |   decltype(bucket2) bucket2;
+      |            ^~~~~~~
+      |            bucket1
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:69:12: error: ‘bucket3’ was not declared in this scope; did you mean ‘bucket2’?
+   69 |   decltype(bucket3) bucket3;
+      |            ^~~~~~~
+      |            bucket2
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:69:12: error: ‘bucket3’ was not declared in this scope; did you mean ‘bucket2’?
+   69 |   decltype(bucket3) bucket3;
+      |            ^~~~~~~
+      |            bucket2
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:70:12: error: ‘bucket4’ was not declared in this scope; did you mean ‘bucket3’?
+   70 |   decltype(bucket4) bucket4;
+      |            ^~~~~~~
+      |            bucket3
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:70:12: error: ‘bucket4’ was not declared in this scope; did you mean ‘bucket3’?
+   70 |   decltype(bucket4) bucket4;
+      |            ^~~~~~~
+      |            bucket3
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:71:12: error: ‘bucket5’ was not declared in this scope; did you mean ‘bucket4’?
+   71 |   decltype(bucket5) bucket5;
+      |            ^~~~~~~
+      |            bucket4
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:71:12: error: ‘bucket5’ was not declared in this scope; did you mean ‘bucket4’?
+   71 |   decltype(bucket5) bucket5;
+      |            ^~~~~~~
+      |            bucket4
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:128:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  128 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  129 |           {std::string("r_reason_sk"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  130 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  131 |               {std::string("r_reason_sk"), 1}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:134:33: error: ‘s’ was not declared in this scope
+  134 |            std::vector<decltype(s)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:134:35: error: template argument 1 is invalid
+  134 |            std::vector<decltype(s)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:134:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:138:22: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  138 |              __items.push_back(s);
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:142:15: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales}.main()::<lambda()>()’, which is of non-class type ‘int’
+  142 |              .size()) > 10)
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:144:37: error: ‘s’ was not declared in this scope
+  144 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:144:59: error: template argument 1 is invalid
+  144 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:144:59: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:148:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  148 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:143:19: error: no matching function for call to ‘__avg(int)’
+  143 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  144 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  145 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  146 |                  if (!(((s.ss_quantity >= 1) && (s.ss_quantity <= 20))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  147 |                    continue;
+      |                    ~~~~~~~~~
+  148 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  149 |                }
+      |                ~   
+  150 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  151 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:143:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  143 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  144 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  145 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  146 |                  if (!(((s.ss_quantity >= 1) && (s.ss_quantity <= 20))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  147 |                    continue;
+      |                    ~~~~~~~~~
+  148 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  149 |                }
+      |                ~   
+  150 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  151 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:153:37: error: ‘s’ was not declared in this scope
+  153 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:153:51: error: template argument 1 is invalid
+  153 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:153:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:157:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  157 |                  __items.push_back(s.ss_net_paid);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:152:19: error: no matching function for call to ‘__avg(int)’
+  152 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  153 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  154 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  155 |                  if (!(((s.ss_quantity >= 1) && (s.ss_quantity <= 20))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  156 |                    continue;
+      |                    ~~~~~~~~~
+  157 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  158 |                }
+      |                ~   
+  159 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  160 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:152:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  152 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  153 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  154 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  155 |                  if (!(((s.ss_quantity >= 1) && (s.ss_quantity <= 20))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  156 |                    continue;
+      |                    ~~~~~~~~~
+  157 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  158 |                }
+      |                ~   
+  159 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  160 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:163:33: error: ‘s’ was not declared in this scope
+  163 |            std::vector<decltype(s)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:163:35: error: template argument 1 is invalid
+  163 |            std::vector<decltype(s)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:163:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:167:22: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  167 |              __items.push_back(s);
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:171:15: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales}.main()::<lambda()>()’, which is of non-class type ‘int’
+  171 |              .size()) > 20)
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:173:37: error: ‘s’ was not declared in this scope
+  173 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:173:59: error: template argument 1 is invalid
+  173 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:173:59: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:177:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  177 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:172:19: error: no matching function for call to ‘__avg(int)’
+  172 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  173 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  174 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  175 |                  if (!(((s.ss_quantity >= 21) && (s.ss_quantity <= 40))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  176 |                    continue;
+      |                    ~~~~~~~~~
+  177 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  178 |                }
+      |                ~   
+  179 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  180 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:172:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  172 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  173 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  174 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  175 |                  if (!(((s.ss_quantity >= 21) && (s.ss_quantity <= 40))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  176 |                    continue;
+      |                    ~~~~~~~~~
+  177 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  178 |                }
+      |                ~   
+  179 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  180 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:182:37: error: ‘s’ was not declared in this scope
+  182 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:182:51: error: template argument 1 is invalid
+  182 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:182:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:186:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  186 |                  __items.push_back(s.ss_net_paid);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:181:19: error: no matching function for call to ‘__avg(int)’
+  181 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  182 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  183 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  184 |                  if (!(((s.ss_quantity >= 21) && (s.ss_quantity <= 40))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  185 |                    continue;
+      |                    ~~~~~~~~~
+  186 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  187 |                }
+      |                ~   
+  188 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  189 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:181:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  181 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  182 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  183 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  184 |                  if (!(((s.ss_quantity >= 21) && (s.ss_quantity <= 40))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  185 |                    continue;
+      |                    ~~~~~~~~~
+  186 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  187 |                }
+      |                ~   
+  188 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  189 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:192:33: error: ‘s’ was not declared in this scope
+  192 |            std::vector<decltype(s)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:192:35: error: template argument 1 is invalid
+  192 |            std::vector<decltype(s)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:192:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:196:22: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  196 |              __items.push_back(s);
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:200:15: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales}.main()::<lambda()>()’, which is of non-class type ‘int’
+  200 |              .size()) > 30)
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:202:37: error: ‘s’ was not declared in this scope
+  202 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:202:59: error: template argument 1 is invalid
+  202 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:202:59: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:206:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  206 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:201:19: error: no matching function for call to ‘__avg(int)’
+  201 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  202 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  203 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  204 |                  if (!(((s.ss_quantity >= 41) && (s.ss_quantity <= 60))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  205 |                    continue;
+      |                    ~~~~~~~~~
+  206 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  207 |                }
+      |                ~   
+  208 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  209 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:201:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  201 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  202 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  203 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  204 |                  if (!(((s.ss_quantity >= 41) && (s.ss_quantity <= 60))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  205 |                    continue;
+      |                    ~~~~~~~~~
+  206 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  207 |                }
+      |                ~   
+  208 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  209 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:211:37: error: ‘s’ was not declared in this scope
+  211 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:211:51: error: template argument 1 is invalid
+  211 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:211:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:215:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  215 |                  __items.push_back(s.ss_net_paid);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:210:19: error: no matching function for call to ‘__avg(int)’
+  210 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  211 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  212 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |                  if (!(((s.ss_quantity >= 41) && (s.ss_quantity <= 60))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  214 |                    continue;
+      |                    ~~~~~~~~~
+  215 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  216 |                }
+      |                ~   
+  217 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  218 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:210:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  210 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  211 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  212 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |                  if (!(((s.ss_quantity >= 41) && (s.ss_quantity <= 60))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  214 |                    continue;
+      |                    ~~~~~~~~~
+  215 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  216 |                }
+      |                ~   
+  217 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  218 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:221:33: error: ‘s’ was not declared in this scope
+  221 |            std::vector<decltype(s)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:221:35: error: template argument 1 is invalid
+  221 |            std::vector<decltype(s)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:221:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:225:22: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  225 |              __items.push_back(s);
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:229:15: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales}.main()::<lambda()>()’, which is of non-class type ‘int’
+  229 |              .size()) > 40)
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:231:37: error: ‘s’ was not declared in this scope
+  231 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:231:59: error: template argument 1 is invalid
+  231 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:231:59: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:235:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  235 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:230:19: error: no matching function for call to ‘__avg(int)’
+  230 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  231 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  232 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  233 |                  if (!(((s.ss_quantity >= 61) && (s.ss_quantity <= 80))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  234 |                    continue;
+      |                    ~~~~~~~~~
+  235 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  236 |                }
+      |                ~   
+  237 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  238 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:230:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  230 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  231 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  232 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  233 |                  if (!(((s.ss_quantity >= 61) && (s.ss_quantity <= 80))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  234 |                    continue;
+      |                    ~~~~~~~~~
+  235 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  236 |                }
+      |                ~   
+  237 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  238 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:240:37: error: ‘s’ was not declared in this scope
+  240 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:240:51: error: template argument 1 is invalid
+  240 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:240:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:244:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  244 |                  __items.push_back(s.ss_net_paid);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:239:19: error: no matching function for call to ‘__avg(int)’
+  239 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  240 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  241 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |                  if (!(((s.ss_quantity >= 61) && (s.ss_quantity <= 80))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  243 |                    continue;
+      |                    ~~~~~~~~~
+  244 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  245 |                }
+      |                ~   
+  246 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  247 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:239:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  239 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  240 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  241 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |                  if (!(((s.ss_quantity >= 61) && (s.ss_quantity <= 80))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  243 |                    continue;
+      |                    ~~~~~~~~~
+  244 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  245 |                }
+      |                ~   
+  246 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  247 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:250:33: error: ‘s’ was not declared in this scope
+  250 |            std::vector<decltype(s)> __items;
+      |                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:250:35: error: template argument 1 is invalid
+  250 |            std::vector<decltype(s)> __items;
+      |                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:250:35: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:254:22: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  254 |              __items.push_back(s);
+      |                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:258:15: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales}.main()::<lambda()>()’, which is of non-class type ‘int’
+  258 |              .size()) > 50)
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:260:37: error: ‘s’ was not declared in this scope
+  260 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:260:59: error: template argument 1 is invalid
+  260 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                                                           ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:260:59: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:264:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  264 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:259:19: error: no matching function for call to ‘__avg(int)’
+  259 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  260 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |                  if (!(((s.ss_quantity >= 81) && (s.ss_quantity <= 100))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |                    continue;
+      |                    ~~~~~~~~~
+  264 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |                }
+      |                ~   
+  266 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  267 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:259:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  259 |            ? __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  260 |                std::vector<decltype(s.ss_ext_discount_amt)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |                  if (!(((s.ss_quantity >= 81) && (s.ss_quantity <= 100))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  263 |                    continue;
+      |                    ~~~~~~~~~
+  264 |                  __items.push_back(s.ss_ext_discount_amt);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  265 |                }
+      |                ~   
+  266 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  267 |              })())
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:269:37: error: ‘s’ was not declared in this scope
+  269 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                     ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:269:51: error: template argument 1 is invalid
+  269 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:269:51: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:273:26: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  273 |                  __items.push_back(s.ss_net_paid);
+      |                          ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:268:19: error: no matching function for call to ‘__avg(int)’
+  268 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  269 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  271 |                  if (!(((s.ss_quantity >= 81) && (s.ss_quantity <= 100))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |                    continue;
+      |                    ~~~~~~~~~
+  273 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |                }
+      |                ~   
+  275 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  276 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   58 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:58:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:268:19: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  268 |            : __avg(([&]() {
+      |              ~~~~~^~~~~~~~~
+  269 |                std::vector<decltype(s.ss_net_paid)> __items;
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  270 |                for (auto s : store_sales) {
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  271 |                  if (!(((s.ss_quantity >= 81) && (s.ss_quantity <= 100))))
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |                    continue;
+      |                    ~~~~~~~~~
+  273 |                  __items.push_back(s.ss_net_paid);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |                }
+      |                ~   
+  275 |                return __items;
+      |                ~~~~~~~~~~~~~~~
+  276 |              })()));
+      |              ~~~~~ 
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9779437260/001/prog.cpp:280:16: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘r_reason_sk’
+  280 |       if (!((r.r_reason_sk == 1)))
+      |                ^~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q90.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q90.error
@@ -1,0 +1,53 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:57:8: error: redefinition of ‘struct WebSale’
+   57 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:52:8: note: previous definition of ‘struct WebSale’
+   52 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:139:13: error: redefinition of ‘void __json(const WebSale&)’
+  139 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:74:13: note: ‘void __json(const WebSale&)’ previously defined here
+   74 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:167:38: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  167 |                 std::vector<decltype(ws)> __items;
+      |                                      ^~
+      |                                      std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:2:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:167:41: error: template argument 1 is invalid
+  167 |                 std::vector<decltype(ws)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:167:41: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:183:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  183 |                         __items.push_back(ws);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:190:20: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{web_sales, household_demographics, time_dim, web_page}.main()::<lambda()>()’, which is of non-class type ‘int’
+  190 |                   .size());
+      |                    ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:192:38: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  192 |                 std::vector<decltype(ws)> __items;
+      |                                      ^~
+      |                                      std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:192:41: error: template argument 1 is invalid
+  192 |                 std::vector<decltype(ws)> __items;
+      |                                         ^
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:192:41: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:208:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  208 |                         __items.push_back(ws);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq90398916581/001/prog.cpp:215:20: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{web_sales, household_demographics, time_dim, web_page}.main()::<lambda()>()’, which is of non-class type ‘int’
+  215 |                   .size());
+      |                    ^~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q91.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q91.error
@@ -1,0 +1,200 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:90:8: error: redefinition of ‘struct CallCenter’
+   90 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:54:8: note: previous definition of ‘struct CallCenter’
+   54 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:96:8: error: redefinition of ‘struct CatalogReturn’
+   96 | struct CatalogReturn {
+      |        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:60:8: note: previous definition of ‘struct CatalogReturn’
+   60 | struct CatalogReturn {
+      |        ^~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:102:8: error: redefinition of ‘struct DateDim’
+  102 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:66:8: note: previous definition of ‘struct DateDim’
+   66 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:107:8: error: redefinition of ‘struct Customer’
+  107 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:71:8: note: previous definition of ‘struct Customer’
+   71 | struct Customer {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:127:12: error: ‘cc’ was not declared in this scope
+  127 |   decltype(cc.cc_call_center_id) id;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:127:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:128:12: error: ‘cc’ was not declared in this scope
+  128 |   decltype(cc.cc_name) name;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:128:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:129:12: error: ‘cc’ was not declared in this scope
+  129 |   decltype(cc.cc_manager) mgr;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:129:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:132:12: error: ‘cc’ was not declared in this scope
+  132 |   decltype(cc) cc;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:132:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:133:12: error: ‘cr’ was not declared in this scope; did you mean ‘cc’?
+  133 |   decltype(cr) cr;
+      |            ^~
+      |            cc
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:133:12: error: ‘cr’ was not declared in this scope; did you mean ‘cc’?
+  133 |   decltype(cr) cr;
+      |            ^~
+      |            cc
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:134:12: error: ‘d’ was not declared in this scope
+  134 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:134:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:135:12: error: ‘c’ was not declared in this scope
+  135 |   decltype(c) c;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:135:12: error: ‘c’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:136:12: error: ‘cd’ was not declared in this scope; did you mean ‘c’?
+  136 |   decltype(cd) cd;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:136:12: error: ‘cd’ was not declared in this scope; did you mean ‘c’?
+  136 |   decltype(cd) cd;
+      |            ^~
+      |            c
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:137:12: error: ‘hd’ was not declared in this scope; did you mean ‘cd’?
+  137 |   decltype(hd) hd;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:137:12: error: ‘hd’ was not declared in this scope; did you mean ‘cd’?
+  137 |   decltype(hd) hd;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:138:12: error: ‘ca’ was not declared in this scope; did you mean ‘cd’?
+  138 |   decltype(ca) ca;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:138:12: error: ‘ca’ was not declared in this scope; did you mean ‘cd’?
+  138 |   decltype(ca) ca;
+      |            ^~
+      |            cd
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:320:13: error: redefinition of ‘void __json(const Customer&)’
+  320 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:225:13: note: ‘void __json(const Customer&)’ previously defined here
+  225 | inline void __json(const Customer &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:360:13: error: redefinition of ‘void __json(const CallCenter&)’
+  360 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:150:13: note: ‘void __json(const CallCenter&)’ previously defined here
+  150 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:405:13: error: redefinition of ‘void __json(const CatalogReturn&)’
+  405 | inline void __json(const CatalogReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:200:13: note: ‘void __json(const CatalogReturn&)’ previously defined here
+  200 | inline void __json(const CatalogReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:430:13: error: redefinition of ‘void __json(const DateDim&)’
+  430 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:285:13: note: ‘void __json(const DateDim&)’ previously defined here
+  285 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:565:33: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+  565 |                       Result{cc.cc_call_center_id, cc.cc_name, cc.cc_manager};
+      |                              ~~~^~~~~~~~~~~~~~~~~
+      |                                 |
+      |                                 std::string {aka std::__cxx11::basic_string<char>}
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:569:53: error: cannot convert ‘CallCenter’ to ‘int’ in initialization
+  569 |                       __g.items.push_back(__struct9{cc, cr, d, c, cd, hd, ca});
+      |                                                     ^~
+      |                                                     |
+      |                                                     CallCenter
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:577:47: error: cannot convert ‘CallCenter’ to ‘int’ in initialization
+  577 |                                               cc, cr, d, c, cd, hd, ca}}});
+      |                                               ^~
+      |                                               |
+      |                                               CallCenter
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:577:72: error: no matching function for call to ‘std::vector<__struct9>::vector(<brace-enclosed initializer list>)’
+  577 |                                               cc, cr, d, c, cd, hd, ca}}});
+      |                                                                        ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:7:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; std::__type_identity_t<_Alloc> = std::allocator<__struct9>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; value_type = std::vector<__struct9>::value_type; allocator_type = std::allocator<__struct9>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; size_type = long unsigned int; allocator_type = std::allocator<__struct9>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct9; _Alloc = std::allocator<__struct9>; allocator_type = std::allocator<__struct9>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct9; _Alloc = std::allocator<__struct9>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:592:60: error: ‘struct __struct9’ has no member named ‘cr_net_loss’
+  592 |             std::vector<decltype(std::declval<__struct9>().cr_net_loss)>
+      |                                                            ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:592:60: error: ‘struct __struct9’ has no member named ‘cr_net_loss’
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:592:72: error: template argument 1 is invalid
+  592 |             std::vector<decltype(std::declval<__struct9>().cr_net_loss)>
+      |                                                                        ^
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:592:72: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:595:23: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  595 |               __items.push_back(x.cr_net_loss);
+      |                       ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:595:35: error: ‘struct __struct9’ has no member named ‘cr_net_loss’
+  595 |               __items.push_back(x.cr_net_loss);
+      |                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:591:13:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:590:38: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  590 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                    ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:590:49: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  590 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                               ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq913489096218/001/prog.cpp:536:35: error: ‘first’ was not declared in this scope
+  536 |   std::vector<__struct9> result = first(([&]() {
+      |                                   ^~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q92.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q92.error
@@ -1,0 +1,88 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:59:8: error: redefinition of ‘struct WebSale’
+   59 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:54:8: note: previous definition of ‘struct WebSale’
+   54 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:130:13: error: redefinition of ‘void __json(const WebSale&)’
+  130 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:80:13: note: ‘void __json(const WebSale&)’ previously defined here
+   80 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:158:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  158 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |                          ^~
+      |                          std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:2:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:158:49: error: template argument 1 is invalid
+  158 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:158:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:160:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  160 |       __items.push_back(ws.ws_ext_discount_amt);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:157:5:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:156:30: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  156 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                            ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:156:41: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  156 |     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                       ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:165:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  165 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |                          ^~
+      |                          std::ws
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:165:49: error: template argument 1 is invalid
+  165 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:165:49: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:167:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  167 |       __items.push_back(ws.ws_ext_discount_amt);
+      |               ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:164:23: error: no matching function for call to ‘__avg(int)’
+  164 |   auto avg_amt = __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  165 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  166 |     for (auto ws : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  167 |       __items.push_back(ws.ws_ext_discount_amt);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  168 |     }
+      |     ~                  
+  169 |     return __items;
+      |     ~~~~~~~~~~~~~~~    
+  170 |   })());
+      |   ~~~~~                
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:72:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+   72 | template <typename T> double __avg(const std::vector<T> &v) {
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:72:30: note:   template argument deduction/substitution failed:
+/tmp/TestCPPCompiler_TPCDSQueriesq921163161566/001/prog.cpp:164:23: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+  164 |   auto avg_amt = __avg(([&]() {
+      |                  ~~~~~^~~~~~~~~
+  165 |     std::vector<decltype(ws.ws_ext_discount_amt)> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  166 |     for (auto ws : web_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  167 |       __items.push_back(ws.ws_ext_discount_amt);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  168 |     }
+      |     ~                  
+  169 |     return __items;
+      |     ~~~~~~~~~~~~~~~    
+  170 |   })());
+      |   ~~~~~                

--- a/tests/dataset/tpc-ds/compiler/cpp/q93.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q93.error
@@ -1,0 +1,171 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:73:8: error: redefinition of ‘struct StoreSale’
+   73 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:56:8: note: previous definition of ‘struct StoreSale’
+   56 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:80:8: error: redefinition of ‘struct StoreReturn’
+   80 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:63:8: note: previous definition of ‘struct StoreReturn’
+   63 | struct StoreReturn {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:86:8: error: redefinition of ‘struct Reason’
+   86 | struct Reason {
+      |        ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:69:8: note: previous definition of ‘struct Reason’
+   69 | struct Reason {
+      |        ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+   91 |   decltype(ss.ss_customer_sk) ss_customer_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:91:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:191:13: error: redefinition of ‘void __json(const Reason&)’
+  191 | inline void __json(const Reason &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:106:13: note: ‘void __json(const Reason&)’ previously defined here
+  106 | inline void __json(const Reason &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:206:13: error: redefinition of ‘void __json(const StoreReturn&)’
+  206 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:121:13: note: ‘void __json(const StoreReturn&)’ previously defined here
+  121 | inline void __json(const StoreReturn &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:261:13: error: redefinition of ‘void __json(const StoreSale&)’
+  261 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:146:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  146 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:309:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  309 |               if (!(((sr != nullptr) && (sr.sr_reason_sk == r.r_reason_sk))))
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:312:25: error: no match for ‘operator==’ (operand types are ‘Reason’ and ‘std::nullptr_t’)
+  312 |               if (!(((r == nullptr) ||
+      |                       ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:317:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  317 |                     ((sr != nullptr)
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:324:25: error: no match for ‘operator==’ (operand types are ‘Reason’ and ‘std::nullptr_t’)
+  324 |               if (!(((r == nullptr) ||
+      |                       ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:329:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  329 |                     ((sr != nullptr)
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:341:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  341 |               if (!(((sr != nullptr) && (sr.sr_reason_sk == r.r_reason_sk))))
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:344:25: error: no match for ‘operator==’ (operand types are ‘Reason’ and ‘std::nullptr_t’)
+  344 |               if (!(((r == nullptr) ||
+      |                       ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:349:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  349 |                     ((sr != nullptr)
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:356:25: error: no match for ‘operator==’ (operand types are ‘Reason’ and ‘std::nullptr_t’)
+  356 |               if (!(((r == nullptr) ||
+      |                       ~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:361:26: error: no match for ‘operator!=’ (operand types are ‘StoreReturn’ and ‘std::nullptr_t’)
+  361 |                     ((sr != nullptr)
+      |                       ~~~^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq93491760966/001/prog.cpp:420:5: error: conversion from ‘vector<Result>’ to non-scalar type ‘vector<T>’ requested
+  372 |   std::vector<T> result = ([&]() {
+      |                           ~~~~~~~~
+  373 |     std::vector<__struct5> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |     for (auto x : t) {
+      |     ~~~~~~~~~~~~~~~~~~
+  375 |       auto __key = x.ss_customer_sk;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  376 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  377 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  378 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  379 |           __g.items.push_back(T{x});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  381 |           break;
+      |           ~~~~~~
+  382 |         }
+      |         ~
+  383 |       }
+      |       ~
+  384 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  385 |         __groups.push_back(__struct5{__key, std::vector<T>{T{x}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  386 |       }
+      |       ~
+  387 |     }
+      |     ~
+  388 |     std::vector<std::pair<__struct7, Result>> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  390 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  391 |           {__struct7{
+      |           ~~~~~~~~~~~
+  392 |                ([&](auto v) {
+      |                ~~~~~~~~~~~~~~
+  393 |                  return std::accumulate(v.begin(), v.end(), 0.0);
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  394 |                })(([&]() {
+      |                ~~~~~~~~~~~
+  395 |                  std::vector<decltype(std::declval<T>().act_sales)> __items;
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |                  for (auto y : g.items) {
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |                    __items.push_back(y.act_sales);
+      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |                  }
+      |                  ~
+  399 |                  return __items;
+      |                  ~~~~~~~~~~~~~~~
+  400 |                })()),
+      |                ~~~~~~
+  401 |                g.key},
+      |                ~~~~~~~
+  402 |            Result{g.key, ([&](auto v) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  403 |                     return std::accumulate(v.begin(), v.end(), 0.0);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  404 |                   })(([&]() {
+      |                   ~~~~~~~~~~~
+  405 |                     std::vector<decltype(std::declval<T>().act_sales)> __items;
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  406 |                     for (auto y : g.items) {
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~
+  407 |                       __items.push_back(y.act_sales);
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  408 |                     }
+      |                     ~
+  409 |                     return __items;
+      |                     ~~~~~~~~~~~~~~~
+  410 |                   })())}});
+      |                   ~~~~~~~~~
+  411 |     }
+      |     ~
+  412 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  413 |       return std::tie(a.first.f0, a.first.f1) <
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  414 |              std::tie(b.first.f0, b.first.f1);
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  415 |     });
+      |     ~~~
+  416 |     std::vector<Result> __res;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  417 |     for (auto &p : __items)
+      |     ~~~~~~~~~~~~~~~~~~~~~~~
+  418 |       __res.push_back(p.second);
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  419 |     return __res;
+      |     ~~~~~~~~~~~~~
+  420 |   })();
+      |   ~~^~

--- a/tests/dataset/tpc-ds/compiler/cpp/q94.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q94.error
@@ -1,0 +1,193 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:79:8: error: redefinition of ‘struct WebSale’
+   79 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:55:8: note: previous definition of ‘struct WebSale’
+   55 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:88:8: error: redefinition of ‘struct DateDim’
+   88 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:67:8: note: previous definition of ‘struct DateDim’
+   67 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:96:8: error: redefinition of ‘struct WebSite’
+   96 | struct WebSite {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:75:8: note: previous definition of ‘struct WebSite’
+   75 | struct WebSite {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:215:13: error: redefinition of ‘void __json(const DateDim&)’
+  215 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:120:13: note: ‘void __json(const DateDim&)’ previously defined here
+  120 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:250:13: error: redefinition of ‘void __json(const WebSite&)’
+  250 | inline void __json(const WebSite &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:185:13: note: ‘void __json(const WebSite&)’ previously defined here
+  185 | inline void __json(const WebSite &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:265:13: error: redefinition of ‘void __json(const WebSale&)’
+  265 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:145:13: note: ‘void __json(const WebSale&)’ previously defined here
+  145 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:309:10: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  309 |     std::vector<decltype(std::unordered_map<std::string, decltype(2)>{
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  310 |         {std::string("wr_order_number"), 2}})>{
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  311 |         std::unordered_map<std::string, decltype(2)>{
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  312 |             {std::string("wr_order_number"), 2}}};
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:318:15: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  318 | auto distinct(auto xs) {
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:330:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  330 |     std::vector<decltype(ws)> __items;
+      |                          ^~
+      |                          std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:330:29: error: template argument 1 is invalid
+  330 |     std::vector<decltype(ws)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:330:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:354:21: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  354 |             __items.push_back(ws);
+      |                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:362:47: error: ‘x’ was not declared in this scope
+  362 |                          std::vector<decltype(x.ws_order_number)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:362:65: error: template argument 1 is invalid
+  362 |                          std::vector<decltype(x.ws_order_number)> __items;
+      |                                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:362:65: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:363:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  363 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:363:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  363 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:364:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  364 |                            __items.push_back(x.ws_order_number);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In instantiation of ‘auto distinct(auto:1) [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:361:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:320:3: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  320 |   for (auto x : xs) {
+      |   ^~~
+      |   std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:320:3: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  320 |   for (auto x : xs) {
+      |   ^~~
+      |   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:321:19: error: ‘contains’ was not declared in this scope
+  321 |     if ((!contains(out, x))) {
+      |           ~~~~~~~~^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:372:47: error: ‘x’ was not declared in this scope
+  372 |                          std::vector<decltype(x.ws_ext_ship_cost)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:372:66: error: template argument 1 is invalid
+  372 |                          std::vector<decltype(x.ws_ext_ship_cost)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:372:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:373:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  373 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:373:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  373 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:374:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  374 |                            __items.push_back(x.ws_ext_ship_cost);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:4)> [with auto:4 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:371:26:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:370:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  370 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:370:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  370 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:381:47: error: ‘x’ was not declared in this scope
+  381 |                          std::vector<decltype(x.ws_net_profit)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:381:63: error: template argument 1 is invalid
+  381 |                          std::vector<decltype(x.ws_net_profit)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:381:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:382:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  382 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:382:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  382 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:383:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  383 |                            __items.push_back(x.ws_net_profit);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:5)> [with auto:5 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:380:26:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:379:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  379 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:379:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  379 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:3)> [with auto:3 = std::__cxx11::basic_string<char>]’:
+/usr/include/c++/13/bits/predefined_ops.h:318:23:   required from ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<std::__cxx11::basic_string<char>*, std::vector<std::__cxx11::basic_string<char> > >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algobase.h:2072:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:3)> >]’
+/usr/include/c++/13/bits/stl_algobase.h:2117:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:3)> >]’
+/usr/include/c++/13/bits/stl_algo.h:3923:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algo.h:477:47:   required from ‘bool std::none_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/usr/include/c++/13/bits/stl_algo.h:496:27:   required from ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__cxx11::basic_string<char>*, vector<__cxx11::basic_string<char> > >; _Predicate = main()::<lambda()>::<lambda(auto:3)>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:349:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq944235460042/001/prog.cpp:351:38: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘wr_order_number’
+  351 |                           return (wr.wr_order_number == ws.ws_order_number);
+      |                                   ~~~^~~~~~~~~~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q95.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q95.error
@@ -1,0 +1,342 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:79:8: error: redefinition of ‘struct WebSale’
+   79 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:55:8: note: previous definition of ‘struct WebSale’
+   55 | struct WebSale {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:88:8: error: redefinition of ‘struct DateDim’
+   88 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:67:8: note: previous definition of ‘struct DateDim’
+   67 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:96:8: error: redefinition of ‘struct WebSite’
+   96 | struct WebSite {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:75:8: note: previous definition of ‘struct WebSite’
+   75 | struct WebSite {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:215:13: error: redefinition of ‘void __json(const DateDim&)’
+  215 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:120:13: note: ‘void __json(const DateDim&)’ previously defined here
+  120 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:250:13: error: redefinition of ‘void __json(const WebSite&)’
+  250 | inline void __json(const WebSite &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:185:13: note: ‘void __json(const WebSite&)’ previously defined here
+  185 | inline void __json(const WebSite &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:265:13: error: redefinition of ‘void __json(const WebSale&)’
+  265 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:145:13: note: ‘void __json(const WebSale&)’ previously defined here
+  145 | inline void __json(const WebSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:306:15: warning: use of ‘auto’ in parameter declaration only available with ‘-std=c++20’ or ‘-fconcepts’
+  306 | auto distinct(auto xs) {
+      |               ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:320:12: error: conversion from ‘vector<std::unordered_map<std::__cxx11::basic_string<char>, int>>’ to non-scalar type ‘vector<std::__cxx11::basic_string<char>>’ requested
+  320 |       std::vector<decltype(std::unordered_map<std::string, decltype(1)>{
+      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  321 |           {std::string("wr_order_number"), 1}})>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  322 |           std::unordered_map<std::string, decltype(1)>{
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  323 |               {std::string("wr_order_number"), 1}}};
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:330:59: error: ‘ws1’ was not declared in this scope
+  330 |         decltype(std::unordered_map<std::string, decltype(ws1.ws_order_number)>{
+      |                                                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:330:79: error: template argument 2 is invalid
+  330 |         decltype(std::unordered_map<std::string, decltype(ws1.ws_order_number)>{
+      |                                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:330:79: error: template argument 5 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:331:68: error: template argument 1 is invalid
+  331 |             {std::string("ws_order_number"), ws1.ws_order_number}})>
+      |                                                                    ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:331:68: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:338:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  338 |         __items.push_back(
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:346:26: error: ‘ws’ was not declared in this scope; did you mean ‘std::ws’?
+  346 |     std::vector<decltype(ws)> __items;
+      |                          ^~
+      |                          std::ws
+In file included from /usr/include/c++/13/istream:1106,
+                 from /usr/include/c++/13/iostream:42,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:3:
+/usr/include/c++/13/bits/istream.tcc:1070:5: note: ‘std::ws’ declared here
+ 1070 |     ws(basic_istream<_CharT, _Traits>& __in)
+      |     ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:346:29: error: template argument 1 is invalid
+  346 |     std::vector<decltype(ws)> __items;
+      |                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:346:29: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:361:49: error: ‘x’ was not declared in this scope
+  361 |                            std::vector<decltype(x.ws_order_number)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:361:67: error: template argument 1 is invalid
+  361 |                            std::vector<decltype(x.ws_order_number)> __items;
+      |                                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:361:67: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:362:42: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  362 |                            for (auto x : ws_wh) {
+      |                                          ^~~~~
+      |                                          std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:362:42: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  362 |                            for (auto x : ws_wh) {
+      |                                          ^~~~~
+      |                                          std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:363:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  363 |                              __items.push_back(x.ws_order_number);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:367:31: error: request for member ‘begin’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & ws_wh)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  367 |                              .begin(),
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:369:49: error: ‘x’ was not declared in this scope
+  369 |                            std::vector<decltype(x.ws_order_number)> __items;
+      |                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:369:67: error: template argument 1 is invalid
+  369 |                            std::vector<decltype(x.ws_order_number)> __items;
+      |                                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:369:67: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:370:42: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  370 |                            for (auto x : ws_wh) {
+      |                                          ^~~~~
+      |                                          std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:370:42: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  370 |                            for (auto x : ws_wh) {
+      |                                          ^~~~~
+      |                                          std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:371:38: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  371 |                              __items.push_back(x.ws_order_number);
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:375:31: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & ws_wh)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  375 |                              .end(),
+      |                               ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:378:45: error: ‘x’ was not declared in this scope
+  378 |                        std::vector<decltype(x.ws_order_number)> __items;
+      |                                             ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:378:63: error: template argument 1 is invalid
+  378 |                        std::vector<decltype(x.ws_order_number)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:378:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:379:38: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  379 |                        for (auto x : ws_wh) {
+      |                                      ^~~~~
+      |                                      std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:379:38: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  379 |                        for (auto x : ws_wh) {
+      |                                      ^~~~~
+      |                                      std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:380:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  380 |                          __items.push_back(x.ws_order_number);
+      |                                  ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:384:27: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & ws_wh)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  384 |                          .end())) &&
+      |                           ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:387:48: error: ‘wr’ was not declared in this scope; did you mean ‘w’?
+  387 |                           std::vector<decltype(wr.wr_order_number)> __items;
+      |                                                ^~
+      |                                                w
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:387:67: error: template argument 1 is invalid
+  387 |                           std::vector<decltype(wr.wr_order_number)> __items;
+      |                                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:387:67: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:389:37: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  389 |                             __items.push_back(wr.wr_order_number);
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:389:50: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘wr_order_number’
+  389 |                             __items.push_back(wr.wr_order_number);
+      |                                                  ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:393:30: error: request for member ‘begin’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & web_returns)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  393 |                             .begin(),
+      |                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:395:48: error: ‘wr’ was not declared in this scope; did you mean ‘w’?
+  395 |                           std::vector<decltype(wr.wr_order_number)> __items;
+      |                                                ^~
+      |                                                w
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:395:67: error: template argument 1 is invalid
+  395 |                           std::vector<decltype(wr.wr_order_number)> __items;
+      |                                                                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:395:67: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:397:37: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  397 |                             __items.push_back(wr.wr_order_number);
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:397:50: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘wr_order_number’
+  397 |                             __items.push_back(wr.wr_order_number);
+      |                                                  ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:401:30: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & web_returns)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  401 |                             .end(),
+      |                              ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:404:44: error: ‘wr’ was not declared in this scope; did you mean ‘w’?
+  404 |                       std::vector<decltype(wr.wr_order_number)> __items;
+      |                                            ^~
+      |                                            w
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:404:63: error: template argument 1 is invalid
+  404 |                       std::vector<decltype(wr.wr_order_number)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:404:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:406:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  406 |                         __items.push_back(wr.wr_order_number);
+      |                                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:406:46: error: ‘class std::__cxx11::basic_string<char>’ has no member named ‘wr_order_number’
+  406 |                         __items.push_back(wr.wr_order_number);
+      |                                              ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:410:26: error: request for member ‘end’ in ‘<lambda closure object>main()::<lambda()>::<lambda()>{(* & web_returns)}.main()::<lambda()>::<lambda()>()’, which is of non-class type ‘int’
+  410 |                         .end()))))
+      |                          ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:412:21: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  412 |             __items.push_back(ws);
+      |                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:420:47: error: ‘x’ was not declared in this scope
+  420 |                          std::vector<decltype(x.ws_order_number)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:420:65: error: template argument 1 is invalid
+  420 |                          std::vector<decltype(x.ws_order_number)> __items;
+      |                                                                 ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:420:65: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:421:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  421 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:421:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  421 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:422:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  422 |                            __items.push_back(x.ws_order_number);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In instantiation of ‘auto distinct(auto:1) [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:419:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:308:3: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  308 |   for (auto x : xs) {
+      |   ^~~
+      |   std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:308:3: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  308 |   for (auto x : xs) {
+      |   ^~~
+      |   std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:309:19: error: ‘contains’ was not declared in this scope
+  309 |     if ((!contains(out, x))) {
+      |           ~~~~~~~~^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:430:47: error: ‘x’ was not declared in this scope
+  430 |                          std::vector<decltype(x.ws_ext_ship_cost)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:430:66: error: template argument 1 is invalid
+  430 |                          std::vector<decltype(x.ws_ext_ship_cost)> __items;
+      |                                                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:430:66: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:431:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  431 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:431:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  431 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:432:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  432 |                            __items.push_back(x.ws_ext_ship_cost);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:2)> [with auto:2 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:429:26:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:428:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  428 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:428:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  428 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                            ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:439:47: error: ‘x’ was not declared in this scope
+  439 |                          std::vector<decltype(x.ws_net_profit)> __items;
+      |                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:439:63: error: template argument 1 is invalid
+  439 |                          std::vector<decltype(x.ws_net_profit)> __items;
+      |                                                               ^
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:439:63: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:440:40: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  440 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::begin
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:440:40: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  440 |                          for (auto x : filtered) {
+      |                                        ^~~~~~~~
+      |                                        std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:441:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  441 |                            __items.push_back(x.ws_net_profit);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp: In instantiation of ‘main()::<lambda(auto:3)> [with auto:3 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:438:26:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:437:51: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  437 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                 ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq951187726932/001/prog.cpp:437:62: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  437 |                          return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                            ~~^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q96.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q96.error
@@ -1,0 +1,51 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:71:8: error: redefinition of ‘struct StoreSale’
+   71 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:53:8: note: previous definition of ‘struct StoreSale’
+   53 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:80:8: error: redefinition of ‘struct TimeDim’
+   80 | struct TimeDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:62:8: note: previous definition of ‘struct TimeDim’
+   62 | struct TimeDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:85:8: error: redefinition of ‘struct Store’
+   85 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:67:8: note: previous definition of ‘struct Store’
+   67 | struct Store {
+      |        ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:174:13: error: redefinition of ‘void __json(const Store&)’
+  174 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:104:13: note: ‘void __json(const Store&)’ previously defined here
+  104 | inline void __json(const Store &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:189:13: error: redefinition of ‘void __json(const StoreSale&)’
+  189 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:119:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  119 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:209:13: error: redefinition of ‘void __json(const TimeDim&)’
+  209 | inline void __json(const TimeDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:139:13: note: ‘void __json(const TimeDim&)’ previously defined here
+  139 | inline void __json(const TimeDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:237:41: error: ‘ss’ was not declared in this scope
+  237 |                    std::vector<decltype(ss)> __items;
+      |                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:237:44: error: template argument 1 is invalid
+  237 |                    std::vector<decltype(ss)> __items;
+      |                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:237:44: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:252:36: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  252 |                            __items.push_back(ss);
+      |                                    ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq962529256213/001/prog.cpp:259:23: error: request for member ‘size’ in ‘<lambda closure object>main()::<lambda()>{store_sales, household_demographics, time_dim, store}.main()::<lambda()>()’, which is of non-class type ‘int’
+  259 |                      .size());
+      |                       ^~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q97.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q97.error
@@ -1,0 +1,426 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:61:8: error: redefinition of ‘struct StoreSale’
+   61 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:53:8: note: previous definition of ‘struct StoreSale’
+   53 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:65:8: error: redefinition of ‘struct CatalogSale’
+   65 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:57:8: note: previous definition of ‘struct CatalogSale’
+   57 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:70:12: error: ‘ss’ was not declared in this scope
+   70 |   decltype(ss.ss_customer_sk) customer_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:70:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:71:12: error: ‘ss’ was not declared in this scope
+   71 |   decltype(ss.ss_item_sk) item_sk;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:71:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:74:12: error: ‘ss’ was not declared in this scope
+   74 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:74:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:81:12: error: ‘cs’ was not declared in this scope
+   81 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:81:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:88:12: error: ‘store_only’ was not declared in this scope
+   88 |   decltype(store_only) store_only;
+      |            ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:88:12: error: ‘store_only’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:89:12: error: ‘catalog_only’ was not declared in this scope
+   89 |   decltype(catalog_only) catalog_only;
+      |            ^~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:89:12: error: ‘catalog_only’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:90:12: error: ‘both’ was not declared in this scope
+   90 |   decltype(both) store_and_catalog;
+      |            ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:90:12: error: ‘both’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:122:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  122 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:92:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+   92 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:152:13: error: redefinition of ‘void __json(const StoreSale&)’
+  152 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:107:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  107 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:217:21: error: no match for ‘operator==’ (operand types are ‘Ssci’ and ‘Ssci’)
+  217 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Ssci   Ssci
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:218:41: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  218 |           __g.items.push_back(__struct4{ss});
+      |                                         ^~
+      |                                         |
+      |                                         StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:225:63: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  225 |             __struct5{__key, std::vector<__struct4>{__struct4{ss}}});
+      |                                                               ^~
+      |                                                               |
+      |                                                               StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:225:66: error: no matching function for call to ‘std::vector<__struct4>::vector(<brace-enclosed initializer list>)’
+  225 |             __struct5{__key, std::vector<__struct4>{__struct4{ss}}});
+      |                                                                  ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct4; _Alloc = std::allocator<__struct4>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; allocator_type = std::allocator<__struct4>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; std::__type_identity_t<_Alloc> = std::allocator<__struct4>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; allocator_type = std::allocator<__struct4>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; allocator_type = std::allocator<__struct4>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; std::__type_identity_t<_Alloc> = std::allocator<__struct4>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; size_type = long unsigned int; value_type = std::vector<__struct4>::value_type; allocator_type = std::allocator<__struct4>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; size_type = long unsigned int; allocator_type = std::allocator<__struct4>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct4; _Alloc = std::allocator<__struct4>; allocator_type = std::allocator<__struct4>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct4; _Alloc = std::allocator<__struct4>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:233:5: error: conversion from ‘vector<Ssci>’ to non-scalar type ‘vector<__struct4>’ requested
+  211 |   std::vector<__struct4> ssci = ([&]() {
+      |                                 ~~~~~~~~
+  212 |     std::vector<__struct5> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  213 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  214 |       auto __key = Ssci{ss.ss_customer_sk, ss.ss_item_sk};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  215 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  216 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  217 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  218 |           __g.items.push_back(__struct4{ss});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  219 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  220 |           break;
+      |           ~~~~~~
+  221 |         }
+      |         ~
+  222 |       }
+      |       ~
+  223 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  224 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  225 |             __struct5{__key, std::vector<__struct4>{__struct4{ss}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  226 |       }
+      |       ~
+  227 |     }
+      |     ~
+  228 |     std::vector<Ssci> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  229 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  230 |       __items.push_back(Ssci{g.key.customer_sk, g.key.item_sk});
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  231 |     }
+      |     ~
+  232 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  233 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:240:21: error: no match for ‘operator==’ (operand types are ‘Ssci’ and ‘Ssci’)
+  240 |         if (__g.key == __key) {
+      |             ~~~~~~~ ^~ ~~~~~
+      |                 |      |
+      |                 Ssci   Ssci
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:241:36: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  241 |           __g.items.push_back(Csci{cs});
+      |                                    ^~
+      |                                    |
+      |                                    CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:247:68: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  247 |         __groups.push_back(__struct7{__key, std::vector<Csci>{Csci{cs}}});
+      |                                                                    ^~
+      |                                                                    |
+      |                                                                    CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:247:71: error: no matching function for call to ‘std::vector<Csci>::vector(<brace-enclosed initializer list>)’
+  247 |         __groups.push_back(__struct7{__key, std::vector<Csci>{Csci{cs}}});
+      |                                                                       ^
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Csci; _Alloc = std::allocator<Csci>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; allocator_type = std::allocator<Csci>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; std::__type_identity_t<_Alloc> = std::allocator<Csci>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = Csci; _Alloc = std::allocator<Csci>; allocator_type = std::allocator<Csci>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = Csci; _Alloc = std::allocator<Csci>; allocator_type = std::allocator<Csci>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; std::__type_identity_t<_Alloc> = std::allocator<Csci>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = Csci; _Alloc = std::allocator<Csci>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = Csci; _Alloc = std::allocator<Csci>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; size_type = long unsigned int; value_type = Csci; allocator_type = std::allocator<Csci>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; size_type = long unsigned int; allocator_type = std::allocator<Csci>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = Csci; _Alloc = std::allocator<Csci>; allocator_type = std::allocator<Csci>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = Csci; _Alloc = std::allocator<Csci>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:255:5: error: conversion from ‘vector<Ssci>’ to non-scalar type ‘vector<Csci>’ requested
+  234 |   std::vector<Csci> csci = ([&]() {
+      |                            ~~~~~~~~
+  235 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  236 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  237 |       auto __key = Ssci{cs.cs_bill_customer_sk, cs.cs_item_sk};
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  238 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  239 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  240 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  241 |           __g.items.push_back(Csci{cs});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  242 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  243 |           break;
+      |           ~~~~~~
+  244 |         }
+      |         ~
+  245 |       }
+      |       ~
+  246 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  247 |         __groups.push_back(__struct7{__key, std::vector<Csci>{Csci{cs}}});
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  248 |       }
+      |       ~
+  249 |     }
+      |     ~
+  250 |     std::vector<Ssci> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  251 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  252 |       __items.push_back(Ssci{g.key.customer_sk, g.key.item_sk});
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  253 |     }
+      |     ~
+  254 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  255 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:260:44: error: ‘struct __struct4’ has no member named ‘customer_sk’
+  260 |                                  if (!(((s.customer_sk == c.customer_sk) &&
+      |                                            ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:260:61: error: ‘struct Csci’ has no member named ‘customer_sk’
+  260 |                                  if (!(((s.customer_sk == c.customer_sk) &&
+      |                                                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:261:44: error: ‘struct __struct4’ has no member named ‘item_sk’
+  261 |                                         (s.item_sk == c.item_sk))))
+      |                                            ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:261:57: error: ‘struct Csci’ has no member named ‘item_sk’
+  261 |                                         (s.item_sk == c.item_sk))))
+      |                                                         ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:256:28: error: conversion from ‘int’ to non-scalar type ‘std::vector<int>’ requested
+  256 |   std::vector<int> both = ((int)([&]() {
+      |                           ~^~~~~~~~~~~~~
+  257 |                              std::vector<decltype(1)> __items;
+      |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  258 |                              for (auto s : ssci) {
+      |                              ~~~~~~~~~~~~~~~~~~~~~
+  259 |                                for (auto c : csci) {
+      |                                ~~~~~~~~~~~~~~~~~~~~~
+  260 |                                  if (!(((s.customer_sk == c.customer_sk) &&
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  261 |                                         (s.item_sk == c.item_sk))))
+      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  262 |                                    continue;
+      |                                    ~~~~~~~~~
+  263 |                                  __items.push_back(1);
+      |                                  ~~~~~~~~~~~~~~~~~~~~~
+  264 |                                }
+      |                                ~
+  265 |                              }
+      |                              ~
+  266 |                              return __items;
+      |                              ~~~~~~~~~~~~~~~
+  267 |                            })()
+      |                            ~~~~
+  268 |                                .size());
+      |                                ~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:274:29: error: ‘struct __struct4’ has no member named ‘customer_sk’
+  274 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                             ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:275:29: error: ‘struct __struct4’ has no member named ‘item_sk’
+  275 |                          (s.item_sk == c.item_sk));
+      |                             ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:270:8: error: conversion from ‘int’ to non-scalar type ‘std::vector<int>’ requested
+  270 |       ((int)([&]() {
+      |       ~^~~~~~~~~~~~~
+  271 |          std::vector<decltype(1)> __items;
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  272 |          for (auto s : ssci) {
+      |          ~~~~~~~~~~~~~~~~~~~~~
+  273 |            if (!((!(std::any_of(csci.begin(), csci.end(), [&](auto c) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  274 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  275 |                          (s.item_sk == c.item_sk));
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  276 |                })))))
+      |                ~~~~~~
+  277 |              continue;
+      |              ~~~~~~~~~
+  278 |            __items.push_back(1);
+      |            ~~~~~~~~~~~~~~~~~~~~~
+  279 |          }
+      |          ~
+  280 |          return __items;
+      |          ~~~~~~~~~~~~~~~
+  281 |        })()
+      |        ~~~~
+  282 |            .size());
+      |            ~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:288:46: error: ‘struct Csci’ has no member named ‘customer_sk’
+  288 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                                              ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:289:42: error: ‘struct Csci’ has no member named ‘item_sk’
+  289 |                          (s.item_sk == c.item_sk));
+      |                                          ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:284:8: error: conversion from ‘int’ to non-scalar type ‘std::vector<int>’ requested
+  284 |       ((int)([&]() {
+      |       ~^~~~~~~~~~~~~
+  285 |          std::vector<decltype(1)> __items;
+      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  286 |          for (auto c : csci) {
+      |          ~~~~~~~~~~~~~~~~~~~~~
+  287 |            if (!((!(std::any_of(ssci.begin(), ssci.end(), [&](auto s) {
+      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  288 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  289 |                          (s.item_sk == c.item_sk));
+      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  290 |                })))))
+      |                ~~~~~~
+  291 |              continue;
+      |              ~~~~~~~~~
+  292 |            __items.push_back(1);
+      |            ~~~~~~~~~~~~~~~~~~~~~
+  293 |          }
+      |          ~
+  294 |          return __items;
+      |          ~~~~~~~~~~~~~~~
+  295 |        })()
+      |        ~~~~
+  296 |            .size());
+      |            ~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:297:24: error: cannot convert ‘std::vector<int>’ to ‘int’ in initialization
+  297 |   auto result = Result{store_only, catalog_only, both};
+      |                        ^~~~~~~~~~
+      |                        |
+      |                        std::vector<int>
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = Csci]’:
+/usr/include/c++/13/bits/predefined_ops.h:318:23:   required from ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<Csci*, std::vector<Csci> >; _Predicate = main()::<lambda()>::<lambda(auto:1)>]’
+/usr/include/c++/13/bits/stl_algobase.h:2072:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<Csci*, vector<Csci> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:1)> >]’
+/usr/include/c++/13/bits/stl_algobase.h:2117:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<Csci*, vector<Csci> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:1)> >]’
+/usr/include/c++/13/bits/stl_algo.h:3923:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<Csci*, vector<Csci> >; _Predicate = main()::<lambda()>::<lambda(auto:1)>]’
+/usr/include/c++/13/bits/stl_algo.h:477:47:   required from ‘bool std::none_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<Csci*, vector<Csci> >; _Predicate = main()::<lambda()>::<lambda(auto:1)>]’
+/usr/include/c++/13/bits/stl_algo.h:496:27:   required from ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<Csci*, vector<Csci> >; _Predicate = main()::<lambda()>::<lambda(auto:1)>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:273:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:274:46: error: ‘struct Csci’ has no member named ‘customer_sk’
+  274 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                                            ~~^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:275:42: error: ‘struct Csci’ has no member named ‘item_sk’
+  275 |                          (s.item_sk == c.item_sk));
+      |                                        ~~^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = __struct4]’:
+/usr/include/c++/13/bits/predefined_ops.h:318:23:   required from ‘bool __gnu_cxx::__ops::_Iter_pred<_Predicate>::operator()(_Iterator) [with _Iterator = __gnu_cxx::__normal_iterator<__struct4*, std::vector<__struct4> >; _Predicate = main()::<lambda()>::<lambda(auto:2)>]’
+/usr/include/c++/13/bits/stl_algobase.h:2072:14:   required from ‘_RandomAccessIterator std::__find_if(_RandomAccessIterator, _RandomAccessIterator, _Predicate, random_access_iterator_tag) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<__struct4*, vector<__struct4> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:2)> >]’
+/usr/include/c++/13/bits/stl_algobase.h:2117:23:   required from ‘_Iterator std::__find_if(_Iterator, _Iterator, _Predicate) [with _Iterator = __gnu_cxx::__normal_iterator<__struct4*, vector<__struct4> >; _Predicate = __gnu_cxx::__ops::_Iter_pred<main()::<lambda()>::<lambda(auto:2)> >]’
+/usr/include/c++/13/bits/stl_algo.h:3923:28:   required from ‘_IIter std::find_if(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__struct4*, vector<__struct4> >; _Predicate = main()::<lambda()>::<lambda(auto:2)>]’
+/usr/include/c++/13/bits/stl_algo.h:477:47:   required from ‘bool std::none_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__struct4*, vector<__struct4> >; _Predicate = main()::<lambda()>::<lambda(auto:2)>]’
+/usr/include/c++/13/bits/stl_algo.h:496:27:   required from ‘bool std::any_of(_IIter, _IIter, _Predicate) [with _IIter = __gnu_cxx::__normal_iterator<__struct4*, vector<__struct4> >; _Predicate = main()::<lambda()>::<lambda(auto:2)>]’
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:287:32:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:288:29: error: ‘struct __struct4’ has no member named ‘customer_sk’
+  288 |                  return ((s.customer_sk == c.customer_sk) &&
+      |                           ~~^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq9749740569/001/prog.cpp:289:29: error: ‘struct __struct4’ has no member named ‘item_sk’
+  289 |                          (s.item_sk == c.item_sk));
+      |                           ~~^~~~~~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q98.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q98.error
@@ -1,0 +1,500 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:73:8: error: redefinition of ‘struct StoreSale’
+   73 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:56:8: note: previous definition of ‘struct StoreSale’
+   56 | struct StoreSale {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:78:8: error: redefinition of ‘struct Item’
+   78 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:61:8: note: previous definition of ‘struct Item’
+   61 | struct Item {
+      |        ^~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:86:8: error: redefinition of ‘struct DateDim’
+   86 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:69:8: note: previous definition of ‘struct DateDim’
+   69 | struct DateDim {
+      |        ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+   91 |   decltype(i.i_item_id) item_id;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:91:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+   92 |   decltype(i.i_item_desc) item_desc;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:92:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+   93 |   decltype(i.i_category) category;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:93:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+   94 |   decltype(i.i_class) class;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:94:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:94:28: error: expected identifier before ‘;’ token
+   94 |   decltype(i.i_class) class;
+      |                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:94:3: error: multiple types in one declaration
+   94 |   decltype(i.i_class) class;
+      |   ^~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope
+   95 |   decltype(i.i_current_price) price;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:95:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:98:12: error: ‘ss’ was not declared in this scope
+   98 |   decltype(ss) ss;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:98:12: error: ‘ss’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+   99 |   decltype(i) i;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:99:12: error: ‘i’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+  100 |   decltype(d) d;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:100:12: error: ‘d’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:110:42: error: expected unqualified-id before ‘class’
+  110 |   decltype(std::declval<__struct6>().key.class) i_class;
+      |                                          ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  115 |   decltype(std::declval<__struct5>().i_class) key;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:115:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:119:48: error: expected identifier before ‘;’ token
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:119:3: error: multiple types in one declaration
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:119:48: error: declaration does not declare anything [-fpermissive]
+  119 |   decltype(std::declval<__struct8>().key) class;
+      |                                                ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  123 |   decltype(std::declval<__struct5>().i_item_id) i_item_id;
+      |                                      ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:123:38: error: ‘struct __struct5’ has no member named ‘i_item_id’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  124 |   decltype(std::declval<__struct5>().i_item_desc) i_item_desc;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:124:38: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+  125 |   decltype(std::declval<__struct5>().i_category) i_category;
+      |                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:125:38: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+  126 |   decltype(std::declval<__struct5>().i_class) i_class;
+      |                                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:126:38: error: ‘struct __struct5’ has no member named ‘i_class’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  127 |   decltype(std::declval<__struct5>().i_current_price) i_current_price;
+      |                                      ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:127:38: error: ‘struct __struct5’ has no member named ‘i_current_price’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  128 |   decltype(std::declval<__struct5>().itemrevenue) itemrevenue;
+      |                                      ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:128:38: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:129:40: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype(((std::declval<__struct5>().itemrevenue * 100) /
+      |                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:129:40: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  129 |   decltype(((std::declval<__struct5>().itemrevenue * 100) /
+      |                                        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:130:39: error: ‘struct __struct5’ has no member named ‘total’
+  130 |             std::declval<__struct5>().total)) revenueratio;
+      |                                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In function ‘void __json(const Total&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:209:12: error: expected unqualified-id before ‘class’
+  209 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:217:13: error: redefinition of ‘void __json(const DateDim&)’
+  217 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:132:13: note: ‘void __json(const DateDim&)’ previously defined here
+  132 | inline void __json(const DateDim &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:307:13: error: redefinition of ‘void __json(const Item&)’
+  307 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:147:13: note: ‘void __json(const Item&)’ previously defined here
+  147 | inline void __json(const Item &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In function ‘void __json(const Grouped&)’:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:364:12: error: expected unqualified-id before ‘class’
+  364 |   __json(v.class);
+      |            ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: At global scope:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:372:13: error: redefinition of ‘void __json(const StoreSale&)’
+  372 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:182:13: note: ‘void __json(const StoreSale&)’ previously defined here
+  182 | inline void __json(const StoreSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:431:60: error: too many initializers for ‘Grouped’
+  431 |                                i.i_class, i.i_current_price};
+      |                                                            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:435:45: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  435 |               __g.items.push_back(__struct5{ss, i, d});
+      |                                             ^~
+      |                                             |
+      |                                             StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:442:67: error: cannot convert ‘StoreSale’ to ‘int’ in initialization
+  442 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                                                                   ^~
+      |                                                                   |
+      |                                                                   StoreSale
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:442:76: error: no matching function for call to ‘std::vector<__struct5>::vector(<brace-enclosed initializer list>)’
+  442 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                                                                            ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:9:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; std::__type_identity_t<_Alloc> = std::allocator<__struct5>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; value_type = std::vector<__struct5>::value_type; allocator_type = std::allocator<__struct5>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; size_type = long unsigned int; allocator_type = std::allocator<__struct5>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct5; _Alloc = std::allocator<__struct5>; allocator_type = std::allocator<__struct5>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct5; _Alloc = std::allocator<__struct5>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:449:34: error: expected primary-expression before ‘{’ token
+  449 |       __items.push_back(__struct7{
+      |                                  ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:463:5: error: conversion from ‘vector<__struct7>’ to non-scalar type ‘vector<__struct5>’ requested
+  421 |   std::vector<__struct5> grouped = ([&]() {
+      |                                    ~~~~~~~~
+  422 |     std::vector<__struct6> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  423 |     for (auto ss : store_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  424 |       for (auto i : item) {
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  425 |         if (!((ss.ss_item_sk == i.i_item_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  426 |           continue;
+      |           ~~~~~~~~~
+  427 |         for (auto d : date_dim) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~
+  428 |           if (!((ss.ss_sold_date_sk == d.d_date_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  429 |             continue;
+      |             ~~~~~~~~~
+  430 |           auto __key = Grouped{i.i_item_id, i.i_item_desc, i.i_category,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  431 |                                i.i_class, i.i_current_price};
+      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |           bool __found = false;
+      |           ~~~~~~~~~~~~~~~~~~~~~
+  433 |           for (auto &__g : __groups) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |             if (__g.key == __key) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~
+  435 |               __g.items.push_back(__struct5{ss, i, d});
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  436 |               __found = true;
+      |               ~~~~~~~~~~~~~~~
+  437 |               break;
+      |               ~~~~~~
+  438 |             }
+      |             ~
+  439 |           }
+      |           ~
+  440 |           if (!__found) {
+      |           ~~~~~~~~~~~~~~~
+  441 |             __groups.push_back(
+      |             ~~~~~~~~~~~~~~~~~~~
+  442 |                 __struct6{__key, std::vector<__struct5>{__struct5{ss, i, d}}});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |           }
+      |           ~
+  444 |         }
+      |         ~
+  445 |       }
+      |       ~
+  446 |     }
+      |     ~
+  447 |     std::vector<__struct7> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  448 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  449 |       __items.push_back(__struct7{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  450 |           g.key.item_id, g.key.item_desc, g.key.category, g.key.class,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  451 |           g.key.price, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  452 |             return std::accumulate(v.begin(), v.end(), 0.0);
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  453 |           })(([&]() {
+      |           ~~~~~~~~~~~
+  454 |             std::vector<decltype(std::declval<__struct5>().ss_ext_sales_price)>
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  455 |                 __items;
+      |                 ~~~~~~~~
+  456 |             for (auto x : g.items) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~
+  457 |               __items.push_back(x.ss_ext_sales_price);
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  458 |             }
+      |             ~
+  459 |             return __items;
+      |             ~~~~~~~~~~~~~~~
+  460 |           })())});
+      |           ~~~~~~~~
+  461 |     }
+      |     ~
+  462 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  463 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:467:22: error: ‘struct __struct5’ has no member named ‘i_class’
+  467 |       auto __key = g.i_class;
+      |                      ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:487:66: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  487 |                   std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                                  ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:487:66: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:487:78: error: template argument 1 is invalid
+  487 |                   std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:487:78: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:490:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  490 |                     __items.push_back(x.itemrevenue);
+      |                             ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:490:41: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  490 |                     __items.push_back(x.itemrevenue);
+      |                                         ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:486:19:   required from here
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:485:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+  485 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                          ~~^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:485:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+  485 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                                                     ~~^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:493:22: error: too many initializers for ‘Total’
+  493 |                 })())});
+      |                      ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:496:5: error: conversion from ‘vector<Total>’ to non-scalar type ‘vector<__struct5>’ requested
+  464 |   std::vector<__struct5> totals = ([&]() {
+      |                                   ~~~~~~~~
+  465 |     std::vector<__struct8> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  466 |     for (auto g : grouped) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~
+  467 |       auto __key = g.i_class;
+      |       ~~~~~~~~~~~~~~~~~~~~~~~
+  468 |       bool __found = false;
+      |       ~~~~~~~~~~~~~~~~~~~~~
+  469 |       for (auto &__g : __groups) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  470 |         if (__g.key == __key) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~
+  471 |           __g.items.push_back(__struct5{g});
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  472 |           __found = true;
+      |           ~~~~~~~~~~~~~~~
+  473 |           break;
+      |           ~~~~~~
+  474 |         }
+      |         ~
+  475 |       }
+      |       ~
+  476 |       if (!__found) {
+      |       ~~~~~~~~~~~~~~~
+  477 |         __groups.push_back(
+      |         ~~~~~~~~~~~~~~~~~~~
+  478 |             __struct8{__key, std::vector<__struct5>{__struct5{g}}});
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  479 |       }
+      |       ~
+  480 |     }
+      |     ~
+  481 |     std::vector<Total> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  482 |     for (auto &cg : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  483 |       __items.push_back(
+      |       ~~~~~~~~~~~~~~~~~~
+  484 |           Total{cg.key, ([&](auto v) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  485 |                   return std::accumulate(v.begin(), v.end(), 0.0);
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  486 |                 })(([&]() {
+      |                 ~~~~~~~~~~~
+  487 |                   std::vector<decltype(std::declval<__struct5>().itemrevenue)>
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  488 |                       __items;
+      |                       ~~~~~~~~
+  489 |                   for (auto x : cg.items) {
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~
+  490 |                     __items.push_back(x.itemrevenue);
+      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  491 |                   }
+      |                   ~
+  492 |                   return __items;
+      |                   ~~~~~~~~~~~~~~~
+  493 |                 })())});
+      |                 ~~~~~~~~
+  494 |     }
+      |     ~
+  495 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  496 |   })();
+      |   ~~^~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:499:54: error: ‘struct __struct5’ has no member named ‘i_category’
+  499 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                      ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:499:54: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:499:67: error: template argument 1 is invalid
+  499 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                   ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:499:73: error: template argument 1 is invalid
+  499 |         std::pair<decltype(std::declval<__struct5>().i_category), Result>>
+      |                                                                         ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:499:73: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:503:18: error: ‘struct __struct5’ has no member named ‘i_class’
+  503 |         if (!((g.i_class == t.class)))
+      |                  ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:503:31: error: expected unqualified-id before ‘class’
+  503 |         if (!((g.i_class == t.class)))
+      |                               ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:503:31: error: expected ‘)’ before ‘class’
+  503 |         if (!((g.i_class == t.class)))
+      |               ~               ^~~~~
+      |                               )
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:504:19: error: expected ‘)’ before ‘;’ token
+  504 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:503:14: note: to match this ‘(’
+  503 |         if (!((g.i_class == t.class)))
+      |              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:504:19: error: expected ‘)’ before ‘;’ token
+  504 |           continue;
+      |                   ^
+      |                   )
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:503:12: note: to match this ‘(’
+  503 |         if (!((g.i_class == t.class)))
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:505:17: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+  505 |         __items.push_back({std::vector<decltype(g.i_category)>{
+      |                 ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:505:51: error: ‘struct __struct5’ has no member named ‘i_category’
+  505 |         __items.push_back({std::vector<decltype(g.i_category)>{
+      |                                                   ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:505:51: error: ‘struct __struct5’ has no member named ‘i_category’
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:505:62: error: template argument 1 is invalid
+  505 |         __items.push_back({std::vector<decltype(g.i_category)>{
+      |                                                              ^
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:505:62: error: template argument 2 is invalid
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:506:34: error: ‘struct __struct5’ has no member named ‘i_category’
+  506 |                                g.i_category, g.i_class, g.i_item_id},
+      |                                  ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:506:48: error: ‘struct __struct5’ has no member named ‘i_class’
+  506 |                                g.i_category, g.i_class, g.i_item_id},
+      |                                                ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:506:59: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  506 |                                g.i_category, g.i_class, g.i_item_id},
+      |                                                           ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:507:37: error: ‘struct __struct5’ has no member named ‘i_item_id’
+  507 |                            Result{g.i_item_id, g.i_item_desc, g.i_category,
+      |                                     ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:507:50: error: ‘struct __struct5’ has no member named ‘i_item_desc’
+  507 |                            Result{g.i_item_id, g.i_item_desc, g.i_category,
+      |                                                  ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:507:65: error: ‘struct __struct5’ has no member named ‘i_category’
+  507 |                            Result{g.i_item_id, g.i_item_desc, g.i_category,
+      |                                                                 ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:508:37: error: ‘struct __struct5’ has no member named ‘i_class’
+  508 |                                   g.i_class, g.i_current_price, g.itemrevenue,
+      |                                     ^~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:508:48: error: ‘struct __struct5’ has no member named ‘i_current_price’
+  508 |                                   g.i_class, g.i_current_price, g.itemrevenue,
+      |                                                ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:508:67: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  508 |                                   g.i_class, g.i_current_price, g.itemrevenue,
+      |                                                                   ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:509:39: error: ‘struct __struct5’ has no member named ‘itemrevenue’
+  509 |                                   ((g.itemrevenue * 100) / t.total)}});
+      |                                       ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:509:62: error: ‘struct __struct5’ has no member named ‘total’
+  509 |                                   ((g.itemrevenue * 100) / t.total)}});
+      |                                                              ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:512:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+  512 |     std::sort(__items.begin(), __items.end(),
+      |                       ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:512:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+  512 |     std::sort(__items.begin(), __items.end(),
+      |                                        ^~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:515:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+  515 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::begin
+In file included from /usr/include/c++/13/string:53,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:3:
+/usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
+  114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+      |                                     ^~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq983296466378/001/prog.cpp:515:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+  515 |     for (auto &p : __items)
+      |                    ^~~~~~~
+      |                    std::end
+/usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
+  116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
+      |                                     ^~~

--- a/tests/dataset/tpc-ds/compiler/cpp/q99.error
+++ b/tests/dataset/tpc-ds/compiler/cpp/q99.error
@@ -1,0 +1,398 @@
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:72:8: error: redefinition of ‘struct CatalogSale’
+   72 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:53:8: note: previous definition of ‘struct CatalogSale’
+   53 | struct CatalogSale {
+      |        ^~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:79:8: error: redefinition of ‘struct Warehouse’
+   79 | struct Warehouse {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:60:8: note: previous definition of ‘struct Warehouse’
+   60 | struct Warehouse {
+      |        ^~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:83:8: error: redefinition of ‘struct ShipMode’
+   83 | struct ShipMode {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:64:8: note: previous definition of ‘struct ShipMode’
+   64 | struct ShipMode {
+      |        ^~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:87:8: error: redefinition of ‘struct CallCenter’
+   87 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:68:8: note: previous definition of ‘struct CallCenter’
+   68 | struct CallCenter {
+      |        ^~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:92:19: error: ‘w’ was not declared in this scope
+   92 |   decltype(substr(w.w_warehouse_name, 0, 20)) warehouse;
+      |                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:92:12: error: ‘substr’ was not declared in this scope
+   92 |   decltype(substr(w.w_warehouse_name, 0, 20)) warehouse;
+      |            ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:92:19: error: ‘w’ was not declared in this scope
+   92 |   decltype(substr(w.w_warehouse_name, 0, 20)) warehouse;
+      |                   ^
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:92:12: error: ‘substr’ was not declared in this scope
+   92 |   decltype(substr(w.w_warehouse_name, 0, 20)) warehouse;
+      |            ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:93:12: error: ‘sm’ was not declared in this scope; did you mean ‘tm’?
+   93 |   decltype(sm.sm_type) sm_type;
+      |            ^~
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:93:12: error: ‘sm’ was not declared in this scope; did you mean ‘tm’?
+   93 |   decltype(sm.sm_type) sm_type;
+      |            ^~
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:94:12: error: ‘cc’ was not declared in this scope
+   94 |   decltype(cc.cc_name) cc_name;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:94:12: error: ‘cc’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:97:12: error: ‘cs’ was not declared in this scope
+   97 |   decltype(cs) cs;
+      |            ^~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:97:12: error: ‘cs’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:98:12: error: ‘w’ was not declared in this scope
+   98 |   decltype(w) w;
+      |            ^
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:98:12: error: ‘w’ was not declared in this scope
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:99:12: error: ‘sm’ was not declared in this scope; did you mean ‘tm’?
+   99 |   decltype(sm) sm;
+      |            ^~
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:99:12: error: ‘sm’ was not declared in this scope; did you mean ‘tm’?
+   99 |   decltype(sm) sm;
+      |            ^~
+      |            tm
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:100:12: error: ‘cc’ was not declared in this scope; did you mean ‘cs’?
+  100 |   decltype(cc) cc;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:100:12: error: ‘cc’ was not declared in this scope; did you mean ‘cs’?
+  100 |   decltype(cc) cc;
+      |            ^~
+      |            cs
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:191:13: error: redefinition of ‘void __json(const CallCenter&)’
+  191 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:116:13: note: ‘void __json(const CallCenter&)’ previously defined here
+  116 | inline void __json(const CallCenter &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:206:13: error: redefinition of ‘void __json(const CatalogSale&)’
+  206 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:131:13: note: ‘void __json(const CatalogSale&)’ previously defined here
+  131 | inline void __json(const CatalogSale &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:236:13: error: redefinition of ‘void __json(const ShipMode&)’
+  236 | inline void __json(const ShipMode &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:161:13: note: ‘void __json(const ShipMode&)’ previously defined here
+  161 | inline void __json(const ShipMode &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:276:13: error: redefinition of ‘void __json(const Warehouse&)’
+  276 | inline void __json(const Warehouse &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:176:13: note: ‘void __json(const Warehouse&)’ previously defined here
+  176 | inline void __json(const Warehouse &v) {
+      |             ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:376:34: error: ‘substr’ was not declared in this scope
+  376 |             auto __key = Grouped{substr(w.w_warehouse_name, 0, 20), sm.sm_type,
+      |                                  ^~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:381:47: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  381 |                 __g.items.push_back(__struct6{cs, w, sm, cc});
+      |                                               ^~
+      |                                               |
+      |                                               CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:388:59: error: cannot convert ‘CatalogSale’ to ‘int’ in initialization
+  388 |                   __key, std::vector<__struct6>{__struct6{cs, w, sm, cc}}});
+      |                                                           ^~
+      |                                                           |
+      |                                                           CatalogSale
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:388:73: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+  388 |                   __key, std::vector<__struct6>{__struct6{cs, w, sm, cc}}});
+      |                                                                         ^
+In file included from /usr/include/c++/13/vector:66,
+                 from /tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:6:
+/usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  707 |         vector(_InputIterator __first, _InputIterator __last,
+      |         ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:707:9: note:   template argument deduction/substitution failed:
+/usr/include/c++/13/bits/stl_vector.h:678:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::initializer_list<_Tp>, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  678 |       vector(initializer_list<value_type> __l,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:678:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:659:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  659 |       vector(vector&& __rv, const __type_identity_t<allocator_type>& __m)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:659:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:640:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::false_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::false_type = std::integral_constant<bool, false>]’
+  640 |       vector(vector&& __rv, const allocator_type& __m, false_type)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:640:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:635:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&, const allocator_type&, std::true_type) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>; std::true_type = std::integral_constant<bool, true>]’
+  635 |       vector(vector&& __rv, const allocator_type& __m, true_type) noexcept
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:635:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:624:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&, std::__type_identity_t<_Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; std::__type_identity_t<_Alloc> = std::allocator<__struct6>]’
+  624 |       vector(const vector& __x, const __type_identity_t<allocator_type>& __a)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:624:7: note:   candidate expects 2 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:620:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(std::vector<_Tp, _Alloc>&&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  620 |       vector(vector&&) noexcept = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:620:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:601:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  601 |       vector(const vector& __x)
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:601:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:569:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; value_type = std::vector<__struct6>::value_type; allocator_type = std::allocator<__struct6>]’
+  569 |       vector(size_type __n, const value_type& __value,
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:569:7: note:   candidate expects 3 arguments, 1 provided
+/usr/include/c++/13/bits/stl_vector.h:556:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(size_type, const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; size_type = long unsigned int; allocator_type = std::allocator<__struct6>]’
+  556 |       vector(size_type __n, const allocator_type& __a = allocator_type())
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:556:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:542:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector(const allocator_type&) [with _Tp = __struct6; _Alloc = std::allocator<__struct6>; allocator_type = std::allocator<__struct6>]’
+  542 |       vector(const allocator_type& __a) _GLIBCXX_NOEXCEPT
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:542:7: note:   conversion of argument 1 would be ill-formed:
+/usr/include/c++/13/bits/stl_vector.h:531:7: note: candidate: ‘std::vector<_Tp, _Alloc>::vector() [with _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
+  531 |       vector() = default;
+      |       ^~~~~~
+/usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:401:26: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  401 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 30)))
+      |                          ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:401:46: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  401 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 30)))
+      |                                              ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:411:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  411 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 30) &&
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:411:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  411 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 30) &&
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:412:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  412 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 60))))
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:412:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  412 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 60))))
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:422:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  422 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 60) &&
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:422:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  422 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 60) &&
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:423:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  423 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 90))))
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:423:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  423 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 90))))
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:433:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  433 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 90) &&
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:433:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  433 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 90) &&
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:434:27: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  434 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 120))))
+      |                           ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:434:47: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  434 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 120))))
+      |                                               ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In lambda function:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:444:26: error: ‘struct __struct6’ has no member named ‘cs_ship_date_sk’
+  444 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) > 120)))
+      |                          ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:444:46: error: ‘struct __struct6’ has no member named ‘cs_sold_date_sk’
+  444 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) > 120)))
+      |                                              ^~~~~~~~~~~~~~~
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp: In function ‘int main()’:
+/tmp/TestCPPCompiler_TPCDSQueriesq994045550400/001/prog.cpp:453:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+  364 |   std::vector<__struct6> grouped = ([&]() {
+      |                                    ~~~~~~~~
+  365 |     std::vector<__struct7> __groups;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  366 |     for (auto cs : catalog_sales) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  367 |       for (auto w : warehouse) {
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  368 |         if (!((cs.cs_warehouse_sk == w.w_warehouse_sk)))
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  369 |           continue;
+      |           ~~~~~~~~~
+  370 |         for (auto sm : ship_mode) {
+      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  371 |           if (!((cs.cs_ship_mode_sk == sm.sm_ship_mode_sk)))
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  372 |             continue;
+      |             ~~~~~~~~~
+  373 |           for (auto cc : call_center) {
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  374 |             if (!((cs.cs_call_center_sk == cc.cc_call_center_sk)))
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  375 |               continue;
+      |               ~~~~~~~~~
+  376 |             auto __key = Grouped{substr(w.w_warehouse_name, 0, 20), sm.sm_type,
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  377 |                                  cc.cc_name};
+      |                                  ~~~~~~~~~~~~
+  378 |             bool __found = false;
+      |             ~~~~~~~~~~~~~~~~~~~~~
+  379 |             for (auto &__g : __groups) {
+      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  380 |               if (__g.key == __key) {
+      |               ~~~~~~~~~~~~~~~~~~~~~~~
+  381 |                 __g.items.push_back(__struct6{cs, w, sm, cc});
+      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  382 |                 __found = true;
+      |                 ~~~~~~~~~~~~~~~
+  383 |                 break;
+      |                 ~~~~~~
+  384 |               }
+      |               ~
+  385 |             }
+      |             ~
+  386 |             if (!__found) {
+      |             ~~~~~~~~~~~~~~~
+  387 |               __groups.push_back(__struct7{
+      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  388 |                   __key, std::vector<__struct6>{__struct6{cs, w, sm, cc}}});
+      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  389 |             }
+      |             ~
+  390 |           }
+      |           ~
+  391 |         }
+      |         ~
+  392 |       }
+      |       ~
+  393 |     }
+      |     ~
+  394 |     std::vector<__struct8> __items;
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  395 |     for (auto &g : __groups) {
+      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+  396 |       __items.push_back(__struct8{
+      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  397 |           g.key.warehouse, g.key.sm_type, g.key.cc_name,
+      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  398 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  399 |              std::vector<__struct6> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  400 |              for (auto x : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  401 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 30)))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  402 |                  continue;
+      |                  ~~~~~~~~~
+  403 |                __items.push_back(x);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  404 |              }
+      |              ~
+  405 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  406 |            })()
+      |            ~~~~
+  407 |                .size()),
+      |                ~~~~~~~~~
+  408 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  409 |              std::vector<__struct6> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  410 |              for (auto x : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  411 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 30) &&
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  412 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 60))))
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  413 |                  continue;
+      |                  ~~~~~~~~~
+  414 |                __items.push_back(x);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  415 |              }
+      |              ~
+  416 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  417 |            })()
+      |            ~~~~
+  418 |                .size()),
+      |                ~~~~~~~~~
+  419 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  420 |              std::vector<__struct6> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  421 |              for (auto x : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  422 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 60) &&
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  423 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 90))))
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  424 |                  continue;
+      |                  ~~~~~~~~~
+  425 |                __items.push_back(x);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  426 |              }
+      |              ~
+  427 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  428 |            })()
+      |            ~~~~
+  429 |                .size()),
+      |                ~~~~~~~~~
+  430 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  431 |              std::vector<__struct6> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  432 |              for (auto x : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  433 |                if (!((((x.cs_ship_date_sk - x.cs_sold_date_sk) > 90) &&
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  434 |                       ((x.cs_ship_date_sk - x.cs_sold_date_sk) <= 120))))
+      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  435 |                  continue;
+      |                  ~~~~~~~~~
+  436 |                __items.push_back(x);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  437 |              }
+      |              ~
+  438 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  439 |            })()
+      |            ~~~~
+  440 |                .size()),
+      |                ~~~~~~~~~
+  441 |           ((int)([&]() {
+      |           ~~~~~~~~~~~~~~
+  442 |              std::vector<__struct6> __items;
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  443 |              for (auto x : g.items) {
+      |              ~~~~~~~~~~~~~~~~~~~~~~~~
+  444 |                if (!(((x.cs_ship_date_sk - x.cs_sold_date_sk) > 120)))
+      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  445 |                  continue;
+      |                  ~~~~~~~~~
+  446 |                __items.push_back(x);
+      |                ~~~~~~~~~~~~~~~~~~~~~
+  447 |              }
+      |              ~
+  448 |              return __items;
+      |              ~~~~~~~~~~~~~~~
+  449 |            })()
+      |            ~~~~
+  450 |                .size())});
+      |                ~~~~~~~~~~~
+  451 |     }
+      |     ~
+  452 |     return __items;
+      |     ~~~~~~~~~~~~~~~
+  453 |   })();
+      |   ~~^~


### PR DESCRIPTION
## Summary
- capture compilation failures for all TPC‑DS C++ golden tests
- document progress in C++ compiler tasks

## Testing
- `go test -tags slow ./compiler/x/cpp -run TPCDS -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6875fe5921c4832090eb443e46ae5e65