### PR TITLE
Add clj VM golden harness

### DIFF
--- a/compiler/x/clj/TASKS.md
+++ b/compiler/x/clj/TASKS.md
@@ -20,6 +20,11 @@ Recent updates (2025-07-16 11:36):
 - Added VM golden tests for `tests/vm/valid` programs.
 - Fixed `_query` helper to pass correct arguments to `:select` functions.
 
+2025-07-19:
+- VM golden tests now compare output only and write results under `tests/machine/x/clj`.
+- Fixed `_rel_path` helper with missing parenthesis and removed unused JSON import in `save` handling.
+- Regenerated machine translations after fixes.
+
 Remaining work:
  - [ ] Support reading relative files for `load_yaml.mochi` during tests.
  - [ ] Expand dataset query coverage beyond TPCH Q1–Q6.

--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -2256,9 +2256,6 @@ func (c *Compiler) compileSaveExpr(s *parser.SaveExpr) (string, error) {
 		opts = v
 	}
 	c.use("_save")
-	if c.imports != nil {
-		c.imports["json"] = "clojure.data.json"
-	}
 	return fmt.Sprintf("(_save %s %s %s)", src, path, opts), nil
 }
 

--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -40,7 +40,7 @@ const (
         (cond
           (.exists (java.io.File. candidate)) candidate
           (< i 5) (recur (.getParentFile dir) (inc i))
-          :else candidate))))`
+          :else candidate)))))`
 
 	helperCount = `(defn _count [v]
   (cond

--- a/compiler/x/clj/tpch_golden_test.go
+++ b/compiler/x/clj/tpch_golden_test.go
@@ -16,11 +16,14 @@ import (
 	"mochi/types"
 )
 
-var update = flag.Bool("update", false, "update golden files")
+var updateTPCH = flag.Bool("update-tpch", false, "update golden files")
 
 func shouldUpdate() bool {
-	f := flag.Lookup("update")
-	return f != nil && f.Value.String() == "true"
+	f := flag.Lookup("update-tpch")
+	if f == nil {
+		return false
+	}
+	return f.Value.String() == "true"
 }
 
 func TestCLJCompiler_TPCHQueries(t *testing.T) {


### PR DESCRIPTION
## Summary
- record tasks for clj compiler work
- avoid importing JSON library in `_save`
- fix missing paren in `_rel_path` helper
- update clojure TPCH test flags
- rework Clojure VM valid golden test

## Testing
- `go test -tags=slow ./compiler/x/clj -run TestClojureCompiler_VMValid_Golden -failfast -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6877df607264832084ac8d5aca7b3f97