### PR TITLE
Fix nil expression panic in TS compiler

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -63,3 +63,7 @@
 - Fixed join logic in runtime to keep rows with NULL values.
 - Added custom channel order in _cmp to satisfy q76 sorting.
 - Regenerated TPC-DS outputs for q40 and q76; all queries now compile and run.
+
+### 2025-07-16 11:41 UTC
+- Added nil check in `compileExpr` to prevent panics on malformed ASTs. Failing
+  Rosetta examples now emit `.error` files instead of crashing the test suite.

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1411,6 +1411,9 @@ func (c *Compiler) compileTestBlock(t *parser.TestBlock) error {
 // --- Expression Compilation ---
 
 func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
+	if e == nil || e.Binary == nil {
+		return "", fmt.Errorf("invalid nil expression")
+	}
 	return c.compileBinaryExpr(e.Binary)
 }
 

--- a/tests/rosetta/out/TypeScript/ackermann-function-3.error
+++ b/tests/rosetta/out/TypeScript/ackermann-function-3.error
@@ -1,0 +1,1 @@
+compile error: invalid nil expression


### PR DESCRIPTION
## Summary
- avoid panics in the TypeScript compiler by checking for nil expressions
- log this change in compiler TASKS
- record failing Rosetta example output

## Testing
- `go test ./compiler/x/ts -run TestCompileBasic -count=1 -tags slow`
- `go test ./tools/rosetta -run TestMochiToTypeScript/ackermann-function-3 -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_68778ee01c9c832095ef6943b88409c2