### PR TITLE
Run Rosetta golden tests for Scheme

### DIFF
--- a/compiler/x/scheme/TASKS.md
+++ b/compiler/x/scheme/TASKS.md
@@ -13,6 +13,8 @@ The Scheme backend now targets chibi-scheme and can compile the `tpc-h/q1.mochi`
   variable handling to avoid runtime errors.
 - 2025-07-16 12:20 – Implemented `now()` builtin using `(chibi time)` to reduce
   runtime failures when compiling Rosetta examples.
+- 2025-07-16 12:45 – Integer division now uses `quotient` when operands are
+  integers, reducing runtime errors for several Rosetta tasks.
 
 ### Remaining Work
 - [ ] Better handling of date comparisons and sorting when running JOB benchmarks


### PR DESCRIPTION
## Summary
- improve Scheme compiler binary expression handling
- add float type inference helpers
- note integer division improvement in TASKS

## Testing
- `go test ./compiler/x/scheme -run Rosetta -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_6877a4fbc8f08320bd5f4cd0c4b911a2