### PR TITLE
Improve C compiler list handling

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -132,3 +132,4 @@ should compile and run successfully.
 - 2025-09-14 - Fixed slice generation to avoid wrapping `list_int` values in
   temporary structs; `slice.mochi` now compiles and runs.
 - 2025-07-17 - Updated struct forward declarations to use sanitized type names so `cast_struct.mochi` compiles.
+- 2025-09-22 - Added float list optimizations and fixed list creation for existing structs in queries.


### PR DESCRIPTION
## Summary
- improve list creation for struct query results
- track float list literals for inference
- optimize `sum`, `avg`, `min` and `max` for constant float lists
- document progress in `TASKS.md`

## Testing
- `go test ./...`
- `go test ./compiler/x/c -run VM -tags slow -count=1` *(fails: golden mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6878afb71d58832080b0686b27c8b7e9