### PR TITLE
Improve Scala compiler option detection

### DIFF
--- a/compiler/x/scala/TASKS.md
+++ b/compiler/x/scala/TASKS.md
@@ -1,6 +1,8 @@
 # Scala Compiler Tasks
 
 ## Recent Enhancements
+- 2025-07-22 00:00 - Improved detection of `Option` values in `if` expressions to
+  reduce `.error` files for join examples
 - 2025-07-13 05:13 - Top-level `let` bindings move inside `main` when no functions follow
 - 2025-07-13 07:24 - Fixed `$` interpolation, improved `json` handling, GROUP BY keys use case classes, empty mutable lists default to `ArrayBuffer[Any]`
 - 2025-07-13 16:29 - Added generated code and tests for TPCH queries q3 and q4

--- a/tests/machine/x/scala/README.md
+++ b/tests/machine/x/scala/README.md
@@ -1,0 +1,7 @@
+# Scala Machine Outputs
+
+This directory contains Scala source files generated from the Mochi test suite.
+Each program under `tests/vm/valid` is compiled to Scala and executed during the
+`vm_golden_test` tests.  Successful runs have a `.out` file with the program
+output.  When compilation or execution fails the error message is stored in a
+matching `.error` file.


### PR DESCRIPTION
## Summary
- enhance Scala compiler to detect `Option` types when input types are `any`
- add helper to extract selectors from expressions
- document Scala machine outputs and update tasks

## Testing
- `go test ./compiler/x/scala -tags slow -c`

------
https://chatgpt.com/codex/tasks/task_e_687850e76a6c83209d8d66749543f7c3