### PR TITLE
Add slow build tags for rosetta tests

### DIFF
--- a/tools/rosetta/mochi_scheme_test.go
+++ b/tools/rosetta/mochi_scheme_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_smalltalk_golden_test.go
+++ b/tools/rosetta/mochi_smalltalk_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_swift_golden_test.go
+++ b/tools/rosetta/mochi_swift_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_swift_test.go
+++ b/tools/rosetta/mochi_swift_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (


### PR DESCRIPTION
## Summary
- mark several Rosetta test files with `//go:build slow`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68778402d3708320888c798942996d15