### PR TITLE
Improve C++ compiler type tracking

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -52,6 +52,9 @@
 - `defineStruct` now falls back to `std::any` if unresolved variable
   references remain after replacement, avoiding g++ errors when struct
   field types reference undefined variables.
+- Improved `compileStructLiteral` and `structFromVars` to replace
+  leftover `decltype` placeholders with types inferred from `vars` or
+  `elemType` (2025-07-17 01:30 UTC).
 
 ## Remaining Enhancements
 - [ ] Improve formatting to better match human examples.

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # C++ Machine Output
 
 This directory contains C++ source code generated from Mochi programs and the corresponding outputs or error logs.
@@ -107,5 +106,3 @@ Compiled programs: 100/100
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-=======
->>>>>>> 15d0dc4b5 (Truncate all README.md)


### PR DESCRIPTION
## Summary
- propagate element types to loop and query variables in the C++ compiler
- replace leftover `decltype` placeholders using vars and predicted types
- remove merge markers from `tests/machine/x/cpp/README.md`
- document the new enhancement in `TASKS.md`

## Testing
- `go test ./compiler/x/cpp -run TestCPPCompiler_VMValid_Golden/cross_join_filter -tags=slow -count=1` *(fails: g++ error)*

------
https://chatgpt.com/codex/tasks/task_e_68784fed9ca88320973d8b660e790011