### PR TITLE
Add final v0.10.27 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Rosetta Code golden tests across compilers with VM runner
 * Deterministic `now` builtin for reproducible timestamps
 * `sha256` builtin for the C backend
-* Virtual machine global variable support
+* Virtual machine global variable support and entry aliasing
+* Struct literals supported in the Smalltalk backend
 
 ### Changed
 

--- a/releases/v0.10.27.md
+++ b/releases/v0.10.27.md
@@ -17,11 +17,14 @@ virtual machine features while refining compilers across languages.
 - `sha256` builtin and join length fixes in the C backend
 - Reserved names escaped in PHP and keywords handled in Kotlin
 - Struct literals for Smalltalk and FFI print helpers for Lua
+- Go and C++ indexing and collection improvements
+- Ex compiler length helper and TypeScript outer joins sort correctly
 
 ## Runtime
 
 - Rosetta VM test runner executes programs consistently
 - Fortran newline handling corrected for generated code
+- Faster compilation when packages include slow build tags
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- document new release notes for v0.10.27
- update the CHANGELOG entry

## Testing
- `go test ./compiler/x/ex` *(fails: build constraints exclude all Go files)*

------
https://chatgpt.com/codex/tasks/task_e_6877d8e99b988320aad16e5cc8dfff1d