### PR TITLE
Enhance Kotlin compiler with query type inference

### DIFF
--- a/compiler/x/kotlin/infer.go
+++ b/compiler/x/kotlin/infer.go
@@ -9,6 +9,16 @@ import (
 
 // inferExprType delegates to types.ExprType.
 func (c *Compiler) inferExprType(e *parser.Expr) types.Type {
+	if e != nil && e.Binary != nil {
+		u := e.Binary.Left
+		if len(e.Binary.Right) == 0 && len(u.Ops) == 0 && u.Value != nil && len(u.Value.Ops) == 0 {
+			if q := u.Value.Target.Query; q != nil {
+				if t, ok := c.queryTypes[q]; ok {
+					return t
+				}
+			}
+		}
+	}
 	return types.ExprType(e, c.env)
 }
 

--- a/compiler/x/kotlin/vm_golden_test.go
+++ b/compiler/x/kotlin/vm_golden_test.go
@@ -57,6 +57,7 @@ func TestKotlinCompiler_VMValid_Golden(t *testing.T) {
 			return nil, fmt.Errorf("kotlinc error: %w", err)
 		}
 		cmd := exec.Command("java", "-jar", jar)
+		cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- improve Kotlin compiler by tracking query result types
- generate structs from map literals and support `group.items`
- resolve relative load paths via `MOCHI_ROOT`

## Testing
- `go test -tags slow ./compiler/x/kotlin -run TestKotlinCompiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878bc511a5c832099d00d894bfa7a65