### PR TITLE
Improve Swift compiler tuple output

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,8 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-19 12:00 – tuple output for query map literals and identifier keys
+  accepted when mapping to structs.
 - 2025-07-18 10:00 – simplified golden tests to only check runtime output and
   added summary reporting. Duplicate compile tests were removed.
 - 2025-07-17 14:30 – added golden tests for `tests/vm/valid` and switched

--- a/tests/machine/x/swift/README.md
+++ b/tests/machine/x/swift/README.md
@@ -1,14 +1,12 @@
-<<<<<<< HEAD
 # Machine-generated Swift Programs
 
 This directory contains Swift code compiled from Mochi programs in `tests/vm/valid` using the experimental compiler.
 
 ## Progress
 
-Compiled: 96/100 programs
+Compiled: 97/100 programs
 
 ## Checklist
-
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -109,5 +107,3 @@ Compiled: 96/100 programs
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
-=======
->>>>>>> 15d0dc4b5 (Truncate all README.md)


### PR DESCRIPTION
## Summary
- allow identifier map keys when mapping to structs
- emit tuple output when select expressions return maps
- record progress in Swift tasks and update README

## Testing
- `go test ./compiler/x/swift -run TestSwiftCompiler_VMValid_Golden -tags slow -count=1` *(fails: values_builtin.out mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687850ea9aec83208f4e9265dfbfdfe5