### PR TITLE
Add slow build tags to rosetta tests

### DIFF
--- a/tools/rosetta/mochi_erlang_golden_test.go
+++ b/tools/rosetta/mochi_erlang_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_erlang_test.go
+++ b/tools/rosetta/mochi_erlang_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_java_golden_test.go
+++ b/tools/rosetta/mochi_java_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_lua_golden_test.go
+++ b/tools/rosetta/mochi_lua_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (

--- a/tools/rosetta/mochi_php_test.go
+++ b/tools/rosetta/mochi_php_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (


### PR DESCRIPTION
## Summary
- tag remaining rosetta tests with `//go:build slow`

## Testing
- `go test -c -tags slow ./tools/rosetta`


------
https://chatgpt.com/codex/tasks/task_e_687792b3f9888320abc5e46a0b7adaf5