### PR TITLE
Improve Go compiler optional struct handling

### DIFF
--- a/tests/machine/x/go/left_join.error
+++ b/tests/machine/x/go/left_join.error
@@ -1,7 +1,0 @@
-exit status 1
-# command-line-arguments
-../../../tests/machine/x/go/left_join.go:52:16: cannot use _getField(c, "id") (value of interface type any) as int value in map index: need type assertion
-../../../tests/machine/x/go/left_join.go:52:38: cannot use c (variable of struct type Customer) as *Customer value in assignment
-../../../tests/machine/x/go/left_join.go:58:18: cannot use &v (value of type **Customer) as Customer value in assignment
-../../../tests/machine/x/go/left_join.go:60:18: cannot use nil as Customer value in assignment
-../../../tests/machine/x/go/left_join.go:68:24: invalid operation: entry.Customer != nil (mismatched types Customer and untyped nil)

--- a/tests/machine/x/go/left_join.out
+++ b/tests/machine/x/go/left_join.out
@@ -1,0 +1,3 @@
+--- Left Join ---
+Order 100 customer {id: 1, name: "Alice"} total 250
+Order 101 customer <nil> total 80


### PR DESCRIPTION
## Summary
- improve join key inference for optional structs
- handle OptionType in selectors
- update query environment to mark optional join vars
- adjust left join map generation for pointer types
- regenerate `left_join` machine output

## Testing
- `go test ./compiler/x/go -tags slow -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878b17b63248320b22e19f7f09796fc