### PR TITLE
Improve Scala VM golden tests

### DIFF
--- a/compiler/x/scala/TASKS.md
+++ b/compiler/x/scala/TASKS.md
@@ -13,6 +13,7 @@
 - 2025-07-18 12:14 - Added `padStart` builtin and Scala code generation support to reduce Rosetta compile errors
 - 2025-07-19 00:30 - Handle `padStart` as string method and keep string type during concatenation to reduce `.error` files
 - 2025-07-20 00:10 - Added golden tests for `tests/vm/valid` and propagated list element types with `SetVarDeep`
+- 2025-07-20 12:00 - VM golden tests now read expected output from `tests/machine/x/scala`; removed duplicate machine test
 
 ## Remaining Work
 - [ ] Review generated Scala for idiomatic improvements

--- a/compiler/x/scala/compiler_test.go
+++ b/compiler/x/scala/compiler_test.go
@@ -5,15 +5,10 @@ package scalacode_test
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	scalacode "mochi/compiler/x/scala"
 	"mochi/golden"
-	"mochi/parser"
-	"mochi/types"
 )
 
 func findRepoRoot(t *testing.T) string {
@@ -33,59 +28,6 @@ func findRepoRoot(t *testing.T) string {
 	}
 	t.Fatal("go.mod not found (not in Go module)")
 	return ""
-}
-
-func TestScalaCompilerMachine(t *testing.T) {
-	if _, err := exec.LookPath("scalac"); err != nil {
-		t.Skip("scalac not installed")
-	}
-	root := findRepoRoot(t)
-	srcDir := filepath.Join(root, "tests", "vm", "valid")
-	files, err := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-	outDir := filepath.Join(root, "tests", "machine", "x", "scala")
-	os.MkdirAll(outDir, 0755)
-
-	for _, src := range files {
-		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
-		t.Run(name, func(t *testing.T) {
-			codePath := filepath.Join(outDir, name+".scala")
-			outPath := filepath.Join(outDir, name+".out")
-			errPath := filepath.Join(outDir, name+".error")
-			prog, err := parser.Parse(src)
-			if err != nil {
-				os.WriteFile(errPath, []byte(err.Error()), 0644)
-				t.Skip("parse error")
-			}
-			env := types.NewEnv(nil)
-			if errs := types.Check(prog, env); len(errs) > 0 {
-				os.WriteFile(errPath, []byte(errs[0].Error()), 0644)
-				t.Skip("type error")
-			}
-			code, err := scalacode.New(env).Compile(prog)
-			if err != nil {
-				os.WriteFile(errPath, []byte(err.Error()), 0644)
-				t.Skip("compile error")
-			}
-			os.WriteFile(codePath, code, 0644)
-			tmp := t.TempDir()
-			if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
-				os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0644)
-				t.Skip("scalac failed")
-			}
-			cmd := exec.Command("scala", "-cp", tmp, name)
-			var runOut bytes.Buffer
-			cmd.Stdout = &runOut
-			cmd.Stderr = &runOut
-			if err := cmd.Run(); err != nil {
-				os.WriteFile(errPath, append([]byte(err.Error()+"\n"), runOut.Bytes()...), 0644)
-				t.Skip("run failed")
-			}
-			os.WriteFile(outPath, runOut.Bytes(), 0644)
-		})
-	}
 }
 
 func TestScalaCompilerGolden(t *testing.T) {

--- a/compiler/x/scala/vm_golden_test.go
+++ b/compiler/x/scala/vm_golden_test.go
@@ -1,7 +1,10 @@
+//go:build slow
+
 package scalacode_test
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,62 +12,89 @@ import (
 	"testing"
 
 	scalacode "mochi/compiler/x/scala"
-	"mochi/golden"
 	"mochi/parser"
 	"mochi/types"
 )
+
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
+}
 
 func TestScalaCompilerVMValid(t *testing.T) {
 	if _, err := exec.LookPath("scalac"); err != nil {
 		t.Skip("scalac not installed")
 	}
 	root := findRepoRoot(t)
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
 	outDir := filepath.Join(root, "tests", "machine", "x", "scala")
 	os.MkdirAll(outDir, 0o755)
 
-	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no source files")
+	}
+	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
-		codePath := filepath.Join(outDir, name+".scala")
-		outPath := filepath.Join(outDir, name+".out")
-		errPath := filepath.Join(outDir, name+".error")
+		t.Run(name, func(t *testing.T) {
+			codePath := filepath.Join(outDir, name+".scala")
+			wantPath := filepath.Join(outDir, name+".out")
+			errPath := filepath.Join(outDir, name+".error")
 
-		prog, err := parser.Parse(src)
-		if err != nil {
-			os.WriteFile(errPath, []byte(err.Error()), 0o644)
-			return nil, err
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
-			return nil, errs[0]
-		}
-		code, err := scalacode.New(env).Compile(prog)
-		if err != nil {
-			os.WriteFile(errPath, []byte(err.Error()), 0o644)
-			return nil, err
-		}
-		if err := os.WriteFile(codePath, code, 0o644); err != nil {
-			return nil, err
-		}
-		tmp := t.TempDir()
-		if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
-			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
-			return nil, err
-		}
-		cmd := exec.Command("scala", "-cp", tmp, name)
-		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
-			cmd.Stdin = bytes.NewReader(data)
-		}
-		var runOut bytes.Buffer
-		cmd.Stdout = &runOut
-		cmd.Stderr = &runOut
-		if err := cmd.Run(); err != nil {
-			os.WriteFile(errPath, append([]byte(err.Error()+"\n"), runOut.Bytes()...), 0o644)
-			return nil, err
-		}
-		outBytes := bytes.TrimSpace(runOut.Bytes())
-		os.WriteFile(outPath, outBytes, 0o644)
-		os.Remove(errPath)
-		return outBytes, nil
-	})
+			prog, err := parser.Parse(src)
+			if err != nil {
+				os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("parse error: %v", err)
+			}
+			env := types.NewEnv(nil)
+			if errs := types.Check(prog, env); len(errs) > 0 {
+				os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
+				t.Fatalf("type error: %v", errs[0])
+			}
+			code, err := scalacode.New(env).Compile(prog)
+			if err != nil {
+				os.WriteFile(errPath, []byte(err.Error()), 0o644)
+				t.Fatalf("compile error: %v", err)
+			}
+			if err := os.WriteFile(codePath, code, 0o644); err != nil {
+				t.Fatalf("write code: %v", err)
+			}
+			tmp := t.TempDir()
+			if out, err := exec.Command("scalac", "-d", tmp, codePath).CombinedOutput(); err != nil {
+				os.WriteFile(errPath, append([]byte(err.Error()+"\n"), out...), 0o644)
+				t.Fatalf("scalac error: %v", err)
+			}
+			cmd := exec.Command("scala", "-cp", tmp, name)
+			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+				cmd.Stdin = bytes.NewReader(data)
+			}
+			var runOut bytes.Buffer
+			cmd.Stdout = &runOut
+			cmd.Stderr = &runOut
+			if err := cmd.Run(); err != nil {
+				os.WriteFile(errPath, append([]byte(err.Error()+"\n"), runOut.Bytes()...), 0o644)
+				t.Fatalf("run error: %v", err)
+			}
+			outBytes := bytes.TrimSpace(runOut.Bytes())
+			if shouldUpdate() {
+				if err := os.WriteFile(wantPath, append(outBytes, '\n'), 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				os.Remove(errPath)
+				return
+			}
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatalf("read golden: %v", err)
+			}
+			want = bytes.TrimSpace(want)
+			if !bytes.Equal(outBytes, want) {
+				t.Errorf("%s\n\n--- Got ---\n%s\n\n--- Want ---\n%s\n", name, outBytes, want)
+			}
+			os.Remove(errPath)
+		})
+	}
 }

--- a/tests/machine/x/scala/group_items_iteration.error
+++ b/tests/machine/x/scala/group_items_iteration.error
@@ -1,12 +1,5 @@
 exit status 1
-/workspace/mochi/tests/machine/x/scala/group_items_iteration.scala:17: error: type mismatch;
- found   : scala.collection.mutable.ArrayBuffer[group_items_iteration.Auto1]
- required: scala.collection.mutable.ArrayBuffer[Nothing]
-Note: group_items_iteration.Auto1 >: Nothing, but class ArrayBuffer is invariant in type A.
-You may wish to investigate a wildcard type such as `_ >: Nothing`. (SLS 3.2.10)
-      tmp = tmp :+ Auto1(tag = g.key, total = total)
-                ^
-/workspace/mochi/tests/machine/x/scala/group_items_iteration.scala:19: error: value tag is not a member of Nothing
+/workspace/mochi/tests/machine/x/scala/group_items_iteration.scala:19: error: value tag is not a member of Any
     val result = (for { r <- tmp } yield r).sortBy(r => r.tag).map(r => r)
                                                           ^
-two errors found
+one error found


### PR DESCRIPTION
## Summary
- adjust Scala compiler golden tests to read output from tests/machine/x/scala
- drop duplicate Scala machine compilation tests
- document VM golden test path in TASKS
- update failing error log for group_items_iteration

## Testing
- `go test -tags slow ./compiler/x/scala -run TestScalaCompilerVMValid/append_builtin -v`
- `go test -tags slow ./compiler/x/scala -run TestScalaCompilerVMValid/group_items_iteration -v` (fails)

------
https://chatgpt.com/codex/tasks/task_e_6877d1633914832093f03cdbd910ccdc