### PR TITLE
Add deterministic now() & extend Rosetta VM tests

### DIFF
--- a/tests/rosetta/x/Mochi/100-prisoners.out
+++ b/tests/rosetta/x/Mochi/100-prisoners.out
@@ -1,8 +1,9 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 2 relative frequency = 0.2%
-  strategy = optimal  pardoned = 309 relative frequency = 30.9%
+  strategy = random  pardoned = 4 relative frequency = 0.4%
+  strategy = optimal  pardoned = 320 relative frequency = 32%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 328 relative frequency = 32.800000000000004%
+  strategy = optimal  pardoned = 286 relative frequency = 28.599999999999998%
+


### PR DESCRIPTION
## Summary
- add environment-based seed for `now()` in the VM so Rosetta examples can be deterministic
- expose `vm.SetNowSeed` for tests
- expand Rosetta VM golden tests and skip flaky examples
- update Rosetta output for 100-prisoners

## Testing
- `go test ./tools/rosetta -tags slow -run TestRosettaVMGolden/100-prisoners -count=1 -v`
- `go test ./tools/rosetta -tags slow -run TestRosettaVMGolden/100-doors-2 -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_6877b54f499c8320bfe7bbf0d1419660