### PR TITLE
Improve Swift compiler equality handling

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,7 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-23 10:00 – direct equality for typed values avoids _equal helper when possible
 - 2025-07-22 08:10 – improved join query nil handling and added struct list
   conversion when saving data so `right_join` and `save_jsonl_stdout` now
   compile.


### PR DESCRIPTION
## Summary
- enhance `expect` statement codegen to use direct equality when both sides have compatible types
- add helper `canCompareDirectly`
- document update in Swift TASKS

## Testing
- `go test ./compiler/x/swift -run VMValid -tags slow -count=1` *(fails: 95 passed, 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878b177c66c8320b1758cbffad22d9a