### PR TITLE
Fix CS machine README cleanup

### DIFF
--- a/tests/machine/x/cs/README.md
+++ b/tests/machine/x/cs/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # C# Machine Output
 
 This directory holds C# source generated from the Mochi programs in `tests/vm/valid`. Each compiled program has a `.cs` file and the expected output in a matching `.out`. If the compiler failed a `.error` file will be present instead.
@@ -107,5 +106,3 @@ Checklist:
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-=======
->>>>>>> 15d0dc4b5 (Truncate all README.md)


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from C# machine README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878992ddbec8320bda269a3c0b8804c