### PR TITLE
Add VM golden tests and cleanup

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -88,3 +88,4 @@ TPC-H progress:
 - 2025-07-16 13:10 - Added VM golden tests for valid programs and removed stale `.error` files after successful runs
 - 2025-07-16 16:55 - Stabilised VM valid golden tests with fixed header time; new failing cases logged.
 - 2025-07-16 23:59 - Replaced compiler_test.go with vm_golden_test.go using golden.Run and updated README generation
+- 2025-07-19 08:01 - Updated golden helpers to delete `.mochi.error` files when running VM tests

--- a/runtime/vm/rosetta_golden_test.go
+++ b/runtime/vm/rosetta_golden_test.go
@@ -103,13 +103,14 @@ func runMochi(src string) ([]byte, error) {
 }
 
 func writeErr(src string, err error) {
-	errPath := strings.TrimSuffix(src, filepath.Ext(src)) + ".error"
-	_ = os.WriteFile(errPath, []byte(err.Error()), 0644)
+	base := strings.TrimSuffix(src, filepath.Ext(src))
+	_ = os.WriteFile(base+".error", []byte(err.Error()), 0644)
 }
 
 func removeErr(src string) {
-	errPath := strings.TrimSuffix(src, filepath.Ext(src)) + ".error"
-	os.Remove(errPath)
+	base := strings.TrimSuffix(src, filepath.Ext(src))
+	os.Remove(base + ".error")
+	os.Remove(base + ".mochi.error")
 }
 
 func findRepoRoot(t *testing.T) string {

--- a/tests/vm/valid/cast_string_to_int.mochi.error
+++ b/tests/vm/valid/cast_string_to_int.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/cast_string_to_int.go.out:17: unsupported statement *ast.TypeSwitchStmt
->>> 16:    var out T
-17:>>> switch any(out).(type) {
-18:    case int:
-19:    switch vv := v.(type) {

--- a/tests/vm/valid/cast_struct.mochi.error
+++ b/tests/vm/valid/cast_struct.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/cast_struct.go.out:23: unsupported statement *ast.TypeSwitchStmt
->>> 22:    var out T
-23:>>> switch any(out).(type) {
-24:    case int:
-25:    switch vv := v.(type) {

--- a/tests/vm/valid/cross_join.mochi.error
+++ b/tests/vm/valid/cross_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/cross_join.go.out:8: unsupported declaration
->>> 7:    func main() {
-8:>>> type CustomersItem struct {
-9:    Id   int    `json:"id"`
-10:    Name string `json:"name"`

--- a/tests/vm/valid/dataset_sort_take_limit.mochi.error
+++ b/tests/vm/valid/dataset_sort_take_limit.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/dataset_sort_take_limit.go.out:65: unsupported statement *ast.TypeSwitchStmt
->>> 64:    var out T
-65:>>> switch any(out).(type) {
-66:    case int:
-67:    switch vv := v.(type) {

--- a/tests/vm/valid/dataset_where_filter.mochi.error
+++ b/tests/vm/valid/dataset_where_filter.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/dataset_where_filter.go.out:8: unsupported declaration
->>> 7:    func main() {
-8:>>> type PeopleItem struct {
-9:    Name string `json:"name"`
-10:    Age  int    `json:"age"`

--- a/tests/vm/valid/dataset_where_filter.out
+++ b/tests/vm/valid/dataset_where_filter.out
@@ -1,4 +1,4 @@
 --- Adults ---
-Alice is 30 
+Alice is 30
 Charlie is 65  (senior)
 Diana is 45

--- a/tests/vm/valid/group_by.mochi.error
+++ b/tests/vm/valid/group_by.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by.go.out:90: unsupported statement *ast.TypeSwitchStmt
->>> 89:    } else {
-90:>>> switch s := v.(type) {
-91:    case []any:
-92:    items = s

--- a/tests/vm/valid/group_by_conditional_sum.mochi.error
+++ b/tests/vm/valid/group_by_conditional_sum.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_conditional_sum.go.out:120: unsupported statement *ast.TypeSwitchStmt
->>> 119:    var out T
-120:>>> switch any(out).(type) {
-121:    case int:
-122:    switch vv := v.(type) {

--- a/tests/vm/valid/group_by_having.mochi.error
+++ b/tests/vm/valid/group_by_having.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_having.go.out:10: unsupported declaration
->>> 9:    func main() {
-10:>>> type PeopleItem struct {
-11:    Name string `json:"name"`
-12:    City string `json:"city"`

--- a/tests/vm/valid/group_by_join.mochi.error
+++ b/tests/vm/valid/group_by_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_join.go.out:9: unsupported declaration
->>> 8:    func main() {
-9:>>> type CustomersItem struct {
-10:    Id   int    `json:"id"`
-11:    Name string `json:"name"`

--- a/tests/vm/valid/group_by_left_join.mochi.error
+++ b/tests/vm/valid/group_by_left_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_left_join.go.out:100: unsupported statement *ast.TypeSwitchStmt
->>> 99:    var out T
-100:>>> switch any(out).(type) {
-101:    case int:
-102:    switch vv := v.(type) {

--- a/tests/vm/valid/group_by_multi_join.mochi.error
+++ b/tests/vm/valid/group_by_multi_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_multi_join.go.out:115: unsupported statement *ast.TypeSwitchStmt
->>> 114:    var out T
-115:>>> switch any(out).(type) {
-116:    case int:
-117:    switch vv := v.(type) {

--- a/tests/vm/valid/group_by_multi_join_sort.mochi.error
+++ b/tests/vm/valid/group_by_multi_join_sort.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_multi_join_sort.go.out:207: unsupported statement *ast.TypeSwitchStmt
->>> 206:    var out T
-207:>>> switch any(out).(type) {
-208:    case int:
-209:    switch vv := v.(type) {

--- a/tests/vm/valid/group_by_sort.mochi.error
+++ b/tests/vm/valid/group_by_sort.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/group_by_sort.go.out:118: unsupported statement *ast.TypeSwitchStmt
->>> 117:    var out T
-118:>>> switch any(out).(type) {
-119:    case int:
-120:    switch vv := v.(type) {

--- a/tests/vm/valid/in_operator_extended.mochi.error
+++ b/tests/vm/valid/in_operator_extended.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/in_operator_extended.go.out:27: unsupported assignment
->>> 26:    _tmp1 := m
-27:>>> _, _tmp2 := _tmp1[_tmp0]
-28:    fmt.Println(_tmp2)
-29:    _tmp3 := "b"

--- a/tests/vm/valid/inner_join.mochi.error
+++ b/tests/vm/valid/inner_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/inner_join.go.out:8: unsupported declaration
->>> 7:    func main() {
-8:>>> type CustomersItem struct {
-9:    Id   int    `json:"id"`
-10:    Name string `json:"name"`

--- a/tests/vm/valid/join_multi.mochi.error
+++ b/tests/vm/valid/join_multi.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/join_multi.go.out:8: unsupported declaration
->>> 7:    func main() {
-8:>>> type CustomersItem struct {
-9:    Id   int    `json:"id"`
-10:    Name string `json:"name"`

--- a/tests/vm/valid/json_builtin.mochi.error
+++ b/tests/vm/valid/json_builtin.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/json_builtin.go.out:10: unsupported assignment
->>> 9:    var m map[string]int = map[string]int{"a": 1, "b": 2}
-10:>>> func() { b, _ := json.Marshal(m); fmt.Println(string(b)) }()
-11:    }
-12:    

--- a/tests/vm/valid/left_join.mochi.error
+++ b/tests/vm/valid/left_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/left_join.go.out:76: unsupported statement *ast.TypeSwitchStmt
->>> 75:    var out T
-76:>>> switch any(out).(type) {
-77:    case int:
-78:    switch vv := v.(type) {

--- a/tests/vm/valid/left_join_multi.mochi.error
+++ b/tests/vm/valid/left_join_multi.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/left_join_multi.go.out:94: unsupported statement *ast.TypeSwitchStmt
->>> 93:    var out T
-94:>>> switch any(out).(type) {
-95:    case int:
-96:    switch vv := v.(type) {

--- a/tests/vm/valid/list_set_ops.mochi.error
+++ b/tests/vm/valid/list_set_ops.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/list_set_ops.go.out:14: unsupported parameter list
->>> 13:    
-14:>>> func _except[T any](a, b []T) []T {
-15:    res := []T{}
-16:    for _, x := range a {

--- a/tests/vm/valid/load_yaml.mochi.error
+++ b/tests/vm/valid/load_yaml.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/load_yaml.go.out:46: unsupported statement *ast.TypeSwitchStmt
->>> 45:    var out T
-46:>>> switch any(out).(type) {
-47:    case int:
-48:    switch vv := v.(type) {

--- a/tests/vm/valid/map_in_operator.mochi.error
+++ b/tests/vm/valid/map_in_operator.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/map_in_operator.go.out:11: unsupported assignment
->>> 10:    _tmp1 := m
-11:>>> _, _tmp2 := _tmp1[_tmp0]
-12:    fmt.Println(_tmp2)
-13:    _tmp3 := 3

--- a/tests/vm/valid/map_membership.mochi.error
+++ b/tests/vm/valid/map_membership.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/map_membership.go.out:11: unsupported assignment
->>> 10:    _tmp1 := m
-11:>>> _, _tmp2 := _tmp1[_tmp0]
-12:    fmt.Println(_tmp2)
-13:    _tmp3 := "c"

--- a/tests/vm/valid/match_expr.mochi.error
+++ b/tests/vm/valid/match_expr.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/match_expr.go.out:26: unsupported parameter list
->>> 25:    
-26:>>> func _equal(a, b any) bool {
-27:    av := reflect.ValueOf(a)
-28:    bv := reflect.ValueOf(b)

--- a/tests/vm/valid/match_full.mochi.error
+++ b/tests/vm/valid/match_full.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/match_full.go.out:70: unsupported parameter list
->>> 69:    
-70:>>> func _equal(a, b any) bool {
-71:    av := reflect.ValueOf(a)
-72:    bv := reflect.ValueOf(b)

--- a/tests/vm/valid/order_by_map.mochi.error
+++ b/tests/vm/valid/order_by_map.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/order_by_map.go.out:42: unsupported statement *ast.TypeSwitchStmt
->>> 41:    var out T
-42:>>> switch any(out).(type) {
-43:    case int:
-44:    switch vv := v.(type) {

--- a/tests/vm/valid/outer_join.mochi.error
+++ b/tests/vm/valid/outer_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/outer_join.go.out:104: unsupported statement *ast.TypeSwitchStmt
->>> 103:    var out T
-104:>>> switch any(out).(type) {
-105:    case int:
-106:    switch vv := v.(type) {

--- a/tests/vm/valid/query_sum_select.mochi.error
+++ b/tests/vm/valid/query_sum_select.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/query_sum_select.go.out:29: unsupported statement *ast.TypeSwitchStmt
->>> 28:    } else {
-29:>>> switch s := v.(type) {
-30:    case []any:
-31:    items = s

--- a/tests/vm/valid/record_assign.mochi.error
+++ b/tests/vm/valid/record_assign.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/record_assign.go.out:28: unsupported statement *ast.TypeSwitchStmt
->>> 27:    var out T
-28:>>> switch any(out).(type) {
-29:    case int:
-30:    switch vv := v.(type) {

--- a/tests/vm/valid/right_join.mochi.error
+++ b/tests/vm/valid/right_join.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/right_join.go.out:91: unsupported statement *ast.TypeSwitchStmt
->>> 90:    var out T
-91:>>> switch any(out).(type) {
-92:    case int:
-93:    switch vv := v.(type) {

--- a/tests/vm/valid/save_jsonl_stdout.mochi.error
+++ b/tests/vm/valid/save_jsonl_stdout.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/save_jsonl_stdout.go.out:27: unsupported assignment
->>> 26:    func _save(src any, path string, opts map[string]any) {
-27:>>> rows, ok := _toMapSlice(src)
-28:    if !ok {
-29:    panic("save source must be list of maps")

--- a/tests/vm/valid/save_jsonl_stdout.out
+++ b/tests/vm/valid/save_jsonl_stdout.out
@@ -1,2 +1,2 @@
-{"name":"Alice","age":30}
-{"name":"Bob","age":25}
+{"age":30,"name":"Alice"}
+{"age":25,"name":"Bob"}

--- a/tests/vm/valid/slice.mochi.error
+++ b/tests/vm/valid/slice.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/slice.go.out:13: unsupported parameter list
->>> 12:    
-13:>>> func _sliceString(s string, i, j int) string {
-14:    start := i
-15:    end := j

--- a/tests/vm/valid/sort_stable.mochi.error
+++ b/tests/vm/valid/sort_stable.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/sort_stable.go.out:42: unsupported statement *ast.TypeSwitchStmt
->>> 41:    var out T
-42:>>> switch any(out).(type) {
-43:    case int:
-44:    switch vv := v.(type) {

--- a/tests/vm/valid/string_prefix_slice.mochi.error
+++ b/tests/vm/valid/string_prefix_slice.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/string_prefix_slice.go.out:15: unsupported parameter list
->>> 14:    
-15:>>> func _sliceString(s string, i, j int) string {
-16:    start := i
-17:    end := j

--- a/tests/vm/valid/test_block.mochi.error
+++ b/tests/vm/valid/test_block.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/test_block.go.out:48: unsupported statement *ast.BlockStmt
->>> 47:    fmt.Println("ok")
-48:>>> {
-49:    printTestStart("addition works")
-50:    start := time.Now()

--- a/tests/vm/valid/tree_sum.mochi.error
+++ b/tests/vm/valid/tree_sum.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/tree_sum.go.out:8: unsupported type spec
->>> 7:    
-8:>>> type Tree interface{ isTree() }
-9:    type Leaf struct {
-10:    }

--- a/tests/vm/valid/typed_let.out
+++ b/tests/vm/valid/typed_let.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/valid/typed_var.out
+++ b/tests/vm/valid/typed_var.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/valid/update_stmt.mochi.error
+++ b/tests/vm/valid/update_stmt.mochi.error
@@ -1,5 +1,0 @@
-tests/vm/valid/update_stmt.go.out:55: unsupported declaration
->>> 54:    
-55:>>> var people []Person
-56:    
-57:    func main() {


### PR DESCRIPTION
## Summary
- update golden tests for runtime/vm
- delete obsolete `.mochi.error` files on success
- record helper change in Go compiler TASKS

## Testing
- `go test ./runtime/vm -tags slow -run TestVMValidPrograms -v`
- `go test ./runtime/vm -tags slow -run TestVMIRGolden -v`
- `go test ./runtime/vm -tags slow -run TestVM_RosettaTasks -v` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6877e279fcb0832084acd472d68df9b1