### PR TITLE
Add C VM golden test

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -113,3 +113,6 @@ should compile and run successfully.
 - 2025-09-02 12:00 - Added sha256 built-in and rosetta golden tests for C compiler
 - 2025-09-03 10:00 - Fixed append assignment to drop constant list tracking so loops like `100-doors.mochi` compile and run
 - 2025-09-05 15:10 - Renamed runtime entry to `_mochi_main` and aliased user `main` functions to avoid duplicate symbols in Rosetta tests
+- 2025-09-06 00:20 - Added VM golden tests for `tests/vm/valid` and included
+  JSON helpers when compiling `save` expressions so `save_jsonl_stdout.mochi`
+  compiles successfully.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -2175,7 +2175,10 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) string {
 	if s.Path != nil {
 		path = fmt.Sprintf("%q", *s.Path)
 	}
+	// include JSON helpers so map_string types and _isnum are defined
 	c.need(needSaveJSON)
+	c.need(needLoadJSON)
+	c.need(needMapStringInt)
 	c.need(needStringHeader)
 	return fmt.Sprintf("_save_json(%s, %s)", src, path)
 }

--- a/compiler/x/c/job_golden_test.go
+++ b/compiler/x/c/job_golden_test.go
@@ -17,10 +17,10 @@ import (
 	"mochi/types"
 )
 
-var update = flag.Bool("update", false, "update golden files")
+var jobUpdate = flag.Bool("update-job", false, "update golden files")
 
 func shouldUpdate() bool {
-	f := flag.Lookup("update")
+	f := flag.Lookup("update-job")
 	return f != nil && f.Value.String() == "true"
 }
 

--- a/compiler/x/c/vm_golden_test.go
+++ b/compiler/x/c/vm_golden_test.go
@@ -1,0 +1,97 @@
+//go:build slow
+
+package ccode_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ccode "mochi/compiler/x/c"
+	"mochi/golden"
+	"mochi/parser"
+	"mochi/types"
+)
+
+// TestCCompiler_VMValid_Golden compiles programs under tests/vm/valid
+// to C, executes them with the system C compiler and compares the
+// generated code and output against golden files under tests/machine/x/c.
+func TestCCompiler_VMValid_Golden(t *testing.T) {
+	cc, err := ccode.EnsureCC()
+	if err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	root := findRepoRootVM(t)
+	outDir := filepath.Join(root, "tests", "machine", "x", "c")
+	os.MkdirAll(outDir, 0o755)
+
+	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		codePath := filepath.Join(outDir, base+".c")
+		outPath := filepath.Join(outDir, base+".out")
+		errPath := filepath.Join(outDir, base+".error")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0o644)
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
+			return nil, errs[0]
+		}
+		os.Setenv("SOURCE_DATE_EPOCH", "1136214245")
+		code, err := ccode.New(env).Compile(prog)
+		if err != nil {
+			os.WriteFile(errPath, []byte(err.Error()), 0o644)
+			return nil, err
+		}
+		if err := os.WriteFile(codePath, code, 0o644); err != nil {
+			return nil, err
+		}
+		tmp := t.TempDir()
+		exe := filepath.Join(tmp, base)
+		if out, err := exec.Command(cc, codePath, "-o", exe).CombinedOutput(); err != nil {
+			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		cmd := exec.Command(exe)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		if err := cmd.Run(); err != nil {
+			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), buf.Bytes()...), 0o644)
+			return nil, err
+		}
+		outBytes := bytes.TrimSpace(buf.Bytes())
+		os.WriteFile(outPath, outBytes, 0o644)
+		os.Remove(errPath)
+		return outBytes, nil
+	})
+}
+
+func findRepoRootVM(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}


### PR DESCRIPTION
## Summary
- add golden test for C compiler for `tests/vm/valid`
- include extra JSON helpers when compiling `save` expressions
- avoid flag collision in JOB golden tests
- document work in `TASKS.md`

## Testing
- `go test -tags=slow ./compiler/x/c -run TestCCompiler_VMValid_Golden -count=1` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6877cf98ed448320a40ead5275a041b1