### PR TITLE
Fix Java compiler main indentation

### DIFF
--- a/compiler/x/java/TASKS.md
+++ b/compiler/x/java/TASKS.md
@@ -33,3 +33,4 @@
 - 2025-07-17 06:10 - added support for DISTINCT queries and added Java machine checklist.
 - 2025-07-17 08:00 - generated machine outputs for all VM valid programs.
 - 2025-07-17 12:34 - regenerated VM valid Java outputs and added README checklist.
+- 2025-07-17T07:19 - fixed indentation in main method

--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -174,7 +174,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	body := new(bytes.Buffer)
 	origBuf := c.buf
 	c.buf = body
-	c.indent = 1
+	c.indent = 2
 	for _, s := range prog.Statements {
 		if s.Var != nil {
 			if !c.globalUsed[s.Var.Name] {


### PR DESCRIPTION
## Summary
- tweak Java compiler to indent main body correctly
- note change in TASKS

## Testing
- `go test -tags slow ./compiler/x/java -run TestJavaCompiler_VMValidPrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878a1d719448320875cc96405e24581