### PR TITLE
Improve TypeScript type inference

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1609,7 +1609,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	typ := c.inferPrimaryType(p.Target)
+	typ := underlyingType(c.inferPrimaryType(p.Target))
 	for _, op := range p.Ops {
 		if op.Index == nil {
 			if op.Call != nil {
@@ -1624,7 +1624,7 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 						return "", err2
 					}
 					rootExpr := &parser.Primary{Selector: &parser.SelectorExpr{Root: sel.Root}}
-                                       rootTyp := underlyingType(c.inferPrimaryType(rootExpr))
+					rootTyp := underlyingType(c.inferPrimaryType(rootExpr))
 					root := sanitizeName(sel.Root)
 					switch method {
 					case "keys":
@@ -1686,11 +1686,11 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				}
 			} else if op.Field != nil {
 				expr = fmt.Sprintf("%s.%s", expr, sanitizeName(op.Field.Name))
-				typ = fieldType(typ, op.Field.Name)
+				typ = underlyingType(fieldType(typ, op.Field.Name))
 			} else if op.Cast != nil {
 				t := c.resolveTypeRef(op.Cast.Type)
 				expr = fmt.Sprintf("(%s as %s)", expr, tsType(t))
-				typ = t
+				typ = underlyingType(t)
 			}
 			continue
 		}
@@ -1895,10 +1895,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	}
 	switch call.Func {
 	case "print":
-               if len(args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
-                       case types.BoolType:
+		if len(args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
+			case types.BoolType:
 				return fmt.Sprintf("console.log(%s ? 'True' : 'False')", args[0]), nil
 			case types.ListType:
 				return fmt.Sprintf("console.log(%s.join(' '))", args[0]), nil
@@ -1909,9 +1909,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			}
 		}
 		parts := make([]string, len(args))
-               for i, a := range args {
-                       t := underlyingType(c.inferExprType(call.Args[i]))
-                       switch t.(type) {
+		for i, a := range args {
+			t := underlyingType(c.inferExprType(call.Args[i]))
+			switch t.(type) {
 			case types.BoolType:
 				parts[i] = fmt.Sprintf("(%s ? 'True' : 'False')", a)
 			case types.ListType:
@@ -1923,21 +1923,21 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			}
 		}
 		return fmt.Sprintf("console.log(%s)", strings.Join(parts, " + ' ' + ")), nil
-       case "keys":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       if mt, ok := t.(types.MapType); ok {
-                               if isInt(mt.Key) || isInt64(mt.Key) || isFloat(mt.Key) {
-                                       return fmt.Sprintf("Object.keys(%s).map(k => Number(k))", args[0]), nil
-                               }
-                       }
-                       return fmt.Sprintf("Object.keys(%s)", args[0]), nil
-               }
-               return "Object.keys()", nil
-       case "len":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
+	case "keys":
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			if mt, ok := t.(types.MapType); ok {
+				if isInt(mt.Key) || isInt64(mt.Key) || isFloat(mt.Key) {
+					return fmt.Sprintf("Object.keys(%s).map(k => Number(k))", args[0]), nil
+				}
+			}
+			return fmt.Sprintf("Object.keys(%s)", args[0]), nil
+		}
+		return "Object.keys()", nil
+	case "len":
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
 			case types.ListType, types.StringType:
 				return fmt.Sprintf("%s.length", args[0]), nil
 			case types.MapType, types.StructType, types.UnionType:
@@ -1954,17 +1954,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		c.use("_input")
 		return "_input()", nil
 	case "count":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
-                       case types.ListType, types.StringType:
-                               return fmt.Sprintf("%s.length", args[0]), nil
-                       case types.MapType, types.StructType, types.UnionType:
-                               return fmt.Sprintf("Object.keys(%s).length", args[0]), nil
-                       case types.GroupType:
-                               return fmt.Sprintf("%s.items.length", args[0]), nil
-                       }
-               }
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
+			case types.ListType, types.StringType:
+				return fmt.Sprintf("%s.length", args[0]), nil
+			case types.MapType, types.StructType, types.UnionType:
+				return fmt.Sprintf("Object.keys(%s).length", args[0]), nil
+			case types.GroupType:
+				return fmt.Sprintf("%s.items.length", args[0]), nil
+			}
+		}
 		c.use("_count")
 		return fmt.Sprintf("_count(%s)", argStr), nil
 	case "append":
@@ -1977,14 +1977,14 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) != 2 {
 			return "", fmt.Errorf("contains expects 2 args")
 		}
-               if len(call.Args) == 2 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
-                       case types.ListType, types.StringType:
-                               return fmt.Sprintf("%s.includes(%s)", args[0], args[1]), nil
-                       case types.MapType, types.StructType, types.UnionType:
-                               return fmt.Sprintf("Object.prototype.hasOwnProperty.call(%s, String(%s))", args[0], args[1]), nil
-                       }
+		if len(call.Args) == 2 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
+			case types.ListType, types.StringType:
+				return fmt.Sprintf("%s.includes(%s)", args[0], args[1]), nil
+			case types.MapType, types.StructType, types.UnionType:
+				return fmt.Sprintf("Object.prototype.hasOwnProperty.call(%s, String(%s))", args[0], args[1]), nil
+			}
 		}
 		c.use("_contains")
 		return fmt.Sprintf("_contains(%s, %s)", args[0], args[1]), nil
@@ -1994,36 +1994,36 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_starts_with")
 		return fmt.Sprintf("_starts_with(%s, %s)", args[0], args[1]), nil
-       case "values":
-               if len(args) != 1 {
-                       return "", fmt.Errorf("values expects 1 arg")
-               }
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
-                       case types.MapType, types.StructType, types.UnionType:
-                               return fmt.Sprintf("Object.values(%s)", args[0]), nil
-                       }
-               }
-               c.use("_values")
-               return fmt.Sprintf("_values(%s)", args[0]), nil
-       case "exists":
-               if len(args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
-                       case types.ListType, types.StringType:
-                               return fmt.Sprintf("(%s.length > 0)", args[0]), nil
-                       case types.MapType, types.StructType, types.UnionType:
-                               return fmt.Sprintf("(Object.keys(%s).length > 0)", args[0]), nil
-                       }
-               }
-               c.use("_exists")
-               return fmt.Sprintf("_exists(%s)", argStr), nil
+	case "values":
+		if len(args) != 1 {
+			return "", fmt.Errorf("values expects 1 arg")
+		}
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
+			case types.MapType, types.StructType, types.UnionType:
+				return fmt.Sprintf("Object.values(%s)", args[0]), nil
+			}
+		}
+		c.use("_values")
+		return fmt.Sprintf("_values(%s)", args[0]), nil
+	case "exists":
+		if len(args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
+			case types.ListType, types.StringType:
+				return fmt.Sprintf("(%s.length > 0)", args[0]), nil
+			case types.MapType, types.StructType, types.UnionType:
+				return fmt.Sprintf("(Object.keys(%s).length > 0)", args[0]), nil
+			}
+		}
+		c.use("_exists")
+		return fmt.Sprintf("_exists(%s)", argStr), nil
 	case "avg":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch tt := t.(type) {
-                       case types.ListType:
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch tt := t.(type) {
+			case types.ListType:
 				if isNumericType(tt.Elem) {
 					return fmt.Sprintf("(%s.reduce((a,b)=>a+b,0) / %s.length)", args[0], args[0]), nil
 				}
@@ -2045,10 +2045,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_reduce")
 		return fmt.Sprintf("_reduce(%s, %s, %s)", args[0], args[1], args[2]), nil
-       case "sum":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch tt := t.(type) {
+	case "sum":
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch tt := t.(type) {
 			case types.ListType:
 				if isNumericType(tt.Elem) {
 					return fmt.Sprintf("%s.reduce((a,b)=>a+b,0)", args[0]), nil
@@ -2063,10 +2063,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_sum")
 		return fmt.Sprintf("_sum(%s)", argStr), nil
-       case "min":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
+	case "min":
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
 			case types.ListType:
 				return fmt.Sprintf("Math.min(...%s)", args[0]), nil
 			case types.GroupType:
@@ -2075,10 +2075,10 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		c.use("_min")
 		return fmt.Sprintf("_min(%s)", argStr), nil
-       case "max":
-               if len(call.Args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       switch t.(type) {
+	case "max":
+		if len(call.Args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			switch t.(type) {
 			case types.ListType:
 				return fmt.Sprintf("Math.max(...%s)", args[0]), nil
 			case types.GroupType:
@@ -2107,13 +2107,13 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 			return fmt.Sprintf("(%s).substring(%s, (%s)+(%s))", args[0], args[1], args[1], args[2]), nil
 		}
 		return fmt.Sprintf("(%s).substring(%s)", args[0], args[1]), nil
-       case "reverse":
-               if len(args) == 1 {
-                       t := underlyingType(c.inferExprType(call.Args[0]))
-                       if _, ok := t.(types.StringType); ok {
-                               return fmt.Sprintf("%s.split('') .reverse().join('')", args[0]), nil
-                       }
-                       return fmt.Sprintf("%s.slice().reverse()", args[0]), nil
+	case "reverse":
+		if len(args) == 1 {
+			t := underlyingType(c.inferExprType(call.Args[0]))
+			if _, ok := t.(types.StringType); ok {
+				return fmt.Sprintf("%s.split('') .reverse().join('')", args[0]), nil
+			}
+			return fmt.Sprintf("%s.slice().reverse()", args[0]), nil
 		}
 		return fmt.Sprintf("[].concat(%s).reverse()", strings.Join(args, ", ")), nil
 	case "first":

--- a/compiler/x/ts/helpers.go
+++ b/compiler/x/ts/helpers.go
@@ -211,36 +211,43 @@ func equalTypes(a, b types.Type) bool {
 }
 
 func isInt64(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.Int64Type)
 	return ok
 }
 
 func isInt(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.IntType)
 	return ok
 }
 
 func isFloat(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.FloatType)
 	return ok
 }
 
 func isString(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.StringType)
 	return ok
 }
 
 func isList(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.ListType)
 	return ok
 }
 
 func isMap(t types.Type) bool {
+	t = underlyingType(t)
 	_, ok := t.(types.MapType)
 	return ok
 }
 
 func isStruct(t types.Type) bool {
+	t = underlyingType(t)
 	switch t.(type) {
 	case types.StructType, types.UnionType:
 		return true
@@ -370,6 +377,7 @@ func fieldType(t types.Type, field string) types.Type {
 }
 
 func tsZeroValue(t types.Type) string {
+	t = underlyingType(t)
 	switch tt := t.(type) {
 	case types.IntType, types.Int64Type, types.FloatType:
 		return "0"
@@ -391,24 +399,24 @@ func tsZeroValue(t types.Type) string {
 }
 
 func underlyingType(t types.Type) types.Type {
-        for {
-                switch tt := t.(type) {
-                case types.OptionType:
-                        t = tt.Elem
-                case types.UnionType:
-                        if len(tt.Variants) == 1 {
-                                for _, v := range tt.Variants {
-                                        if len(v.Fields) == 1 {
-                                                for _, ft := range v.Fields {
-                                                        t = ft
-                                                }
-                                                continue
-                                        }
-                                }
-                        }
-                        return t
-                default:
-                        return t
-                }
-        }
+	for {
+		switch tt := t.(type) {
+		case types.OptionType:
+			t = tt.Elem
+		case types.UnionType:
+			if len(tt.Variants) == 1 {
+				for _, v := range tt.Variants {
+					if len(v.Fields) == 1 {
+						for _, ft := range v.Fields {
+							t = ft
+						}
+						continue
+					}
+				}
+			}
+			return t
+		default:
+			return t
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- make helper `is*` functions unwrap option and union types
- unwrap option types in `tsZeroValue`
- use underlying types in `compilePostfix`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68791c1e79c48320a8fb10fb8f07ae8d