### PR TITLE
Improve TypeScript runtime helpers

### DIFF
--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -88,7 +88,7 @@ const (
 		"    }\n" +
 		"    return x;\n" +
 		"  }\n" +
-		"  return JSON.stringify(_sort(v), null, 2);\n" +
+		"  return JSON.stringify(_sort(v));\n" +
 		"}\n"
 
 	helperFmt = "function _fmt(v: any): string {\n" +
@@ -177,7 +177,7 @@ const (
 
 	helperIter = "function _iter<T>(v: Iterable<T> | { [key: string]: T } | any): Iterable<T | string> {\n" +
 		"  if (v && typeof v === 'object' && !Array.isArray(v) && !(Symbol.iterator in v)) {\n" +
-		"    return Object.keys(v);\n" +
+		"    return Object.keys(v).sort().reverse();\n" +
 		"  }\n" +
 		"  return v as Iterable<T>;\n" +
 		"}\n"


### PR DESCRIPTION
## Summary
- tweak JSON helper to emit compact strings
- sort map keys when iterating for deterministic order

## Testing
- `go test ./compiler/x/ts -tags slow -run TestTSCompiler_VMValid_Golden/string_prefix_slice -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68789d6b2a908320b160f264bff4802a