### PR TITLE
Improve Haskell runtime helper selection

### DIFF
--- a/compiler/x/hs/TASKS.md
+++ b/compiler/x/hs/TASKS.md
@@ -1,4 +1,8 @@
 # Haskell Backend Progress
+## Recent Updates (2025-08-10 05:00)
+- Runtime cast helpers are now included individually. The compiler tracks `_asInt`,
+  `_asDouble`, `_asString`, and `_asBool` separately so unused functions are not
+  emitted.
 ## Recent Updates (2025-07-30 05:00)
 - Added fine-grained tracking for AnyValue cast helpers. The runtime now omits
   `_asInt` and related functions when they are not referenced in generated code.

--- a/compiler/x/hs/runtime.go
+++ b/compiler/x/hs/runtime.go
@@ -156,19 +156,25 @@ _showAny (VString s) = s
 _showAny (VBool b) = if b then "true" else "false"
 `
 
-const anyCastRuntime = `
+const asIntRuntime = `
 _asInt :: AnyValue -> Int
 _asInt (VInt n) = n
 _asInt v = error ("expected int, got " ++ show v)
+`
 
+const asDoubleRuntime = `
 _asDouble :: AnyValue -> Double
 _asDouble (VDouble d) = d
 _asDouble v = error ("expected double, got " ++ show v)
+`
 
+const asStringRuntime = `
 _asString :: AnyValue -> String
 _asString (VString s) = s
 _asString v = error ("expected string, got " ++ show v)
+`
 
+const asBoolRuntime = `
 _asBool :: AnyValue -> Bool
 _asBool (VBool b) = b
 _asBool v = error ("expected bool, got " ++ show v)


### PR DESCRIPTION
## Summary
- add new flags to track usage of individual AnyValue cast helpers
- emit cast helpers only when referenced
- support union types in hsType
- document update in TASKS

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6878e433a8448320a26c6adcb35f3902