### PR TITLE
Improve Racket backend runtime helper selection

### DIFF
--- a/compiler/x/racket/runtime.go
+++ b/compiler/x/racket/runtime.go
@@ -2,23 +2,23 @@
 
 package racket
 
-const runtimeHelpers = `(define (_date_number s)
+const helperDateNumber = `(define (_date_number s)
   (let ([parts (string-split s "-")])
     (if (= (length parts) 3)
         (+ (* (string->number (list-ref parts 0)) 10000)
            (* (string->number (list-ref parts 1)) 100)
            (string->number (list-ref parts 2)))
-        #f)))
+        #f)))`
 
-(define (_to_string v)
+const helperToString = `(define (_to_string v)
   (cond
     [(eq? v #t) "true"]
     [(eq? v #f) "false"]
     [(void? v) "<nil>"]
     [(list? v) (string-join (map _to_string v) " ")]
-    [else (format "~a" v)]))
+    [else (format "~a" v)]))`
 
-(define (_lt a b)
+const helperLt = `(define (_lt a b)
   (cond
     [(and (number? a) (number? b)) (< a b)]
     [(and (string? a) (string? b))
@@ -34,13 +34,13 @@ const runtimeHelpers = `(define (_date_number s)
                    (if (equal? ka kb)
                        (_lt (cdr a) (cdr b))
                        (_lt ka kb)))])]
-    [else (string<? (_to_string a) (_to_string b))]))
+    [else (string<? (_to_string a) (_to_string b))]))`
 
-(define (_gt a b) (_lt b a))
-(define (_le a b) (or (_lt a b) (equal? a b)))
-(define (_ge a b) (or (_gt a b) (equal? a b)))
+const helperGt = `(define (_gt a b) (_lt b a))`
+const helperLe = `(define (_le a b) (or (_lt a b) (equal? a b)))`
+const helperGe = `(define (_ge a b) (or (_gt a b) (equal? a b)))`
 
-(define (_min v)
+const helperMin = `(define (_min v)
   (let* ([lst (cond [(and (hash? v) (hash-has-key? v 'items)) (hash-ref v 'items)]
                     [(list? v) v]
                     [else '()])]
@@ -49,9 +49,9 @@ const runtimeHelpers = `(define (_date_number s)
       (set! m (car lst))
       (for ([n (cdr lst)])
         (when (_lt n m) (set! m n))))
-    m))
+    m))`
 
-(define (_max v)
+const helperMax = `(define (_max v)
   (let* ([lst (cond [(and (hash? v) (hash-has-key? v 'items)) (hash-ref v 'items)]
                     [(list? v) v]
                     [else '()])]
@@ -60,16 +60,16 @@ const runtimeHelpers = `(define (_date_number s)
       (set! m (car lst))
       (for ([n (cdr lst)])
         (when (_gt n m) (set! m n))))
-    m))
+    m))`
 
-(define (_json-fix v)
+const helperJSONFix = `(define (_json-fix v)
   (cond
     [(and (number? v) (rational? v) (not (integer? v))) (real->double-flonum v)]
     [(list? v) (map _json-fix v)]
     [(hash? v) (for/hash ([(k val) v]) (values k (_json-fix val)))]
-    [else v]))
+    [else v]))`
 
-(define (_simple-yaml-parse s)
+const helperSimpleYAMLParse = `(define (_simple-yaml-parse s)
   (define items '())
   (define current #f)
   (for ([ln (string-split s "\n")])
@@ -91,5 +91,17 @@ const runtimeHelpers = `(define (_date_number s)
            (define v (string-trim (list-ref m 2)))
            (hash-set! current k (if (regexp-match? #px"^[0-9]+$" v) (string->number v) v))))]))
   (when current (set! items (cons current items)))
-  (reverse items))
-`
+  (reverse items))`
+
+var runtimeHelperMap = map[string]string{
+	"_date_number":       helperDateNumber,
+	"_to_string":         helperToString,
+	"_lt":                helperLt,
+	"_gt":                helperGt,
+	"_le":                helperLe,
+	"_ge":                helperGe,
+	"_min":               helperMin,
+	"_max":               helperMax,
+	"_json-fix":          helperJSONFix,
+	"_simple-yaml-parse": helperSimpleYAMLParse,
+}


### PR DESCRIPTION
## Summary
- split runtime helper code into individual constants
- track runtime helpers used during compilation and emit only those
- add simple expression type inference so `str` results are known
- update print, min/max, json and yaml helpers to use runtimeFuncs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878bafa04448320affda9aaa96e2031