### PR TITLE
Update Scheme compiler

### DIFF
--- a/compiler/x/scheme/TASKS.md
+++ b/compiler/x/scheme/TASKS.md
@@ -17,6 +17,8 @@ The Scheme backend now targets chibi-scheme and can compile the `tpc-h/q1.mochi`
   integers, reducing runtime errors for several Rosetta tasks.
 - 2025-07-16 13:10 – Added golden tests for `tests/vm/valid` programs and
   enabled Python `math` imports without the `auto` keyword.
+- 2025-07-17 01:30 – Improved `_date_number` to handle timestamps and `/`-based
+  separators when comparing dates.
 
 ### Remaining Work
 - [ ] Better handling of date comparisons and sorting when running JOB benchmarks

--- a/compiler/x/scheme/compiler.go
+++ b/compiler/x/scheme/compiler.go
@@ -96,7 +96,14 @@ const datasetHelpers = `(import (srfi 1) (srfi 95) (chibi json) (chibi io) (chib
       (close-output-port out))))
 
 (define (_date_number s)
-  (let ((parts (string-split s #\-)))
+  (let* ((d (if (> (string-length s) 10)
+                (substring s 0 10)
+                s))
+         (clean (string-map (lambda (c) (if (char=? c #\/)
+                                           #\-
+                                           c))
+                             d))
+         (parts (string-split clean #\-)))
     (if (= (length parts) 3)
         (+ (* (string->number (list-ref parts 0)) 10000)
            (* (string->number (list-ref parts 1)) 100)

--- a/tests/machine/x/scheme/README.md
+++ b/tests/machine/x/scheme/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Scheme Machine Output (100/100 compiled and run)
 
 This directory contains Scheme code generated from the Mochi programs in `tests/vm/valid`. Each program was executed with chibi-scheme. Successful runs have a `.out` file and failures provide a `.error`.
@@ -120,5 +119,3 @@ This directory contains Scheme code generated from the Mochi programs in `tests/
 - [ ] Improve error messages for invalid constructs
 
 All programs executed successfully.
-=======
->>>>>>> 15d0dc4b5 (Truncate all README.md)


### PR DESCRIPTION
## Summary
- clean up machine-generated Scheme README
- improve Scheme compiler date parsing to handle timestamps and slash separators
- document new enhancement in Scheme TASKS list

## Testing
- `go test -tags=slow ./compiler/x/scheme -run TestVMValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687850e5e2048320ae4c7851edb1e5bd