### PR TITLE
Improve TS sort inference

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -136,3 +136,6 @@
 - Builtin functions like `count`, `exists`, `values`, `contains`, `sum`, `avg`, `min`, and `max` now use native operations whenever the underlying type is known, further reducing reliance on runtime helpers.
 ### 2025-10-08 00:00 UTC
 - `starts_with` now compiles to `String.startsWith` when both arguments are strings, removing the `_starts_with` helper in those cases.
+
+### 2025-10-10 00:00 UTC
+- Sort expressions inline numeric, string, or boolean comparisons instead of calling the `_cmp` helper when the key type is known.


### PR DESCRIPTION
## Summary
- inline simple sort comparisons without relying on `_cmp`
- document new enhancement in tasks log

## Testing
- `go build ./compiler/x/ts`
- `go build -tags=slow ./compiler/x/ts`

------
https://chatgpt.com/codex/tasks/task_e_687923ce5de48320b8104b248cc0a6f8