### PR TITLE
Fix go build and test

### DIFF
--- a/compiler/x/fortran/doc.go
+++ b/compiler/x/fortran/doc.go
@@ -1,0 +1,5 @@
+// Package ftncode provides a Fortran code generator used in slow tests.
+// The actual implementation lives in files guarded by the "slow" build tag so
+// that normal builds do not require a Fortran toolchain.
+package ftncode
+

--- a/compiler/x/fortran/ensure_test.go
+++ b/compiler/x/fortran/ensure_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ftncode_test
 
 import (


### PR DESCRIPTION
## Summary
- add documentation stub so `go build` works for `ftncode` package
- gate `ensure_test` on the `slow` build tag so normal `go test` doesn't fail

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68785a86e8148320bc21e6911f21c259