### PR TITLE
Improve Elixir compiler

### DIFF
--- a/compiler/x/ex/TASKS.md
+++ b/compiler/x/ex/TASKS.md
@@ -56,3 +56,6 @@ fails if any `.error` file is present.
 - Regenerated machine outputs so all 100 programs under `tests/vm/valid` now have corresponding Elixir sources and output files.
 - Loops now iterate over strings and groups without relying on the `_iter` helper.
 - `len()` on groups is compiled to `length(g.items)` instead of calling `_length`.
+- `concat` now emits `++` or `<>` when all arguments are lists or strings.
+- `avg` uses integer division when the element type is integer so results match the VM.
+- `min` and `max` call `Enum.min`/`Enum.max` for lists and groups.


### PR DESCRIPTION
## Summary
- optimize concat generation by using `++` for lists and `<>` for strings
- emit integer results for `avg` when element type is integer
- use `Enum.min`/`Enum.max` when types are known
- document helper reductions in TASKS

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_VMValid_Golden -tags=slow -v` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6878bc824f2083208b1714b0ed620601