### PR TITLE
Fix Haskell group record fields

### DIFF
--- a/compiler/x/hs/TASKS.md
+++ b/compiler/x/hs/TASKS.md
@@ -1,5 +1,9 @@
 # Haskell Backend Progress
 
+## Recent Updates (2025-07-25 05:00)
+- Renamed `MGroup` record fields to `gKey` and `gItems` so dataset variables like
+  `items` no longer clash with generated selectors.
+
 ## Recent Updates (2025-07-17 07:18)
 - Group-by queries now cast dynamic keys to strings when necessary so generated Haskell code compiles without missing `Ord` instances.
 

--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1498,7 +1498,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		if p.Call.Func == "count" {
 			if len(args) == 1 {
 				if _, ok := c.inferExprType(p.Call.Args[0]).(types.GroupType); ok {
-					return fmt.Sprintf("length (items %s)", args[0]), nil
+					return fmt.Sprintf("length (gItems %s)", args[0]), nil
 				}
 			}
 			return fmt.Sprintf("length %s", strings.Join(args, " ")), nil
@@ -1581,17 +1581,17 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			switch tt := typ.(type) {
 			case types.GroupType:
 				if field == "key" {
-					expr = fmt.Sprintf("key (%s)", expr)
+					expr = fmt.Sprintf("gKey (%s)", expr)
 					typ = types.AnyType{}
 					continue
 				} else if field == "items" {
-					expr = fmt.Sprintf("items (%s)", expr)
+					expr = fmt.Sprintf("gItems (%s)", expr)
 					typ = types.ListType{Elem: tt.Elem}
 					continue
 				}
 				c.usesMap = true
 				c.usesMaybe = true
-				expr = fmt.Sprintf("fromMaybe (error \"missing\") (Map.lookup %q (key %s))", field, expr)
+				expr = fmt.Sprintf("fromMaybe (error \"missing\") (Map.lookup %q (gKey %s))", field, expr)
 				typ = types.AnyType{}
 			case types.MapType:
 				c.usesMap = true

--- a/compiler/x/hs/runtime.go
+++ b/compiler/x/hs/runtime.go
@@ -25,7 +25,7 @@ avg :: (Real a, Fractional b) => [a] -> b
 avg xs | null xs = 0
        | otherwise = realToFrac (sum xs) / fromIntegral (length xs)
 
-data MGroup k a = MGroup { key :: k, items :: [a] } deriving (Show)
+data MGroup k a = MGroup { gKey :: k, gItems :: [a] } deriving (Show)
 
 _group_by :: Ord k => [a] -> (a -> k) -> [MGroup k a]
 _group_by src keyfn =


### PR DESCRIPTION
## Summary
- avoid name conflicts by renaming group record selectors to `gKey` and `gItems`
- update `compilePrimary` to use new field names
- note change in Haskell backend TASKS

## Testing
- `go test -tags slow ./compiler/x/hs -run TestHSCompiler_VMValid_GoldenRun/tail_recursion -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6878a94731688320be69baa7b86963ec