### PR TITLE
Improve Haskell compiler type inference

### DIFF
--- a/compiler/x/hs/TASKS.md
+++ b/compiler/x/hs/TASKS.md
@@ -1,4 +1,9 @@
 # Haskell Backend Progress
+## Recent Updates (2025-07-27 05:00)
+- Type inference now uses `types.CheckExprType` when an environment is available.
+  This improves precision for nested expressions and reduces `_asInt` casts in generated code.
+
+ 
 
 ## Recent Updates (2025-07-25 05:00)
 - Renamed `MGroup` record fields to `gKey` and `gItems` so dataset variables like

--- a/compiler/x/hs/infer.go
+++ b/compiler/x/hs/infer.go
@@ -9,7 +9,10 @@ import (
 
 // inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
-	return types.ExprType(e, c.env)
+	if c.env == nil {
+		return types.ExprType(e, nil)
+	}
+	return types.CheckExprType(e, c.env)
 }
 
 func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
@@ -17,7 +20,10 @@ func (c *Compiler) inferUnaryType(u *parser.Unary) types.Type {
 		return types.AnyType{}
 	}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: u}}
-	return types.ExprType(expr, c.env)
+	if c.env == nil {
+		return types.ExprType(expr, nil)
+	}
+	return types.CheckExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
@@ -26,7 +32,10 @@ func (c *Compiler) inferPostfixType(p *parser.PostfixExpr) types.Type {
 	}
 	unary := &parser.Unary{Value: p}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.ExprType(expr, c.env)
+	if c.env == nil {
+		return types.ExprType(expr, nil)
+	}
+	return types.CheckExprType(expr, c.env)
 }
 
 func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
@@ -36,7 +45,10 @@ func (c *Compiler) inferPrimaryType(p *parser.Primary) types.Type {
 	postfix := &parser.PostfixExpr{Target: p}
 	unary := &parser.Unary{Value: postfix}
 	expr := &parser.Expr{Binary: &parser.BinaryExpr{Left: unary}}
-	return types.ExprType(expr, c.env)
+	if c.env == nil {
+		return types.ExprType(expr, nil)
+	}
+	return types.CheckExprType(expr, c.env)
 }
 
 func (c *Compiler) resolveTypeRef(t *parser.TypeRef) types.Type {


### PR DESCRIPTION
## Summary
- improve hs backend type inference using `types.CheckExprType`
- update TASKS with note about better inference

## Testing
- `go test ./compiler/x/hs -c -tags slow` *(fails: build constraints exclude all files? actually compiles)*


------
https://chatgpt.com/codex/tasks/task_e_6878b732395c83208338cd3d72335d07