### PR TITLE
Update Go Rosetta golden tests

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -83,3 +83,5 @@ TPC-H progress:
 - 2025-07-16 01:32 - Added rosetta_golden_test.go and enabled `#` comments in the parser so more Rosetta tasks compile
 - 2025-07-16 11:31 - Handled bool values in `_exists` and added type assertion for unary `!`; regenerated Rosetta Go outputs
 - 2025-07-16 12:45 - Improved indexing on `any` by casting to `map[string]any` or `[]any`; infer simple map types from literals
+- 2025-07-16 12:23 - Enabled full Rosetta golden tests for Go and expanded map
+  inference using `stringKey`; mismatched map literals now unify key/value types

--- a/tests/rosetta/out/Go/100-prisoners.error
+++ b/tests/rosetta/out/Go/100-prisoners.error
@@ -1,4 +1,4 @@
 run: exit status 1
 # command-line-arguments
-/tmp/TestGoCompiler_Rosetta_Golden100-prisoners11273137/001/main.go:103:6: main redeclared in this block
-	/tmp/TestGoCompiler_Rosetta_Golden100-prisoners11273137/001/main.go:93:6: other declaration of main
+/tmp/X/001/main.go:103:6: main redeclared in this block
+	/tmp/X/001/main.go:93:6: other declaration of main

--- a/tests/rosetta/out/Go/15-puzzle-game.error
+++ b/tests/rosetta/out/Go/15-puzzle-game.error
@@ -1,5 +1,5 @@
-parse: error[P999]: /workspace/mochi/tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18: unexpected token "!" (expected PostfixExpr)
-  --> /workspace/mochi/tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18
+parse: error[P999]: tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18: unexpected token "!" (expected PostfixExpr)
+  --> tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18
 
 108 |   while !quit && !isSolved() {
     |                  ^

--- a/types/infer.go
+++ b/types/infer.go
@@ -597,17 +597,17 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 	case p.Map != nil:
 		if len(p.Map.Items) > 0 {
 			st := StructType{Fields: make(map[string]Type), Order: make([]string, len(p.Map.Items))}
-			allId := true
+			allConst := true
 			for i, it := range p.Map.Items {
-				key, ok := identName(it.Key)
+				key, ok := stringKey(it.Key)
 				if !ok {
-					allId = false
+					allConst = false
 					break
 				}
 				st.Fields[key] = ExprType(it.Value, env)
 				st.Order[i] = key
 			}
-			if allId {
+			if allConst {
 				return st
 			}
 		}
@@ -629,10 +629,10 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 					kt = ExprType(it.Key, env)
 				}
 				vt := ExprType(it.Value, env)
-				if !equalTypes(keyType, kt) {
+				if !unify(keyType, kt, nil) {
 					keyType = AnyType{}
 				}
-				if !equalTypes(valType, vt) {
+				if !unify(valType, vt, nil) {
 					valType = AnyType{}
 				}
 			}


### PR DESCRIPTION
## Summary
- run Go Rosetta tests with an adjustable limit
- sanitize temporary paths in `.error` files
- infer map types from string-keyed literals and unify item types
- regenerate a few Rosetta golden errors

## Testing
- `UPDATE=1 ROSETTA_MAX=5 go test ./compiler/x/go -run Rosetta_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68779892aa3c8320a82d121cdf523bd4