### PR TITLE
Add Go VM golden summary

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -89,3 +89,4 @@ TPC-H progress:
 - 2025-07-16 16:55 - Stabilised VM valid golden tests with fixed header time; new failing cases logged.
 - 2025-07-16 23:59 - Replaced compiler_test.go with vm_golden_test.go using golden.Run and updated README generation
 - 2025-07-19 08:01 - Updated golden helpers to delete `.mochi.error` files when running VM tests
+- 2025-07-19 12:00 - Renamed VM test to vm_valid_golden_test.go and summarized pass/fail counts

--- a/compiler/x/go/vm_valid_golden_test.go
+++ b/compiler/x/go/vm_valid_golden_test.go
@@ -18,14 +18,14 @@ import (
 )
 
 func TestGoCompiler_VMValid_Golden(t *testing.T) {
-	if _, err := exec.LookPath("go"); err != nil {
-		t.Skip("go toolchain not installed")
-	}
-	root := findRepoRootVM(t)
-	outDir := filepath.Join(root, "tests", "machine", "x", "go")
-	os.MkdirAll(outDir, 0o755)
+        if _, err := exec.LookPath("go"); err != nil {
+                t.Skip("go toolchain not installed")
+        }
+        root := findRepoRootVM(t)
+        outDir := filepath.Join(root, "tests", "machine", "x", "go")
+        os.MkdirAll(outDir, 0o755)
 
-	golden.Run(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+        golden.RunWithSummary(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
 		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
 		codePath := filepath.Join(outDir, base+".go")
 		outPath := filepath.Join(outDir, base+".out")


### PR DESCRIPTION
## Summary
- rename go VM golden test to `vm_valid_golden_test.go`
- run through all programs with `golden.RunWithSummary`
- log the change in compiler tasks

## Testing
- `go test ./compiler/x/go -run VMValid -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6877ed00b98083209063aab62222c43d