### PR TITLE
Add Scala VM golden tests

### DIFF
--- a/compiler/x/scala/TASKS.md
+++ b/compiler/x/scala/TASKS.md
@@ -12,6 +12,7 @@
 - 2025-07-17 05:20 - `substring` now accepts `bigint` indices to avoid false type errors during Rosetta tests
 - 2025-07-18 12:14 - Added `padStart` builtin and Scala code generation support to reduce Rosetta compile errors
 - 2025-07-19 00:30 - Handle `padStart` as string method and keep string type during concatenation to reduce `.error` files
+- 2025-07-20 00:10 - Added golden tests for `tests/vm/valid` and propagated list element types with `SetVarDeep`
 
 ## Remaining Work
 - [ ] Review generated Scala for idiomatic improvements

--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -1542,7 +1542,7 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 				if lt, ok2 := vt.(types.ListType); ok2 {
 					if _, any := lt.Elem.(types.AnyType); any {
 						elemT := c.namedType(types.ExprType(call.Args[1], c.env))
-						c.env.SetVar(name, types.ListType{Elem: elemT}, true)
+						c.env.SetVarDeep(name, types.ListType{Elem: elemT}, true)
 					}
 				}
 			}

--- a/compiler/x/scala/vm_golden_test.go
+++ b/compiler/x/scala/vm_golden_test.go
@@ -1,0 +1,70 @@
+package scalacode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	scalacode "mochi/compiler/x/scala"
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/types"
+)
+
+func TestScalaCompilerVMValid(t *testing.T) {
+	if _, err := exec.LookPath("scalac"); err != nil {
+		t.Skip("scalac not installed")
+	}
+	root := findRepoRoot(t)
+	outDir := filepath.Join(root, "tests", "machine", "x", "scala")
+	os.MkdirAll(outDir, 0o755)
+
+	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		codePath := filepath.Join(outDir, name+".scala")
+		outPath := filepath.Join(outDir, name+".out")
+		errPath := filepath.Join(outDir, name+".error")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0o644)
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
+			return nil, errs[0]
+		}
+		code, err := scalacode.New(env).Compile(prog)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0o644)
+			return nil, err
+		}
+		if err := os.WriteFile(codePath, code, 0o644); err != nil {
+			return nil, err
+		}
+		tmp := t.TempDir()
+		if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
+			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		cmd := exec.Command("scala", "-cp", tmp, name)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		var runOut bytes.Buffer
+		cmd.Stdout = &runOut
+		cmd.Stderr = &runOut
+		if err := cmd.Run(); err != nil {
+			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), runOut.Bytes()...), 0o644)
+			return nil, err
+		}
+		outBytes := bytes.TrimSpace(runOut.Bytes())
+		os.WriteFile(outPath, outBytes, 0o644)
+		os.Remove(errPath)
+		return outBytes, nil
+	})
+}

--- a/types/env.go
+++ b/types/env.go
@@ -163,6 +163,18 @@ func (e *Env) SetVar(name string, typ Type, mutable bool) {
 	e.mut[name] = mutable
 }
 
+// SetVarDeep updates the type of an existing variable in the current
+// environment or any parent scope. If the variable is not already defined,
+// it is created in the current scope.
+func (e *Env) SetVarDeep(name string, typ Type, mutable bool) {
+	if _, ok := e.types[name]; ok || e.parent == nil {
+		e.types[name] = typ
+		e.mut[name] = mutable
+		return
+	}
+	e.parent.SetVarDeep(name, typ, mutable)
+}
+
 // GetVar looks up a variable's static type.
 func (e *Env) GetVar(name string) (Type, error) {
 	if t, ok := e.types[name]; ok {


### PR DESCRIPTION
## Summary
- enhance type environment with `SetVarDeep`
- propagate list element type during `append` calls
- implement Scala golden tests for `tests/vm/valid`
- document latest work in Scala compiler tasks

## Testing
- `go test ./compiler/x/scala -run TestScalaCompilerVMValid/group_items_iteration -tags=slow -count=1` *(fails: process error)*

------
https://chatgpt.com/codex/tasks/task_e_6877c4c98b808320a3ab6b56949b6d04