### PR TITLE
Add slow build tags to rosetta tests

### DIFF
--- a/tools/rosetta/mochi_hs_test.go
+++ b/tools/rosetta/mochi_hs_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_python_golden_test.go
+++ b/tools/rosetta/mochi_python_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_rb_golden_test.go
+++ b/tools/rosetta/mochi_rb_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (


### PR DESCRIPTION
## Summary
- mark more rosetta tests with the `slow` build tag

## Testing
- `go test ./... -run TestNonexistent`

------
https://chatgpt.com/codex/tasks/task_e_687776831578832096b5b60bd6580d3c