### PR TITLE
Fix C compiler list creation

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -131,3 +131,4 @@ should compile and run successfully.
   compile and run successfully.
 - 2025-09-14 - Fixed slice generation to avoid wrapping `list_int` values in
   temporary structs; `slice.mochi` now compiles and runs.
+- 2025-07-17 - Fixed list creation call for struct lists so `dataset_sort_take_limit.mochi` compiles and runs.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -3904,6 +3904,8 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 	if hasStruct {
 		listC = sanitizeListName(selStruct.Name)
 		listCreate = createListFuncName(selStruct.Name)
+	} else if st, ok := retT.(types.StructType); ok {
+		listCreate = createListFuncName(st.Name)
 	} else {
 		listCreate = listC + "_create"
 	}

--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -64,7 +64,7 @@ The C backend compiles Mochi programs in `tests/vm/valid`. The table below lists
 - [ ] cast_struct
 - [x] cross_join_filter
 - [x] cross_join_triple
-- [ ] dataset_sort_take_limit
+- [x] dataset_sort_take_limit
  - [x] for_map_collection
 - [ ] group_by
 - [ ] group_by_conditional_sum

--- a/tests/machine/x/c/dataset_sort_take_limit.c
+++ b/tests/machine/x/c/dataset_sort_take_limit.c
@@ -30,7 +30,7 @@ int _mochi_main() {
                           (product_t){.name = "Mouse", .price = 50},
                           (product_t){.name = "Headphones", .price = 200}};
   int products_len = sizeof(products) / sizeof(products[0]);
-  product_list_t tmp1 = product_list_t_create(products_len);
+  product_list_t tmp1 = create_product_list(products_len);
   int *tmp4 = (int *)malloc(sizeof(int) * products_len);
   int tmp2 = 0;
   int tmp5 = 1;

--- a/tests/machine/x/c/dataset_sort_take_limit.error
+++ b/tests/machine/x/c/dataset_sort_take_limit.error
@@ -1,6 +1,0 @@
-exit status 1
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c: In function ‘_mochi_main’:
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c:33:25: warning: implicit declaration of function ‘product_list_t_create’ [-Wimplicit-function-declaration]
-   33 |   product_list_t tmp1 = product_list_t_create(products_len);
-      |                         ^~~~~~~~~~~~~~~~~~~~~
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c:33:25: error: invalid initializer


### PR DESCRIPTION
## Summary
- support struct lists in C backend query outputs
- update generated C for `dataset_sort_take_limit.mochi`
- mark dataset_sort_take_limit as working in C README
- log progress in TASKS

## Testing
- `gcc tests/machine/x/c/dataset_sort_take_limit.c -std=c11 -lm -o /tmp/test_prog`
- `/tmp/test_prog > /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_6878ac29d8f48320ac832d04e9eee78a