### PR TITLE
Fix VM test runner

### DIFF
--- a/tests/vm_extended/valid/bigint_ops.ir.out
+++ b/tests/vm_extended/valid/bigint_ops.ir.out
@@ -1,33 +1,35 @@
-func main (regs=11)
+func main (regs=13)
   // let a: bigint = 10
   Const        r0, 10
   Cast         r1, r0, bigint
+  Move         r2, r1
   // let b: bigint = 5
-  Const        r2, 5
-  Cast         r3, r2, bigint
+  Const        r3, 5
+  Cast         r4, r3, bigint
+  Move         r5, r4
   // print(a + b)
-  Const        r4, 10
-  Const        r5, 5
-  Add          r6, r4, r5
-  Print        r6
-  // print(a - b)
-  Const        r4, 10
-  Const        r5, 5
-  Sub          r7, r4, r5
-  Print        r7
-  // print(a * b)
-  Const        r4, 10
-  Const        r5, 5
-  Mul          r8, r4, r5
+  Const        r6, 10
+  Const        r7, 5
+  Add          r8, r6, r7
   Print        r8
-  // print(a / b)
-  Const        r4, 10
-  Const        r5, 5
-  Div          r9, r4, r5
+  // print(a - b)
+  Const        r6, 10
+  Const        r7, 5
+  Sub          r9, r6, r7
   Print        r9
-  // print(a % b)
-  Const        r4, 10
-  Const        r5, 5
-  Mod          r10, r4, r5
+  // print(a * b)
+  Const        r6, 10
+  Const        r7, 5
+  Mul          r10, r6, r7
   Print        r10
+  // print(a / b)
+  Const        r6, 10
+  Const        r7, 5
+  Div          r11, r6, r7
+  Print        r11
+  // print(a % b)
+  Const        r6, 10
+  Const        r7, 5
+  Mod          r12, r6, r7
+  Print        r12
   Return       r0


### PR DESCRIPTION
## Summary
- fix VM runner to supply zero values for parameters
- simplify func compiler initialization and parameter handling
- update bigint IR golden file

## Testing
- `go test ./tests/vm_extended -run TestVM_BigInt -v`
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_6877c3a797748320a311cf7435ae8e0a