### PR TITLE
Improve Go compiler join detection

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -2801,7 +2801,8 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr, hint types.Type) (strin
 	needsHelper := q.Sort != nil
 	for _, j := range q.Joins {
 		if j.Side != nil {
-			if !(len(q.Joins) == 1 && *j.Side == "left" && len(q.Froms) == 0 && q.Group == nil && q.Sort == nil && q.Skip == nil && q.Take == nil) {
+			simple := len(q.Joins) == 1 && len(q.Froms) == 0 && q.Group == nil && q.Sort == nil && q.Skip == nil && q.Take == nil
+			if !simple || (*j.Side != "left" && *j.Side != "right" && *j.Side != "outer") {
 				needsHelper = true
 				break
 			}


### PR DESCRIPTION
## Summary
- handle simple outer/right joins without `_query` helper

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_VMValid_Golden -tags slow` *(fails: 53 passed, 47 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878e37ab82c8320a73485c87f840848