### PR TITLE
Run PHP golden tests

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -14,6 +14,8 @@
 - 2025-07-15 06:32 - Added TPC-DS support. Generated PHP outputs for queries q1-q99 (except q51) via compile_tpcds_php.go and added tpcds_golden_test.go.
 - 2025-07-16 00:10 - Added _print helper and FifteenPuzzleExample stub for Rosetta tests.
 - 2025-07-16 12:13 - Generated PHP code for select Rosetta tasks via compile_rosetta_php.go.
+- 2025-07-16 16:20 - Sanitizer now avoids PHP reserved names like `shuffle` and
+  `this` so more Rosetta tasks compile successfully.
 
 ## Remaining Work
 - [ ] Improve runtime helpers for grouping and aggregation

--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -11,6 +11,11 @@ import (
 	"mochi/types"
 )
 
+var reservedNames = map[string]struct{}{
+	"shuffle": {},
+	"this":    {},
+}
+
 func sanitizeName(name string) string {
 	if name == "" {
 		return ""
@@ -25,6 +30,9 @@ func sanitizeName(name string) string {
 	}
 	s := b.String()
 	if s == "" || !((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z') || s[0] == '_') {
+		s = "_" + s
+	}
+	if _, ok := reservedNames[s]; ok {
 		s = "_" + s
 	}
 	return s

--- a/tests/rosetta/out/Php/100-prisoners.error
+++ b/tests/rosetta/out/Php/100-prisoners.error
@@ -1,3 +1,0 @@
-run: exit status 255
-
-Fatal error: Cannot redeclare function shuffle() in /tmp/100-prisoners.php on line 2

--- a/tests/rosetta/out/Php/100-prisoners.php
+++ b/tests/rosetta/out/Php/100-prisoners.php
@@ -1,9 +1,9 @@
 <?php
-function shuffle($xs) {
+function _shuffle($xs) {
     $arr = $xs;
     $i = 99;
     while ($i > 0) {
-        $j = $now() % ($i + 1);
+        $j = time() % ($i + 1);
         $tmp = $arr[$i];
         $arr[$i] = $arr[$j];
         $arr[$j] = $tmp;
@@ -21,7 +21,7 @@ function doTrials($trials, $np, $strategy) {
             $drawers = array_merge($drawers, [$i]);
             $i = $i + 1;
         }
-        $drawers = shuffle($drawers);
+        $drawers = _shuffle($drawers);
         $p = 0;
         $success = true;
         while ($p < $np) {
@@ -30,12 +30,12 @@ function doTrials($trials, $np, $strategy) {
                 $prev = $p;
                 $d = 0;
                 while ($d < 50) {
-                    $this = $drawers[$prev];
-                    if ($this == $p) {
+                    $_this = $drawers[$prev];
+                    if ($_this == $p) {
                         $found = true;
                         break;
                     }
-                    $prev = $this;
+                    $prev = $_this;
                     $d = $d + 1;
                 }
             } else {
@@ -47,9 +47,9 @@ function doTrials($trials, $np, $strategy) {
                 }
                 $d = 0;
                 while ($d < 50) {
-                    $n = $now() % 100;
+                    $n = time() % 100;
                     while ($opened[$n]) {
-                        $n = $now() % 100;
+                        $n = time() % 100;
                     }
                     $opened[$n] = true;
                     if ($drawers[$n] == $p) {


### PR DESCRIPTION
## Summary
- fix PHP name sanitizer to avoid built‑in names
- update PHP Rosetta output for 100-prisoners
- document fix in TASKS

## Testing
- `UPDATE=true go test -tags=slow ./compiler/x/php -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6877a043b3388320aae91884532c02dc