### PR TITLE
Add VM golden tests update

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -87,3 +87,4 @@ TPC-H progress:
   inference using `stringKey`; mismatched map literals now unify key/value types
 - 2025-07-16 13:10 - Added VM golden tests for valid programs and removed stale `.error` files after successful runs
 - 2025-07-16 16:55 - Stabilised VM valid golden tests with fixed header time; new failing cases logged.
+- 2025-07-16 17:25 - Regenerated VM golden outputs after fixing dataset sort and typed examples; `TestVMValidPrograms` now passes.

--- a/tests/vm/valid/dataset_where_filter.out
+++ b/tests/vm/valid/dataset_where_filter.out
@@ -1,4 +1,4 @@
 --- Adults ---
-Alice is 30 
+Alice is 30
 Charlie is 65  (senior)
 Diana is 45

--- a/tests/vm/valid/save_jsonl_stdout.out
+++ b/tests/vm/valid/save_jsonl_stdout.out
@@ -1,2 +1,2 @@
-{"name":"Alice","age":30}
-{"name":"Bob","age":25}
+{"age":30,"name":"Alice"}
+{"age":25,"name":"Bob"}

--- a/tests/vm/valid/typed_let.out
+++ b/tests/vm/valid/typed_let.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/valid/typed_var.out
+++ b/tests/vm/valid/typed_var.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -24,52 +24,6 @@ func shouldUpdate() bool {
 	return f != nil && f.Value.String() == "true"
 }
 
-func TestVM_ValidPrograms(t *testing.T) {
-	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
-		if err != nil {
-			return nil, fmt.Errorf("parse error: %w", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("type error: %v", errs[0])
-		}
-		p, err := vm.Compile(prog, env)
-		if err != nil {
-			return nil, fmt.Errorf("compile error: %w", err)
-		}
-		var out bytes.Buffer
-		m := vm.New(p, &out)
-		if err := m.Run(); err != nil {
-			return nil, fmt.Errorf("run error: %w", err)
-		}
-		return bytes.TrimSpace(out.Bytes()), nil
-	})
-}
-
-func TestVM_IR(t *testing.T) {
-	golden.Run(t, "tests/vm/valid", ".mochi", ".ir.out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
-		if err != nil {
-			return nil, fmt.Errorf("parse error: %w", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("type error: %v", errs[0])
-		}
-		p, err := vm.Compile(prog, env)
-		if err != nil {
-			return nil, fmt.Errorf("compile error: %w", err)
-		}
-		data, err := os.ReadFile(src)
-		if err != nil {
-			return nil, err
-		}
-		ir := p.Disassemble(string(data))
-		return []byte(ir), nil
-	})
-}
-
 func TestVM_Fetch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- regenerate VM golden outputs
- remove duplicate runtime tests from `tests/vm/vm_test.go`
- document update in Go compiler TASKS

## Testing
- `go test ./runtime/vm -tags slow -run TestVMValidPrograms -count=1 -v`
- `go test ./runtime/vm -tags slow -run TestVMIRGolden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6877de7328908320a8d4d79782886cda