### PR TITLE
Improve Fortran compiler constant folding

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -44,6 +44,8 @@
   compilation checklist in `tests/machine/x/fortran/README.md`.
 - 2025-07-17 07:00: The compiler runs the type checker before emitting code so
   variables inferred from external functions use the correct Fortran types.
+- 2025-07-17 08:30: `len` and `count` constant-fold list literals to numeric
+  literals during code generation, avoiding runtime size checks.
 
 ## Remaining Work
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.

--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -1167,6 +1167,9 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 		if len(call.Args) != 1 {
 			return "", fmt.Errorf("len expects 1 arg")
 		}
+		if lst := listLiteral(call.Args[0]); lst != nil {
+			return fmt.Sprintf("%d", len(lst.Elems)), nil
+		}
 		if types.IsStringExpr(call.Args[0], c.env) {
 			return fmt.Sprintf("len(%s)", args[0]), nil
 		}
@@ -1195,6 +1198,9 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 	case "count":
 		if len(call.Args) != 1 {
 			return "", fmt.Errorf("count expects 1 arg")
+		}
+		if lst := listLiteral(call.Args[0]); lst != nil {
+			return fmt.Sprintf("%d", len(lst.Elems)), nil
 		}
 		return fmt.Sprintf("size(%s)", args[0]), nil
 	case "str":

--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -2,6 +2,9 @@
 
 The Fortran backend compiles each Mochi program under `tests/vm/valid`. This directory stores the generated `.f90` source files and their runtime output. No `.error` files are present because all examples compile successfully.
 
+List literal lengths are now computed at compile time so programs using `len` or
+`count` on constant arrays avoid runtime helper code.
+
 Compiled programs: 100/100
 
 Checklist:


### PR DESCRIPTION
## Summary
- inline constant results for `len` and `count` when called on list literals
- document new behaviour in TASKS and machine README

## Testing
- `go test ./compiler/x/fortran -run VMValid_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878b73f3d3c8320b491a00a2c87115b