### PR TITLE
Improve Dart _print helper

### DIFF
--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -43,9 +43,13 @@ void _json(dynamic v) {
 }
 
 void _print(List<dynamic> args) {
-    for (var i = 0; i < args.length; i++) {
-        if (i > 0) stdout.write(' ');
-        var v = args[i];
+    var first = true;
+    for (var v in args) {
+        if (v is String && v.isEmpty) {
+            continue;
+        }
+        if (!first) stdout.write(' ');
+        first = false;
         if (v is List) {
             stdout.write(v.join(' '));
         } else if (v is double && v == v.roundToDouble()) {


### PR DESCRIPTION
## Summary
- avoid trailing spaces when printing in generated Dart code

## Testing
- `go test ./compiler/x/dart -tags slow -run TestDartCompiler_VMValid_Golden -count=1` *(fails: Summary: 70 passed, 30 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878abb464f083209e6edffa8fb32393