### PR TITLE
Improve TypeScript builtin generation

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -106,3 +106,6 @@
 ### 2025-07-17 00:00 UTC
 - Short list literals are now emitted on a single line for closer parity with
   the hand-written examples.
+### 2025-07-17 08:11 UTC
+- Improved built-in handling for `contains`, `values` and `exists` using native
+  expressions when types are known.

--- a/tests/machine/x/ts/exists_builtin.ts
+++ b/tests/machine/x/ts/exists_builtin.ts
@@ -6,20 +6,9 @@ let flag: boolean;
 
 function main(): void {
   data = [1, 2];
-  flag = _exists(data.filter((x) => (x == 1)).map((x) => x));
+  flag = data.filter((x) => (x == 1)).map((x) => x).length > 0;
   _print(flag);
 }
-function _exists(v: unknown): boolean {
-  if (Array.isArray(v)) return v.length > 0;
-  if (v && typeof v === "object") {
-    if (Array.isArray((v as any).items)) return (v as any).items.length > 0;
-    if (Array.isArray((v as any).Items)) return (v as any).Items.length > 0;
-    return Object.keys(v).length > 0;
-  }
-  if (typeof v === "string") return v.length > 0;
-  return false;
-}
-
 function _print(...args: unknown[]): void {
   const out = args.map((a) => {
     if (Array.isArray(a)) return a.join(" ");

--- a/tests/machine/x/ts/values_builtin.ts
+++ b/tests/machine/x/ts/values_builtin.ts
@@ -9,7 +9,7 @@ function main(): void {
     "b": 2,
     "c": 3,
   };
-  _print(_values(m));
+  _print(Object.values(m));
 }
 function _print(...args: unknown[]): void {
   const out = args.map((a) => {
@@ -18,13 +18,6 @@ function _print(...args: unknown[]): void {
     return String(a);
   }).join(" ").trimEnd();
   console.log(out);
-}
-
-function _values<T>(m: { [key: string]: T }): T[] {
-  if (m && typeof m === "object" && !Array.isArray(m)) {
-    return Object.values(m);
-  }
-  throw new Error("values() expects map");
 }
 
 main();


### PR DESCRIPTION
## Summary
- specialize builtins `contains`, `values` and `exists` when types are known
- regenerate TypeScript outputs
- note improvement in TASKS log

## Testing
- `go test ./compiler/x/ts -run VMValid -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878af3b86288320aca5e6a02eeaaeb9