### PR TITLE
fortran: fold len/count on constant lists

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -55,6 +55,8 @@
 - 2025-07-17 12:00: `len`, `count`, `append`, and list set operations now fold
   integer lists even when referenced through variables, eliminating more helper
   calls at runtime.
+- 2025-07-17 12:30: Type inference handles any constant list in `len` and
+  `count`, folding the length at compile time to remove unnecessary helper code.
 
 ## Remaining Work
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.

--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -1221,8 +1221,8 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 		if len(call.Args) != 1 {
 			return "", fmt.Errorf("len expects 1 arg")
 		}
-		if ints, ok := c.constIntListExpr(call.Args[0]); ok {
-			return fmt.Sprintf("%d", len(ints)), nil
+		if n, ok := c.constListLenExpr(call.Args[0]); ok {
+			return fmt.Sprintf("%d", n), nil
 		}
 		if types.IsStringExpr(call.Args[0], c.env) {
 			return fmt.Sprintf("len(%s)", args[0]), nil
@@ -1253,8 +1253,8 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 		if len(call.Args) != 1 {
 			return "", fmt.Errorf("count expects 1 arg")
 		}
-		if ints, ok := c.constIntListExpr(call.Args[0]); ok {
-			return fmt.Sprintf("%d", len(ints)), nil
+		if n, ok := c.constListLenExpr(call.Args[0]); ok {
+			return fmt.Sprintf("%d", n), nil
 		}
 		return fmt.Sprintf("size(%s)", args[0]), nil
 	case "str":
@@ -1568,6 +1568,16 @@ func (c *Compiler) constIntListExpr(e *parser.Expr) ([]int, bool) {
 		return ints, ok
 	}
 	return nil, false
+}
+
+func (c *Compiler) constListLenExpr(e *parser.Expr) (int, bool) {
+	if ints, ok := c.constIntListExpr(e); ok {
+		return len(ints), true
+	}
+	if l := listLiteral(e); l != nil {
+		return len(l.Elems), true
+	}
+	return 0, false
 }
 
 func (c *Compiler) constIntListFromUnary(u *parser.Unary) ([]int, bool) {

--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -4,7 +4,10 @@ The Fortran backend compiles each Mochi program under `tests/vm/valid`. This dir
 
 List literal lengths are now computed at compile time so programs using `len` or
 `count` on constant arrays avoid runtime helper code. List set operations like
-`union` and `except` with constant integer lists are also folded at compile time. Append operations on constant integer lists stored in variables are resolved during compilation as well.
+`union` and `except` with constant integer lists are also folded at compile time.
+Append operations on constant integer lists stored in variables are resolved
+during compilation as well. The compiler now folds `len` and `count` for any
+constant list, removing even more helper calls at runtime.
 
 Compiled programs: 100/100
 


### PR DESCRIPTION
## Summary
- improve Fortran compiler constant folding
- track lengths of constant lists for `len` and `count`
- document the new optimisation

## Testing
- `go test ./compiler/x/fortran -run TestFortranCompiler_VMValid_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6879223147d08320a00dddbdab02d1c0