### PR TITLE
Add slow build tags

### DIFF
--- a/compiler/meta/meta.go
+++ b/compiler/meta/meta.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package meta
 
 import (

--- a/compiler/x/cpp/helpers.go
+++ b/compiler/x/cpp/helpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/compiler/x/erlang/tools.go
+++ b/compiler/x/erlang/tools.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erlang
 
 import (

--- a/compiler/x/kotlin/testutil_test.go
+++ b/compiler/x/kotlin/testutil_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kotlin_test
 
 import "bytes"

--- a/compiler/x/racket/runtime.go
+++ b/compiler/x/racket/runtime.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package racket
 
 const runtimeHelpers = `(define (_date_number s)

--- a/compiler/x/st/rosetta_golden_test.go
+++ b/compiler/x/st/rosetta_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st_test
 
 import (

--- a/tools/rosetta/mochi_rust_golden_test.go
+++ b/tools/rosetta/mochi_rust_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rosetta
 
 import (


### PR DESCRIPTION
## Summary
- add `slow` build tags to the remaining compiler code
- mark missing Rosetta tests with the `slow` build tag

## Testing
- `go test -tags slow ./... -run=^$` *(fails: mochi/compiler/x/zig [build failed], mochi/scripts [build failed], mochi/tools [build failed])*

------
https://chatgpt.com/codex/tasks/task_e_6877b4cc0e58832089e4bd8da734b37c