### PR TITLE
Add int builtin support for Python

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -958,6 +958,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		return fmt.Sprintf("print(json.dumps(%s, default=lambda o: vars(o)))", argStr), nil
 	case "str":
 		return fmt.Sprintf("str(%s)", argStr), nil
+	case "int":
+		return fmt.Sprintf("int(%s)", argStr), nil
 	case "input":
 		return "input()", nil
 	case "count":


### PR DESCRIPTION
## Summary
- support `int()` builtin in interpreter and typechecker
- emit native `int()` calls from Python compiler

## Testing
- `go test ./interpreter/... -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68777ee43fb0832081ba4b3da9ae8fc7