### PR TITLE
Run Racket golden tests

### DIFF
--- a/compiler/x/racket/TASKS.md
+++ b/compiler/x/racket/TASKS.md
@@ -2,6 +2,9 @@
 
 Recent enhancements:
 
+- 2025-07-25 05:04 - Compiler now supports casts to and from `bigint`
+  and honors `SOURCE_DATE_EPOCH` for reproducible outputs.
+
 - 2025-07-21 05:04 - Added Rosetta Code golden tests and compile script
   `compile_rosetta_racket.go`.
 

--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -438,7 +438,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 		case op.Cast != nil:
 			if op.Cast.Type.Simple != nil {
 				tname := *op.Cast.Type.Simple
-				if tname == "int" {
+				if tname == "int" || tname == "bigint" || tname == "bigrat" {
 					val = fmt.Sprintf("(string->number %s)", val)
 				} else if tname == "float" {
 					val = fmt.Sprintf("(exact->inexact (if (string? %s) (string->number %s) %s))", val, val, val)

--- a/scripts/compile_rosetta_racket.go
+++ b/scripts/compile_rosetta_racket.go
@@ -35,6 +35,8 @@ func writeError(dir, name, msg string) {
 }
 
 func main() {
+	os.Setenv("SOURCE_DATE_EPOCH", "0")
+	defer os.Unsetenv("SOURCE_DATE_EPOCH")
 	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
 	defer os.Unsetenv("MOCHI_HEADER_TIME")
 


### PR DESCRIPTION
## Summary
- support bigint casts in the Racket backend
- make Racket Rosetta script respect `SOURCE_DATE_EPOCH`
- note bigint cast support in the Racket TASKS

## Testing
- `UPDATE=1 go test -v ./compiler/x/racket -run Rosetta -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68779608e45c83209007ee17e9866f15