### PR TITLE
Improve Prolog backend short-circuit

### DIFF
--- a/compiler/x/pl/TASKS.md
+++ b/compiler/x/pl/TASKS.md
@@ -28,3 +28,8 @@
 ## Progress (2025-07-17 06:40 UTC)
 - Fixed handling of zero-argument predicates so generated clauses omit the stray comma.
 - Updated dynamic and static call generation to avoid an empty argument list.
+
+## Progress (2025-07-27 00:00 UTC)
+- Added short-circuit handling for `&&` and `||` in `buildBinary`.
+- Extended `isBoolExpr` to recognize expressions containing `->` or `;`.
+- Regenerated code for `bool_chain` using `go run ./cmd/mochix buildx -t pl`.

--- a/compiler/x/pl/compiler.go
+++ b/compiler/x/pl/compiler.go
@@ -983,10 +983,14 @@ func (c *Compiler) buildBinary(left string, leftArith bool, op string, right str
 		left = fmt.Sprintf("(%s %s %s)", left, cmp, right)
 		arith = false
 	case "&&":
-		left = fmt.Sprintf("(%s, %s)", left, right)
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("(%s -> (%s -> %s = true ; %s = false) ; %s = false),", left, right, tmp, tmp, tmp))
+		left = tmp
 		arith = false
 	case "||":
-		left = fmt.Sprintf("(%s ; %s)", left, right)
+		tmp := c.newTmp()
+		c.writeln(fmt.Sprintf("(%s -> %s = true ; %s -> %s = true ; %s = false),", left, tmp, right, tmp, tmp))
+		left = tmp
 		arith = false
 	case "in":
 		tmp := c.newTmp()
@@ -1622,7 +1626,7 @@ func isBoolExpr(s string) bool {
 			return s == "true" || s == "false"
 		}
 	}
-	ops := []string{"=:=", "=\\=", "<", "<=", ">", ">=", "==", "\\=="}
+	ops := []string{"=:=", "=\\=", "<", "<=", ">", ">=", "==", "\\==", "->", ";"}
 	for _, op := range ops {
 		if strings.Contains(s, op) {
 			return true


### PR DESCRIPTION
## Summary
- implement short-circuit code generation for `&&` and `||`
- detect boolean expressions with `->`/`;`
- document progress in Prolog backend TASKS

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68789e878e788320bb0275eb8060c4c4