### PR TITLE
Enhance Fortran compiler

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -49,6 +49,9 @@
 - 2025-07-17 10:00: List set operations (`union`, `union_all`, `except`,
   `intersect`) compute at compile time when both operands are integer list
   literals, eliminating helper functions at runtime.
+- 2025-07-17 11:00: Constant integer lists propagate through variables so
+  `append` on known lists is resolved at compile time, removing temporary
+  buffers.
 
 ## Remaining Work
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.

--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -1269,6 +1269,14 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 		if len(call.Args) != 2 {
 			return "", fmt.Errorf("append expects 2 args")
 		}
+		if lst := listLiteral(call.Args[0]); lst != nil {
+			if ints, ok := intList(lst); ok {
+				if iv := literalInt(call.Args[1]); iv != nil {
+					out := append(ints, *iv)
+					return formatIntList(out), nil
+				}
+			}
+		}
 		arr := args[0]
 		elem := args[1]
 		tmp := fmt.Sprintf("app%d", c.tmpIndex)
@@ -1498,6 +1506,20 @@ func literalIntPrimary(p *parser.Primary) *int {
 		return nil
 	}
 	return p.Lit.Int
+}
+
+func literalInt(e *parser.Expr) *int {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) != 0 {
+		return nil
+	}
+	u := e.Binary.Left
+	if len(u.Ops) != 0 || u.Value == nil || u.Value.Target == nil {
+		return nil
+	}
+	if u.Value.Target.Lit != nil && u.Value.Target.Lit.Int != nil {
+		return u.Value.Target.Lit.Int
+	}
+	return nil
 }
 
 func listLiteralFromUnary(u *parser.Unary) *parser.ListLiteral {


### PR DESCRIPTION
## Summary
- fold simple integer `append` calls at compile time
- document progress in Fortran TASKS

## Testing
- `go test ./compiler/x/fortran -run TestFortranCompiler_VMValid_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6878e41b54688320a41b4c874d2b577f