### PR TITLE
Improve C++ compiler type inference

### DIFF
--- a/compiler/x/cpp/TASKS.md
+++ b/compiler/x/cpp/TASKS.md
@@ -70,4 +70,6 @@
 - Map literal value type inference recognizes numeric literals to avoid
   `std::any` fallbacks.
 - Double values are printed with one decimal place using `<iomanip>` helpers.
+- Struct field types now update from `std::any` when later elements provide
+  concrete types, reducing helper usage at runtime.
 


### PR DESCRIPTION
## Summary
- refine struct field type updates so `std::any` is replaced when later elements provide concrete types
- clean up `cpp` TASKS notes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6879234e36e083209d4d85abb91df469