### PR TITLE
Improve PHP avg inference

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -34,3 +34,5 @@
 - 2025-07-20 10:00 - Generated PHP machine outputs for all VM valid programs and added README checklist.
 - 2025-07-21 08:00 - Printing now uses `var_dump`; `_print` helper removed.
 - 2025-07-21 12:00 - Avg builtin inlines numeric lists to avoid runtime helper.
+- 2025-07-21 12:30 - Avg builtin now uses full type inference so group queries
+  may inline numeric averages without runtime helpers.

--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -902,7 +902,7 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("avg expects 1 arg")
 		}
 		src := args[0]
-		typ := types.TypeOfExprBasic(call.Args[0], c.env)
+               typ := types.ExprType(call.Args[0], c.env)
 		if isNumericListLiteral(call.Args[0]) {
 			return fmt.Sprintf("count(%s) ? array_sum(%s) / count(%s) : 0", src, src, src), nil
 		}

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -2,6 +2,7 @@
 
 This directory contains PHP code generated from the Mochi programs in `tests/vm/valid`. Each program was compiled using the PHP backend and executed with `php`. Successful runs have a `.out` file while failures produce a `.error` file.
 Printing now relies on PHP's built‑in `var_dump` so no `_print` helper is emitted.
+Average calculations inline PHP's numeric operations when types allow.
 
 Compiled programs: 100/100
 


### PR DESCRIPTION
## Summary
- refine avg helper usage by using full type inference
- track progress in TASKS
- document runtime improvement in machine README

## Testing
- `go test ./compiler/x/php -tags slow -run TestPHPCompiler_VMValid_Golden/append_builtin -count=1`
- `go test ./compiler/x/php -tags slow -run TestPHPCompiler_VMValid_Golden/group_by -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878e6c223248320b194d6ec27713185