### PR TITLE
Add Ruby VM golden tests

### DIFF
--- a/compiler/x/rb/TASKS.md
+++ b/compiler/x/rb/TASKS.md
@@ -13,6 +13,10 @@
 - 2025-07-16 15:30 - Added `vm_golden_test.go` for programs in `tests/vm/valid`
   to verify generated Ruby code and runtime output. Regenerated `.rb` and `.out`
   files with the `-update` flag.
+- 2025-07-18 12:00 - Tweaked `_group_by` runtime helper to always unwrap joined
+  rows which reduces `.error` files for dataset queries.
+- 2025-07-20 09:15 - Removed obsolete `compiler_test.go` in favor of
+  `vm_golden_test.go` and verified VM tests pass.
 
 ## Progress (2025-07-15 04:48)
 - Recompiled `tpc-h` queries `q4`-`q22` using the updated compiler.

--- a/compiler/x/rb/compiler_test.go
+++ b/compiler/x/rb/compiler_test.go
@@ -6,16 +6,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
-
-	rbcode "mochi/compiler/x/rb"
-	"mochi/parser"
-	"mochi/types"
 )
 
 func findRepoRoot(t *testing.T) string {
@@ -58,52 +52,4 @@ func writeError(dir, name string, code, stderr []byte) {
 		fmt.Fprintf(&buf, "%d: %s\n", i+1, lines[i])
 	}
 	os.WriteFile(filepath.Join(dir, name+".error"), buf.Bytes(), 0644)
-}
-
-func TestCompileValidPrograms(t *testing.T) {
-	if _, err := exec.LookPath("ruby"); err != nil {
-		t.Skip("ruby not installed")
-	}
-	root := findRepoRoot(t)
-	pattern := filepath.Join(root, "tests", "vm", "valid", "*.mochi")
-	files, err := filepath.Glob(pattern)
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-	outDir := filepath.Join(root, "tests", "machine", "x", "rb")
-	os.MkdirAll(outDir, 0755)
-	for _, src := range files {
-		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
-		t.Run(name, func(t *testing.T) {
-			prog, err := parser.Parse(src)
-			if err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
-			env := types.NewEnv(nil)
-			if errs := types.Check(prog, env); len(errs) > 0 {
-				t.Fatalf("type error: %v", errs[0])
-			}
-			code, err := rbcode.New(env).Compile(prog)
-			if err != nil {
-				t.Fatalf("compile error: %v", err)
-			}
-			codePath := filepath.Join(outDir, name+".rb")
-			if err := os.WriteFile(codePath, code, 0644); err != nil {
-				t.Fatalf("write code: %v", err)
-			}
-			cmd := exec.Command("ruby", codePath)
-			cmd.Dir = root
-			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
-				cmd.Stdin = bytes.NewReader(data)
-			}
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				writeError(outDir, name, code, out)
-				t.Logf("ruby run error: %v\n%s", err, out)
-				return
-			}
-			out = bytes.TrimSpace(out)
-			os.WriteFile(filepath.Join(outDir, name+".out"), out, 0644)
-		})
-	}
 }


### PR DESCRIPTION
## Summary
- remove obsolete Ruby compiler tests
- document golden tests in Ruby TASKS notes

## Testing
- `go test ./compiler/x/rb -run VMValid -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_6877d0c9f7108320a82607c2cac3e9e6