### PR TITLE
Add release notes for v0.10.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # 📦 CHANGELOG.md
+## [0.10.27] – 2025-07-16T22:58:30+07:00
+
+### Added
+
+* Rosetta Code golden tests across compilers with VM runner
+* Deterministic `now` builtin for reproducible timestamps
+* `sha256` builtin for the C backend
+* Virtual machine global variable support
+
+### Changed
+
+* PHP and Kotlin escape reserved names and keywords
+* Go and C++ improve indexing and collections
+* Ex compiler adds length helper; Lua provides FFI print helpers
+* C backend aliases `main` to avoid duplicate entries
+
+### Fixed
+
+* Fortran newline strings and void function handling
+* Outer join sort corrected for TypeScript
+* Join length calculation fixed in the C backend
+* Faster compilation for packages with slow build tags
+
 ## [0.10.26] – 2025-07-14T19:44:27+07:00
 
 ### Added

--- a/releases/v0.10.27.md
+++ b/releases/v0.10.27.md
@@ -1,0 +1,28 @@
+# Jul 2025 (v0.10.27)
+
+Released on Wed Jul 16 22:58:30 2025 +0700.
+
+Mochi v0.10.27 expands Rosetta Code coverage with deterministic outputs and new
+virtual machine features while refining compilers across languages.
+
+## Examples
+
+- Rosetta Code programs compiled across languages with golden tests
+- Deterministic `now()` builtin ensures reproducible timestamps
+- Machine outputs refreshed for datasets and tasks
+
+## Compilers
+
+- Virtual machine adds global variable support and entry aliasing
+- `sha256` builtin and join length fixes in the C backend
+- Reserved names escaped in PHP and keywords handled in Kotlin
+- Struct literals for Smalltalk and FFI print helpers for Lua
+
+## Runtime
+
+- Rosetta VM test runner executes programs consistently
+- Fortran newline handling corrected for generated code
+
+## Documentation
+
+- Machine READMEs updated with Rosetta tasks and slow build tags


### PR DESCRIPTION
## Summary
- document release v0.10.27
- update changelog with v0.10.27 entry

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_6877cc63613c8320945ad53206feee69