### PR TITLE
Improve Haskell compiler inference

### DIFF
--- a/compiler/x/hs/TASKS.md
+++ b/compiler/x/hs/TASKS.md
@@ -1,4 +1,9 @@
 # Haskell Backend Progress
+## Recent Updates (2025-08-15 05:00)
+- Added `containsAny` helper and improved binary operator casting so `Option` and
+  nested types are checked for `AnyValue`. Map literals now wrap values
+  correctly when the container type is `any` and `json` calls trigger the
+  `AnyValue` runtime when needed.
 ## Recent Updates (2025-08-10 05:00)
 - Runtime cast helpers are now included individually. The compiler tracks `_asInt`,
   `_asDouble`, `_asString`, and `_asBool` separately so unused functions are not

--- a/compiler/x/hs/compiler.go
+++ b/compiler/x/hs/compiler.go
@@ -1181,23 +1181,23 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				opSym = "/="
 			}
 			if opSym == "+" || opSym == "-" || opSym == "*" || opSym == "/" {
-				if isAny(leftType) && isInt(rightType) {
+				if (isAny(leftType) || containsAny(leftType)) && isInt(rightType) {
 					expr = fmt.Sprintf("_asInt (%s)", expr)
 					c.usesAnyCast = true
 					c.usesAsInt = true
 					leftType = types.IntType{}
-				} else if isAny(leftType) && isFloat(rightType) {
+				} else if (isAny(leftType) || containsAny(leftType)) && isFloat(rightType) {
 					expr = fmt.Sprintf("_asDouble (%s)", expr)
 					c.usesAnyCast = true
 					c.usesAsDouble = true
 					leftType = types.FloatType{}
 				}
-				if isAny(rightType) && isInt(leftType) {
+				if (isAny(rightType) || containsAny(rightType)) && isInt(leftType) {
 					r = fmt.Sprintf("_asInt (%s)", r)
 					c.usesAnyCast = true
 					c.usesAsInt = true
 					rightType = types.IntType{}
-				} else if isAny(rightType) && isFloat(leftType) {
+				} else if (isAny(rightType) || containsAny(rightType)) && isFloat(leftType) {
 					r = fmt.Sprintf("_asDouble (%s)", r)
 					c.usesAnyCast = true
 					c.usesAsDouble = true
@@ -1205,23 +1205,23 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 				}
 			}
 			if opSym == "==" || opSym == "/=" || opSym == "<" || opSym == "<=" || opSym == ">" || opSym == ">=" {
-				if isAny(leftType) && isInt(rightType) {
+				if (isAny(leftType) || containsAny(leftType)) && isInt(rightType) {
 					expr = fmt.Sprintf("_asInt (%s)", expr)
 					c.usesAnyCast = true
 					c.usesAsInt = true
 					leftType = types.IntType{}
-				} else if isAny(leftType) && isFloat(rightType) {
+				} else if (isAny(leftType) || containsAny(leftType)) && isFloat(rightType) {
 					expr = fmt.Sprintf("_asDouble (%s)", expr)
 					c.usesAnyCast = true
 					c.usesAsDouble = true
 					leftType = types.FloatType{}
 				}
-				if isAny(rightType) && isInt(leftType) {
+				if (isAny(rightType) || containsAny(rightType)) && isInt(leftType) {
 					r = fmt.Sprintf("_asInt (%s)", r)
 					c.usesAnyCast = true
 					c.usesAsInt = true
 					rightType = types.IntType{}
-				} else if isAny(rightType) && isFloat(leftType) {
+				} else if (isAny(rightType) || containsAny(rightType)) && isFloat(leftType) {
 					r = fmt.Sprintf("_asDouble (%s)", r)
 					c.usesAnyCast = true
 					c.usesAsDouble = true
@@ -1541,7 +1541,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			}
 			if anyVal {
 				vt := c.inferExprType(it.Value)
-				if isAny(vt) {
+				if !isAny(vt) {
 					c.usesAnyValue = true
 					v = wrapAnyValue(vt, v)
 				}
@@ -1638,6 +1638,10 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		}
 		if p.Call.Func == "json" {
 			c.usesJSON = true
+			if len(p.Call.Args) > 0 && containsAny(c.inferExprType(p.Call.Args[0])) {
+				c.usesAnyValue = true
+				c.usesLoad = true
+			}
 			return fmt.Sprintf("_json %s", strings.Join(args, " ")), nil
 		}
 		if p.Call.Func == "input" {

--- a/compiler/x/hs/infer.go
+++ b/compiler/x/hs/infer.go
@@ -97,6 +97,29 @@ func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
 	return ok
 }
 
+// containsAny reports whether the type t or any nested component is AnyType.
+func containsAny(t types.Type) bool {
+	switch tt := t.(type) {
+	case types.AnyType:
+		return true
+	case types.ListType:
+		return containsAny(tt.Elem)
+	case types.MapType:
+		return containsAny(tt.Key) || containsAny(tt.Value)
+	case types.OptionType:
+		return containsAny(tt.Elem)
+	case types.GroupType:
+		return containsAny(tt.Key) || containsAny(tt.Elem)
+	case types.StructType:
+		for _, ft := range tt.Fields {
+			if containsAny(ft) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // local helpers
 func isInt(t types.Type) bool {
 	switch t.(type) {


### PR DESCRIPTION
## Summary
- improve AnyValue detection with new `containsAny` helper
- wrap map literal values correctly when map expects `any`
- cast numeric binary operations when optional or nested `any` types appear
- include AnyValue runtime when `json` is used with dynamic types
- document progress in TASKS

## Testing
- `go test ./compiler/x/hs -tags slow -run TestHSCompiler_VMValid_GoldenRun` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6879240452ac8320b7389a054d82bb6c