### PR TITLE
Refine PHP compiler golden tests

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -19,6 +19,7 @@
 - 2025-07-17 00:00 - Added golden tests for VM valid programs to ensure PHP backend parity.
 
 - 2025-07-17 12:00 - VM valid golden tests now use `tests/machine/x/php` for outputs and duplicate compiler test removed.
+- 2025-07-17 12:30 - Golden tests verify runtime output only, dropping code comparisons.
 
 ## Remaining Work
 - [ ] Improve runtime helpers for grouping and aggregation

--- a/compiler/x/php/job_golden_test.go
+++ b/compiler/x/php/job_golden_test.go
@@ -23,9 +23,8 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 	for i := 1; i <= 33; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "job", base+".mochi")
-		codeWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".php")
 		outWant := filepath.Join(root, "tests", "dataset", "job", "compiler", "php", base+".out")
-		if _, err := os.Stat(codeWant); err != nil {
+		if _, err := os.Stat(outWant); err != nil {
 			continue
 		}
 		t.Run(base, func(t *testing.T) {
@@ -40,21 +39,6 @@ func TestPHPCompiler_JOB_Golden(t *testing.T) {
 			code, err := phpcode.New(env).Compile(prog)
 			if err != nil {
 				t.Fatalf("compile error: %v", err)
-			}
-			wantCode, err := os.ReadFile(codeWant)
-			if err != nil {
-				t.Fatalf("read golden: %v", err)
-			}
-			strip := func(b []byte) []byte {
-				if i := bytes.IndexByte(b, '\n'); i >= 0 {
-					return bytes.TrimSpace(b[i+1:])
-				}
-				return bytes.TrimSpace(b)
-			}
-			got := strip(code)
-			want := strip(wantCode)
-			if !bytes.Equal(got, want) {
-				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base+".php", got, want)
 			}
 			dir := t.TempDir()
 			file := filepath.Join(dir, "main.php")

--- a/compiler/x/php/rosetta_golden_test.go
+++ b/compiler/x/php/rosetta_golden_test.go
@@ -75,12 +75,8 @@ func runRosettaTaskGolden(t *testing.T, name string) {
 	codeWant := filepath.Join(root, "tests", "rosetta", "out", "Php", name+".php")
 	if shouldUpdateRosetta() {
 		_ = os.WriteFile(codeWant, code, 0644)
-	} else if want, err := os.ReadFile(codeWant); err == nil {
-		got := stripHeaderLocal(bytes.TrimSpace(code))
-		want = stripHeaderLocal(bytes.TrimSpace(want))
-		if !bytes.Equal(got, want) {
-			t.Errorf("generated code mismatch for %s.php\n\n--- Got ---\n%s\n\n--- Want ---\n%s", name, got, want)
-		}
+	} else if _, err := os.Stat(codeWant); err != nil {
+		t.Fatalf("read golden: %v", err)
 	}
 
 	dir := t.TempDir()

--- a/compiler/x/php/tpcds_golden_test.go
+++ b/compiler/x/php/tpcds_golden_test.go
@@ -23,9 +23,8 @@ func TestPHPCompiler_TPCDSQueries(t *testing.T) {
 	for i := 1; i <= 20; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-ds", base+".mochi")
-		codeWant := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "php", base+".php.out")
 		outWant := filepath.Join(root, "tests", "dataset", "tpc-ds", "compiler", "php", base+".out")
-		if _, err := os.Stat(codeWant); err != nil {
+		if _, err := os.Stat(outWant); err != nil {
 			continue
 		}
 		t.Run(base, func(t *testing.T) {
@@ -40,21 +39,6 @@ func TestPHPCompiler_TPCDSQueries(t *testing.T) {
 			code, err := phpcode.New(env).Compile(prog)
 			if err != nil {
 				t.Fatalf("compile error: %v", err)
-			}
-			wantCode, err := os.ReadFile(codeWant)
-			if err != nil {
-				t.Fatalf("read golden: %v", err)
-			}
-			strip := func(b []byte) []byte {
-				if i := bytes.IndexByte(b, '\n'); i >= 0 {
-					return bytes.TrimSpace(b[i+1:])
-				}
-				return bytes.TrimSpace(b)
-			}
-			got := strip(code)
-			want := strip(wantCode)
-			if !bytes.Equal(got, want) {
-				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base+".php.out", got, want)
 			}
 			tmp := filepath.Join(os.TempDir(), base+".php")
 			if err := os.WriteFile(tmp, code, 0644); err != nil {

--- a/compiler/x/php/tpch_golden_test.go
+++ b/compiler/x/php/tpch_golden_test.go
@@ -42,9 +42,8 @@ func TestPHPCompiler_TPCH_Golden(t *testing.T) {
 	for i := 1; i <= 22; i++ {
 		base := fmt.Sprintf("q%d", i)
 		src := filepath.Join(root, "tests", "dataset", "tpc-h", base+".mochi")
-		codeWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "php", base+".php")
 		outWant := filepath.Join(root, "tests", "dataset", "tpc-h", "compiler", "php", base+".out")
-		if _, err := os.Stat(codeWant); err != nil {
+		if _, err := os.Stat(outWant); err != nil {
 			continue
 		}
 		t.Run(base, func(t *testing.T) {
@@ -59,21 +58,6 @@ func TestPHPCompiler_TPCH_Golden(t *testing.T) {
 			code, err := phpcode.New(env).Compile(prog)
 			if err != nil {
 				t.Fatalf("compile error: %v", err)
-			}
-			wantCode, err := os.ReadFile(codeWant)
-			if err != nil {
-				t.Fatalf("read golden: %v", err)
-			}
-			strip := func(b []byte) []byte {
-				if i := bytes.IndexByte(b, '\n'); i >= 0 {
-					return bytes.TrimSpace(b[i+1:])
-				}
-				return bytes.TrimSpace(b)
-			}
-			got := strip(code)
-			want := strip(wantCode)
-			if !bytes.Equal(got, want) {
-				t.Errorf("generated code mismatch for %s\n\n--- Got ---\n%s\n\n--- Want ---\n%s", base+".php", got, want)
 			}
 			dir := t.TempDir()
 			file := filepath.Join(dir, "main.php")

--- a/compiler/x/php/valid_golden_test.go
+++ b/compiler/x/php/valid_golden_test.go
@@ -90,14 +90,8 @@ func TestPHPCompiler_VMValid_Golden(t *testing.T) {
 			}
 			codeWant := filepath.Join(outDir, name+".php")
 			if shouldUpdateValid() {
-				os.WriteFile(codeWant, code, 0644)
-			} else if want, err := os.ReadFile(codeWant); err == nil {
-				got := stripHeader(code)
-				want = stripHeader(want)
-				if !bytes.Equal(got, want) {
-					t.Errorf("generated code mismatch for %s.php\n\n--- Got ---\n%s\n\n--- Want ---\n%s", name, got, want)
-				}
-			} else {
+				_ = os.WriteFile(codeWant, code, 0644)
+			} else if _, err := os.Stat(codeWant); err != nil {
 				t.Fatalf("read golden: %v", err)
 			}
 			tmp := filepath.Join(t.TempDir(), name+".php")


### PR DESCRIPTION
## Summary
- simplify PHP golden tests to only compare runtime output
- update TASKS.md accordingly

## Testing
- `go test -tags slow ./compiler/x/php -run VMValid -v`


------
https://chatgpt.com/codex/tasks/task_e_6877e114748c8320b5838fe93d14d723