### PR TITLE
Improve TS match expression compilation

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -121,3 +121,7 @@
 ### 2025-09-16 00:00 UTC
 - Removed `_print` helper. Print calls now inline a `console.log` conversion.
 - Regenerated VM golden outputs.
+### 2025-09-20 00:00 UTC
+- Match expressions now emit direct comparisons for primitive patterns,
+  avoiding the `_equal` helper when possible.
+- Regenerated VM golden outputs.

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -3269,6 +3269,7 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	targetType := c.inferExprType(m.Target)
 	var b strings.Builder
 	b.WriteString("(() => {\n")
 	b.WriteString("\tconst _t = " + target + ";\n")
@@ -3313,8 +3314,13 @@ func (c *Compiler) compileMatchExpr(m *parser.MatchExpr) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			c.use("_equal")
-			cond = fmt.Sprintf("_equal(_t, %s)", p)
+			pType := c.inferExprType(cs.Pattern)
+			if isPrimitive(targetType) && isPrimitive(pType) {
+				cond = fmt.Sprintf("_t === %s", p)
+			} else {
+				c.use("_equal")
+				cond = fmt.Sprintf("_equal(_t, %s)", p)
+			}
 		}
 		b.WriteString(fmt.Sprintf("\tif (%s) { return %s }\n", cond, r))
 	}

--- a/tests/machine/x/ts/match_expr.ts
+++ b/tests/machine/x/ts/match_expr.ts
@@ -8,34 +8,11 @@ function main(): void {
   x = 2;
   label = (() => {
     const _t = x;
-    if (_equal(_t, 1)) return "one";
-    if (_equal(_t, 2)) return "two";
-    if (_equal(_t, 3)) return "three";
+    if (_t === 1) return "one";
+    if (_t === 2) return "two";
+    if (_t === 3) return "three";
     return "unknown";
   })();
   console.log(label);
 }
-function _equal(a: unknown, b: unknown): boolean {
-  if (typeof a === "number" && typeof b === "number") {
-    return Math.abs(a - b) < 1e-9;
-  }
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (!_equal(a[i], b[i])) return false;
-    return true;
-  }
-  if (a && b && typeof a === "object" && typeof b === "object") {
-    const ak = Object.keys(a);
-    const bk = Object.keys(b);
-    if (ak.length !== bk.length) return false;
-    for (const k of ak) {
-      if (!bk.includes(k) || !_equal((a as any)[k], (b as any)[k])) {
-        return false;
-      }
-    }
-    return true;
-  }
-  return a === b;
-}
-
 main();

--- a/tests/machine/x/ts/match_full.ts
+++ b/tests/machine/x/ts/match_full.ts
@@ -4,8 +4,8 @@
 function classify(n: number): string {
   return (() => {
     const _t = n;
-    if (_equal(_t, 0)) return "zero";
-    if (_equal(_t, 1)) return "one";
+    if (_t === 0) return "zero";
+    if (_t === 1) return "one";
     return "many";
   })();
 }
@@ -21,53 +21,30 @@ function main(): void {
   x = 2;
   label = (() => {
     const _t = x;
-    if (_equal(_t, 1)) return "one";
-    if (_equal(_t, 2)) return "two";
-    if (_equal(_t, 3)) return "three";
+    if (_t === 1) return "one";
+    if (_t === 2) return "two";
+    if (_t === 3) return "three";
     return "unknown";
   })();
   console.log(label);
   day = "sun";
   mood = (() => {
     const _t = day;
-    if (_equal(_t, "mon")) return "tired";
-    if (_equal(_t, "fri")) return "excited";
-    if (_equal(_t, "sun")) return "relaxed";
+    if (_t === "mon") return "tired";
+    if (_t === "fri") return "excited";
+    if (_t === "sun") return "relaxed";
     return "normal";
   })();
   console.log(mood);
   ok = true;
   status = (() => {
     const _t = ok;
-    if (_equal(_t, true)) return "confirmed";
-    if (_equal(_t, false)) return "denied";
+    if (_t === true) return "confirmed";
+    if (_t === false) return "denied";
     return undefined;
   })();
   console.log(status);
   console.log(classify(0));
   console.log(classify(5));
 }
-function _equal(a: unknown, b: unknown): boolean {
-  if (typeof a === "number" && typeof b === "number") {
-    return Math.abs(a - b) < 1e-9;
-  }
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) if (!_equal(a[i], b[i])) return false;
-    return true;
-  }
-  if (a && b && typeof a === "object" && typeof b === "object") {
-    const ak = Object.keys(a);
-    const bk = Object.keys(b);
-    if (ak.length !== bk.length) return false;
-    for (const k of ak) {
-      if (!bk.includes(k) || !_equal((a as any)[k], (b as any)[k])) {
-        return false;
-      }
-    }
-    return true;
-  }
-  return a === b;
-}
-
 main();


### PR DESCRIPTION
## Summary
- upgrade ts compiler's match expression logic to avoid `_equal` helper for primitive patterns
- regenerate TypeScript code for match_expr and match_full examples
- document enhancement in `TASKS.md`

## Testing
- `go test ./compiler/x/ts -tags slow -run TestTSCompiler_VMValid_Golden/match_expr -update`
- `go test ./compiler/x/ts -tags slow -run TestTSCompiler_VMValid_Golden/match_full -update`
- `go test ./compiler/x/ts -tags slow -run TestTSCompiler_VMValid_Golden -count=1` *(fails: golden mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_6878dfed1e10832084df291f25d804e8