### PR TITLE
Java compiler improvements

### DIFF
--- a/compiler/x/java/TASKS.md
+++ b/compiler/x/java/TASKS.md
@@ -39,3 +39,4 @@
 
 - 2025-07-17T08:21 - regenerated print_hello output with newline and improved indentation
 - 2025-07-17T08:52 - avoided data class conversion for small maps used with `in` operator
+- 2025-07-17T09:15 - removed unused append helper by rewriting self-assignments

--- a/tests/machine/x/java/group_items_iteration.java
+++ b/tests/machine/x/java/group_items_iteration.java
@@ -2,45 +2,12 @@
 // group_items_iteration.mochi
 import java.util.*;
 
-class TagVal {
-    String tag;
-    int val;
-    TagVal(String tag, int val) {
-        this.tag = tag;
-        this.val = val;
-    }
-    @Override public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TagVal other)) return false;
-        return Objects.equals(this.tag, other.tag) && Objects.equals(this.val, other.val);
-    }
-    @Override public int hashCode() {
-        return Objects.hash(tag, val);
-    }
-    int size() { return 2; }
-}
-class TagTotal {
-    Object tag;
-    int total;
-    TagTotal(Object tag, int total) {
-        this.tag = tag;
-        this.total = total;
-    }
-    @Override public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TagTotal other)) return false;
-        return Objects.equals(this.tag, other.tag) && Objects.equals(this.total, other.total);
-    }
-    @Override public int hashCode() {
-        return Objects.hash(tag, total);
-    }
-    int size() { return 2; }
-}
 public class GroupItemsIteration {
-    static <T> List<T> append(List<T> list, T item) {
-        List<T> res = new ArrayList<>(list);
-        res.add(item);
-        return res;
+    static <K,V> Map.Entry<K,V> entry(K k, V v) { return new AbstractMap.SimpleEntry<>(k, v); }
+    static <K,V> LinkedHashMap<K,V> mapOfEntries(Map.Entry<? extends K,? extends V>... entries) {
+        LinkedHashMap<K,V> m = new LinkedHashMap<>();
+        for (var e : entries) m.put(e.getKey(), e.getValue());
+        return m;
     }
     static class Group<K,V> implements Iterable<V> {
         K key;
@@ -50,39 +17,39 @@ public class GroupItemsIteration {
         int size() { return items.size(); }
     }
     public static void main(String[] args) {
-    List<TagVal> data = new ArrayList<>(Arrays.asList(new TagVal("a", 1), new TagVal("a", 2), new TagVal("b", 3)));
-    List<Group<String,TagVal>> groups = (new java.util.function.Supplier<List<Group<String,TagVal>>>(){public List<Group<String,TagVal>> get(){
-    List<Group<String,TagVal>> res0 = new ArrayList<>();
-    Map<String,List<TagVal>> groups1 = new LinkedHashMap<>();
+        List<Map<String,Object>> data = new ArrayList<>(Arrays.asList(mapOfEntries(entry("tag", "a"), entry("val", 1)), mapOfEntries(entry("tag", "a"), entry("val", 2)), mapOfEntries(entry("tag", "b"), entry("val", 3))));
+        List<Group<Object,Map<String,Object>>> groups = (new java.util.function.Supplier<List<Group<Object,Map<String,Object>>>>(){public List<Group<Object,Map<String,Object>>> get(){
+    List<Group<Object,Map<String,Object>>> res0 = new ArrayList<>();
+    Map<Object,List<Map<String,Object>>> groups1 = new LinkedHashMap<>();
     for (var d : data) {
         var row2 = d;
-        String key3 = d.tag;
-        List<TagVal> bucket4 = groups1.get(key3);
+        Object key3 = ((Map<String,Object>)d).get("tag");
+        List<Map<String,Object>> bucket4 = groups1.get(key3);
         if (bucket4 == null) { bucket4 = new ArrayList<>(); groups1.put(key3, bucket4); }
         bucket4.add(row2);
     }
-    for (Map.Entry<String,List<TagVal>> __e : groups1.entrySet()) {
-        String g_key = __e.getKey();
-        Group<String,TagVal> g = new Group<>(g_key, __e.getValue());
+    for (Map.Entry<Object,List<Map<String,Object>>> __e : groups1.entrySet()) {
+        Object g_key = __e.getKey();
+        Group<Object,Map<String,Object>> g = new Group<>(g_key, __e.getValue());
         res0.add(g);
     }
     return res0;
 }}).get();
-    List<Object> tmp = new ArrayList<>(Arrays.asList());
-    for (Group<String,TagVal> g : groups) {
-        int total = 0;
-        for (TagVal x : g.items) {
-            total = (int)(total + x.val);
+        List<Object> tmp = new ArrayList<>(Arrays.asList());
+        for (Group<Object,Map<String,Object>> g : groups) {
+            int total = 0;
+            for (Map<String,Object> x : g.items) {
+                total = (int)(total + ((Number)((Map<String,Object>)x).get("val")).doubleValue());
+            }
+            tmp.add(mapOfEntries(entry("tag", g.key), entry("total", total)));
         }
-        tmp.add(new TagTotal(g.key, total));
-    }
-    List<Object> result = (new java.util.function.Supplier<List<Object>>(){public List<Object> get(){
+        List<Object> result = (new java.util.function.Supplier<List<Object>>(){public List<Object> get(){
     List<Object> res5 = new ArrayList<>();
     for (var r : tmp) {
         res5.add(r);
     }
     return res5;
 }}).get();
-    System.out.println(result);
+        System.out.println(result);
     }
 }

--- a/tests/machine/x/java/group_items_iteration.out
+++ b/tests/machine/x/java/group_items_iteration.out
@@ -1,1 +1,1 @@
-[TagTotal@f83, TagTotal@fa2]
+[{tag=a, total=3}, {tag=b, total=3}]


### PR DESCRIPTION
## Summary
- remove unused append helper when assigning `list = append(list, x)`
- regenerate Java output for group_items_iteration
- document progress in Java TASKS

## Testing
- `go test -tags slow ./compiler/x/java -run TestJavaCompiler_VMValidPrograms/group_items_iteration -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6878bc9db5308320a909fa155580a58a