### PR TITLE
Update C backend dataset sort limit

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -132,3 +132,6 @@ should compile and run successfully.
 - 2025-09-14 - Fixed slice generation to avoid wrapping `list_int` values in
   temporary structs; `slice.mochi` now compiles and runs.
 - 2025-07-17 - Updated struct forward declarations to use sanitized type names so `cast_struct.mochi` compiles.
+- 2025-09-15 - Fixed list allocation for struct query results when the select
+  expression isn't a map literal. `dataset_sort_take_limit.mochi` now compiles
+  and runs.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -3897,6 +3897,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) string {
 	retT := c.exprType(q.Select)
 	if hasStruct {
 		retT = selStruct
+	} else if st, ok := retT.(types.StructType); ok {
+		selStruct = st
+		hasStruct = true
 	}
 	retList := types.ListType{Elem: retT}
 	listC := cTypeFromType(retList)

--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -64,7 +64,7 @@ The C backend compiles Mochi programs in `tests/vm/valid`. The table below lists
 - [x] cast_struct
 - [x] cross_join_filter
 - [x] cross_join_triple
-- [ ] dataset_sort_take_limit
+ - [x] dataset_sort_take_limit
  - [x] for_map_collection
 - [ ] group_by
 - [ ] group_by_conditional_sum

--- a/tests/machine/x/c/dataset_sort_take_limit.c
+++ b/tests/machine/x/c/dataset_sort_take_limit.c
@@ -30,7 +30,7 @@ int _mochi_main() {
                           (product_t){.name = "Mouse", .price = 50},
                           (product_t){.name = "Headphones", .price = 200}};
   int products_len = sizeof(products) / sizeof(products[0]);
-  product_list_t tmp1 = product_list_t_create(products_len);
+  product_list_t tmp1 = create_product_list(products_len);
   int *tmp4 = (int *)malloc(sizeof(int) * products_len);
   int tmp2 = 0;
   int tmp5 = 1;

--- a/tests/machine/x/c/dataset_sort_take_limit.error
+++ b/tests/machine/x/c/dataset_sort_take_limit.error
@@ -1,6 +1,0 @@
-exit status 1
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c: In function ‘_mochi_main’:
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c:33:25: warning: implicit declaration of function ‘product_list_t_create’ [-Wimplicit-function-declaration]
-   33 |   product_list_t tmp1 = product_list_t_create(products_len);
-      |                         ^~~~~~~~~~~~~~~~~~~~~
-/workspace/mochi/tests/machine/x/c/dataset_sort_take_limit.c:33:25: error: invalid initializer

--- a/tests/machine/x/c/dataset_sort_take_limit.out
+++ b/tests/machine/x/c/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300


### PR DESCRIPTION
## Summary
- improve struct result detection in `compileQueryExpr`
- regenerate C output for `dataset_sort_take_limit`
- mark dataset_sort_take_limit as passing
- note progress in C compiler tasks

## Testing
- `go test ./compiler/x/c -tags=slow -run TestCCompiler_VMValid_Golden/dataset_sort_take_limit`

------
https://chatgpt.com/codex/tasks/task_e_6878aea2b82c8320bc22bb2d56cb57b2