### PR TITLE
Improve numeric bool handling in Python compiler

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -1271,12 +1271,8 @@ func (c *Compiler) needsNumericBool(e *parser.Expr) bool {
 	if len(e.Binary.Right) == 1 {
 		op := e.Binary.Right[0].Op
 		if op == "in" {
-			return true
-		}
-		if op == "<" || op == "<=" || op == ">" || op == ">=" || op == "==" || op == "!=" {
-			lt := c.inferUnaryType(u)
 			rt := c.inferPostfixType(e.Binary.Right[0].Right)
-			if isString(lt) || isString(rt) {
+			if _, ok := rt.(types.ListType); ok {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary
- refine `needsNumericBool` for Python generation to only cast to `int` when
  membership uses lists or boolean comes from `contains` or `exists`

## Testing
- `go test -tags=slow ./compiler/x/python -run TestPythonCompiler_VMValid_Golden/exists_builtin -count 1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6878ad0dafe0832098604eca31712def