### PR TITLE
Update dart compiler tests

### DIFF
--- a/compiler/x/dart/TASKS.md
+++ b/compiler/x/dart/TASKS.md
@@ -21,5 +21,7 @@
 - [2025-07-17 00:45 UTC] Normalized numeric printing so integers don't appear
   with trailing `.0` and set `SOURCE_DATE_EPOCH` in VM golden tests to generate
   stable headers.
+- [2025-07-21 00:00 UTC] Added non-null map indexing (`[key]!`) for numeric
+  operations to reduce `.error` files in `tests/vm/valid`.
 ## Remaining Enhancements
 - [ ] Improve generated code formatting to more closely match `tests/human/x/dart` examples.

--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -1006,7 +1006,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					return "", err
 				}
 				if mt, ok := t.(types.MapType); ok {
-					val = fmt.Sprintf("(%s as Map)[%s]", val, idx)
+					val = fmt.Sprintf("(%s as Map)[%s]!", val, idx)
 					t = mt.Value
 				} else {
 					val = fmt.Sprintf("%s[%s]", val, idx)


### PR DESCRIPTION
## Summary
- fix map indexing for Dart compiler
- note the change in `TASKS.md`

## Testing
- `go test ./compiler/x/dart -run TestDartCompiler_VMValid_Golden -count=1 -tags=slow -v` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68784850637483208dfb07032e248d27