### PR TITLE
Improve Dart equality codegen

### DIFF
--- a/compiler/x/dart/TASKS.md
+++ b/compiler/x/dart/TASKS.md
@@ -29,5 +29,7 @@
   hand-written examples. VM outputs regenerated.
 - [2025-07-20 00:00 UTC] Added multiline formatting for list and map literals,
   improving readability of generated code.
+- [2025-07-17 07:47 UTC] Improved equality handling so comparisons with `null`
+  do not trigger the `_equal` helper, keeping generated programs smaller.
 ## Remaining Enhancements
 - None.

--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -931,6 +931,9 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 		return fmt.Sprintf("%s.where((x) => %s.contains(x)).toList()", left, right), leftType, nil
 	default:
 		if op == "==" || op == "!=" {
+			if left == "null" || right == "null" {
+				return fmt.Sprintf("%s %s %s", left, op, right), types.BoolType{}, nil
+			}
 			if isListType(leftType) || isListType(rightType) || isMapType(leftType) || isMapType(rightType) {
 				c.useEqual = true
 				expr := fmt.Sprintf("_equal(%s, %s)", left, right)


### PR DESCRIPTION
## Summary
- avoid `_equal` helper when comparing lists or maps with null
- note improvement in Dart compiler tasks

## Testing
- `go test ./compiler/x/dart -tags slow -run TestDartCompiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878a92ce41c8320b43c5a82fcac2ec9