### PR TITLE
Improve Fortran constant folding

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -46,6 +46,9 @@
   variables inferred from external functions use the correct Fortran types.
 - 2025-07-17 08:30: `len` and `count` constant-fold list literals to numeric
   literals during code generation, avoiding runtime size checks.
+- 2025-07-17 10:00: List set operations (`union`, `union_all`, `except`,
+  `intersect`) compute at compile time when both operands are integer list
+  literals, eliminating helper functions at runtime.
 
 ## Remaining Work
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.

--- a/compiler/x/fortran/vm_valid_golden_test.go
+++ b/compiler/x/fortran/vm_valid_golden_test.go
@@ -40,7 +40,9 @@ func TestFortranCompiler_VMValid_Golden(t *testing.T) {
 		}
 		env := types.NewEnv(nil)
 		os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
+		os.Setenv("MOCHI_FORTRAN_NODATASET", "1")
 		code, err := ftncode.New(env).Compile(prog)
+		os.Unsetenv("MOCHI_FORTRAN_NODATASET")
 		os.Unsetenv("MOCHI_HEADER_TIME")
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)

--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -3,7 +3,8 @@
 The Fortran backend compiles each Mochi program under `tests/vm/valid`. This directory stores the generated `.f90` source files and their runtime output. No `.error` files are present because all examples compile successfully.
 
 List literal lengths are now computed at compile time so programs using `len` or
-`count` on constant arrays avoid runtime helper code.
+`count` on constant arrays avoid runtime helper code. List set operations like
+`union` and `except` with constant integer lists are also folded at compile time.
 
 Compiled programs: 100/100
 


### PR DESCRIPTION
## Summary
- constant-fold list set operations (`union`, `union_all`, `except`, `intersect`) when both operands are integer literals
- run Fortran VM valid tests without using prewritten sources
- note the new behaviour in documentation

## Testing
- `go test -tags slow -run TestFortranCompiler_VMValid_Golden -v` *(fails: gfortran not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b9d7302c8320a86eef43a1838a96