### PR TITLE
Improve Kotlin compiler inference

### DIFF
--- a/compiler/x/kotlin/TASKS.md
+++ b/compiler/x/kotlin/TASKS.md
@@ -1,3 +1,4 @@
+- 2025-07-17 16:39 UTC: Removed unused `starts_with` helper and reduced numeric casts via improved inference.
 - 2025-07-17 12:03 UTC: Improved selector type inference to avoid helper casts in loops.
 - 2025-07-17 07:10 UTC: Added string selector support and improved union match coverage; 92 VM tests compile.
 # Kotlin Compiler Tasks


### PR DESCRIPTION
## Summary
- kotlin compiler: remove unconditional starts_with runtime helper
- reduce unnecessary numeric helper casts for better type inference
- note the refinement in TASKS

## Testing
- `go test -tags slow ./compiler/x/kotlin -run TestKotlinCompiler_VMValid_Golden -count=1` *(fails: context deadline exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6879246f7df08320b917b76d5a29cfc4