### PR TITLE
Add Python Rosetta compiler tests

### DIFF
--- a/tools/rosetta/mochi_python_test.go
+++ b/tools/rosetta/mochi_python_test.go
@@ -1,0 +1,108 @@
+//go:build slow
+
+package rosetta
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pycode "mochi/compiler/x/python"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestMochiToPython(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+
+	root := findRepoRoot(t)
+	srcDir := filepath.Join(root, "tests/rosetta/x/Mochi")
+	outDir := filepath.Join(root, "tests/rosetta/out/Python")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatalf("mkout: %v", err)
+	}
+
+	outs, err := filepath.Glob(filepath.Join(srcDir, "*.out"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(outs) == 0 {
+		t.Fatal("no Mochi Rosetta tests found")
+	}
+
+	for _, outPath := range outs {
+		name := strings.TrimSuffix(filepath.Base(outPath), ".out")
+		srcPath := filepath.Join(srcDir, name+".mochi")
+		if _, err := os.Stat(srcPath); err != nil {
+			t.Fatalf("missing source for %s", name)
+		}
+		t.Run(name, func(t *testing.T) {
+			compileAndRunPython(t, srcPath, outPath, outDir, name)
+		})
+	}
+}
+
+func compileAndRunPython(t *testing.T, srcPath, wantPath, outDir, name string) {
+	if _, err := os.ReadFile(srcPath); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	prog, err := parser.Parse(srcPath)
+	if err != nil {
+		writePythonError(outDir, name, fmt.Errorf("parse error: %w", err))
+		t.Skip("parse error")
+		return
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writePythonError(outDir, name, fmt.Errorf("type error: %v", errs[0]))
+		t.Skip("type error")
+		return
+	}
+	c := pycode.New(env)
+	c.SetTypeHints(false)
+	code, err := c.Compile(prog)
+	if err != nil {
+		writePythonError(outDir, name, fmt.Errorf("compile error: %w", err))
+		t.Skip("compile error")
+		return
+	}
+	pyFile := filepath.Join(outDir, name+".py")
+	if err := os.WriteFile(pyFile, code, 0o644); err != nil {
+		t.Fatalf("write py: %v", err)
+	}
+
+	cmd := exec.Command("python3", pyFile)
+	root := findRepoRoot(t)
+	cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		writePythonError(outDir, name, fmt.Errorf("run error: %v\n%s", err, buf.Bytes()))
+		return
+	}
+	got := bytes.TrimSpace(buf.Bytes())
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	want = bytes.TrimSpace(want)
+	if !bytes.Equal(got, want) {
+		writePythonError(outDir, name, fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, want))
+		return
+	}
+	if err := os.WriteFile(filepath.Join(outDir, name+".out"), got, 0o644); err != nil {
+		t.Fatalf("write out: %v", err)
+	}
+	_ = os.Remove(filepath.Join(outDir, name+".error"))
+}
+
+func writePythonError(dir, name string, err error) {
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(err.Error()), 0o644)
+}


### PR DESCRIPTION
## Summary
- add golden tests for compiling Rosetta Mochi programs to Python

## Testing
- `go test ./tools/rosetta -run TestMochiToPython -tags=slow -c`


------
https://chatgpt.com/codex/tasks/task_e_6877694becd88320b6a2eb8a02a36208