### PR TITLE
Fix C cross join codegen

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -123,3 +123,4 @@ should compile and run successfully.
 - 2025-09-09 - Removed archived_compiler_test.go and reran VM golden tests using `-update`. Results stored under tests/machine/x/c.
 - 2025-09-10 - Fixed list allocation name for grouped query results; `group_by_multi_join.mochi` now compiles.
 - 2025-09-11 - Added missing `listResCreate` initialization for pair-string grouping, enabling VM tests to build.
+- 2025-09-12 - Skipped redundant assignments when list literals initialize a variable directly. `cross_join_filter` and `cross_join_triple` now compile.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -1485,7 +1485,7 @@ func (c *Compiler) compileLet(stmt *parser.LetStmt) error {
 						}
 					}
 				}
-				if val != name || !c.stackArrays[name] {
+				if val != name {
 					c.writeln(formatFuncPtrDecl(typ, name, val))
 					for i, a := range c.allocs {
 						if a == val {
@@ -1506,7 +1506,7 @@ func (c *Compiler) compileLet(stmt *parser.LetStmt) error {
 					}
 				}
 			}
-			if val != name || !c.stackArrays[name] {
+			if val != name {
 				c.writeln(formatFuncPtrDecl(typ, name, val))
 				for i, a := range c.allocs {
 					if a == val {
@@ -1691,7 +1691,7 @@ func (c *Compiler) compileVar(stmt *parser.VarStmt) error {
 				c.assignVar = name
 				val := c.compileExpr(stmt.Value)
 				c.assignVar = ""
-				if val != name || !c.stackArrays[name] {
+				if val != name {
 					c.writeln(formatFuncPtrDecl(typ, name, val))
 					for i, a := range c.allocs {
 						if a == val {
@@ -1704,7 +1704,7 @@ func (c *Compiler) compileVar(stmt *parser.VarStmt) error {
 			c.assignVar = name
 			val := c.compileExpr(stmt.Value)
 			c.assignVar = ""
-			if val != name || !c.stackArrays[name] {
+			if val != name {
 				c.writeln(formatFuncPtrDecl(typ, name, val))
 				for i, a := range c.allocs {
 					if a == val {

--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -62,8 +62,8 @@ The C backend compiles Mochi programs in `tests/vm/valid`. The table below lists
 - [x] while_loop
 - [ ] avg_builtin
 - [ ] cast_struct
-- [ ] cross_join_filter
-- [ ] cross_join_triple
+- [x] cross_join_filter
+- [x] cross_join_triple
 - [ ] dataset_sort_take_limit
 - [ ] for_map_collection
 - [ ] group_by

--- a/tests/machine/x/c/cross_join_filter.c
+++ b/tests/machine/x/c/cross_join_filter.c
@@ -58,7 +58,6 @@ int _mochi_main() {
   list_string letters = list_string_create(2);
   letters.data[0] = "A";
   letters.data[1] = "B";
-  int letters = letters;
   list_int tmp1 = list_int_create(3);
   tmp1.data[0] = 1;
   tmp1.data[1] = 2;

--- a/tests/machine/x/c/cross_join_filter.error
+++ b/tests/machine/x/c/cross_join_filter.error
@@ -1,8 +1,0 @@
-exit status 1
-/workspace/mochi/tests/machine/x/c/cross_join_filter.c: In function ‘_mochi_main’:
-/workspace/mochi/tests/machine/x/c/cross_join_filter.c:61:7: error: conflicting types for ‘letters’; have ‘int’
-   61 |   int letters = letters;
-      |       ^~~~~~~
-/workspace/mochi/tests/machine/x/c/cross_join_filter.c:58:15: note: previous definition of ‘letters’ with type ‘list_string’
-   58 |   list_string letters = list_string_create(2);
-      |               ^~~~~~~

--- a/tests/machine/x/c/cross_join_filter.out
+++ b/tests/machine/x/c/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/machine/x/c/cross_join_triple.c
+++ b/tests/machine/x/c/cross_join_triple.c
@@ -58,7 +58,6 @@ int _mochi_main() {
   list_string letters = list_string_create(2);
   letters.data[0] = "A";
   letters.data[1] = "B";
-  int letters = letters;
   list_int bools = list_int_create(2);
   bools.data[0] = 1;
   bools.data[1] = 0;

--- a/tests/machine/x/c/cross_join_triple.error
+++ b/tests/machine/x/c/cross_join_triple.error
@@ -1,8 +1,0 @@
-exit status 1
-/workspace/mochi/tests/machine/x/c/cross_join_triple.c: In function ‘_mochi_main’:
-/workspace/mochi/tests/machine/x/c/cross_join_triple.c:61:7: error: conflicting types for ‘letters’; have ‘int’
-   61 |   int letters = letters;
-      |       ^~~~~~~
-/workspace/mochi/tests/machine/x/c/cross_join_triple.c:58:15: note: previous definition of ‘letters’ with type ‘list_string’
-   58 |   list_string letters = list_string_create(2);
-      |               ^~~~~~~

--- a/tests/machine/x/c/cross_join_triple.out
+++ b/tests/machine/x/c/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false


### PR DESCRIPTION
## Summary
- fix redundant assignments when compiling list literals in C backend
- regenerate cross join outputs for the C machine tests
- mark cross_join_filter and cross_join_triple as working
- log progress in the C TASKS

## Testing
- `go test -tags slow ./compiler/x/c -run TestCCompiler_VMValid_Golden/cross_join_filter -update`
- `go test -tags slow ./compiler/x/c -run TestCCompiler_VMValid_Golden/cross_join_triple -update`


------
https://chatgpt.com/codex/tasks/task_e_68786100e74c8320956e1d059ea26753