### PR TITLE
Add Rosetta VM golden tests and improve bigint support

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -205,7 +205,7 @@ type FunStmt struct {
 
 type ReturnStmt struct {
 	Pos   lexer.Position
-	Value *Expr `parser:"'return' @@"`
+	Value *Expr `parser:"'return' @@?"`
 }
 
 type BreakStmt struct {

--- a/runtime/vm/queryutil.go
+++ b/runtime/vm/queryutil.go
@@ -169,7 +169,9 @@ func scanStmtVars(s *parser.Statement, vars map[string]struct{}) {
 	case s.Assign != nil:
 		exprVars(s.Assign.Value, vars)
 	case s.Return != nil:
-		exprVars(s.Return.Value, vars)
+		if s.Return.Value != nil {
+			exprVars(s.Return.Value, vars)
+		}
 	case s.Expr != nil:
 		exprVars(s.Expr.Expr, vars)
 	case s.For != nil:

--- a/runtime/vm/rosetta_golden_test.go
+++ b/runtime/vm/rosetta_golden_test.go
@@ -1,0 +1,113 @@
+//go:build slow
+
+package vm_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
+)
+
+func TestVM_RosettaTasks(t *testing.T) {
+	root := findRepoRoot(t)
+	dir := filepath.Join(root, "tests/rosetta/x/Mochi")
+
+	outs, err := filepath.Glob(filepath.Join(dir, "*.out"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(outs) == 0 {
+		t.Fatal("no Mochi Rosetta tests found")
+	}
+
+	for _, out := range outs {
+		name := strings.TrimSuffix(filepath.Base(out), ".out")
+		src := filepath.Join(dir, name+".mochi")
+		if _, err := os.Stat(src); err != nil {
+			t.Fatalf("missing source for %s", name)
+		}
+
+		t.Run(name, func(t *testing.T) {
+			got, err := runMochi(src)
+			if err != nil {
+				t.Fatalf("run error: %v", err)
+			}
+			want, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+
+			got = bytes.TrimSpace(got)
+			want = bytes.TrimSpace(want)
+			if !bytes.Equal(got, want) {
+				t.Errorf("golden mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, got, want)
+			}
+		})
+	}
+}
+
+func runMochi(src string) ([]byte, error) {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		writeErr(src, err)
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		writeErr(src, errs[0])
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		writeErr(src, err)
+		return nil, fmt.Errorf("compile error: %w", err)
+	}
+	var out bytes.Buffer
+	m := vm.New(p, &out)
+	if err := m.Run(); err != nil {
+		writeErr(src, err)
+		return nil, fmt.Errorf("run error: %w", err)
+	}
+	removeErr(src)
+	b := bytes.TrimSpace(out.Bytes())
+	if b == nil {
+		b = []byte{}
+	}
+	return b, nil
+}
+
+func writeErr(src string, err error) {
+	errPath := strings.TrimSuffix(src, filepath.Ext(src)) + ".error"
+	_ = os.WriteFile(errPath, []byte(err.Error()), 0644)
+}
+
+func removeErr(src string) {
+	errPath := strings.TrimSuffix(src, filepath.Ext(src)) + ".error"
+	os.Remove(errPath)
+}
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2577,7 +2577,10 @@ func (fc *funcCompiler) compileStmt(s *parser.Statement) error {
 		}
 		return nil
 	case s.Return != nil:
-		r := fc.compileExpr(s.Return.Value)
+		var r int
+		if s.Return.Value != nil {
+			r = fc.compileExpr(s.Return.Value)
+		}
 		fc.emit(s.Return.Pos, Instr{Op: OpReturn, A: r})
 		return nil
 	case s.Expr != nil:

--- a/tests/rosetta/x/Mochi/ackermann-function-3.error
+++ b/tests/rosetta/x/Mochi/ackermann-function-3.error
@@ -1,0 +1,2 @@
+assignment to undeclared variable: err
+

--- a/tests/rosetta/x/Mochi/ackermann-function-3.mochi
+++ b/tests/rosetta/x/Mochi/ackermann-function-3.mochi
@@ -43,9 +43,9 @@ fun ackermann2(m: bigint, n: bigint): bigint {
     }
   }
   if bit_len(n) == 0 {
-    return ackermann2(m - 1, 1 as bigint)
+    return ackermann2(m - (1 as bigint), 1 as bigint)
   }
-  return ackermann2(m - 1, ackermann2(m, n - 1))
+  return ackermann2(m - (1 as bigint), ackermann2(m, n - (1 as bigint)))
 }
 
 fun show(m: int, n: int) {

--- a/types/check.go
+++ b/types/check.go
@@ -1363,6 +1363,9 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 			if unify(left, FloatType{}, nil) || unify(right, FloatType{}, nil) {
 				return FloatType{}, nil
 			}
+			if unify(left, BigIntType{}, nil) || unify(right, BigIntType{}, nil) {
+				return BigIntType{}, nil
+			}
 			if unify(left, Int64Type{}, nil) || unify(right, Int64Type{}, nil) {
 				return Int64Type{}, nil
 			}


### PR DESCRIPTION
## Summary
- add slow golden tests for running Rosetta programs on the VM
- support `return` without a value
- infer bigint results for numeric ops
- allow Rosetta Ackermann sample to compile better
- regenerate `.error` file for failing sample

## Testing
- `go test -tags=slow ./runtime/vm -run RosettaTasks/ackermann-function-3 -v`
- `go test ./runtime/vm -run=^$ -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_687783e09b3c832087c2d76bca684f18