### PR TITLE
Update Clojure machine README

### DIFF
--- a/compiler/x/clj/TASKS.md
+++ b/compiler/x/clj/TASKS.md
@@ -39,3 +39,4 @@ Remaining work:
 - 99/100 examples pass (only outer_join fails).
 
 2025-07-21: Fixed _query helper for outer joins; all 100 VM examples compile and run successfully.
+2025-07-22: Updated machine README to mark all examples passing. No outstanding tasks.

--- a/tests/machine/x/clj/README.md
+++ b/tests/machine/x/clj/README.md
@@ -68,7 +68,7 @@ Compiled programs: 100/100 successful.
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
 - [x] order_by_map.mochi
-- [ ] outer_join.mochi
+- [x] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
@@ -108,4 +108,4 @@ Compiled programs: 100/100 successful.
 All programs compiled successfully.
 
 ## Remaining tasks
-- [ ] Fix failing examples
+- [ ] None


### PR DESCRIPTION
## Summary
- mark `outer_join.mochi` as passing in the Clojure machine README
- remove outdated TODO note and log the update in TASKS

## Testing
- `go test ./compiler/x/clj -run VMValid -tags slow` *(fails: clojure not installed? skip)*

------
https://chatgpt.com/codex/tasks/task_e_68789fe447408320a594e6bdd50697ec