### PR TITLE
Update Go compiler helpers

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -99,3 +99,4 @@ TPC-H progress:
 - 2025-07-20 13:10 - Improved OptionType handling in selectors and query environments; left_join program compiles
 - 2025-07-21 00:00 - Optimised exists() for option types to avoid runtime helper
 - 2025-07-21 12:34 - Added optimised outer join translation using maps; outer_join program compiles
+ - 2025-07-21 18:00 - Expanded exists() and castExpr to avoid runtime helpers for common types

--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4475,6 +4475,8 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				return fmt.Sprintf("len(%s.Items) > 0", args[0]), nil
 			case types.OptionType:
 				return fmt.Sprintf("%s != nil", args[0]), nil
+			case types.BoolType:
+				return args[0], nil
 			}
 		}
 		// Fallback to the runtime helper for imprecise types.

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -292,8 +292,20 @@ func (c *Compiler) castExpr(expr string, from, to types.Type) string {
 		return fmt.Sprintf("%s(%s)", toGo, expr)
 	}
 
-	if isBool(to) && strings.HasPrefix(fromGo, "*") {
-		return fmt.Sprintf("%s != nil", expr)
+	if isBool(to) {
+		switch from.(type) {
+		case types.OptionType:
+			return fmt.Sprintf("%s != nil", expr)
+		case types.ListType, types.MapType:
+			return fmt.Sprintf("len(%s) > 0", expr)
+		case types.StringType:
+			return fmt.Sprintf("len([]rune(%s)) > 0", expr)
+		case types.GroupType:
+			return fmt.Sprintf("len(%s.Items) > 0", expr)
+		}
+		if strings.HasPrefix(fromGo, "*") {
+			return fmt.Sprintf("%s != nil", expr)
+		}
 	}
 
 	if _, ok := from.(types.AnyType); ok {


### PR DESCRIPTION
## Summary
- extend compile-time optimisations for `exists()` and boolean casts in Go backend
- document the update in `TASKS.md`

## Testing
- `go test ./compiler/x/go -run TestGoCompiler_VMValid_Golden -tags slow` *(fails: 54 passed, 46 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878e656a8cc83209945ec59cbeedfbb