### PR TITLE
Remove _print helper from TypeScript compiler

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -118,3 +118,6 @@
 ### 2025-09-15 00:00 UTC
 - String slicing and indexing now emit native `slice` and `[]` operations instead of helper functions.
 - Regenerated VM golden outputs.
+### 2025-09-16 00:00 UTC
+- Removed `_print` helper. Print calls now inline a `console.log` conversion.
+- Regenerated VM golden outputs.

--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -101,15 +101,6 @@ const (
 		"  return String(v);\n" +
 		"}\n"
 
-	helperPrint = "function _print(...args: unknown[]): void {\n" +
-		"  const out = args.map(a => {\n" +
-		"    if (Array.isArray(a)) return a.join(' ');\n" +
-		"    if (typeof a === 'boolean') return a ? '1' : '0';\n" +
-		"    return String(a);\n" +
-		"  }).join(' ').trimEnd();\n" +
-		"  console.log(out);\n" +
-		"}\n"
-
 	helperMin = "function _min(v: unknown): unknown {\n" +
 		"  let list: any[] | null = null;\n" +
 		"  if (Array.isArray(v)) list = v;\n" +
@@ -589,7 +580,6 @@ var helperMap = map[string]string{
 	"_dataset":     helperDataset,
 	"_json":        helperJSON,
 	"_fmt":         helperFmt,
-	"_print":       helperPrint,
 }
 
 func (c *Compiler) use(name string) {

--- a/tests/machine/x/ts/append_builtin.ts
+++ b/tests/machine/x/ts/append_builtin.ts
@@ -5,15 +5,6 @@ let a: number[];
 
 function main(): void {
   a = [1, 2];
-  _print([...a, 3]);
+  console.log([...a, 3].join(" "));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/avg_builtin.ts
+++ b/tests/machine/x/ts/avg_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/avg_builtin.mochi
 
 function main(): void {
-  _print([1, 2, 3].reduce((a, b) => a + Number(b), 0) / [1, 2, 3].length);
+  console.log([1, 2, 3].reduce((a, b) => a + Number(b), 0) / [1, 2, 3].length);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/basic_compare.ts
+++ b/tests/machine/x/ts/basic_compare.ts
@@ -7,17 +7,8 @@ let b: any;
 function main(): void {
   a = 10 - 3;
   b = 2 + 2;
-  _print(a);
-  _print(a == 7);
-  _print(b < 5);
+  console.log(a);
+  console.log((a == 7) ? 1 : 0);
+  console.log((b < 5) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/binary_precedence.ts
+++ b/tests/machine/x/ts/binary_precedence.ts
@@ -2,18 +2,9 @@
 // Source: /workspace/mochi/tests/vm/valid/binary_precedence.mochi
 
 function main(): void {
-  _print(1 + (2 * 3));
-  _print((1 + 2) * 3);
-  _print((2 * 3) + 1);
-  _print(2 * (3 + 1));
+  console.log(1 + (2 * 3));
+  console.log((1 + 2) * 3);
+  console.log((2 * 3) + 1);
+  console.log(2 * (3 + 1));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/bool_chain.ts
+++ b/tests/machine/x/ts/bool_chain.ts
@@ -2,22 +2,13 @@
 // Source: /workspace/mochi/tests/vm/valid/bool_chain.mochi
 
 function boom(): boolean {
-  _print("boom");
+  console.log("boom");
   return true;
 }
 
 function main(): void {
-  _print(((1 < 2) && (2 < 3)) && (3 < 4));
-  _print(((1 < 2) && (2 > 3)) && boom());
-  _print((((1 < 2) && (2 < 3)) && (3 > 4)) && boom());
+  console.log((((1 < 2) && (2 < 3)) && (3 < 4)) ? 1 : 0);
+  console.log((((1 < 2) && (2 > 3)) && boom()) ? 1 : 0);
+  console.log(((((1 < 2) && (2 < 3)) && (3 > 4)) && boom()) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/break_continue.ts
+++ b/tests/machine/x/ts/break_continue.ts
@@ -22,16 +22,13 @@ function main(): void {
     if ((n > 7)) {
       break;
     }
-    _print("odd number:", n);
+    console.log(
+      ["odd number:", n].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/cast_string_to_int.ts
+++ b/tests/machine/x/ts/cast_string_to_int.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/cast_string_to_int.mochi
 
 function main(): void {
-  _print("1995" as number);
+  console.log("1995" as number);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/cast_struct.ts
+++ b/tests/machine/x/ts/cast_struct.ts
@@ -9,15 +9,6 @@ let todo: Todo;
 
 function main(): void {
   todo = { "title": "hi" } as Todo;
-  _print(todo.title);
+  console.log(todo.title);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/closure.ts
+++ b/tests/machine/x/ts/closure.ts
@@ -11,15 +11,6 @@ let add10: (p0: number) => number;
 
 function main(): void {
   add10 = makeAdder(10);
-  _print(add10(7));
+  console.log(add10(7));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/count_builtin.ts
+++ b/tests/machine/x/ts/count_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/count_builtin.mochi
 
 function main(): void {
-  _print([1, 2, 3].length);
+  console.log([1, 2, 3].length);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/cross_join.ts
+++ b/tests/machine/x/ts/cross_join.ts
@@ -52,27 +52,24 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Cross Join: All order-customer pairs ---");
+  console.log("--- Cross Join: All order-customer pairs ---");
   for (const entry of result) {
-    _print(
-      "Order",
-      entry.orderId,
-      "(customerId:",
-      entry.orderCustomerId,
-      ", total: $",
-      entry.orderTotal,
-      ") paired with",
-      entry.pairedCustomerName,
+    console.log(
+      [
+        "Order",
+        entry.orderId,
+        "(customerId:",
+        entry.orderCustomerId,
+        ", total: $",
+        entry.orderTotal,
+        ") paired with",
+        entry.pairedCustomerName,
+      ].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
     );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/cross_join_filter.ts
+++ b/tests/machine/x/ts/cross_join_filter.ts
@@ -22,18 +22,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Even pairs ---");
+  console.log("--- Even pairs ---");
   for (const p of pairs) {
-    _print(p.n, p.l);
+    console.log(
+      [p.n, p.l].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/cross_join_triple.ts
+++ b/tests/machine/x/ts/cross_join_triple.ts
@@ -26,18 +26,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Cross Join of three lists ---");
+  console.log("--- Cross Join of three lists ---");
   for (const c of combos) {
-    _print(c.n, c.l, c.b);
+    console.log(
+      [c.n, c.l, c.b].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/dataset_sort_take_limit.ts
+++ b/tests/machine/x/ts/dataset_sort_take_limit.ts
@@ -63,9 +63,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Top products (excluding most expensive) ---");
+  console.log("--- Top products (excluding most expensive) ---");
   for (const item of expensive) {
-    _print(item.name, "costs $", item.price);
+    console.log(
+      [item.name, "costs $", item.price].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
 function _cmp(a: unknown, b: unknown): number {
@@ -86,15 +92,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/dataset_where_filter.ts
+++ b/tests/machine/x/ts/dataset_where_filter.ts
@@ -28,18 +28,17 @@ function main(): void {
     "age": person.age,
     "is_senior": (person.age >= 60),
   }));
-  _print("--- Adults ---");
+  console.log("--- Adults ---");
   for (const person of adults) {
-    _print(person.name, "is", person.age, person.is_senior ? " (senior)" : "");
+    console.log(
+      [person.name, "is", person.age, person.is_senior ? " (senior)" : ""].map(
+        (a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        },
+      ).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/exists_builtin.ts
+++ b/tests/machine/x/ts/exists_builtin.ts
@@ -7,15 +7,6 @@ let flag: boolean;
 function main(): void {
   data = [1, 2];
   flag = data.filter((x) => (x == 1)).map((x) => x).length > 0;
-  _print(flag);
+  console.log(flag ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/for_list_collection.ts
+++ b/tests/machine/x/ts/for_list_collection.ts
@@ -3,16 +3,7 @@
 
 function main(): void {
   for (const n of [1, 2, 3]) {
-    _print(n);
+    console.log(n);
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/for_loop.ts
+++ b/tests/machine/x/ts/for_loop.ts
@@ -3,16 +3,7 @@
 
 function main(): void {
   for (let i: number = 1; i < 4; i++) {
-    _print(i);
+    console.log(i);
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/for_map_collection.ts
+++ b/tests/machine/x/ts/for_map_collection.ts
@@ -9,16 +9,7 @@ function main(): void {
     "b": 2,
   };
   for (const k of Object.keys(m)) {
-    _print(k);
+    console.log(k);
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/fun_call.ts
+++ b/tests/machine/x/ts/fun_call.ts
@@ -6,15 +6,6 @@ function add(a: number, b: number): number {
 }
 
 function main(): void {
-  _print(5);
+  console.log(5);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/fun_expr_in_let.ts
+++ b/tests/machine/x/ts/fun_expr_in_let.ts
@@ -7,15 +7,6 @@ function main(): void {
   square = function (x: number): number {
     return (x * x);
   };
-  _print(square(6));
+  console.log(square(6));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/fun_three_args.ts
+++ b/tests/machine/x/ts/fun_three_args.ts
@@ -6,15 +6,6 @@ function sum3(a: number, b: number, c: number): number {
 }
 
 function main(): void {
-  _print(6);
+  console.log(6);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/go_auto.ts
+++ b/tests/machine/x/ts/go_auto.ts
@@ -4,17 +4,8 @@
 const testpkg = { Add: (a: number, b: number) => a + b, Pi: 3.14, Answer: 42 };
 
 function main(): void {
-  _print(testpkg.Add(2, 3));
-  _print(testpkg.Pi);
-  _print(testpkg.Answer);
+  console.log(testpkg.Add(2, 3));
+  console.log(testpkg.Pi);
+  console.log(testpkg.Answer);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/group_by.ts
+++ b/tests/machine/x/ts/group_by.ts
@@ -66,18 +66,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- People grouped by city ---");
+  console.log("--- People grouped by city ---");
   for (const s of stats) {
-    _print(s.city, ": count =", s.count, ", avg_age =", s.avg_age);
+    console.log(
+      [s.city, ": count =", s.count, ", avg_age =", s.avg_age].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/group_by_conditional_sum.ts
+++ b/tests/machine/x/ts/group_by_conditional_sum.ts
@@ -58,7 +58,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(result);
+  console.log(result.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -78,15 +78,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/group_by_left_join.ts
+++ b/tests/machine/x/ts/group_by_left_join.ts
@@ -61,20 +61,17 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Group Left Join ---");
+  console.log("--- Group Left Join ---");
   for (const s of stats) {
-    _print(s.name, "orders:", s.count);
+    console.log(
+      [s.name, "orders:", s.count].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 function _query(src: any[], joins: any[], opts: any): any {
   let items = src.map((v) => [v]);
   for (const j of joins) {

--- a/tests/machine/x/ts/group_by_multi_join.ts
+++ b/tests/machine/x/ts/group_by_multi_join.ts
@@ -90,15 +90,6 @@ function main(): void {
     }
     return _res;
   })();
-  _print(grouped);
+  console.log(grouped.join(" "));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/group_by_multi_join_sort.ts
+++ b/tests/machine/x/ts/group_by_multi_join_sort.ts
@@ -121,7 +121,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(result);
+  console.log(result.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -141,15 +141,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/group_by_sort.ts
+++ b/tests/machine/x/ts/group_by_sort.ts
@@ -58,7 +58,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(grouped);
+  console.log(grouped.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -78,15 +78,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/group_items_iteration.ts
+++ b/tests/machine/x/ts/group_items_iteration.ts
@@ -73,7 +73,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(result);
+  console.log(result.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -93,15 +93,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/if_else.ts
+++ b/tests/machine/x/ts/if_else.ts
@@ -6,18 +6,9 @@ let x: number;
 function main(): void {
   x = 5;
   if ((x > 3)) {
-    _print("big");
+    console.log("big");
   } else {
-    _print("small");
+    console.log("small");
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/if_then_else.ts
+++ b/tests/machine/x/ts/if_then_else.ts
@@ -7,15 +7,6 @@ let x: number;
 function main(): void {
   x = 12;
   msg = (x > 10) ? "yes" : "no";
-  _print(msg);
+  console.log(msg);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/if_then_else_nested.ts
+++ b/tests/machine/x/ts/if_then_else_nested.ts
@@ -7,15 +7,6 @@ let x: number;
 function main(): void {
   x = 8;
   msg = (x > 10) ? "big" : ((x > 5) ? "medium" : "small");
-  _print(msg);
+  console.log(msg);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/in_operator.ts
+++ b/tests/machine/x/ts/in_operator.ts
@@ -5,16 +5,7 @@ let xs: number[];
 
 function main(): void {
   xs = [1, 2, 3];
-  _print(xs.includes(2) ? 1 : 0);
-  _print(!(xs.includes(5) ? 1 : 0));
+  console.log((xs.includes(2) ? 1 : 0) ? 1 : 0);
+  console.log((!(xs.includes(5) ? 1 : 0)) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/in_operator_extended.ts
+++ b/tests/machine/x/ts/in_operator_extended.ts
@@ -9,22 +9,17 @@ let ys: number[];
 function main(): void {
   xs = [1, 2, 3];
   ys = xs.filter((x) => ((x % 2) == 1)).map((x) => x);
-  _print(ys.includes(1) ? 1 : 0);
-  _print(ys.includes(2) ? 1 : 0);
+  console.log((ys.includes(1) ? 1 : 0) ? 1 : 0);
+  console.log((ys.includes(2) ? 1 : 0) ? 1 : 0);
   m = { "a": 1 };
-  _print(Object.prototype.hasOwnProperty.call(m, String("a")) ? 1 : 0);
-  _print(Object.prototype.hasOwnProperty.call(m, String("b")) ? 1 : 0);
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String("a")) ? 1 : 0) ? 1 : 0,
+  );
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String("b")) ? 1 : 0) ? 1 : 0,
+  );
   s = "hello";
-  _print(s.includes("ell") ? 1 : 0);
-  _print(s.includes("foo") ? 1 : 0);
+  console.log((s.includes("ell") ? 1 : 0) ? 1 : 0);
+  console.log((s.includes("foo") ? 1 : 0) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/inner_join.ts
+++ b/tests/machine/x/ts/inner_join.ts
@@ -58,15 +58,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Orders with customer info ---");
+  console.log("--- Orders with customer info ---");
   for (const entry of result) {
-    _print(
-      "Order",
-      entry.orderId,
-      "by",
-      entry.customerName,
-      "- $",
-      entry.total,
+    console.log(
+      ["Order", entry.orderId, "by", entry.customerName, "- $", entry.total]
+        .map((a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        }).join(" ").trimEnd(),
     );
   }
 }
@@ -90,15 +90,6 @@ function _hashJoin(
     for (const r of arr) out.push([l, r]);
   }
   return out;
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/join_multi.ts
+++ b/tests/machine/x/ts/join_multi.ts
@@ -54,18 +54,15 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Multi Join ---");
+  console.log("--- Multi Join ---");
   for (const r of result) {
-    _print(r.name, "bought item", r.sku);
+    console.log(
+      [r.name, "bought item", r.sku].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/left_join.ts
+++ b/tests/machine/x/ts/left_join.ts
@@ -54,25 +54,16 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Left Join ---");
+  console.log("--- Left Join ---");
   for (const entry of result) {
-    _print(
-      "Order",
-      entry.orderId,
-      "customer",
-      entry.customer,
-      "total",
-      entry.total,
+    console.log(
+      ["Order", entry.orderId, "customer", entry.customer, "total", entry.total]
+        .map((a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        }).join(" ").trimEnd(),
     );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/left_join_multi.ts
+++ b/tests/machine/x/ts/left_join_multi.ts
@@ -46,20 +46,17 @@ function main(): void {
       }),
     });
   })();
-  _print("--- Left Join Multi ---");
+  console.log("--- Left Join Multi ---");
   for (const r of result) {
-    _print(r.orderId, r.name, r.item);
+    console.log(
+      [r.orderId, r.name, r.item].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 function _query(src: any[], joins: any[], opts: any): any {
   let items = src.map((v) => [v]);
   for (const j of joins) {

--- a/tests/machine/x/ts/len_builtin.ts
+++ b/tests/machine/x/ts/len_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/len_builtin.mochi
 
 function main(): void {
-  _print([1, 2, 3].length);
+  console.log([1, 2, 3].length);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/len_map.ts
+++ b/tests/machine/x/ts/len_map.ts
@@ -2,20 +2,11 @@
 // Source: /workspace/mochi/tests/vm/valid/len_map.mochi
 
 function main(): void {
-  _print(
+  console.log(
     Object.keys({
       "a": 1,
       "b": 2,
     }).length,
   );
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/len_string.ts
+++ b/tests/machine/x/ts/len_string.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/len_string.mochi
 
 function main(): void {
-  _print(5);
+  console.log(5);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/let_and_print.ts
+++ b/tests/machine/x/ts/let_and_print.ts
@@ -7,15 +7,6 @@ let b: number;
 function main(): void {
   a = 10;
   b = 20;
-  _print(a + b);
+  console.log(a + b);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/list_assign.ts
+++ b/tests/machine/x/ts/list_assign.ts
@@ -6,15 +6,6 @@ var nums: number[];
 function main(): void {
   nums = [1, 2];
   nums[1] = 3;
-  _print(nums[1]);
+  console.log(nums[1]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/list_index.ts
+++ b/tests/machine/x/ts/list_index.ts
@@ -5,15 +5,6 @@ let xs: number[];
 
 function main(): void {
   xs = [10, 20, 30];
-  _print(xs[1]);
+  console.log(xs[1]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/list_nested_assign.ts
+++ b/tests/machine/x/ts/list_nested_assign.ts
@@ -6,15 +6,6 @@ var matrix: number[][];
 function main(): void {
   matrix = [[1, 2], [3, 4]];
   matrix[1][0] = 5;
-  _print(matrix[1][0]);
+  console.log(matrix[1][0]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/list_set_ops.ts
+++ b/tests/machine/x/ts/list_set_ops.ts
@@ -2,18 +2,9 @@
 // Source: /workspace/mochi/tests/vm/valid/list_set_ops.mochi
 
 function main(): void {
-  _print(Array.from(new Set([...[1, 2], ...[2, 3]])));
-  _print([1, 2, 3].filter((v) => ![2].includes(v)));
-  _print([1, 2, 3].filter((v) => [2, 4].includes(v)));
-  _print([1, 2].concat([2, 3]).length);
+  console.log(Array.from(new Set([...[1, 2], ...[2, 3]])).join(" "));
+  console.log([1, 2, 3].filter((v) => ![2].includes(v)).join(" "));
+  console.log([1, 2, 3].filter((v) => [2, 4].includes(v)).join(" "));
+  console.log([1, 2].concat([2, 3]).length);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/load_yaml.ts
+++ b/tests/machine/x/ts/load_yaml.ts
@@ -20,7 +20,13 @@ function main(): void {
     "email": p.email,
   }));
   for (const a of adults) {
-    _print(a.name, a.email);
+    console.log(
+      [a.name, a.email].map((a) => {
+        if (Array.isArray(a)) return a.join(" ");
+        if (typeof a === "boolean") return a ? "1" : "0";
+        return String(a);
+      }).join(" ").trimEnd(),
+    );
   }
 }
 import { readAllSync } from "https://deno.land/std@0.221.0/io/read_all.ts";
@@ -156,15 +162,6 @@ function _save(rows: any[], path: string | null, opts: any): void {
       }
       _writeOutput(path, lines.join("\n") + "\n");
   }
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 function _toAnyMap(m: unknown): Record<string, unknown> {

--- a/tests/machine/x/ts/map_assign.ts
+++ b/tests/machine/x/ts/map_assign.ts
@@ -6,15 +6,6 @@ var scores: { [key: string]: number };
 function main(): void {
   scores = { "alice": 1 };
   scores["bob"] = 2;
-  _print(scores["bob"]);
+  console.log(scores["bob"]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_in_operator.ts
+++ b/tests/machine/x/ts/map_in_operator.ts
@@ -8,16 +8,11 @@ function main(): void {
     [1]: "a",
     [2]: "b",
   };
-  _print(Object.prototype.hasOwnProperty.call(m, String(1)) ? 1 : 0);
-  _print(Object.prototype.hasOwnProperty.call(m, String(3)) ? 1 : 0);
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String(1)) ? 1 : 0) ? 1 : 0,
+  );
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String(3)) ? 1 : 0) ? 1 : 0,
+  );
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_index.ts
+++ b/tests/machine/x/ts/map_index.ts
@@ -8,15 +8,6 @@ function main(): void {
     "a": 1,
     "b": 2,
   };
-  _print(m["b"]);
+  console.log(m["b"]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_int_key.ts
+++ b/tests/machine/x/ts/map_int_key.ts
@@ -8,15 +8,6 @@ function main(): void {
     [1]: "a",
     [2]: "b",
   };
-  _print(m[1]);
+  console.log(m[1]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_literal_dynamic.ts
+++ b/tests/machine/x/ts/map_literal_dynamic.ts
@@ -12,15 +12,12 @@ function main(): void {
     "a": x,
     "b": y,
   };
-  _print(m["a"], m["b"]);
+  console.log(
+    [m["a"], m["b"]].map((a) => {
+      if (Array.isArray(a)) return a.join(" ");
+      if (typeof a === "boolean") return a ? "1" : "0";
+      return String(a);
+    }).join(" ").trimEnd(),
+  );
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_membership.ts
+++ b/tests/machine/x/ts/map_membership.ts
@@ -8,16 +8,11 @@ function main(): void {
     "a": 1,
     "b": 2,
   };
-  _print(Object.prototype.hasOwnProperty.call(m, String("a")) ? 1 : 0);
-  _print(Object.prototype.hasOwnProperty.call(m, String("c")) ? 1 : 0);
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String("a")) ? 1 : 0) ? 1 : 0,
+  );
+  console.log(
+    (Object.prototype.hasOwnProperty.call(m, String("c")) ? 1 : 0) ? 1 : 0,
+  );
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/map_nested_assign.ts
+++ b/tests/machine/x/ts/map_nested_assign.ts
@@ -6,15 +6,6 @@ var data: { [key: string]: { [key: string]: number } };
 function main(): void {
   data = { "outer": { "inner": 1 } };
   data["outer"]["inner"] = 2;
-  _print(data["outer"]["inner"]);
+  console.log(data["outer"]["inner"]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/match_expr.ts
+++ b/tests/machine/x/ts/match_expr.ts
@@ -13,7 +13,7 @@ function main(): void {
     if (_equal(_t, 3)) return "three";
     return "unknown";
   })();
-  _print(label);
+  console.log(label);
 }
 function _equal(a: unknown, b: unknown): boolean {
   if (typeof a === "number" && typeof b === "number") {
@@ -36,15 +36,6 @@ function _equal(a: unknown, b: unknown): boolean {
     return true;
   }
   return a === b;
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/match_full.ts
+++ b/tests/machine/x/ts/match_full.ts
@@ -26,7 +26,7 @@ function main(): void {
     if (_equal(_t, 3)) return "three";
     return "unknown";
   })();
-  _print(label);
+  console.log(label);
   day = "sun";
   mood = (() => {
     const _t = day;
@@ -35,7 +35,7 @@ function main(): void {
     if (_equal(_t, "sun")) return "relaxed";
     return "normal";
   })();
-  _print(mood);
+  console.log(mood);
   ok = true;
   status = (() => {
     const _t = ok;
@@ -43,9 +43,9 @@ function main(): void {
     if (_equal(_t, false)) return "denied";
     return undefined;
   })();
-  _print(status);
-  _print(classify(0));
-  _print(classify(5));
+  console.log(status);
+  console.log(classify(0));
+  console.log(classify(5));
 }
 function _equal(a: unknown, b: unknown): boolean {
   if (typeof a === "number" && typeof b === "number") {
@@ -68,15 +68,6 @@ function _equal(a: unknown, b: unknown): boolean {
     return true;
   }
   return a === b;
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/math_ops.ts
+++ b/tests/machine/x/ts/math_ops.ts
@@ -2,17 +2,8 @@
 // Source: /workspace/mochi/tests/vm/valid/math_ops.mochi
 
 function main(): void {
-  _print(6 * 7);
-  _print(7 / 2);
-  _print(7 % 2);
+  console.log(6 * 7);
+  console.log(7 / 2);
+  console.log(7 % 2);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/membership.ts
+++ b/tests/machine/x/ts/membership.ts
@@ -5,16 +5,7 @@ let nums: number[];
 
 function main(): void {
   nums = [1, 2, 3];
-  _print(nums.includes(2) ? 1 : 0);
-  _print(nums.includes(4) ? 1 : 0);
+  console.log((nums.includes(2) ? 1 : 0) ? 1 : 0);
+  console.log((nums.includes(4) ? 1 : 0) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/min_max_builtin.ts
+++ b/tests/machine/x/ts/min_max_builtin.ts
@@ -5,16 +5,7 @@ let nums: number[];
 
 function main(): void {
   nums = [3, 1, 4];
-  _print(Math.min(...nums));
-  _print(Math.max(...nums));
+  console.log(Math.min(...nums));
+  console.log(Math.max(...nums));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/nested_function.ts
+++ b/tests/machine/x/ts/nested_function.ts
@@ -9,15 +9,6 @@ function outer(x: number): number {
 }
 
 function main(): void {
-  _print(outer(3));
+  console.log(outer(3));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/order_by_map.ts
+++ b/tests/machine/x/ts/order_by_map.ts
@@ -45,7 +45,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(sorted);
+  console.log(sorted.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -65,15 +65,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/outer_join.ts
+++ b/tests/machine/x/ts/outer_join.ts
@@ -83,33 +83,44 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Outer Join using syntax ---");
+  console.log("--- Outer Join using syntax ---");
   for (const row of result) {
     if (row.order) {
       if (row.customer) {
-        _print(
-          "Order",
-          row.order.id,
-          "by",
-          row.customer.name,
-          "- $",
-          row.order.total,
+        console.log(
+          [
+            "Order",
+            row.order.id,
+            "by",
+            row.customer.name,
+            "- $",
+            row.order.total,
+          ].map((a) => {
+            if (Array.isArray(a)) return a.join(" ");
+            if (typeof a === "boolean") return a ? "1" : "0";
+            return String(a);
+          }).join(" ").trimEnd(),
         );
       } else {
-        _print("Order", row.order.id, "by", "Unknown", "- $", row.order.total);
+        console.log(
+          ["Order", row.order.id, "by", "Unknown", "- $", row.order.total].map(
+            (a) => {
+              if (Array.isArray(a)) return a.join(" ");
+              if (typeof a === "boolean") return a ? "1" : "0";
+              return String(a);
+            },
+          ).join(" ").trimEnd(),
+        );
       }
     } else {
-      _print("Customer", row.customer.name, "has no orders");
+      console.log(
+        ["Customer", row.customer.name, "has no orders"].map((a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        }).join(" ").trimEnd(),
+      );
     }
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/partial_application.ts
+++ b/tests/machine/x/ts/partial_application.ts
@@ -9,15 +9,6 @@ let add5: (p0: number) => number;
 
 function main(): void {
   add5 = (b) => add(5, b);
-  _print(add5(3));
+  console.log(add5(3));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/print_hello.ts
+++ b/tests/machine/x/ts/print_hello.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/print_hello.mochi
 
 function main(): void {
-  _print("hello");
+  console.log("hello");
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/pure_fold.ts
+++ b/tests/machine/x/ts/pure_fold.ts
@@ -6,15 +6,6 @@ function triple(x: number): number {
 }
 
 function main(): void {
-  _print(triple(1 + 2));
+  console.log(triple(1 + 2));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/pure_global_fold.ts
+++ b/tests/machine/x/ts/pure_global_fold.ts
@@ -9,15 +9,6 @@ let k: number;
 
 function main(): void {
   k = 2;
-  _print(inc(3));
+  console.log(inc(3));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/python_auto.ts
+++ b/tests/machine/x/ts/python_auto.ts
@@ -11,16 +11,7 @@ const math = {
 };
 
 function main(): void {
-  _print(math.sqrt(16));
-  _print(math.pi);
+  console.log(math.sqrt(16));
+  console.log(math.pi);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/python_math.ts
+++ b/tests/machine/x/ts/python_math.ts
@@ -22,18 +22,33 @@ function main(): void {
   root = math.sqrt(49);
   sin45 = math.sin(math.pi / 4);
   log_e = math.log(math.e);
-  _print("Circle area with r =", r, "=>", area);
-  _print("Square root of 49:", root);
-  _print("sin(π/4):", sin45);
-  _print("log(e):", log_e);
+  console.log(
+    ["Circle area with r =", r, "=>", area].map((a) => {
+      if (Array.isArray(a)) return a.join(" ");
+      if (typeof a === "boolean") return a ? "1" : "0";
+      return String(a);
+    }).join(" ").trimEnd(),
+  );
+  console.log(
+    ["Square root of 49:", root].map((a) => {
+      if (Array.isArray(a)) return a.join(" ");
+      if (typeof a === "boolean") return a ? "1" : "0";
+      return String(a);
+    }).join(" ").trimEnd(),
+  );
+  console.log(
+    ["sin(π/4):", sin45].map((a) => {
+      if (Array.isArray(a)) return a.join(" ");
+      if (typeof a === "boolean") return a ? "1" : "0";
+      return String(a);
+    }).join(" ").trimEnd(),
+  );
+  console.log(
+    ["log(e):", log_e].map((a) => {
+      if (Array.isArray(a)) return a.join(" ");
+      if (typeof a === "boolean") return a ? "1" : "0";
+      return String(a);
+    }).join(" ").trimEnd(),
+  );
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/query_sum_select.ts
+++ b/tests/machine/x/ts/query_sum_select.ts
@@ -10,15 +10,6 @@ function main(): void {
     const _items = nums.filter((n) => (n > 1)).map((n) => n);
     return _items.reduce((a, b) => a + Number(b), 0);
   })();
-  _print(result);
+  console.log(result);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/record_assign.ts
+++ b/tests/machine/x/ts/record_assign.ts
@@ -14,15 +14,6 @@ var c: Counter;
 function main(): void {
   c = { n: 0 };
   inc(c);
-  _print(c.n);
+  console.log(c.n);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/right_join.ts
+++ b/tests/machine/x/ts/right_join.ts
@@ -65,29 +65,32 @@ function main(): void {
     }
     return _res;
   })();
-  _print("--- Right Join using syntax ---");
+  console.log("--- Right Join using syntax ---");
   for (const entry of result) {
     if (entry.order) {
-      _print(
-        "Customer",
-        entry.customerName,
-        "has order",
-        entry.order.id,
-        "- $",
-        entry.order.total,
+      console.log(
+        [
+          "Customer",
+          entry.customerName,
+          "has order",
+          entry.order.id,
+          "- $",
+          entry.order.total,
+        ].map((a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        }).join(" ").trimEnd(),
       );
     } else {
-      _print("Customer", entry.customerName, "has no orders");
+      console.log(
+        ["Customer", entry.customerName, "has no orders"].map((a) => {
+          if (Array.isArray(a)) return a.join(" ");
+          if (typeof a === "boolean") return a ? "1" : "0";
+          return String(a);
+        }).join(" ").trimEnd(),
+      );
     }
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/short_circuit.ts
+++ b/tests/machine/x/ts/short_circuit.ts
@@ -2,21 +2,12 @@
 // Source: /workspace/mochi/tests/vm/valid/short_circuit.mochi
 
 function boom(a: number, b: number): boolean {
-  _print("boom");
+  console.log("boom");
   return true;
 }
 
 function main(): void {
-  _print(false && boom(1, 2));
-  _print(true || boom(1, 2));
+  console.log((false && boom(1, 2)) ? 1 : 0);
+  console.log((true || boom(1, 2)) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/slice.ts
+++ b/tests/machine/x/ts/slice.ts
@@ -2,17 +2,8 @@
 // Source: /workspace/mochi/tests/vm/valid/slice.mochi
 
 function main(): void {
-  _print([1, 2, 3].slice(1, 3));
-  _print([1, 2, 3].slice(0, 2));
-  _print("hello".slice(1, 4));
+  console.log([1, 2, 3].slice(1, 3).join(" "));
+  console.log([1, 2, 3].slice(0, 2).join(" "));
+  console.log("hello".slice(1, 4));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/sort_stable.ts
+++ b/tests/machine/x/ts/sort_stable.ts
@@ -39,7 +39,7 @@ function main(): void {
     }
     return _res;
   })();
-  _print(result);
+  console.log(result.join(" "));
 }
 function _cmp(a: unknown, b: unknown): number {
   if (Array.isArray(a) && Array.isArray(b)) {
@@ -59,15 +59,6 @@ function _cmp(a: unknown, b: unknown): number {
     return a < b ? -1 : (a > b ? 1 : 0);
   }
   return String(a) < String(b) ? -1 : (String(a) > String(b) ? 1 : 0);
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/str_builtin.ts
+++ b/tests/machine/x/ts/str_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/str_builtin.mochi
 
 function main(): void {
-  _print("123");
+  console.log("123");
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_compare.ts
+++ b/tests/machine/x/ts/string_compare.ts
@@ -2,18 +2,9 @@
 // Source: /workspace/mochi/tests/vm/valid/string_compare.mochi
 
 function main(): void {
-  _print("a" < "b");
-  _print("a" <= "a");
-  _print("b" > "a");
-  _print("b" >= "b");
+  console.log(("a" < "b") ? 1 : 0);
+  console.log(("a" <= "a") ? 1 : 0);
+  console.log(("b" > "a") ? 1 : 0);
+  console.log(("b" >= "b") ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_concat.ts
+++ b/tests/machine/x/ts/string_concat.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/string_concat.mochi
 
 function main(): void {
-  _print(`hello world`);
+  console.log(`hello world`);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_contains.ts
+++ b/tests/machine/x/ts/string_contains.ts
@@ -5,16 +5,7 @@ let s: string;
 
 function main(): void {
   s = "catch";
-  _print(s.includes("cat"));
-  _print(s.includes("dog"));
+  console.log(s.includes("cat") ? 1 : 0);
+  console.log(s.includes("dog") ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_in_operator.ts
+++ b/tests/machine/x/ts/string_in_operator.ts
@@ -5,16 +5,7 @@ let s: string;
 
 function main(): void {
   s = "catch";
-  _print(s.includes("cat") ? 1 : 0);
-  _print(s.includes("dog") ? 1 : 0);
+  console.log((s.includes("cat") ? 1 : 0) ? 1 : 0);
+  console.log((s.includes("dog") ? 1 : 0) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_index.ts
+++ b/tests/machine/x/ts/string_index.ts
@@ -5,15 +5,6 @@ let s: string;
 
 function main(): void {
   s = "mochi";
-  _print(s[1]);
+  console.log(s[1]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/string_prefix_slice.ts
+++ b/tests/machine/x/ts/string_prefix_slice.ts
@@ -8,17 +8,8 @@ let s2: string;
 function main(): void {
   prefix = "fore";
   s1 = "forest";
-  _print(s1.slice(0, prefix.length) == prefix);
+  console.log((s1.slice(0, prefix.length) == prefix) ? 1 : 0);
   s2 = "desert";
-  _print(s2.slice(0, prefix.length) == prefix);
+  console.log((s2.slice(0, prefix.length) == prefix) ? 1 : 0);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/substring_builtin.ts
+++ b/tests/machine/x/ts/substring_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/substring_builtin.mochi
 
 function main(): void {
-  _print("och");
+  console.log("och");
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/sum_builtin.ts
+++ b/tests/machine/x/ts/sum_builtin.ts
@@ -2,15 +2,6 @@
 // Source: /workspace/mochi/tests/vm/valid/sum_builtin.mochi
 
 function main(): void {
-  _print([1, 2, 3].reduce((a, b) => a + Number(b), 0));
+  console.log([1, 2, 3].reduce((a, b) => a + Number(b), 0));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/tail_recursion.ts
+++ b/tests/machine/x/ts/tail_recursion.ts
@@ -9,15 +9,6 @@ function sum_rec(n: number, acc: number): number {
 }
 
 function main(): void {
-  _print(sum_rec(10, 0));
+  console.log(sum_rec(10, 0));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/test_block.ts
+++ b/tests/machine/x/ts/test_block.ts
@@ -7,16 +7,7 @@ function test_addition_works(): void {
 }
 
 function main(): void {
-  _print("ok");
+  console.log("ok");
   test_addition_works();
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/tree_sum.ts
+++ b/tests/machine/x/ts/tree_sum.ts
@@ -47,15 +47,6 @@ function main(): void {
       right: { __name: "Leaf" },
     },
   };
-  _print(sum_tree(t));
+  console.log(sum_tree(t));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/two-sum.ts
+++ b/tests/machine/x/ts/two-sum.ts
@@ -17,16 +17,7 @@ let result: number[];
 
 function main(): void {
   result = twoSum([2, 7, 11, 15], 9);
-  _print(result[0]);
-  _print(result[1]);
+  console.log(result[0]);
+  console.log(result[1]);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/typed_let.ts
+++ b/tests/machine/x/ts/typed_let.ts
@@ -5,15 +5,6 @@ let y: number;
 
 function main(): void {
   y = 0;
-  _print(y);
+  console.log(y);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/typed_var.ts
+++ b/tests/machine/x/ts/typed_var.ts
@@ -5,15 +5,6 @@ var x: number;
 
 function main(): void {
   x = 0;
-  _print(x);
+  console.log(x);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/unary_neg.ts
+++ b/tests/machine/x/ts/unary_neg.ts
@@ -2,16 +2,7 @@
 // Source: /workspace/mochi/tests/vm/valid/unary_neg.mochi
 
 function main(): void {
-  _print(-3);
-  _print(5 + (-2));
+  console.log(-3);
+  console.log(5 + (-2));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/update_stmt.ts
+++ b/tests/machine/x/ts/update_stmt.ts
@@ -70,7 +70,7 @@ function main(): void {
     }
     people[_i] = _item;
   }
-  _print("ok");
+  console.log("ok");
   test_update_adult_status();
 }
 function _equal(a: unknown, b: unknown): boolean {
@@ -94,15 +94,6 @@ function _equal(a: unknown, b: unknown): boolean {
     return true;
   }
   return a === b;
-}
-
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
 }
 
 main();

--- a/tests/machine/x/ts/user_type_literal.ts
+++ b/tests/machine/x/ts/user_type_literal.ts
@@ -21,15 +21,6 @@ function main(): void {
       age: 42,
     },
   };
-  _print(book.author.name);
+  console.log(book.author.name);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/values_builtin.ts
+++ b/tests/machine/x/ts/values_builtin.ts
@@ -9,15 +9,6 @@ function main(): void {
     "b": 2,
     "c": 3,
   };
-  _print(Object.values(m));
+  console.log(Object.values(m).join(" "));
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/var_assignment.ts
+++ b/tests/machine/x/ts/var_assignment.ts
@@ -6,15 +6,6 @@ var x: number;
 function main(): void {
   x = 1;
   x = 2;
-  _print(x);
+  console.log(x);
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();

--- a/tests/machine/x/ts/while_loop.ts
+++ b/tests/machine/x/ts/while_loop.ts
@@ -6,17 +6,8 @@ var i: number;
 function main(): void {
   i = 0;
   while ((i < 3)) {
-    _print(i);
+    console.log(i);
     i = i + 1;
   }
 }
-function _print(...args: unknown[]): void {
-  const out = args.map((a) => {
-    if (Array.isArray(a)) return a.join(" ");
-    if (typeof a === "boolean") return a ? "1" : "0";
-    return String(a);
-  }).join(" ").trimEnd();
-  console.log(out);
-}
-
 main();


### PR DESCRIPTION
## Summary
- inline `console.log` in generated TypeScript instead of using `_print`
- delete `_print` helper from TypeScript runtime
- note the change in `TASKS.md`
- regenerate VM outputs for TypeScript

## Testing
- `go test -tags slow ./compiler/x/ts -run TestTSCompiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878bc0bb08483209bdf42df17b46f82