### PR TITLE
Improve Swift compiler inference

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,7 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-24 09:00 – arithmetic expressions now infer numeric types so expectation comparisons use `==` without the `_equal` helper when possible
 - 2025-07-23 10:00 – direct equality for typed values avoids _equal helper when possible
 - 2025-07-22 08:10 – improved join query nil handling and added struct list
   conversion when saving data so `right_join` and `save_jsonl_stdout` now

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1749,8 +1749,12 @@ func inferTypeRef(t *parser.TypeRef) string {
 		switch strings.ToLower(name) {
 		case "string":
 			return "string"
-		case "int", "float", "bool":
-			return "number"
+		case "int":
+			return "int"
+		case "float":
+			return "float"
+		case "bool":
+			return "bool"
 		default:
 			return name
 		}
@@ -1782,8 +1786,12 @@ func (c *compiler) inferType(t *parser.TypeRef, val *parser.Expr) string {
 			switch strings.ToLower(name) {
 			case "string":
 				return "string"
-			case "int", "float", "bool":
-				return "number"
+			case "int":
+				return "int"
+			case "float":
+				return "float"
+			case "bool":
+				return "bool"
 			default:
 				return name
 			}
@@ -1838,6 +1846,40 @@ func (c *compiler) inferType(t *parser.TypeRef, val *parser.Expr) string {
 				return "list_" + et
 			}
 			return "list"
+		}
+
+		if len(val.Binary.Right) > 0 {
+			num := true
+			isFloat := false
+			lt := c.unaryType(val.Binary.Left)
+			if lt != "" {
+				if lt == "float" {
+					isFloat = true
+				} else if lt != "int" {
+					num = false
+				}
+			}
+			for _, op := range val.Binary.Right {
+				switch op.Op {
+				case "+", "-", "*", "/", "%":
+					rt := c.postfixType(op.Right)
+					if rt != "" {
+						if rt == "float" {
+							isFloat = true
+						} else if rt != "int" {
+							num = false
+						}
+					}
+				default:
+					num = false
+				}
+			}
+			if num {
+				if isFloat {
+					return "float"
+				}
+				return "int"
+			}
 		}
 	}
 	return ""

--- a/tests/machine/x/swift/test_block.swift
+++ b/tests/machine/x/swift/test_block.swift
@@ -4,57 +4,6 @@ import Foundation
 func expect(_ cond: Bool) {
     if !cond { fatalError("expect failed") }
 }
-func _structMap(_ v: Any) -> [String:Any]? {
-    let mirror = Mirror(reflecting: v)
-    if mirror.displayStyle == .struct || mirror.displayStyle == .class {
-        var m: [String:Any] = [:]
-        for child in mirror.children {
-            if let k = child.label { m[k] = child.value }
-        }
-        return m
-    }
-    return nil
-}
-func _equal(_ a: Any, _ b: Any) -> Bool {
-    if let am = _structMap(a), let bm = _structMap(b) {
-        return _equal(am, bm)
-    }
-    if let am = _structMap(a), let bd = b as? [String: Any] {
-        return _equal(am, bd)
-    }
-    if let ad = a as? [String: Any], let bm = _structMap(b) {
-        return _equal(ad, bm)
-    }
-    switch (a, b) {
-    case let (x as [Any], y as [Any]):
-        if x.count != y.count { return false }
-        for i in 0..<x.count {
-            if !_equal(x[i], y[i]) { return false }
-        }
-        return true
-    case let (x as [String: Any], y as [String: Any]):
-        if x.count != y.count { return false }
-        for (k, av) in x {
-            guard let bv = y[k] else { return false }
-            if !_equal(av, bv) { return false }
-        }
-        return true
-    case let (ai as Double, bi as Int):
-        return ai == Double(bi)
-    case let (ai as Int, bi as Double):
-        return Double(ai) == bi
-    case let (ai as Double, bi as Double):
-        return ai == bi
-    case let (ai as Int, bi as Int):
-        return ai == bi
-    case let (sa as String, sb as String):
-        return sa == sb
-    case let (ab as Bool, bb as Bool):
-        return ab == bb
-    default:
-        return false
-    }
-}
 let x = 1 + 2
-expect(_equal(x, 3))
+expect(x == 3)
 print("ok")


### PR DESCRIPTION
## Summary
- improve Swift type inference for arithmetic expressions
- avoid `_equal` helper in `test_block` generated output
- update task progress notes

## Testing
- `go test ./compiler/x/swift -tags slow -run TestSwiftCompiler_VMValid_Golden/test_block -count=1`
- `go test ./compiler/x/swift -tags slow -run TestSwiftCompiler_VMValid_Golden/update_stmt -count=1`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878b6c4cb3c8320933d65c1f4645f6c