### PR TITLE
Improve C# compiler inference

### DIFF
--- a/compiler/x/cs/TASKS.md
+++ b/compiler/x/cs/TASKS.md
@@ -67,3 +67,8 @@
   `cast_struct`, `closure`, `count_builtin`, `cross_join`,
   `dataset_where_filter`, `string_contains`, `values_builtin`, `group_by`,
   `len_string`, `len_map` and `substring_builtin` bringing totals to 29/100.
+
+## Recent Updates (2025-07-24 00:00)
+- `isListPostfix` and `isStringPostfix` now consult `inferPostfixType` so
+  expressions returned from functions or calls are recognized. This allows
+  direct indexing and slicing of typed values without helper functions.

--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -3422,6 +3422,9 @@ func (c *Compiler) isListPostfix(p *parser.PostfixExpr) bool {
 			}
 		}
 	}
+	if _, ok := c.inferPostfixType(p).(types.ListType); ok {
+		return true
+	}
 	return false
 }
 
@@ -3449,6 +3452,9 @@ func (c *Compiler) isStringPostfix(p *parser.PostfixExpr) bool {
 				return true
 			}
 		}
+	}
+	if _, ok := c.inferPostfixType(p).(types.StringType); ok {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- improve inference of list and string postfix expressions in C# backend
- document latest progress in `TASKS.md`

## Testing
- `go test -tags=slow ./compiler/x/cs -run TestCSCompiler_VMValid_Golden -count=1 -timeout 30s` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6878e72ef6d0832098d7d36dc7d76b4d