### PR TITLE
Improve C backend aggregate optimization

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -138,3 +138,4 @@ should compile and run successfully.
 - 2025-07-17 - Fixed YAML loader to deduplicate struct fields so `load_yaml.mochi` compiles.
 - 2025-07-17 - Updated group by list allocation to use create_* helpers; now group_by and join queries compile.
 - 2025-09-16 - Fixed struct literal generation to use sanitized type names. record_assign.mochi compiles.
+- 2025-09-17 - Precomputed aggregates for constant integer lists to remove runtime helpers.


### PR DESCRIPTION
## Summary
- precompute aggregates for constant integer lists to avoid runtime helpers
- document the optimization in `TASKS.md`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6878e303fad48320a51ab6af93462935