### PR TITLE
Improve Swift arithmetic type inference

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,7 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-25 09:30 – improved expression type detection for arithmetic chains so direct comparisons avoid `_equal` when possible
 - 2025-07-24 09:00 – arithmetic expressions now infer numeric types so expectation comparisons use `==` without the `_equal` helper when possible
 - 2025-07-23 10:00 – direct equality for typed values avoids _equal helper when possible
 - 2025-07-22 08:10 – improved join query nil handling and added struct list

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1897,6 +1897,39 @@ func (c *compiler) exprType(e *parser.Expr) string {
 	if p == nil || p.Target == nil {
 		return ""
 	}
+	if len(e.Binary.Right) > 0 {
+		num := true
+		isFloat := false
+		lt := c.unaryType(e.Binary.Left)
+		if lt != "" {
+			if lt == "float" {
+				isFloat = true
+			} else if lt != "int" {
+				num = false
+			}
+		}
+		for _, op := range e.Binary.Right {
+			switch op.Op {
+			case "+", "-", "*", "/", "%":
+				rt := c.postfixType(op.Right)
+				if rt != "" {
+					if rt == "float" {
+						isFloat = true
+					} else if rt != "int" {
+						num = false
+					}
+				}
+			default:
+				num = false
+			}
+		}
+		if num {
+			if isFloat {
+				return "float"
+			}
+			return "int"
+		}
+	}
 	if p.Target.Selector != nil {
 		if len(p.Target.Selector.Tail) == 0 {
 			if typ, ok := c.varTypes[p.Target.Selector.Root]; ok {


### PR DESCRIPTION
## Summary
- enhance Swift compiler type inference
- note improved expression detection in TASKS

## Testing
- `go test -tags slow ./compiler/x/swift -run TestSwiftCompiler_VMValid_Golden -count=1` *(fails: output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6878bbc04314832096ecd9f55a97d6f7