### PR TITLE
Improve Python slice inference

### DIFF
--- a/compiler/x/python/TASKS.md
+++ b/compiler/x/python/TASKS.md
@@ -9,6 +9,9 @@
 ## Recent Enhancements (2025-07-24 00:00)
 - Builtin operations now detect optional list and map types, avoiding helper
   emission when Python primitives suffice.
+## Recent Enhancements (2025-07-24 12:00)
+- Indexing and slicing optional lists or strings now skips the `_slice` helper
+  in favour of native Python slices.
 
 ## Recent Enhancements (2025-07-17 01:20)
 - Print calls skip `_fmt` for constant string arguments and attempt to collapse

--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -644,11 +644,14 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 						return "", err
 					}
 				}
-				switch typ.(type) {
+				base := unwrapOption(typ)
+				switch base.(type) {
 				case types.ListType, types.StringType:
 					expr = fmt.Sprintf("%s[%s:%s]", expr, start, end)
-					if _, ok := typ.(types.StringType); ok {
+					if _, ok := base.(types.StringType); ok {
 						typ = types.StringType{}
+					} else {
+						typ = base
 					}
 				default:
 					startArg, endArg := "0", "0"
@@ -667,7 +670,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				if err != nil {
 					return "", err
 				}
-				switch tt := typ.(type) {
+				base := unwrapOption(typ)
+				switch tt := base.(type) {
 				case types.ListType:
 					expr = fmt.Sprintf("%s[%s]", expr, idxExpr)
 					typ = tt.Elem


### PR DESCRIPTION
## Summary
- improve Python compiler inference for index and slice ops
- document new optimization in TASKS

## Testing
- `go test ./compiler/x/python -tags slow -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6878e9d16d2883208608bb1813f7c04a