### PR TITLE
Improve Java compiler struct 'in' checks

### DIFF
--- a/compiler/x/java/TASKS.md
+++ b/compiler/x/java/TASKS.md
@@ -41,3 +41,4 @@
 - 2025-07-17T08:52 - avoided data class conversion for small maps used with `in` operator
 - 2025-07-17T09:15 - removed unused append helper by rewriting self-assignments
 - 2025-07-17T09:45 - replaced mapOfEntries helper with Map.ofEntries for map literals
+- 2025-07-17T12:27 - added struct membership inference to avoid inOp helper

--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -2364,6 +2364,15 @@ func (c *Compiler) compileBinaryOp(left string, op *parser.BinaryOp, right strin
 			return fmt.Sprintf("%s.contains(%s)", right, left), nil
 		} else if strings.HasPrefix(typ, "Map<") {
 			return fmt.Sprintf("%s.containsKey(%s)", right, left), nil
+		} else if dc := c.dataClassByName(typ); dc != nil {
+			var checks []string
+			for _, f := range dc.fields {
+				checks = append(checks, fmt.Sprintf("Objects.equals(%s, \"%s\")", left, f))
+			}
+			if len(checks) == 0 {
+				return "false", nil
+			}
+			return strings.Join(checks, " || "), nil
 		}
 		c.helpers["in"] = true
 		return fmt.Sprintf("inOp(%s, %s)", left, right), nil

--- a/tests/machine/x/java/map_membership.java
+++ b/tests/machine/x/java/map_membership.java
@@ -20,15 +20,9 @@ class M {
     int size() { return 2; }
 }
 public class MapMembership {
-    static boolean inOp(Object item, Object collection) {
-        if (collection instanceof Map<?,?> m) return m.containsKey(item);
-        if (collection instanceof Collection<?> c) return c.contains(item);
-        if (collection instanceof String s) return s.contains(String.valueOf(item));
-        return false;
-    }
     public static void main(String[] args) {
         M m = new M(1, 2);
-        System.out.println(inOp("a", m));
-        System.out.println(inOp("c", m));
+        System.out.println(Objects.equals("a", "a") || Objects.equals("a", "b"));
+        System.out.println(Objects.equals("c", "a") || Objects.equals("c", "b"));
     }
 }

--- a/tests/machine/x/java/map_membership.out
+++ b/tests/machine/x/java/map_membership.out
@@ -1,2 +1,2 @@
-false
+true
 false


### PR DESCRIPTION
## Summary
- improve `in` operator handling for struct types in Java compiler
- regenerate `map_membership` Java machine output
- document progress in Java TASKS

## Testing
- `go test ./compiler/x/java -run VMValidPrograms -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6878e8d7055c8320b9ae0e7be2218b48