### PR TITLE
Fix deterministic now() for vm

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -1242,7 +1242,7 @@ func (m *VM) call(fnIndex int, args []Value, trace []StackFrame) (Value, error) 
 			fmt.Fprintln(m.writer, strings.TrimSpace(sb.String()))
 		case OpNow:
 			if seededNow {
-				nowSeed = nowSeed*1664525 + 1013904223
+				nowSeed = (nowSeed*1664525 + 1013904223) % 2147483647
 				fr.regs[ins.A] = Value{Tag: ValueInt, Int: int(nowSeed)}
 			} else {
 				fr.regs[ins.A] = Value{Tag: ValueInt, Int: int(time.Now().UnixNano())}

--- a/tests/rosetta/x/Mochi/24-game-solve.out
+++ b/tests/rosetta/x/Mochi/24-game-solve.out
@@ -18,3 +18,4 @@ No solution
 No solution
 :  
 No solution
+

--- a/tests/rosetta/x/Mochi/24-game.out
+++ b/tests/rosetta/x/Mochi/24-game.out
@@ -1,4 +1,5 @@
-Your numbers: 2368
+Your numbers: 1336
 
 Enter RPN: 
 invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)
+


### PR DESCRIPTION
## Summary
- fix `now()` RNG in vm to avoid negative numbers
- update 24-game golden output

## Testing
- `go test ./tools/rosetta -run TestRosettaVMGolden/24-game -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6877d2dba5848320869f335365e2176b