### PR TITLE
Improve Swift struct type inference

### DIFF
--- a/tests/machine/x/swift/test_block.swift
+++ b/tests/machine/x/swift/test_block.swift
@@ -4,57 +4,6 @@ import Foundation
 func expect(_ cond: Bool) {
     if !cond { fatalError("expect failed") }
 }
-func _structMap(_ v: Any) -> [String:Any]? {
-    let mirror = Mirror(reflecting: v)
-    if mirror.displayStyle == .struct || mirror.displayStyle == .class {
-        var m: [String:Any] = [:]
-        for child in mirror.children {
-            if let k = child.label { m[k] = child.value }
-        }
-        return m
-    }
-    return nil
-}
-func _equal(_ a: Any, _ b: Any) -> Bool {
-    if let am = _structMap(a), let bm = _structMap(b) {
-        return _equal(am, bm)
-    }
-    if let am = _structMap(a), let bd = b as? [String: Any] {
-        return _equal(am, bd)
-    }
-    if let ad = a as? [String: Any], let bm = _structMap(b) {
-        return _equal(ad, bm)
-    }
-    switch (a, b) {
-    case let (x as [Any], y as [Any]):
-        if x.count != y.count { return false }
-        for i in 0..<x.count {
-            if !_equal(x[i], y[i]) { return false }
-        }
-        return true
-    case let (x as [String: Any], y as [String: Any]):
-        if x.count != y.count { return false }
-        for (k, av) in x {
-            guard let bv = y[k] else { return false }
-            if !_equal(av, bv) { return false }
-        }
-        return true
-    case let (ai as Double, bi as Int):
-        return ai == Double(bi)
-    case let (ai as Int, bi as Double):
-        return Double(ai) == bi
-    case let (ai as Double, bi as Double):
-        return ai == bi
-    case let (ai as Int, bi as Int):
-        return ai == bi
-    case let (sa as String, sb as String):
-        return sa == sb
-    case let (ab as Bool, bb as Bool):
-        return ab == bb
-    default:
-        return false
-    }
-}
 let x = 1 + 2
-expect(_equal(x, 3))
+expect(x == 3)
 print("ok")

--- a/tests/machine/x/swift/update_stmt.swift
+++ b/tests/machine/x/swift/update_stmt.swift
@@ -4,57 +4,6 @@ import Foundation
 func expect(_ cond: Bool) {
     if !cond { fatalError("expect failed") }
 }
-func _structMap(_ v: Any) -> [String:Any]? {
-    let mirror = Mirror(reflecting: v)
-    if mirror.displayStyle == .struct || mirror.displayStyle == .class {
-        var m: [String:Any] = [:]
-        for child in mirror.children {
-            if let k = child.label { m[k] = child.value }
-        }
-        return m
-    }
-    return nil
-}
-func _equal(_ a: Any, _ b: Any) -> Bool {
-    if let am = _structMap(a), let bm = _structMap(b) {
-        return _equal(am, bm)
-    }
-    if let am = _structMap(a), let bd = b as? [String: Any] {
-        return _equal(am, bd)
-    }
-    if let ad = a as? [String: Any], let bm = _structMap(b) {
-        return _equal(ad, bm)
-    }
-    switch (a, b) {
-    case let (x as [Any], y as [Any]):
-        if x.count != y.count { return false }
-        for i in 0..<x.count {
-            if !_equal(x[i], y[i]) { return false }
-        }
-        return true
-    case let (x as [String: Any], y as [String: Any]):
-        if x.count != y.count { return false }
-        for (k, av) in x {
-            guard let bv = y[k] else { return false }
-            if !_equal(av, bv) { return false }
-        }
-        return true
-    case let (ai as Double, bi as Int):
-        return ai == Double(bi)
-    case let (ai as Int, bi as Double):
-        return Double(ai) == bi
-    case let (ai as Double, bi as Double):
-        return ai == bi
-    case let (ai as Int, bi as Int):
-        return ai == bi
-    case let (sa as String, sb as String):
-        return sa == sb
-    case let (ab as Bool, bb as Bool):
-        return ab == bb
-    default:
-        return false
-    }
-}
 struct Person: Equatable {
     var name: String
     var age: Int
@@ -69,5 +18,5 @@ for i in 0..<people.count {
     }
     people[i] = elem
 }
-expect(_equal(people, [Person(name: "Alice", age: 17, status: "minor"), Person(name: "Bob", age: 26, status: "adult"), Person(name: "Charlie", age: 19, status: "adult"), Person(name: "Diana", age: 16, status: "minor")]))
+expect(people == [Person(name: "Alice", age: 17, status: "minor"), Person(name: "Bob", age: 26, status: "adult"), Person(name: "Charlie", age: 19, status: "adult"), Person(name: "Diana", age: 16, status: "minor")])
 print("ok")


### PR DESCRIPTION
## Summary
- enhance Swift compiler type inference for struct literals and casts
- update generated Swift outputs for test_block and update_stmt

## Testing
- `go test -tags slow ./compiler/x/swift -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878b760a7248320958d20303365a9df