### PR TITLE
Add Racket golden tests and runtime enhancements

### DIFF
--- a/compiler/x/racket/TASKS.md
+++ b/compiler/x/racket/TASKS.md
@@ -2,6 +2,9 @@
 
 Recent enhancements:
 
+- 2025-08-30 05:04 - Added golden tests for `tests/vm/valid` to
+  verify generated Racket code and runtime output.
+
 - 2025-07-25 05:04 - Compiler now supports casts to and from `bigint`
   and honors `SOURCE_DATE_EPOCH` for reproducible outputs.
 

--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -105,7 +105,7 @@ func (c *Compiler) compileStmtFull(s *parser.Statement, breakLbl, contLbl, retLb
 		return nil
 	case s.Let != nil:
 		name := s.Let.Name
-		expr := "0"
+		expr := "(void)"
 		if s.Let.Value != nil {
 			v, err := c.compileExpr(s.Let.Value)
 			if err != nil {
@@ -162,7 +162,7 @@ func (c *Compiler) compileStmtFull(s *parser.Statement, breakLbl, contLbl, retLb
 		c.writeln(fmt.Sprintf("(set! %s %s)", s.Assign.Name, val))
 	case s.Var != nil:
 		name := s.Var.Name
-		expr := "0"
+		expr := "(void)"
 		if s.Var.Value != nil {
 			v, err := c.compileExpr(s.Var.Value)
 			if err != nil {
@@ -512,10 +512,11 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			if len(args) == 0 {
 				return "", fmt.Errorf("print expects at least 1 arg")
 			}
+			c.needRuntime = true
 			if len(args) == 1 {
-				return fmt.Sprintf("(displayln %s)", args[0]), nil
+				return fmt.Sprintf("(displayln (_to_string %s))", args[0]), nil
 			}
-			return fmt.Sprintf("(displayln (string-join (map ~a (list %s)) \" \"))",
+			return fmt.Sprintf("(displayln (string-join (map _to_string (list %s)) \" \"))",
 				strings.Join(args, " ")), nil
 		case "append":
 			if len(args) != 2 {

--- a/compiler/x/racket/runtime.go
+++ b/compiler/x/racket/runtime.go
@@ -10,7 +10,13 @@ const runtimeHelpers = `(define (_date_number s)
            (string->number (list-ref parts 2)))
         #f)))
 
-(define (_to_string v) (format "~a" v))
+(define (_to_string v)
+  (cond
+    [(eq? v #t) "true"]
+    [(eq? v #f) "false"]
+    [(void? v) "<nil>"]
+    [(list? v) (string-join (map _to_string v) " ")]
+    [else (format "~a" v)]))
 
 (define (_lt a b)
   (cond

--- a/compiler/x/racket/vm_golden_test.go
+++ b/compiler/x/racket/vm_golden_test.go
@@ -1,0 +1,78 @@
+package racket_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	rack "mochi/compiler/x/racket"
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestRacketCompiler_VM_Code_Golden compiles each program under tests/vm/valid
+// to Racket source and compares with the .rkt.out golden files.
+func TestRacketCompiler_VM_Code_Golden(t *testing.T) {
+	if err := rack.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	golden.Run(t, "tests/vm/valid", ".mochi", ".rkt.out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		code, err := rack.New().Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("compile error: %w", err)
+		}
+		return code, nil
+	})
+}
+
+// TestRacketCompiler_VM_Run_Golden compiles and executes each program under
+// tests/vm/valid and compares the runtime output with the .out files.
+func TestRacketCompiler_VM_Run_Golden(t *testing.T) {
+	if err := rack.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+		prog, err := parser.Parse(src)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: %w", err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			return nil, fmt.Errorf("type error: %v", errs[0])
+		}
+		code, err := rack.New().Compile(prog)
+		if err != nil {
+			return nil, fmt.Errorf("compile error: %w", err)
+		}
+		tmp, err := os.CreateTemp("", "mochi_*.rkt")
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(tmp.Name())
+		if _, err := tmp.Write(code); err != nil {
+			return nil, err
+		}
+		tmp.Close()
+		cmd := exec.Command("racket", tmp.Name())
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return out, fmt.Errorf("run error: %w", err)
+		}
+		return bytes.TrimSpace(out), nil
+	})
+}


### PR DESCRIPTION
## Summary
- add VM golden tests for the Racket backend
- improve print handling using `_to_string`
- initialize unassigned variables with `(void)`
- document new progress in `TASKS.md`

## Testing
- `go test ./compiler/x/racket -run VM_ -tags=slow -count=1` *(fails: numerous golden mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6877c4a0014083209d7620fc7f9a9609