### PR TITLE
Improve Kotlin compiler query inference

### DIFF
--- a/compiler/x/kotlin/TASKS.md
+++ b/compiler/x/kotlin/TASKS.md
@@ -31,6 +31,7 @@
   variants are covered; reran VM golden tests (71 passed, 29 failed).
 - 2025-07-17 06:44 UTC: Fixed map literal parentheses handling and compiled
   `dataset_where_filter`.
+- 2025-07-17 08:00 UTC: Added query row struct inference to reduce casts; `group_by_multi_join_sort` now compiles.
 
 ## Remaining Work
 - [ ] Implement dataset join and group-by operations fully.

--- a/tests/machine/x/kotlin/README.md
+++ b/tests/machine/x/kotlin/README.md
@@ -2,7 +2,7 @@
 
 This directory contains Kotlin source code generated from the Mochi programs in `tests/vm/valid`. Each program has a corresponding `.kt` file. When the compiler and the Kotlin runtime successfully run the program a `.out` file is written. If compilation or execution fails a `.error` file will be present instead.
 
-Compiled programs: 92/100
+Compiled programs: 93/100
 
 Checklist:
 - [x] append_builtin
@@ -34,7 +34,7 @@ Checklist:
 - [x] group_by_join
 - [x] group_by_left_join
 - [x] group_by_multi_join
-- [ ] group_by_multi_join_sort
+ - [x] group_by_multi_join_sort
 - [x] group_by_sort
 - [ ] group_items_iteration
 - [x] if_else

--- a/tests/machine/x/kotlin/group_by_multi_join_sort.error
+++ b/tests/machine/x/kotlin/group_by_multi_join_sort.error
@@ -1,3 +1,0 @@
-Exception in thread "main" java.lang.ExceptionInInitializerError
-Caused by: java.lang.ClassCastException: class Lineitem cannot be cast to class java.util.Map (Lineitem is in unnamed module of loader 'app'; java.util.Map is in module java.base of loader 'bootstrap')
-	at Group_by_multi_join_sortKt.<clinit>(group_by_multi_join_sort.kt:96)

--- a/tests/machine/x/kotlin/group_by_multi_join_sort.out
+++ b/tests/machine/x/kotlin/group_by_multi_join_sort.out
@@ -1,0 +1,1 @@
+[{c_custkey=1, c_name=Alice, revenue=900, c_acctbal=100.0, n_name=BRAZIL, c_address=123 St, c_phone=123-456, c_comment=Loyal}]


### PR DESCRIPTION
## Summary
- improve Kotlin compiler by inferring struct types for query rows
- emit inferred structs after compilation
- update Kotlin machine outputs for `group_by_multi_join_sort`
- document progress in README and TASKS

## Testing
- `go run -tags slow /tmp/compile_run_kotlin.go tests/vm/valid/group_by_multi_join_sort.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6878b7443e948320afdfdd0fee1f5761