### PR TITLE
Improve Swift compiler numeric inference

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,8 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-20 09:00 – numeric literal inference now distinguishes ints and floats so
+  join and group queries with decimal fields compile correctly.
 - 2025-07-19 12:00 – tuple output for query map literals and identifier keys
   accepted when mapping to structs.
 - 2025-07-18 10:00 – simplified golden tests to only check runtime output and

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1655,7 +1655,11 @@ func swiftTypeOf(t string) string {
 		return "String"
 	case "bool":
 		return "Bool"
-	case "number", "int", "float":
+	case "int":
+		return "Int"
+	case "float":
+		return "Double"
+	case "number":
 		return "Int"
 	case "map":
 		return "[String:Any]"
@@ -1743,8 +1747,10 @@ func (c *compiler) inferType(t *parser.TypeRef, val *parser.Expr) string {
 				return "string"
 			case p.Target.Lit != nil && p.Target.Lit.Bool != nil:
 				return "bool"
-			case p.Target.Lit != nil && (p.Target.Lit.Int != nil || p.Target.Lit.Float != nil):
-				return "number"
+			case p.Target.Lit != nil && p.Target.Lit.Float != nil:
+				return "float"
+			case p.Target.Lit != nil && p.Target.Lit.Int != nil:
+				return "int"
 			case p.Target.List != nil:
 				if len(p.Target.List.Elems) > 0 && p.Target.List.Elems[0].Binary != nil {
 					et := c.exprType(p.Target.List.Elems[0])
@@ -1833,8 +1839,13 @@ func (c *compiler) exprType(e *parser.Expr) string {
 	if p.Target.Lit != nil && p.Target.Lit.Bool != nil {
 		return "bool"
 	}
-	if p.Target.Lit != nil && (p.Target.Lit.Int != nil || p.Target.Lit.Float != nil) {
-		return "number"
+	if p.Target.Lit != nil {
+		if p.Target.Lit.Float != nil {
+			return "float"
+		}
+		if p.Target.Lit.Int != nil {
+			return "int"
+		}
 	}
 	if p.Target.List != nil {
 		if len(p.Target.List.Elems) > 0 {


### PR DESCRIPTION
## Summary
- enhance Swift compiler numeric type inference
- document progress in TASKS

## Testing
- `go test -tags slow ./compiler/x/swift -run TestSwiftCompiler_VMValid_Golden/group_by_conditional_sum$ -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6878996bc6a08320821f6e1f7447cc20