### PR TITLE
Update PHP machine docs

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -28,3 +28,6 @@
 - [ ] Improve runtime helpers for grouping and aggregation
 - [ ] Keep machine output close to human reference implementations
 - 2025-07-17 01:10 - Marked VM golden tests with the "slow" build tag to avoid running during default test passes.
+
+## July 2025 Progress
+- 2025-07-19 13:20 - Verified that all 100 VM valid programs compile and run successfully with the PHP backend. Updated README checklist accordingly.

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -1,8 +1,9 @@
 # PHP Machine Outputs
 
 This directory contains PHP source files and expected output for the Mochi VM
-valid programs. Each item below has been compiled and executed successfully using
-the PHP backend.
+valid programs. Each item below has been compiled and executed successfully
+using the PHP backend. As of July 2025 all 100 programs in `tests/vm/valid`
+compile and run correctly.
 
 - [x] append_builtin
 - [x] avg_builtin
@@ -104,3 +105,5 @@ the PHP backend.
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
+\nAll 100 programs succeeded.
+


### PR DESCRIPTION
## Summary
- document that all VM valid programs compile and run for PHP
- note progress in TASKS

## Testing
- `go test -tags slow ./compiler/x/php -run TestPHPCompiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878995261a88320bb5593f20f65104d