### PR TITLE
Improve F# compiler type inference

### DIFF
--- a/compiler/x/fs/TASKS.md
+++ b/compiler/x/fs/TASKS.md
@@ -1,6 +1,8 @@
 # F# Compiler Enhancement Notes
 
 ## Recent Updates
+- 2025-09-06 - Added option-aware join inference and disabled anonymous struct
+  generation during hint collection; 77 of 100 programs compile and run.
 - 2025-07-27 00:00 UTC - Improved builtin type inference for common functions and fixed module import syntax.
 - 2025-07-27 12:00 UTC - Fixed string `in` operator orientation, corrected group
   bindings formatting, and inferred numeric map key types.

--- a/tests/machine/x/fs/README.md
+++ b/tests/machine/x/fs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains F# source code generated from Mochi programs. Successful runs have a `.out` file, failures produce a `.error` file.
 
-Compiled programs: 76/100
+Compiled programs: 77/100
 
 Checklist:
 - [x] append_builtin


### PR DESCRIPTION
## Summary
- enhance F# compiler join typing
- skip anon struct generation while gathering hints
- note progress in TASKS.md and README

## Testing
- `go test -tags slow ./compiler/x/fs -run TestFSCompiler -count=1` *(fails: TestFSCompiler_TPCH/q1)*

------
https://chatgpt.com/codex/tasks/task_e_6878bc73253c83209f54059e4e1a88b2