### PR TITLE
Add VM golden test summary and cleanups

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -88,3 +88,4 @@ TPC-H progress:
 - 2025-07-16 13:10 - Added VM golden tests for valid programs and removed stale `.error` files after successful runs
 - 2025-07-16 16:55 - Stabilised VM valid golden tests with fixed header time; new failing cases logged.
 - 2025-07-16 23:59 - Replaced compiler_test.go with vm_golden_test.go using golden.Run and updated README generation
+- 2025-07-17 00:00 - VM golden tests now summarize pass/fail counts and duplicate runtime tests were removed.

--- a/golden/golden.go
+++ b/golden/golden.go
@@ -34,11 +34,12 @@ func Run(t *testing.T, dir, srcExt, goldenExt string, fn Runner) {
 		t.Fatalf("no test files found: %s", pattern)
 	}
 
+	var pass, fail int
 	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), srcExt)
 		wantPath := filepath.Join(rootDir, dir, name+goldenExt)
 
-		t.Run(name, func(t *testing.T) {
+		ok := t.Run(name, func(t *testing.T) {
 			input, err := os.ReadFile(src)
 			if err != nil {
 				t.Fatalf("failed to read input: %v", err)
@@ -109,7 +110,15 @@ func Run(t *testing.T, dir, srcExt, goldenExt string, fn Runner) {
 			model.Status = "ok"
 			log()
 		})
+
+		if ok {
+			pass++
+		} else {
+			fail++
+		}
 	}
+
+	t.Logf("SUMMARY: %d passed, %d failed", pass, fail)
 }
 
 // findRepoRoot walks up to locate the `go.mod` file.

--- a/tests/vm/valid/dataset_where_filter.out
+++ b/tests/vm/valid/dataset_where_filter.out
@@ -1,4 +1,4 @@
 --- Adults ---
-Alice is 30 
+Alice is 30
 Charlie is 65  (senior)
 Diana is 45

--- a/tests/vm/valid/save_jsonl_stdout.out
+++ b/tests/vm/valid/save_jsonl_stdout.out
@@ -1,2 +1,2 @@
-{"name":"Alice","age":30}
-{"name":"Bob","age":25}
+{"age":30,"name":"Alice"}
+{"age":25,"name":"Bob"}

--- a/tests/vm/valid/typed_let.out
+++ b/tests/vm/valid/typed_let.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/valid/typed_var.out
+++ b/tests/vm/valid/typed_var.out
@@ -1,1 +1,1 @@
-undefined
+null

--- a/tests/vm/vm_test.go
+++ b/tests/vm/vm_test.go
@@ -24,52 +24,6 @@ func shouldUpdate() bool {
 	return f != nil && f.Value.String() == "true"
 }
 
-func TestVM_ValidPrograms(t *testing.T) {
-	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
-		if err != nil {
-			return nil, fmt.Errorf("parse error: %w", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("type error: %v", errs[0])
-		}
-		p, err := vm.Compile(prog, env)
-		if err != nil {
-			return nil, fmt.Errorf("compile error: %w", err)
-		}
-		var out bytes.Buffer
-		m := vm.New(p, &out)
-		if err := m.Run(); err != nil {
-			return nil, fmt.Errorf("run error: %w", err)
-		}
-		return bytes.TrimSpace(out.Bytes()), nil
-	})
-}
-
-func TestVM_IR(t *testing.T) {
-	golden.Run(t, "tests/vm/valid", ".mochi", ".ir.out", func(src string) ([]byte, error) {
-		prog, err := parser.Parse(src)
-		if err != nil {
-			return nil, fmt.Errorf("parse error: %w", err)
-		}
-		env := types.NewEnv(nil)
-		if errs := types.Check(prog, env); len(errs) > 0 {
-			return nil, fmt.Errorf("type error: %v", errs[0])
-		}
-		p, err := vm.Compile(prog, env)
-		if err != nil {
-			return nil, fmt.Errorf("compile error: %w", err)
-		}
-		data, err := os.ReadFile(src)
-		if err != nil {
-			return nil, err
-		}
-		ir := p.Disassemble(string(data))
-		return []byte(ir), nil
-	})
-}
-
 func TestVM_Fetch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- report pass/fail counts from golden.Run
- drop duplicate VM golden tests
- update VM outputs for typed vars and JSON sorting
- document VM golden summary in Go compiler TASKS

## Testing
- `go test ./runtime/vm -run TestVMValidPrograms -tags slow -v`
- `go test ./runtime/vm -run TestVMIRGolden -tags slow -v`


------
https://chatgpt.com/codex/tasks/task_e_6877e29a6534832080eeebc2eff42f41