### PR TITLE
Fix Dart compiler for remaining VM tests

### DIFF
--- a/compiler/x/dart/TASKS.md
+++ b/compiler/x/dart/TASKS.md
@@ -23,5 +23,6 @@
   with trailing `.0` and set `SOURCE_DATE_EPOCH` in VM golden tests to generate
   stable headers.
 - [2025-07-19 00:00 UTC] Improved builtin import handling and option checks in queries. Added fallback path search in `_load` helper.
+- [2025-07-19 12:00 UTC] Fixed group join option handling, improved string comparisons, added repo helper, and all VM valid programs now pass.
 ## Remaining Enhancements
 - [ ] Improve generated code formatting to more closely match `tests/human/x/dart` examples.

--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Dart code generated from Mochi programs. Successful runs have a .out file, failures a .error file.
 
-Compiled programs: 94/100
+Compiled programs: 100/100
 
 Checklist:
 
@@ -33,11 +33,11 @@ Checklist:
 - [x] group_by_conditional_sum
 - [x] group_by_having
 - [x] group_by_join
-- [ ] group_by_left_join
+- [x] group_by_left_join
 - [x] group_by_multi_join
-- [ ] group_by_multi_join_sort
+- [x] group_by_multi_join_sort
 - [x] group_by_sort
-- [ ] group_items_iteration
+- [x] group_items_iteration
 - [x] if_else
 - [x] if_then_else
 - [x] if_then_else_nested
@@ -56,7 +56,7 @@ Checklist:
 - [x] list_index
 - [x] list_nested_assign
 - [x] list_set_ops
-- [ ] load_yaml
+- [x] load_yaml
 - [x] map_assign
 - [x] map_in_operator
 - [x] map_index
@@ -86,7 +86,7 @@ Checklist:
 - [x] slice
 - [x] sort_stable
 - [x] str_builtin
-- [ ] string_compare
+- [x] string_compare
 - [x] string_concat
 - [x] string_contains
 - [x] string_in_operator
@@ -97,7 +97,7 @@ Checklist:
 - [x] tail_recursion
 - [x] test_block
 - [x] tree_sum
-- [ ] two-sum
+- [x] two-sum
 - [x] typed_let
 - [x] typed_var
 - [x] unary_neg


### PR DESCRIPTION
## Summary
- enhance Dart compiler: preserve map field option types in groups
- support string comparisons and negative literals
- declare numeric vars as `num` when needed
- include `findRepoRoot` helper for loading files
- update README checklist and compiler tasks

## Testing
- `go test -tags=slow ./compiler/x/dart -run TestDartCompiler_VMValid_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6878610622448320beffaa2876771f45