### PR TITLE
Add VM golden tests for C++

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -36,6 +36,12 @@
 - Added fallback scalar type inference for struct fields referencing query
   variables when their struct information is missing.
 
+## Recent Enhancements (2025-07-16 17:29 UTC)
+- Simplified VM golden tests to check only runtime output and always emit
+  generated `.cpp` and `.out` files.
+- Improved `defineStruct` to replace field types referencing variables using
+  either `varStruct` or `elemType` information.
+
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.
 - [ ] Implement additional TPCH optimizations.

--- a/tests/machine/x/cpp/cross_join.error
+++ b/tests/machine/x/cpp/cross_join.error
@@ -1,21 +1,21 @@
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:16:12: error: ‘o’ was not declared in this scope
    16 |   decltype(o.id) orderId;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:17:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:17:12: error: ‘o’ was not declared in this scope
    17 |   decltype(o.customerId) orderCustomerId;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:17:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:18:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:17:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:18:12: error: ‘c’ was not declared in this scope
    18 |   decltype(c.name) pairedCustomerName;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:18:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:19:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:18:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:19:12: error: ‘o’ was not declared in this scope
    19 |   decltype(o.total) orderTotal;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:19:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldencross_join2429111127/001/prog.cpp:31:56: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:19:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/cross_join.cpp:31:56: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    31 |         __items.push_back(Result{o.id, o.customerId, c.name, o.total});
       |                                                      ~~^~~~
       |                                                        |

--- a/tests/machine/x/cpp/cross_join_filter.error
+++ b/tests/machine/x/cpp/cross_join_filter.error
@@ -1,13 +1,13 @@
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp:22:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp:22:12: error: ‘n’ was not declared in this scope
    22 |   decltype(n) n;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp:22:12: error: ‘n’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp:23:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp:22:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp:23:12: error: ‘l’ was not declared in this scope
    23 |   decltype(l) l;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp:23:12: error: ‘l’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_filter844619513/001/prog.cpp:34:35: error: cannot convert ‘std::any’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp:23:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/cross_join_filter.cpp:34:35: error: cannot convert ‘std::any’ to ‘int’ in initialization
    34 |         __items.push_back(Pair{n, l});
       |                                   ^
       |                                   |

--- a/tests/machine/x/cpp/cross_join_triple.error
+++ b/tests/machine/x/cpp/cross_join_triple.error
@@ -1,17 +1,17 @@
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:22:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:22:12: error: ‘n’ was not declared in this scope
    22 |   decltype(n) n;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:22:12: error: ‘n’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:23:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:22:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:23:12: error: ‘l’ was not declared in this scope
    23 |   decltype(l) l;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:23:12: error: ‘l’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:24:12: error: ‘b’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:23:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:24:12: error: ‘b’ was not declared in this scope
    24 |   decltype(b) b;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:24:12: error: ‘b’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldencross_join_triple1459464005/001/prog.cpp:35:38: error: cannot convert ‘std::any’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:24:12: error: ‘b’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/cross_join_triple.cpp:35:38: error: cannot convert ‘std::any’ to ‘int’ in initialization
    35 |           __items.push_back(Combo{n, l, b});
       |                                      ^
       |                                      |

--- a/tests/machine/x/cpp/dataset_sort_take_limit.error
+++ b/tests/machine/x/cpp/dataset_sort_take_limit.error
@@ -1,47 +1,47 @@
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:21:38: error: ‘p’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:21:38: error: ‘p’ was not declared in this scope
    21 |     std::vector<std::pair<decltype((-p.price)), decltype(p)>> __items;
       |                                      ^
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:21:49: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:21:49: error: template argument 1 is invalid
    21 |     std::vector<std::pair<decltype((-p.price)), decltype(p)>> __items;
       |                                                 ^~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:21:49: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:21:60: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:21:49: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:21:60: error: template argument 1 is invalid
    21 |     std::vector<std::pair<decltype((-p.price)), decltype(p)>> __items;
       |                                                            ^~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:21:60: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:23:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:21:60: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:23:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
    23 |       __items.push_back({(-p.price), p});
       |               ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:25:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:25:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
    25 |     std::sort(__items.begin(), __items.end(),
       |                       ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:25:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:25:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
    25 |     std::sort(__items.begin(), __items.end(),
       |                                        ^~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:27:29: error: request for member ‘size’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:27:29: error: request for member ‘size’ in ‘__items’, which is of non-class type ‘int’
    27 |     if ((size_t)1 < __items.size())
       |                             ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:28:15: error: request for member ‘erase’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:28:15: error: request for member ‘erase’ in ‘__items’, which is of non-class type ‘int’
    28 |       __items.erase(__items.begin(), __items.begin() + 1);
       |               ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:28:29: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:28:29: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
    28 |       __items.erase(__items.begin(), __items.begin() + 1);
       |                             ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:28:46: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:28:46: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
    28 |       __items.erase(__items.begin(), __items.begin() + 1);
       |                                              ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:29:29: error: request for member ‘size’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:29:29: error: request for member ‘size’ in ‘__items’, which is of non-class type ‘int’
    29 |     if ((size_t)3 < __items.size())
       |                             ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:30:15: error: request for member ‘resize’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:30:15: error: request for member ‘resize’ in ‘__items’, which is of non-class type ‘int’
    30 |       __items.resize(3);
       |               ^~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:31:28: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:31:28: error: template argument 1 is invalid
    31 |     std::vector<decltype(p)> __res;
       |                            ^
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:31:28: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:32:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:31:28: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:32:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
    32 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::begin
@@ -51,29 +51,29 @@ In file included from /usr/include/c++/13/string:53,
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:3:
 /usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
   114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
       |                                     ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:32:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:32:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
    32 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::end
 /usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
   116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
       |                                     ^~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:33:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:33:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
    33 |       __res.push_back(p.second);
       |             ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:38:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:38:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
    38 |   for (auto item : expensive) {
       |                    ^~~~~~~~~
       |                    std::begin
 /usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
   114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
       |                                     ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldendataset_sort_take_limit1481267367/001/prog.cpp:38:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+/workspace/mochi/tests/machine/x/cpp/dataset_sort_take_limit.cpp:38:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
    38 |   for (auto item : expensive) {
       |                    ^~~~~~~~~
       |                    std::end

--- a/tests/machine/x/cpp/dataset_where_filter.error
+++ b/tests/machine/x/cpp/dataset_where_filter.error
@@ -1,21 +1,21 @@
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp:11:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp:11:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    11 |   decltype(person.name) name;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp:11:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp:11:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    11 |   decltype(person.name) name;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    12 |   decltype(person.age) age;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    12 |   decltype(person.age) age;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldendataset_where_filter1583935992/001/prog.cpp:24:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/dataset_where_filter.cpp:24:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    24 |       __items.push_back(Adult{person.name, person.age, (person.age >= 60)});
       |                               ~~~~~~~^~~~
       |                                      |

--- a/tests/machine/x/cpp/group_by.error
+++ b/tests/machine/x/cpp/group_by.error
@@ -1,17 +1,17 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    12 |   decltype(person) person;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:12:12: error: ‘person’ was not declared in this scope; did you mean ‘perror’?
    12 |   decltype(person) person;
       |            ^~~~~~
       |            perror
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:15:33: error: ‘struct Stat’ has no member named ‘city’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:15:33: error: ‘struct Stat’ has no member named ‘city’
    15 |   decltype(std::declval<Stat>().city) key;
       |                                 ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:15:33: error: ‘struct Stat’ has no member named ‘city’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:15:33: error: ‘struct Stat’ has no member named ‘city’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
    45 |         if (__g.key == __key) {
       |             ~~~~~~~ ^~ ~~~~~
       |                 |      |
@@ -24,12 +24,12 @@ In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:3
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:2:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by.cpp:2:
 /usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/iosfwd:42,
@@ -38,14 +38,14 @@ In file included from /usr/include/c++/13/iosfwd:42,
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/string:48:
@@ -53,28 +53,28 @@ In file included from /usr/include/c++/13/string:48:
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
@@ -83,7 +83,7 @@ In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -92,42 +92,42 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const _CharT*’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/memory_resource.h:47,
@@ -136,7 +136,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:47,
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/locale_facets.h:48,
@@ -146,16 +146,16 @@ In file included from /usr/include/c++/13/bits/locale_facets.h:48,
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:4:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by.cpp:4:
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:45:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:45:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
    45 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -189,17 +189,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:46:36: error: cannot convert ‘People’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:46:36: error: cannot convert ‘People’ to ‘int’ in initialization
    46 |           __g.items.push_back(Stat{person});
       |                                    ^~~~~~
       |                                    |
       |                                    People
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:52:68: error: cannot convert ‘People’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:52:68: error: cannot convert ‘People’ to ‘int’ in initialization
    52 |         __groups.push_back(__struct3{__key, std::vector<Stat>{Stat{person}}});
       |                                                                    ^~~~~~
       |                                                                    |
       |                                                                    People
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:52:75: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:52:75: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
    52 |         __groups.push_back(__struct3{__key, std::vector<Stat>{Stat{person}}});
       |                                                                           ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Stat; _Alloc = std::allocator<Stat>]’
@@ -250,23 +250,23 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:59:65: error: ‘struct Stat’ has no member named ‘age’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:59:65: error: ‘struct Stat’ has no member named ‘age’
    59 |                       std::vector<decltype(std::declval<Stat>().age)> __items;
       |                                                                 ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:59:65: error: ‘struct Stat’ has no member named ‘age’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:59:69: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:59:65: error: ‘struct Stat’ has no member named ‘age’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:59:69: error: template argument 1 is invalid
    59 |                       std::vector<decltype(std::declval<Stat>().age)> __items;
       |                                                                     ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:59:69: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:61:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:59:69: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:61:33: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
    61 |                         __items.push_back(p.age);
       |                                 ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:61:45: error: ‘struct Stat’ has no member named ‘age’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:61:45: error: ‘struct Stat’ has no member named ‘age’
    61 |                         __items.push_back(p.age);
       |                                             ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:58:56: error: no matching function for call to ‘__avg(int)’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:58:56: error: no matching function for call to ‘__avg(int)’
    58 |           __struct4{g.key, ((int)g.items.size()), __avg(([&]() {
       |                                                   ~~~~~^~~~~~~~~
    59 |                       std::vector<decltype(std::declval<Stat>().age)> __items;
@@ -281,11 +281,11 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |                       ~~~~~~~~~~~~~~~                   
    64 |                     })())});
       |                     ~~~~~                               
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:18:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:18:30: note: candidate: ‘template<class T> double __avg(const std::vector<T>&)’
    18 | template <typename T> double __avg(const std::vector<T> &v) {
       |                              ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:18:30: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:58:56: note:   mismatched types ‘const std::vector<T>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:18:30: note:   template argument deduction/substitution failed:
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:58:56: note:   mismatched types ‘const std::vector<T>’ and ‘int’
    58 |           __struct4{g.key, ((int)g.items.size()), __avg(([&]() {
       |                                                   ~~~~~^~~~~~~~~
    59 |                       std::vector<decltype(std::declval<Stat>().age)> __items;
@@ -300,8 +300,8 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |                       ~~~~~~~~~~~~~~~                   
    64 |                     })())});
       |                     ~~~~~                               
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:67:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Stat>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:67:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Stat>’ requested
    39 |   std::vector<Stat> stats = ([&]() {
       |                             ~~~~~~~~
    40 |     std::vector<__struct3> __groups;
@@ -360,12 +360,12 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ~~~~~~~~~~~~~~~
    67 |   })();
       |   ~~^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:71:22: error: ‘struct Stat’ has no member named ‘city’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:71:22: error: ‘struct Stat’ has no member named ‘city’
    71 |       std::cout << s.city;
       |                      ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:75:22: error: ‘struct Stat’ has no member named ‘count’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:75:22: error: ‘struct Stat’ has no member named ‘count’
    75 |       std::cout << s.count;
       |                      ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by1305496685/001/prog.cpp:79:22: error: ‘struct Stat’ has no member named ‘avg_age’
+/workspace/mochi/tests/machine/x/cpp/group_by.cpp:79:22: error: ‘struct Stat’ has no member named ‘avg_age’
    79 |       std::cout << s.avg_age;
       |                      ^~~~~~~

--- a/tests/machine/x/cpp/group_by_conditional_sum.error
+++ b/tests/machine/x/cpp/group_by_conditional_sum.error
@@ -1,30 +1,30 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:77:12: error: ‘i’ was not declared in this scope
    77 |   decltype(i) i;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:77:12: error: ‘i’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:80:35: error: ‘struct Result’ has no member named ‘cat’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:77:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:80:35: error: ‘struct Result’ has no member named ‘cat’
    80 |   decltype(std::declval<Result>().cat) key;
       |                                   ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:80:35: error: ‘struct Result’ has no member named ‘cat’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:139:22: error: ‘class std::any’ has no member named ‘cat’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:80:35: error: ‘struct Result’ has no member named ‘cat’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:139:22: error: ‘class std::any’ has no member named ‘cat’
   139 |       auto __key = i.cat;
       |                      ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:143:38: error: cannot convert ‘std::any’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:143:38: error: cannot convert ‘std::any’ to ‘int’ in initialization
   143 |           __g.items.push_back(Result{i});
       |                                      ^
       |                                      |
       |                                      std::any
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:149:72: error: cannot convert ‘std::any’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:149:72: error: cannot convert ‘std::any’ to ‘int’ in initialization
   149 |         __groups.push_back(__struct3{__key, std::vector<Result>{Result{i}}});
       |                                                                        ^
       |                                                                        |
       |                                                                        std::any
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:149:74: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:149:74: error: no matching function for call to ‘std::vector<Result>::vector(<brace-enclosed initializer list>)’
   149 |         __groups.push_back(__struct3{__key, std::vector<Result>{Result{i}}});
       |                                                                          ^
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:10:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:10:
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Result; _Alloc = std::allocator<Result>]’
   707 |         vector(_InputIterator __first, _InputIterator __last,
       |         ^~~~~~
@@ -73,65 +73,65 @@ In file included from /usr/include/c++/13/vector:66,
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:162:64: error: ‘struct Result’ has no member named ‘flag’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:162:64: error: ‘struct Result’ has no member named ‘flag’
   162 |                   std::vector<decltype((std::declval<Result>().flag
       |                                                                ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:163:70: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:163:70: error: ‘struct Result’ has no member named ‘val’
   163 |                                             ? std::declval<Result>().val
       |                                                                      ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:162:64: error: ‘struct Result’ has no member named ‘flag’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:162:64: error: ‘struct Result’ has no member named ‘flag’
   162 |                   std::vector<decltype((std::declval<Result>().flag
       |                                                                ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:163:70: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:163:70: error: ‘struct Result’ has no member named ‘val’
   163 |                                             ? std::declval<Result>().val
       |                                                                      ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:164:50: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:164:50: error: template argument 1 is invalid
   164 |                                             : 0))>
       |                                                  ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:164:50: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:167:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:164:50: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:167:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   167 |                     __items.push_back((x.flag ? x.val : 0));
       |                             ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:167:42: error: ‘struct Result’ has no member named ‘flag’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:167:42: error: ‘struct Result’ has no member named ‘flag’
   167 |                     __items.push_back((x.flag ? x.val : 0));
       |                                          ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:167:51: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:167:51: error: ‘struct Result’ has no member named ‘val’
   167 |                     __items.push_back((x.flag ? x.val : 0));
       |                                                   ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:161:19:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:160:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:161:19:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:160:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   160 |                   return std::accumulate(v.begin(), v.end(), 0.0);
       |                                          ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:160:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:160:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   160 |                   return std::accumulate(v.begin(), v.end(), 0.0);
       |                                                     ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:174:63: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:174:63: error: ‘struct Result’ has no member named ‘val’
   174 |                   std::vector<decltype(std::declval<Result>().val)> __items;
       |                                                               ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:174:63: error: ‘struct Result’ has no member named ‘val’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:174:67: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:174:63: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:174:67: error: template argument 1 is invalid
   174 |                   std::vector<decltype(std::declval<Result>().val)> __items;
       |                                                                   ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:174:67: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:176:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:174:67: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:176:29: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   176 |                     __items.push_back(x.val);
       |                             ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:176:41: error: ‘struct Result’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:176:41: error: ‘struct Result’ has no member named ‘val’
   176 |                     __items.push_back(x.val);
       |                                         ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:173:19:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:172:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:173:19:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:172:44: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   172 |                   return std::accumulate(v.begin(), v.end(), 0.0);
       |                                          ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:172:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:172:55: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   172 |                   return std::accumulate(v.begin(), v.end(), 0.0);
       |                                                     ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:155:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct4> >::push_back(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:155:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct4> >::push_back(<brace-enclosed initializer list>)’
   155 |       __items.push_back(
       |       ~~~~~~~~~~~~~~~~~^
   156 |           {g.key,
@@ -194,8 +194,8 @@ In file included from /usr/include/c++/13/vector:66,
 /usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<int, __struct4> >::value_type&&’ {aka ‘std::pair<int, __struct4>&&’}
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_conditional_sum2886837094/001/prog.cpp:187:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Result>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_conditional_sum.cpp:187:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Result>’ requested
   136 |   std::vector<Result> result = ([&]() {
       |                                ~~~~~~~~
   137 |     std::vector<__struct3> __groups;

--- a/tests/machine/x/cpp/group_by_having.error
+++ b/tests/machine/x/cpp/group_by_having.error
@@ -1,13 +1,13 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:58:12: error: ‘p’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:58:12: error: ‘p’ was not declared in this scope
    58 |   decltype(p) p;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:58:12: error: ‘p’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:61:32: error: ‘struct Big’ has no member named ‘city’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:58:12: error: ‘p’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:61:32: error: ‘struct Big’ has no member named ‘city’
    61 |   decltype(std::declval<Big>().city) key;
       |                                ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:61:32: error: ‘struct Big’ has no member named ‘city’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:61:32: error: ‘struct Big’ has no member named ‘city’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
   123 |         if (__g.key == __key) {
       |             ~~~~~~~ ^~ ~~~~~
       |                 |      |
@@ -20,12 +20,12 @@ In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:3
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:2:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:2:
 /usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/iosfwd:42,
@@ -34,14 +34,14 @@ In file included from /usr/include/c++/13/iosfwd:42,
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/string:48:
@@ -49,28 +49,28 @@ In file included from /usr/include/c++/13/string:48:
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
@@ -79,7 +79,7 @@ In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -88,42 +88,42 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const _CharT*’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/memory_resource.h:47,
@@ -132,7 +132,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:47,
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/locale_facets.h:48,
@@ -142,16 +142,16 @@ In file included from /usr/include/c++/13/bits/locale_facets.h:48,
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/map:63,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:3:
 /usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
  1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/map:64:
@@ -159,32 +159,32 @@ In file included from /usr/include/c++/13/map:64:
  1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/unordered_map:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:5:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:5:
 /usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
  2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
  2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:6:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:6:
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:123:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:123:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
   123 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -218,17 +218,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:124:35: error: cannot convert ‘People’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:124:35: error: cannot convert ‘People’ to ‘int’ in initialization
   124 |           __g.items.push_back(Big{p});
       |                                   ^
       |                                   |
       |                                   People
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:130:66: error: cannot convert ‘People’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:130:66: error: cannot convert ‘People’ to ‘int’ in initialization
   130 |         __groups.push_back(__struct3{__key, std::vector<Big>{Big{p}}});
       |                                                                  ^
       |                                                                  |
       |                                                                  People
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:130:68: error: no matching function for call to ‘std::vector<Big>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:130:68: error: no matching function for call to ‘std::vector<Big>::vector(<brace-enclosed initializer list>)’
   130 |         __groups.push_back(__struct3{__key, std::vector<Big>{Big{p}}});
       |                                                                    ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Big; _Alloc = std::allocator<Big>]’
@@ -279,8 +279,8 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_having3150528043/001/prog.cpp:140:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Big>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_having.cpp:140:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Big>’ requested
   117 |   std::vector<Big> big = ([&]() {
       |                          ~~~~~~~~
   118 |     std::vector<__struct3> __groups;

--- a/tests/machine/x/cpp/group_by_join.error
+++ b/tests/machine/x/cpp/group_by_join.error
@@ -1,17 +1,17 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:15:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:15:12: error: ‘o’ was not declared in this scope
    15 |   decltype(o) o;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:15:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:16:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:15:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:16:12: error: ‘c’ was not declared in this scope
    16 |   decltype(c) c;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:16:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:19:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:16:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:19:12: error: ‘c’ was not declared in this scope
    19 |   decltype(c.name) key;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:19:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:23: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:19:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:23: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
    39 |           if (__g.key == __key) {
       |               ~~~~~~~ ^~ ~~~~~
       |                   |      |
@@ -24,12 +24,12 @@ In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:3
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:2:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:2:
 /usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/iosfwd:42,
@@ -38,14 +38,14 @@ In file included from /usr/include/c++/13/iosfwd:42,
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/string:48:
@@ -53,28 +53,28 @@ In file included from /usr/include/c++/13/string:48:
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
@@ -83,7 +83,7 @@ In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -92,42 +92,42 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const _CharT*’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/bits/memory_resource.h:47,
@@ -136,7 +136,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:47,
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/bits/locale_facets.h:48,
@@ -146,16 +146,16 @@ In file included from /usr/include/c++/13/bits/locale_facets.h:48,
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:4:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:4:
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:39:26: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:39:26: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
    39 |           if (__g.key == __key) {
       |                          ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -189,17 +189,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:40:38: error: cannot convert ‘Order’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:40:38: error: cannot convert ‘Order’ to ‘int’ in initialization
    40 |             __g.items.push_back(Stat{o, c});
       |                                      ^
       |                                      |
       |                                      Order
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:46:70: error: cannot convert ‘Order’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:46:70: error: cannot convert ‘Order’ to ‘int’ in initialization
    46 |           __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{o, c}}});
       |                                                                      ^
       |                                                                      |
       |                                                                      Order
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:46:75: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:46:75: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
    46 |           __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{o, c}}});
       |                                                                           ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Stat; _Alloc = std::allocator<Stat>]’
@@ -250,8 +250,8 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:55:5: error: conversion from ‘vector<__struct5>’ to non-scalar type ‘vector<Stat>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:55:5: error: conversion from ‘vector<__struct5>’ to non-scalar type ‘vector<Stat>’ requested
    30 |   std::vector<Stat> stats = ([&]() {
       |                             ~~~~~~~~
    31 |     std::vector<__struct4> __groups;
@@ -304,9 +304,9 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ~~~~~~~~~~~~~~~
    55 |   })();
       |   ~~^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:59:22: error: ‘struct Stat’ has no member named ‘name’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:59:22: error: ‘struct Stat’ has no member named ‘name’
    59 |       std::cout << s.name;
       |                      ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_join4163992783/001/prog.cpp:63:22: error: ‘struct Stat’ has no member named ‘count’
+/workspace/mochi/tests/machine/x/cpp/group_by_join.cpp:63:22: error: ‘struct Stat’ has no member named ‘count’
    63 |       std::cout << s.count;
       |                      ^~~~~

--- a/tests/machine/x/cpp/group_by_left_join.error
+++ b/tests/machine/x/cpp/group_by_left_join.error
@@ -1,17 +1,17 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:15:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:15:12: error: ‘c’ was not declared in this scope
    15 |   decltype(c) c;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:15:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:15:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:16:12: error: ‘o’ was not declared in this scope
    16 |   decltype(o) o;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:19:33: error: ‘struct Stat’ has no member named ‘name’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:19:33: error: ‘struct Stat’ has no member named ‘name’
    19 |   decltype(std::declval<Stat>().name) key;
       |                                 ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:19:33: error: ‘struct Stat’ has no member named ‘name’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:25: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:19:33: error: ‘struct Stat’ has no member named ‘name’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:25: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
    43 |             if (__g.key == __key) {
       |                 ~~~~~~~ ^~ ~~~~~
       |                     |      |
@@ -24,12 +24,12 @@ In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:3
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:2:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:2:
 /usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/iosfwd:42,
@@ -38,14 +38,14 @@ In file included from /usr/include/c++/13/iosfwd:42,
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/string:48:
@@ -53,28 +53,28 @@ In file included from /usr/include/c++/13/string:48:
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
@@ -83,7 +83,7 @@ In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -92,42 +92,42 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const _CharT*’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/bits/memory_resource.h:47,
@@ -136,7 +136,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:47,
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/bits/locale_facets.h:48,
@@ -146,16 +146,16 @@ In file included from /usr/include/c++/13/bits/locale_facets.h:48,
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:4:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:4:
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:43:28: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:43:28: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
    43 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -189,17 +189,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:44:40: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:44:40: error: cannot convert ‘Customer’ to ‘int’ in initialization
    44 |               __g.items.push_back(Stat{c, o});
       |                                        ^
       |                                        |
       |                                        Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:50:72: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:50:72: error: cannot convert ‘Customer’ to ‘int’ in initialization
    50 |             __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{c, o}}});
       |                                                                        ^
       |                                                                        |
       |                                                                        Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:50:77: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:50:77: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
    50 |             __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{c, o}}});
       |                                                                             ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Stat; _Alloc = std::allocator<Stat>]’
@@ -250,7 +250,7 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:25: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:25: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
    58 |             if (__g.key == __key) {
       |                 ~~~~~~~ ^~ ~~~~~
       |                     |      |
@@ -259,119 +259,119 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note: candidate: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_Iterator>&)’
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/string_view:609:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, basic_string_view<_CharT, _Traits>)’
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const _CharT*’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/tuple:1919:5: note: candidate: ‘template<class ... _TElements, class ... _UElements> constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_UTypes ...>&)’
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note: candidate: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:58:28: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:58:28: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
    58 |             if (__g.key == __key) {
       |                            ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -404,17 +404,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:59:40: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:59:40: error: cannot convert ‘Customer’ to ‘int’ in initialization
    59 |               __g.items.push_back(Stat{c, o});
       |                                        ^
       |                                        |
       |                                        Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:65:72: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:65:72: error: cannot convert ‘Customer’ to ‘int’ in initialization
    65 |             __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{c, o}}});
       |                                                                        ^
       |                                                                        |
       |                                                                        Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:65:77: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:65:77: error: no matching function for call to ‘std::vector<Stat>::vector(<brace-enclosed initializer list>)’
    65 |             __groups.push_back(__struct4{__key, std::vector<Stat>{Stat{c, o}}});
       |                                                                             ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Stat; _Alloc = std::allocator<Stat>]’
@@ -465,8 +465,8 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:84:5: error: conversion from ‘vector<__struct5>’ to non-scalar type ‘vector<Stat>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:84:5: error: conversion from ‘vector<__struct5>’ to non-scalar type ‘vector<Stat>’ requested
    31 |   std::vector<Stat> stats = ([&]() {
       |                             ~~~~~~~~
    32 |     std::vector<__struct4> __groups;
@@ -575,9 +575,9 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ~~~~~~~~~~~~~~~
    84 |   })();
       |   ~~^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:88:22: error: ‘struct Stat’ has no member named ‘name’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:88:22: error: ‘struct Stat’ has no member named ‘name’
    88 |       std::cout << s.name;
       |                      ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_left_join1621759243/001/prog.cpp:92:22: error: ‘struct Stat’ has no member named ‘count’
+/workspace/mochi/tests/machine/x/cpp/group_by_left_join.cpp:92:22: error: ‘struct Stat’ has no member named ‘count’
    92 |       std::cout << s.count;
       |                      ^~~~~

--- a/tests/machine/x/cpp/group_by_multi_join.error
+++ b/tests/machine/x/cpp/group_by_multi_join.error
@@ -1,21 +1,21 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:69:12: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:69:12: error: ‘ps’ was not declared in this scope
    69 |   decltype(ps.part) part;
       |            ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:69:12: error: ‘ps’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:70:13: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:69:12: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:70:13: error: ‘ps’ was not declared in this scope
    70 |   decltype((ps.cost * ps.qty)) value;
       |             ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:70:23: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:70:23: error: ‘ps’ was not declared in this scope
    70 |   decltype((ps.cost * ps.qty)) value;
       |                       ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:70:13: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:70:13: error: ‘ps’ was not declared in this scope
    70 |   decltype((ps.cost * ps.qty)) value;
       |             ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:70:23: error: ‘ps’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:70:23: error: ‘ps’ was not declared in this scope
    70 |   decltype((ps.cost * ps.qty)) value;
       |                       ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join2501757451/001/prog.cpp:219:5: error: conversion from ‘vector<Grouped>’ to non-scalar type ‘vector<Filtered>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join.cpp:219:5: error: conversion from ‘vector<Grouped>’ to non-scalar type ‘vector<Filtered>’ requested
   188 |   std::vector<Filtered> grouped = ([&]() {
       |                                   ~~~~~~~~
   189 |     std::vector<__struct5> __groups;

--- a/tests/machine/x/cpp/group_by_multi_join_sort.error
+++ b/tests/machine/x/cpp/group_by_multi_join_sort.error
@@ -1,68 +1,68 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:81:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:81:12: error: ‘c’ was not declared in this scope
    81 |   decltype(c.c_custkey) c_custkey;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:81:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:82:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:81:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:82:12: error: ‘c’ was not declared in this scope
    82 |   decltype(c.c_name) c_name;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:82:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:83:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:82:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:83:12: error: ‘c’ was not declared in this scope
    83 |   decltype(c.c_acctbal) c_acctbal;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:83:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:84:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:83:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:84:12: error: ‘c’ was not declared in this scope
    84 |   decltype(c.c_address) c_address;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:84:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:85:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:84:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:85:12: error: ‘c’ was not declared in this scope
    85 |   decltype(c.c_phone) c_phone;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:85:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:86:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:85:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:86:12: error: ‘c’ was not declared in this scope
    86 |   decltype(c.c_comment) c_comment;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:86:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:87:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:86:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:87:12: error: ‘n’ was not declared in this scope
    87 |   decltype(n.n_name) n_name;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:87:12: error: ‘n’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:90:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:87:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:90:12: error: ‘c’ was not declared in this scope
    90 |   decltype(c) c;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:90:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:91:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:90:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:91:12: error: ‘o’ was not declared in this scope
    91 |   decltype(o) o;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:91:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:92:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:91:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:92:12: error: ‘l’ was not declared in this scope
    92 |   decltype(l) l;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:92:12: error: ‘l’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:93:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:92:12: error: ‘l’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:93:12: error: ‘n’ was not declared in this scope
    93 |   decltype(n) n;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:93:12: error: ‘n’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:347:39: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:93:12: error: ‘n’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:347:39: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
   347 |                 Result{c.c_custkey, c.c_name,    c.c_acctbal, c.c_address,
       |                                     ~~^~~~~~
       |                                       |
       |                                       std::string {aka std::__cxx11::basic_string<char>}
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:352:47: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:352:47: error: cannot convert ‘Customer’ to ‘int’ in initialization
   352 |                 __g.items.push_back(__struct6{c, o, l, n});
       |                                               ^
       |                                               |
       |                                               Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:359:59: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:359:59: error: cannot convert ‘Customer’ to ‘int’ in initialization
   359 |                   __key, std::vector<__struct6>{__struct6{c, o, l, n}}});
       |                                                           ^
       |                                                           |
       |                                                           Customer
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:359:70: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:359:70: error: no matching function for call to ‘std::vector<__struct6>::vector(<brace-enclosed initializer list>)’
   359 |                   __key, std::vector<__struct6>{__struct6{c, o, l, n}}});
       |                                                                      ^
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:9:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:9:
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = __struct6; _Alloc = std::allocator<__struct6>]’
   707 |         vector(_InputIterator __first, _InputIterator __last,
       |         ^~~~~~
@@ -111,76 +111,76 @@ In file included from /usr/include/c++/13/vector:66,
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:371:50: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:371:50: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   371 |                      std::declval<__struct6>().l.l_extendedprice *
       |                                                  ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:372:56: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:372:56: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   372 |                      ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                        ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:371:50: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:371:50: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   371 |                      std::declval<__struct6>().l.l_extendedprice *
       |                                                  ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:372:56: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:372:56: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   372 |                      ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                        ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:372:70: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:372:70: error: template argument 1 is invalid
   372 |                      ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                                      ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:372:70: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:375:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:372:70: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:375:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   375 |                    __items.push_back(
       |                            ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:376:29: error: request for member ‘l_extendedprice’ in ‘x.__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:376:29: error: request for member ‘l_extendedprice’ in ‘x.__struct6::l’, which is of non-class type ‘int’
   376 |                        (x.l.l_extendedprice * ((1 - x.l.l_discount))));
       |                             ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:376:57: error: request for member ‘l_discount’ in ‘x.__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:376:57: error: request for member ‘l_discount’ in ‘x.__struct6::l’, which is of non-class type ‘int’
   376 |                        (x.l.l_extendedprice * ((1 - x.l.l_discount))));
       |                                                         ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:368:80:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:368:54: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:368:80:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:368:54: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   368 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
       |                                                    ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:368:65: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:368:65: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   368 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
       |                                                               ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:384:56: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:384:56: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   384 |                            std::declval<__struct6>().l.l_extendedprice *
       |                                                        ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:385:62: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:385:62: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   385 |                            ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                              ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:384:56: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:384:56: error: request for member ‘l_extendedprice’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   384 |                            std::declval<__struct6>().l.l_extendedprice *
       |                                                        ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:385:62: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:385:62: error: request for member ‘l_discount’ in ‘std::declval<__struct6>().__struct6::l’, which is of non-class type ‘int’
   385 |                            ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                              ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:385:76: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:385:76: error: template argument 1 is invalid
   385 |                            ((1 - std::declval<__struct6>().l.l_discount))))>
       |                                                                            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:385:76: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:388:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:385:76: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:388:34: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   388 |                          __items.push_back(
       |                                  ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:389:35: error: request for member ‘l_extendedprice’ in ‘x.__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:389:35: error: request for member ‘l_extendedprice’ in ‘x.__struct6::l’, which is of non-class type ‘int’
   389 |                              (x.l.l_extendedprice * ((1 - x.l.l_discount))));
       |                                   ^~~~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:389:63: error: request for member ‘l_discount’ in ‘x.__struct6::l’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:389:63: error: request for member ‘l_discount’ in ‘x.__struct6::l’, which is of non-class type ‘int’
   389 |                              (x.l.l_extendedprice * ((1 - x.l.l_discount))));
       |                                                               ^~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:382:24:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:381:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:382:24:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:381:49: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   381 |                        return std::accumulate(v.begin(), v.end(), 0.0);
       |                                               ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:381:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:381:60: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   381 |                        return std::accumulate(v.begin(), v.end(), 0.0);
       |                                                          ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:367:24: error: no matching function for call to ‘std::vector<std::pair<double, __struct8> >::push_back(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:367:24: error: no matching function for call to ‘std::vector<std::pair<double, __struct8> >::push_back(<brace-enclosed initializer list>)’
   367 |       __items.push_back(
       |       ~~~~~~~~~~~~~~~~~^
   368 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
@@ -249,8 +249,8 @@ In file included from /usr/include/c++/13/vector:66,
 /usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<double, __struct8> >::value_type&&’ {aka ‘std::pair<double, __struct8>&&’}
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_multi_join_sort397195563/001/prog.cpp:402:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_multi_join_sort.cpp:402:5: error: conversion from ‘vector<__struct8>’ to non-scalar type ‘vector<__struct6>’ requested
   330 |   std::vector<__struct6> result = ([&]() {
       |                                   ~~~~~~~~
   331 |     std::vector<__struct7> __groups;

--- a/tests/machine/x/cpp/group_by_sort.error
+++ b/tests/machine/x/cpp/group_by_sort.error
@@ -1,13 +1,13 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:61:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:61:12: error: ‘i’ was not declared in this scope
    61 |   decltype(i) i;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:61:12: error: ‘i’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:64:36: error: ‘struct Grouped’ has no member named ‘cat’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:61:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:64:36: error: ‘struct Grouped’ has no member named ‘cat’
    64 |   decltype(std::declval<Grouped>().cat) key;
       |                                    ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:64:36: error: ‘struct Grouped’ has no member named ‘cat’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:64:36: error: ‘struct Grouped’ has no member named ‘cat’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:21: error: no match for ‘operator==’ (operand types are ‘int’ and ‘std::__cxx11::basic_string<char>’)
   121 |         if (__g.key == __key) {
       |             ~~~~~~~ ^~ ~~~~~
       |                 |      |
@@ -20,22 +20,22 @@ In file included from /usr/include/x86_64-linux-gnu/c++/13/bits/c++allocator.h:3
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:3:
 /usr/include/c++/13/bits/new_allocator.h:215:9: note: candidate: ‘template<class _Up> bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’
   215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
       |         ^~~~~~~~
 /usr/include/c++/13/bits/new_allocator.h:215:9: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘const std::__new_allocator<_Tp>’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:64,
                  from /usr/include/c++/13/algorithm:60,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:2:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:2:
 /usr/include/c++/13/bits/stl_pair.h:812:5: note: candidate: ‘template<class _T1, class _T2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_T1, _T2>&)’
   812 |     operator==(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_pair.h:812:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::pair<_T1, _T2>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
@@ -43,28 +43,28 @@ In file included from /usr/include/c++/13/bits/stl_algobase.h:67:
   448 |     operator==(const reverse_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:448:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_Iterator>&, const reverse_iterator<_IteratorR>&)’
   493 |     operator==(const reverse_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:493:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::reverse_iterator<_Iterator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note: candidate: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&)’
  1678 |     operator==(const move_iterator<_IteratorL>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1678:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note: candidate: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
  1748 |     operator==(const move_iterator<_Iterator>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_iterator.h:1748:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::move_iterator<_IteratorL>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/iosfwd:42,
@@ -73,14 +73,14 @@ In file included from /usr/include/c++/13/iosfwd:42,
   192 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/postypes.h:192:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::fpos<_StateT>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note: candidate: ‘template<class _T1, class _T2> bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’
   237 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/allocator.h:237:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::allocator<_CharT>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/basic_string.h:47,
@@ -89,42 +89,42 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   609 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:609:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:616:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, __type_identity_t<basic_string_view<_CharT, _Traits> >)’
   616 |     operator==(basic_string_view<_CharT, _Traits> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:616:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘std::basic_string_view<_CharT, _Traits>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/string_view:642:5: note: candidate: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(__type_identity_t<basic_string_view<_CharT, _Traits> >, basic_string_view<_CharT, _Traits>)’
   642 |     operator==(__type_identity_t<basic_string_view<_CharT, _Traits>> __x,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:642:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   ‘std::__cxx11::basic_string<char>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3710 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3710:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
  3727 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3727:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> bool std::operator==(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  3774 |     operator==(const _CharT* __lhs,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:3774:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const _CharT*’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const _CharT*’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/memory_resource.h:47,
@@ -133,7 +133,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:47,
  1919 |     operator==(const tuple<_TElements...>& __t,
       |     ^~~~~~~~
 /usr/include/c++/13/tuple:1919:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::tuple<_UTypes ...>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/bits/locale_facets.h:48,
@@ -143,16 +143,16 @@ In file included from /usr/include/c++/13/bits/locale_facets.h:48,
   234 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/streambuf_iterator.h:234:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::istreambuf_iterator<_CharT, _Traits>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/map:63,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:4:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:4:
 /usr/include/c++/13/bits/stl_map.h:1513:5: note: candidate: ‘template<class _Key, class _Tp, class _Compare, class _Alloc> bool std::operator==(const map<_Key, _Tp, _Compare, _Allocator>&, const map<_Key, _Tp, _Compare, _Allocator>&)’
  1513 |     operator==(const map<_Key, _Tp, _Compare, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_map.h:1513:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::map<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/map:64:
@@ -160,32 +160,32 @@ In file included from /usr/include/c++/13/map:64:
  1134 |     operator==(const multimap<_Key, _Tp, _Compare, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_multimap.h:1134:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::multimap<_Key, _Tp, _Compare, _Allocator>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/unordered_map:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:7:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:7:
 /usr/include/c++/13/bits/unordered_map.h:2143:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
  2143 |     operator==(const unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/unordered_map.h:2143:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::unordered_map<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/unordered_map.h:2157:5: note: candidate: ‘template<class _Key1, class _Tp1, class _Hash1, class _Pred1, class _Alloc1> bool std::operator==(const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&, const unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>&)’
  2157 |     operator==(const unordered_multimap<_Key, _Tp, _Hash, _Pred, _Alloc>& __x,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/unordered_map.h:2157:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::unordered_multimap<_Key1, _Tp1, _Hash1, _Pred1, _Alloc1>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:9:
+                 from /workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:9:
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note: candidate: ‘template<class _Tp, class _Alloc> bool std::operator==(const vector<_Tp, _Alloc>&, const vector<_Tp, _Alloc>&)’
  2040 |     operator==(const vector<_Tp, _Alloc>& __x, const vector<_Tp, _Alloc>& __y)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:2040:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:121:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:121:24: note:   mismatched types ‘const std::vector<_Tp, _Alloc>’ and ‘int’
   121 |         if (__g.key == __key) {
       |                        ^~~~~
 /usr/include/c++/13/bits/allocator.h:216:7: note: candidate: ‘bool std::operator==(const allocator<char>&, const allocator<char>&)’
@@ -219,17 +219,17 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/system_error:517:37: note:   no known conversion for argument 1 from ‘int’ to ‘const std::error_condition&’
   517 |   operator==(const error_condition& __lhs, const error_code& __rhs) noexcept
       |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:122:39: error: cannot convert ‘Item’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:122:39: error: cannot convert ‘Item’ to ‘int’ in initialization
   122 |           __g.items.push_back(Grouped{i});
       |                                       ^
       |                                       |
       |                                       Item
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:128:74: error: cannot convert ‘Item’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:128:74: error: cannot convert ‘Item’ to ‘int’ in initialization
   128 |         __groups.push_back(__struct3{__key, std::vector<Grouped>{Grouped{i}}});
       |                                                                          ^
       |                                                                          |
       |                                                                          Item
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:128:76: error: no matching function for call to ‘std::vector<Grouped>::vector(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:128:76: error: no matching function for call to ‘std::vector<Grouped>::vector(<brace-enclosed initializer list>)’
   128 |         __groups.push_back(__struct3{__key, std::vector<Grouped>{Grouped{i}}});
       |                                                                            ^
 /usr/include/c++/13/bits/stl_vector.h:707:9: note: candidate: ‘template<class _InputIterator, class> std::vector<_Tp, _Alloc>::vector(_InputIterator, _InputIterator, const allocator_type&) [with <template-parameter-2-2> = _InputIterator; _Tp = Grouped; _Alloc = std::allocator<Grouped>]’
@@ -280,54 +280,54 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   531 |       vector() = default;
       |       ^~~~~~
 /usr/include/c++/13/bits/stl_vector.h:531:7: note:   candidate expects 0 arguments, 1 provided
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:136:63: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:136:63: error: ‘struct Grouped’ has no member named ‘val’
   136 |                  std::vector<decltype(std::declval<Grouped>().val)> __items;
       |                                                               ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:136:63: error: ‘struct Grouped’ has no member named ‘val’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:136:67: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:136:63: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:136:67: error: template argument 1 is invalid
   136 |                  std::vector<decltype(std::declval<Grouped>().val)> __items;
       |                                                                   ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:136:67: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:138:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:136:67: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:138:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   138 |                    __items.push_back(x.val);
       |                            ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:138:40: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:138:40: error: ‘struct Grouped’ has no member named ‘val’
   138 |                    __items.push_back(x.val);
       |                                        ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:134:80:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:134:54: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:1)> [with auto:1 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:134:80:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:134:54: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   134 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
       |                                                    ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:134:65: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:134:65: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   134 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
       |                                                               ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:146:63: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:146:63: error: ‘struct Grouped’ has no member named ‘val’
   146 |                  std::vector<decltype(std::declval<Grouped>().val)> __items;
       |                                                               ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:146:63: error: ‘struct Grouped’ has no member named ‘val’
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:146:67: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:146:63: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:146:67: error: template argument 1 is invalid
   146 |                  std::vector<decltype(std::declval<Grouped>().val)> __items;
       |                                                                   ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:146:67: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:148:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:146:67: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:148:28: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
   148 |                    __items.push_back(x.val);
       |                            ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:148:40: error: ‘struct Grouped’ has no member named ‘val’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:148:40: error: ‘struct Grouped’ has no member named ‘val’
   148 |                    __items.push_back(x.val);
       |                                        ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:145:18:   required from here
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:144:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In instantiation of ‘main()::<lambda()>::<lambda(auto:2)> [with auto:2 = int]’:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:145:18:   required from here
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:144:43: error: request for member ‘begin’ in ‘v’, which is of non-class type ‘int’
   144 |                  return std::accumulate(v.begin(), v.end(), 0.0);
       |                                         ~~^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:144:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:144:54: error: request for member ‘end’ in ‘v’, which is of non-class type ‘int’
   144 |                  return std::accumulate(v.begin(), v.end(), 0.0);
       |                                                    ~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:133:24: error: no matching function for call to ‘std::vector<std::pair<double, __struct4> >::push_back(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:133:24: error: no matching function for call to ‘std::vector<std::pair<double, __struct4> >::push_back(<brace-enclosed initializer list>)’
   133 |       __items.push_back(
       |       ~~~~~~~~~~~~~~~~~^
   134 |           {(-([&](auto v) { return std::accumulate(v.begin(), v.end(), 0.0); })(
@@ -378,8 +378,8 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
 /usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<std::pair<double, __struct4> >::value_type&&’ {aka ‘std::pair<double, __struct4>&&’}
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_by_sort1777697097/001/prog.cpp:159:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Grouped>’ requested
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_by_sort.cpp:159:5: error: conversion from ‘vector<__struct4>’ to non-scalar type ‘vector<Grouped>’ requested
   115 |   std::vector<Grouped> grouped = ([&]() {
       |                                  ~~~~~~~~
   116 |     std::vector<__struct3> __groups;

--- a/tests/machine/x/cpp/group_items_iteration.error
+++ b/tests/machine/x/cpp/group_items_iteration.error
@@ -1,38 +1,38 @@
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:60:12: error: ‘d’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:60:12: error: ‘d’ was not declared in this scope
    60 |   decltype(d.tag) key;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:60:12: error: ‘d’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:61:19: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:60:12: error: ‘d’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:61:19: error: template argument 1 is invalid
    61 |   std::vector<auto> items;
       |                   ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:61:19: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:23: error: ‘d’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:61:19: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:23: error: ‘d’ was not declared in this scope
   102 |     std::map<decltype(d.tag), std::vector<auto>> __groups;
       |                       ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:47: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:47: error: template argument 1 is invalid
   102 |     std::map<decltype(d.tag), std::vector<auto>> __groups;
       |                                               ^~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:47: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:50: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:47: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:50: error: template argument 1 is invalid
   102 |     std::map<decltype(d.tag), std::vector<auto>> __groups;
       |                                                  ^~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:50: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:50: error: template argument 3 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:102:50: error: template argument 4 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:104:7: error: ‘__groups’ was not declared in this scope; did you mean ‘groups’?
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:50: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:50: error: template argument 3 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:102:50: error: template argument 4 is invalid
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:104:7: error: ‘__groups’ was not declared in this scope; did you mean ‘groups’?
   104 |       __groups[d.tag].push_back(auto{d});
       |       ^~~~~~~~
       |       groups
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:104:39: warning: ‘auto{x}’ only available with ‘-std=c++2b’ or ‘-std=gnu++2b’ [-Wc++23-extensions]
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:104:39: warning: ‘auto{x}’ only available with ‘-std=c++2b’ or ‘-std=gnu++2b’ [-Wc++23-extensions]
   104 |       __groups[d.tag].push_back(auto{d});
       |                                       ^
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:107:21: error: ‘__groups’ was not declared in this scope; did you mean ‘groups’?
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:107:21: error: ‘__groups’ was not declared in this scope; did you mean ‘groups’?
   107 |     for (auto &kv : __groups) {
       |                     ^~~~~~~~
       |                     groups
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:115:21: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:115:21: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
   115 |     for (auto x : g.items) {
       |                     ^~~~~
       |                     std::begin
@@ -42,22 +42,22 @@ In file included from /usr/include/c++/13/string:53,
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:3:
 /usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
   114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
       |                                     ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:115:21: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:115:21: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
   115 |     for (auto x : g.items) {
       |                     ^~~~~
       |                     std::end
 /usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
   116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
       |                                     ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:118:18: error: no matching function for call to ‘std::vector<int>::push_back(__struct3)’
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:118:18: error: no matching function for call to ‘std::vector<int>::push_back(__struct3)’
   118 |     tmp.push_back(__struct3{g.key, total});
       |     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:8:
+                 from /workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:8:
 /usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]’
  1281 |       push_back(const value_type& __x)
       |       ^~~~~~~~~
@@ -70,11 +70,11 @@ In file included from /usr/include/c++/13/vector:66,
 /usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘__struct3’ to ‘std::vector<int>::value_type&&’ {aka ‘int&&’}
  1298 |       push_back(value_type&& __x)
       |                 ~~~~~~~~~~~~~^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:124:28: error: request for member ‘tag’ in ‘r’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:124:28: error: request for member ‘tag’ in ‘r’, which is of non-class type ‘int’
   124 |       __items.push_back({r.tag, r});
       |                            ^~~
-/tmp/TestCPPCompiler_VMValid_Goldengroup_items_iteration2793884661/001/prog.cpp:124:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct3> >::push_back(<brace-enclosed initializer list>)’
+/workspace/mochi/tests/machine/x/cpp/group_items_iteration.cpp:124:24: error: no matching function for call to ‘std::vector<std::pair<int, __struct3> >::push_back(<brace-enclosed initializer list>)’
   124 |       __items.push_back({r.tag, r});
       |       ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
 /usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = std::pair<int, __struct3>; _Alloc = std::allocator<std::pair<int, __struct3> >; value_type = std::pair<int, __struct3>]’

--- a/tests/machine/x/cpp/in_operator_extended.error
+++ b/tests/machine/x/cpp/in_operator_extended.error
@@ -1,31 +1,31 @@
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:11:26: error: ‘x’ was not declared in this scope; did you mean ‘xs’?
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:11:26: error: ‘x’ was not declared in this scope; did you mean ‘xs’?
    11 |     std::vector<decltype(x)> __items;
       |                          ^
       |                          xs
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:11:28: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:11:28: error: template argument 1 is invalid
    11 |     std::vector<decltype(x)> __items;
       |                            ^
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:11:28: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:15:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:11:28: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:15:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
    15 |       __items.push_back(x);
       |               ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:19:30: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:19:30: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
    19 |   std::cout << (std::find(ys.begin(), ys.end(), 1) != ys.end()) << std::endl;
       |                              ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:19:42: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:19:42: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
    19 |   std::cout << (std::find(ys.begin(), ys.end(), 1) != ys.end()) << std::endl;
       |                                          ^~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:19:58: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:19:58: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
    19 |   std::cout << (std::find(ys.begin(), ys.end(), 1) != ys.end()) << std::endl;
       |                                                          ^~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:20:30: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:20:30: error: request for member ‘begin’ in ‘ys’, which is of non-class type ‘int’
    20 |   std::cout << (std::find(ys.begin(), ys.end(), 2) != ys.end()) << std::endl;
       |                              ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:20:42: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:20:42: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
    20 |   std::cout << (std::find(ys.begin(), ys.end(), 2) != ys.end()) << std::endl;
       |                                          ^~~
-/tmp/TestCPPCompiler_VMValid_Goldenin_operator_extended1929144352/001/prog.cpp:20:58: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/in_operator_extended.cpp:20:58: error: request for member ‘end’ in ‘ys’, which is of non-class type ‘int’
    20 |   std::cout << (std::find(ys.begin(), ys.end(), 2) != ys.end()) << std::endl;
       |                                                          ^~~

--- a/tests/machine/x/cpp/inner_join.error
+++ b/tests/machine/x/cpp/inner_join.error
@@ -1,17 +1,17 @@
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:16:12: error: ‘o’ was not declared in this scope
    16 |   decltype(o.id) orderId;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:17:12: error: ‘c’ was not declared in this scope
    17 |   decltype(c.name) customerName;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:18:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:18:12: error: ‘o’ was not declared in this scope
    18 |   decltype(o.total) total;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:18:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldeninner_join130693007/001/prog.cpp:32:42: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:18:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/inner_join.cpp:32:42: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    32 |         __items.push_back(Result{o.id, c.name, o.total});
       |                                        ~~^~~~
       |                                          |

--- a/tests/machine/x/cpp/join_multi.error
+++ b/tests/machine/x/cpp/join_multi.error
@@ -1,13 +1,13 @@
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp:19:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp:19:12: error: ‘c’ was not declared in this scope
    19 |   decltype(c.name) name;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp:19:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp:20:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp:19:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp:20:12: error: ‘i’ was not declared in this scope
    20 |   decltype(i.sku) sku;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp:20:12: error: ‘i’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenjoin_multi3627900378/001/prog.cpp:37:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp:20:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/join_multi.cpp:37:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    37 |           __items.push_back(Result{c.name, i.sku});
       |                                    ~~^~~~
       |                                      |

--- a/tests/machine/x/cpp/left_join.error
+++ b/tests/machine/x/cpp/left_join.error
@@ -1,22 +1,22 @@
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:16:12: error: ‘o’ was not declared in this scope
    16 |   decltype(o.id) orderId;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:17:12: error: ‘c’ was not declared in this scope
    17 |   decltype(c) customer;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:18:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:18:12: error: ‘o’ was not declared in this scope
    18 |   decltype(o.total) total;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:18:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:33:42: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:18:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:33:42: error: cannot convert ‘Customer’ to ‘int’ in initialization
    33 |           __items.push_back(Result{o.id, c, o.total});
       |                                          ^
       |                                          |
       |                                          Customer
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join955912258/001/prog.cpp:37:42: error: cannot convert ‘Customer’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/left_join.cpp:37:42: error: cannot convert ‘Customer’ to ‘int’ in initialization
    37 |           __items.push_back(Result{o.id, c, o.total});
       |                                          ^
       |                                          |

--- a/tests/machine/x/cpp/left_join_multi.error
+++ b/tests/machine/x/cpp/left_join_multi.error
@@ -1,22 +1,22 @@
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:19:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:19:12: error: ‘o’ was not declared in this scope
    19 |   decltype(o.id) orderId;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:19:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:20:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:19:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:20:12: error: ‘c’ was not declared in this scope
    20 |   decltype(c.name) name;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:20:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:21:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:20:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:21:12: error: ‘i’ was not declared in this scope
    21 |   decltype(i) item;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:21:12: error: ‘i’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:40:46: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:21:12: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:40:46: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    40 |             __items.push_back(Result{o.id, c.name, i});
       |                                            ~~^~~~
       |                                              |
       |                                              std::string {aka std::__cxx11::basic_string<char>}
-/tmp/TestCPPCompiler_VMValid_Goldenleft_join_multi2926184301/001/prog.cpp:44:46: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/left_join_multi.cpp:44:46: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    44 |             __items.push_back(Result{o.id, c.name, i});
       |                                            ~~^~~~
       |                                              |

--- a/tests/machine/x/cpp/list_nested_assign.error
+++ b/tests/machine/x/cpp/list_nested_assign.error
@@ -1,7 +1,7 @@
-/tmp/TestCPPCompiler_VMValid_Goldenlist_nested_assign1871326212/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenlist_nested_assign1871326212/001/prog.cpp:23:12: error: no match for ‘operator[]’ (operand types are ‘__gnu_cxx::__alloc_traits<std::allocator<std::any>, std::any>::value_type’ {aka ‘std::any’} and ‘int’)
+/workspace/mochi/tests/machine/x/cpp/list_nested_assign.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/list_nested_assign.cpp:23:12: error: no match for ‘operator[]’ (operand types are ‘__gnu_cxx::__alloc_traits<std::allocator<std::any>, std::any>::value_type’ {aka ‘std::any’} and ‘int’)
    23 |   matrix[1][0] = 5;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenlist_nested_assign1871326212/001/prog.cpp:24:25: error: no match for ‘operator[]’ (operand types are ‘__gnu_cxx::__alloc_traits<std::allocator<std::any>, std::any>::value_type’ {aka ‘std::any’} and ‘int’)
+/workspace/mochi/tests/machine/x/cpp/list_nested_assign.cpp:24:25: error: no match for ‘operator[]’ (operand types are ‘__gnu_cxx::__alloc_traits<std::allocator<std::any>, std::any>::value_type’ {aka ‘std::any’} and ‘int’)
    24 |   std::cout << matrix[1][0] << std::endl;
       |                         ^

--- a/tests/machine/x/cpp/map_index.error
+++ b/tests/machine/x/cpp/map_index.error
@@ -1,8 +1,8 @@
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:13: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:13: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
    24 |   std::cout << m[std::string("b")] << std::endl;
 In file included from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/map_index.cpp:3:
 /usr/include/c++/13/ostream:110:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
       |       ^~~~~~~~
@@ -122,14 +122,14 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   761 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:761:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/bits/basic_string.h:4032:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  4032 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:4032:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 In file included from /usr/include/c++/13/bits/memory_resource.h:38,
@@ -138,7 +138,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:38,
   124 |     operator<<(byte __b, _IntegerType __shift) noexcept
       |     ^~~~~~~~
 /usr/include/c++/13/cstddef:124:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:8: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:8: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |   ~~~~~^~~~
 In file included from /usr/include/c++/13/bits/ios_base.h:46:
@@ -146,77 +146,77 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   339 |     operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
       |     ^~~~~~~~
 /usr/include/c++/13/system_error:339:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:554:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, _CharT)’
   554 |     operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:554:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:564:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, char)’
   564 |     operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:564:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:570:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char)’
   570 |     operator<<(basic_ostream<char, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:570:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:581:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, signed char)’
   581 |     operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:581:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:586:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, unsigned char)’
   586 |     operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:586:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:645:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const _CharT*)’
   645 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:645:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   mismatched types ‘const _CharT*’ and ‘std::any’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   mismatched types ‘const _CharT*’ and ‘std::any’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/bits/ostream.tcc:307:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const char*)’
   307 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/ostream.tcc:307:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:662:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const char*)’
   662 |     operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:662:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:675:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const signed char*)’
   675 |     operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:675:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:680:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const unsigned char*)’
   680 |     operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:680:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
    24 |   std::cout << m[std::string("b")] << std::endl;
       |                                  ^
 /usr/include/c++/13/ostream:801:5: note: candidate: ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&)’
@@ -224,5 +224,5 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:801:5: note:   template argument deduction/substitution failed:
 /usr/include/c++/13/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::basic_ostream<char>&; _Tp = std::any]’:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_index134616665/001/prog.cpp:24:34:   required from here
+/workspace/mochi/tests/machine/x/cpp/map_index.cpp:24:34:   required from here
 /usr/include/c++/13/ostream:801:5: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’

--- a/tests/machine/x/cpp/map_literal_dynamic.error
+++ b/tests/machine/x/cpp/map_literal_dynamic.error
@@ -1,8 +1,8 @@
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:15: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:15: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
    27 |     std::cout << m[std::string("a")];
 In file included from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:3:
 /usr/include/c++/13/ostream:110:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
       |       ^~~~~~~~
@@ -122,14 +122,14 @@ In file included from /usr/include/c++/13/bits/basic_string.h:47,
   761 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:761:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/bits/basic_string.h:4032:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  4032 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:4032:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 In file included from /usr/include/c++/13/bits/memory_resource.h:38,
@@ -138,7 +138,7 @@ In file included from /usr/include/c++/13/bits/memory_resource.h:38,
   124 |     operator<<(byte __b, _IntegerType __shift) noexcept
       |     ^~~~~~~~
 /usr/include/c++/13/cstddef:124:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:10: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:10: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
    27 |     std::cout << m[std::string("a")];
       |     ~~~~~^~~~
 In file included from /usr/include/c++/13/bits/ios_base.h:46:
@@ -146,77 +146,77 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   339 |     operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
       |     ^~~~~~~~
 /usr/include/c++/13/system_error:339:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:554:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, _CharT)’
   554 |     operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:554:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:564:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, char)’
   564 |     operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:564:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:570:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char)’
   570 |     operator<<(basic_ostream<char, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:570:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:581:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, signed char)’
   581 |     operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:581:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:586:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, unsigned char)’
   586 |     operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:586:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:645:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const _CharT*)’
   645 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:645:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   mismatched types ‘const _CharT*’ and ‘std::any’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   mismatched types ‘const _CharT*’ and ‘std::any’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/bits/ostream.tcc:307:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const char*)’
   307 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/ostream.tcc:307:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:662:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const char*)’
   662 |     operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:662:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:675:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const signed char*)’
   675 |     operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:675:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:680:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const unsigned char*)’
   680 |     operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:680:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"a"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
    27 |     std::cout << m[std::string("a")];
       |                                    ^
 /usr/include/c++/13/ostream:801:5: note: candidate: ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&)’
@@ -224,9 +224,9 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:801:5: note:   template argument deduction/substitution failed:
 /usr/include/c++/13/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::basic_ostream<char>&; _Tp = std::any]’:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:27:36:   required from here
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:27:36:   required from here
 /usr/include/c++/13/ostream:801:5: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:15: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:15: error: no match for ‘operator<<’ (operand types are ‘std::ostream’ {aka ‘std::basic_ostream<char>’} and ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’})
    29 |     std::cout << m[std::string("b")];
 /usr/include/c++/13/ostream:110:7: note: candidate: ‘std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(__ostream_type& (*)(__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; __ostream_type = std::basic_ostream<char>]’
   110 |       operator<<(__ostream_type& (*__pf)(__ostream_type&))
@@ -340,98 +340,98 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
   761 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/string_view:761:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   ‘std::any’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/bits/basic_string.h:4032:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
  4032 |     operator<<(basic_ostream<_CharT, _Traits>& __os,
       |     ^~~~~~~~
 /usr/include/c++/13/bits/basic_string.h:4032:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/cstddef:124:5: note: candidate: ‘template<class _IntegerType> constexpr std::__byte_op_t<_IntegerType> std::operator<<(byte, _IntegerType)’
   124 |     operator<<(byte __b, _IntegerType __shift) noexcept
       |     ^~~~~~~~
 /usr/include/c++/13/cstddef:124:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:10: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:10: note:   cannot convert ‘std::cout’ (type ‘std::ostream’ {aka ‘std::basic_ostream<char>’}) to type ‘std::byte’
    29 |     std::cout << m[std::string("b")];
       |     ~~~~~^~~~
 /usr/include/c++/13/system_error:339:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const error_code&)’
   339 |     operator<<(basic_ostream<_CharT, _Traits>& __os, const error_code& __e)
       |     ^~~~~~~~
 /usr/include/c++/13/system_error:339:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const std::error_code&’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:554:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, _CharT)’
   554 |     operator<<(basic_ostream<_CharT, _Traits>& __out, _CharT __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:554:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   deduced conflicting types for parameter ‘_CharT’ (‘char’ and ‘std::any’)
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:564:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, char)’
   564 |     operator<<(basic_ostream<_CharT, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:564:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:570:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, char)’
   570 |     operator<<(basic_ostream<char, _Traits>& __out, char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:570:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘char’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:581:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, signed char)’
   581 |     operator<<(basic_ostream<char, _Traits>& __out, signed char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:581:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘signed char’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:586:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, unsigned char)’
   586 |     operator<<(basic_ostream<char, _Traits>& __out, unsigned char __c)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:586:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘unsigned char’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:645:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const _CharT*)’
   645 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const _CharT* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:645:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   mismatched types ‘const _CharT*’ and ‘std::any’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   mismatched types ‘const _CharT*’ and ‘std::any’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/bits/ostream.tcc:307:5: note: candidate: ‘template<class _CharT, class _Traits> std::basic_ostream<_CharT, _Traits>& std::operator<<(basic_ostream<_CharT, _Traits>&, const char*)’
   307 |     operator<<(basic_ostream<_CharT, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/bits/ostream.tcc:307:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:662:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const char*)’
   662 |     operator<<(basic_ostream<char, _Traits>& __out, const char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:662:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const char*’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:675:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const signed char*)’
   675 |     operator<<(basic_ostream<char, _Traits>& __out, const signed char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:675:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const signed char*’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:680:5: note: candidate: ‘template<class _Traits> std::basic_ostream<char, _Traits>& std::operator<<(basic_ostream<char, _Traits>&, const unsigned char*)’
   680 |     operator<<(basic_ostream<char, _Traits>& __out, const unsigned char* __s)
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:680:5: note:   template argument deduction/substitution failed:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36: note:   cannot convert ‘m.std::unordered_map<std::__cxx11::basic_string<char>, std::any>::operator[](std::__cxx11::basic_string<char>(((const char*)"b"), std::allocator<char>()))’ (type ‘std::unordered_map<std::__cxx11::basic_string<char>, std::any>::mapped_type’ {aka ‘std::any’}) to type ‘const unsigned char*’
    29 |     std::cout << m[std::string("b")];
       |                                    ^
 /usr/include/c++/13/ostream:801:5: note: candidate: ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&)’
@@ -439,5 +439,5 @@ In file included from /usr/include/c++/13/bits/ios_base.h:46:
       |     ^~~~~~~~
 /usr/include/c++/13/ostream:801:5: note:   template argument deduction/substitution failed:
 /usr/include/c++/13/ostream: In substitution of ‘template<class _Ostream, class _Tp> _Ostream&& std::operator<<(_Ostream&&, const _Tp&) [with _Ostream = std::basic_ostream<char>&; _Tp = std::any]’:
-/tmp/TestCPPCompiler_VMValid_Goldenmap_literal_dynamic3626929630/001/prog.cpp:29:36:   required from here
+/workspace/mochi/tests/machine/x/cpp/map_literal_dynamic.cpp:29:36:   required from here
 /usr/include/c++/13/ostream:801:5: error: no type named ‘type’ in ‘struct std::enable_if<false, void>’

--- a/tests/machine/x/cpp/order_by_map.error
+++ b/tests/machine/x/cpp/order_by_map.error
@@ -1,28 +1,28 @@
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:14:42: error: ‘x’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:14:42: error: ‘x’ was not declared in this scope
    14 |     std::vector<std::pair<Data, decltype(x)>> __items;
       |                                          ^
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:14:33: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:14:33: error: template argument 2 is invalid
    14 |     std::vector<std::pair<Data, decltype(x)>> __items;
       |                                 ^~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:14:44: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:14:44: error: template argument 1 is invalid
    14 |     std::vector<std::pair<Data, decltype(x)>> __items;
       |                                            ^~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:14:44: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:16:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:14:44: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:16:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
    16 |       __items.push_back({Data{x.a, x.b}, x});
       |               ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:18:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:18:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
    18 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
       |                       ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:18:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:18:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
    18 |     std::sort(__items.begin(), __items.end(), [](auto &a, auto &b) {
       |                                        ^~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:21:28: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:21:28: error: template argument 1 is invalid
    21 |     std::vector<decltype(x)> __res;
       |                            ^
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:21:28: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:22:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:21:28: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:22:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
    22 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::begin
@@ -32,24 +32,24 @@ In file included from /usr/include/c++/13/string:53,
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:3:
 /usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
   114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
       |                                     ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:22:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:22:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
    22 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::end
 /usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
   116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
       |                                     ^~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:23:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:23:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
    23 |       __res.push_back(p.second);
       |             ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:26:33: error: request for member ‘size’ in ‘sorted’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:26:33: error: request for member ‘size’ in ‘sorted’, which is of non-class type ‘int’
    26 |   for (size_t i = 0; i < sorted.size(); ++i) {
       |                                 ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldenorder_by_map3551024615/001/prog.cpp:29:24: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
+/workspace/mochi/tests/machine/x/cpp/order_by_map.cpp:29:24: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
    29 |     std::cout << sorted[i];
       |                        ^

--- a/tests/machine/x/cpp/outer_join.error
+++ b/tests/machine/x/cpp/outer_join.error
@@ -1,38 +1,38 @@
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:16:12: error: ‘o’ was not declared in this scope
    16 |   decltype(o) order;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:16:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:16:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:17:12: error: ‘c’ was not declared in this scope
    17 |   decltype(c) customer;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:17:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:34:36: error: cannot convert ‘Order’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:17:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:34:36: error: cannot convert ‘Order’ to ‘int’ in initialization
    34 |           __items.push_back(Result{o, c});
       |                                    ^
       |                                    |
       |                                    Order
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:38:36: error: cannot convert ‘Order’ to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:38:36: error: cannot convert ‘Order’ to ‘int’ in initialization
    38 |           __items.push_back(Result{o, c});
       |                                    ^
       |                                    |
       |                                    Order
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:51:34: error: request for member ‘id’ in ‘row.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:51:34: error: request for member ‘id’ in ‘row.Result::order’, which is of non-class type ‘int’
    51 |           std::cout << row.order.id;
       |                                  ^~
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:55:37: error: request for member ‘name’ in ‘row.Result::customer’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:55:37: error: request for member ‘name’ in ‘row.Result::customer’, which is of non-class type ‘int’
    55 |           std::cout << row.customer.name;
       |                                     ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:59:34: error: request for member ‘total’ in ‘row.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:59:34: error: request for member ‘total’ in ‘row.Result::order’, which is of non-class type ‘int’
    59 |           std::cout << row.order.total;
       |                                  ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:66:34: error: request for member ‘id’ in ‘row.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:66:34: error: request for member ‘id’ in ‘row.Result::order’, which is of non-class type ‘int’
    66 |           std::cout << row.order.id;
       |                                  ^~
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:74:34: error: request for member ‘total’ in ‘row.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:74:34: error: request for member ‘total’ in ‘row.Result::order’, which is of non-class type ‘int’
    74 |           std::cout << row.order.total;
       |                                  ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldenouter_join4056951133/001/prog.cpp:82:35: error: request for member ‘name’ in ‘row.Result::customer’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/outer_join.cpp:82:35: error: request for member ‘name’ in ‘row.Result::customer’, which is of non-class type ‘int’
    82 |         std::cout << row.customer.name;
       |                                   ^~~~

--- a/tests/machine/x/cpp/right_join.error
+++ b/tests/machine/x/cpp/right_join.error
@@ -1,26 +1,26 @@
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:16:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:16:12: error: ‘c’ was not declared in this scope
    16 |   decltype(c.name) customerName;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:16:12: error: ‘c’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:17:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:16:12: error: ‘c’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:17:12: error: ‘o’ was not declared in this scope
    17 |   decltype(o) order;
       |            ^
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:17:12: error: ‘o’ was not declared in this scope
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:34:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:17:12: error: ‘o’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:34:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    34 |           __items.push_back(Result{c.name, o});
       |                                    ~~^~~~
       |                                      |
       |                                      std::string {aka std::__cxx11::basic_string<char>}
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:38:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:38:38: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘int’ in initialization
    38 |           __items.push_back(Result{c.name, o});
       |                                    ~~^~~~
       |                                      |
       |                                      std::string {aka std::__cxx11::basic_string<char>}
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:54:34: error: request for member ‘id’ in ‘entry.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:54:34: error: request for member ‘id’ in ‘entry.Result::order’, which is of non-class type ‘int’
    54 |         std::cout << entry.order.id;
       |                                  ^~
-/tmp/TestCPPCompiler_VMValid_Goldenright_join1988658772/001/prog.cpp:58:34: error: request for member ‘total’ in ‘entry.Result::order’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/right_join.cpp:58:34: error: request for member ‘total’ in ‘entry.Result::order’, which is of non-class type ‘int’
    58 |         std::cout << entry.order.total;
       |                                  ^~~~~

--- a/tests/machine/x/cpp/sort_stable.error
+++ b/tests/machine/x/cpp/sort_stable.error
@@ -1,29 +1,29 @@
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:17:36: error: ‘i’ was not declared in this scope
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:17:36: error: ‘i’ was not declared in this scope
    17 |     std::vector<std::pair<decltype(i.n), decltype(i.v)>> __items;
       |                                    ^
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:17:42: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:17:42: error: template argument 1 is invalid
    17 |     std::vector<std::pair<decltype(i.n), decltype(i.v)>> __items;
       |                                          ^~~~~~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:17:42: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:17:55: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:17:42: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:17:55: error: template argument 1 is invalid
    17 |     std::vector<std::pair<decltype(i.n), decltype(i.v)>> __items;
       |                                                       ^~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:17:55: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:19:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:17:55: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:19:15: error: request for member ‘push_back’ in ‘__items’, which is of non-class type ‘int’
    19 |       __items.push_back({i.n, i.v});
       |               ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:21:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:21:23: error: request for member ‘begin’ in ‘__items’, which is of non-class type ‘int’
    21 |     std::sort(__items.begin(), __items.end(),
       |                       ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:21:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:21:40: error: request for member ‘end’ in ‘__items’, which is of non-class type ‘int’
    21 |     std::sort(__items.begin(), __items.end(),
       |                                        ^~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:23:30: error: template argument 1 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:23:30: error: template argument 1 is invalid
    23 |     std::vector<decltype(i.v)> __res;
       |                              ^
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:23:30: error: template argument 2 is invalid
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:24:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:23:30: error: template argument 2 is invalid
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:24:20: error: ‘begin’ was not declared in this scope; did you mean ‘std::begin’?
    24 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::begin
@@ -33,24 +33,24 @@ In file included from /usr/include/c++/13/string:53,
                  from /usr/include/c++/13/ios:44,
                  from /usr/include/c++/13/ostream:40,
                  from /usr/include/c++/13/iostream:41,
-                 from /tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:3:
+                 from /workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:3:
 /usr/include/c++/13/bits/range_access.h:114:37: note: ‘std::begin’ declared here
   114 |   template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
       |                                     ^~~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:24:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:24:20: error: ‘end’ was not declared in this scope; did you mean ‘std::end’?
    24 |     for (auto &p : __items)
       |                    ^~~~~~~
       |                    std::end
 /usr/include/c++/13/bits/range_access.h:116:37: note: ‘std::end’ declared here
   116 |   template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
       |                                     ^~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:25:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:25:13: error: request for member ‘push_back’ in ‘__res’, which is of non-class type ‘int’
    25 |       __res.push_back(p.second);
       |             ^~~~~~~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp: In function ‘int main()’:
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:28:33: error: request for member ‘size’ in ‘result’, which is of non-class type ‘int’
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp: In function ‘int main()’:
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:28:33: error: request for member ‘size’ in ‘result’, which is of non-class type ‘int’
    28 |   for (size_t i = 0; i < result.size(); ++i) {
       |                                 ^~~~
-/tmp/TestCPPCompiler_VMValid_Goldensort_stable1144240747/001/prog.cpp:31:24: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
+/workspace/mochi/tests/machine/x/cpp/sort_stable.cpp:31:24: error: invalid types ‘int[size_t {aka long unsigned int}]’ for array subscript
    31 |     std::cout << result[i];
       |                        ^

--- a/tests/machine/x/cpp/values_builtin.error
+++ b/tests/machine/x/cpp/values_builtin.error
@@ -1,9 +1,9 @@
-/tmp/TestCPPCompiler_VMValid_Goldenvalues_builtin3349382315/001/prog.cpp: In lambda function:
-/tmp/TestCPPCompiler_VMValid_Goldenvalues_builtin3349382315/001/prog.cpp:29:20: error: no matching function for call to ‘std::vector<int>::push_back(std::any&)’
+/workspace/mochi/tests/machine/x/cpp/values_builtin.cpp: In lambda function:
+/workspace/mochi/tests/machine/x/cpp/values_builtin.cpp:29:20: error: no matching function for call to ‘std::vector<int>::push_back(std::any&)’
    29 |         v.push_back(p.second);
       |         ~~~~~~~~~~~^~~~~~~~~~
 In file included from /usr/include/c++/13/vector:66,
-                 from /tmp/TestCPPCompiler_VMValid_Goldenvalues_builtin3349382315/001/prog.cpp:6:
+                 from /workspace/mochi/tests/machine/x/cpp/values_builtin.cpp:6:
 /usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = int; _Alloc = std::allocator<int>; value_type = int]’
  1281 |       push_back(const value_type& __x)
       |       ^~~~~~~~~


### PR DESCRIPTION
## Summary
- simplify C++ VM golden tests to only check runtime output
- emit .cpp/.out and capture errors in tests/machine/x/cpp
- improve struct field type replacement using elemType fallback
- document latest compiler tasks

## Testing
- `go test ./compiler/x/cpp -run TestCPPCompiler_VMValid_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6877df1aab1c83209917e6b3afde596e