### PR TITLE
Improve Rust compiler constants

### DIFF
--- a/tests/machine/x/rust/load_yaml.out
+++ b/tests/machine/x/rust/load_yaml.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/machine/x/rust/load_yaml.rs
+++ b/tests/machine/x/rust/load_yaml.rs
@@ -12,12 +12,8 @@ struct Result {
     email: &'static str,
 }
 
-fn _load<T: Default + Clone>(_path: &str, _opts: std::collections::HashMap<String, String>) -> Vec<T> {
-    Vec::new()
-}
-
 fn main() {
-    let people = _load::<Person>("../interpreter/valid/people.yaml", { let mut m = std::collections::HashMap::new(); m.insert("format".to_string(), "yaml".to_string()); m });
+    let people = vec![Person { name: "Alice", age: 30, email: "alice@example.com" }, Person { name: "Bob", age: 15, email: "bob@example.com" }, Person { name: "Charlie", age: 20, email: "charlie@example.com" }];
     let adults = { let mut tmp1 = Vec::new();for p in &people { if !(p.age >= 18) { continue; } tmp1.push(Result { name: p.name, email: p.email }); } tmp1 };
     for a in adults {
         println!("{}", vec![format!("{}", a.name), format!("{}", a.email)].into_iter().filter(|s| !s.is_empty()).collect::<Vec<_>>().join(" ") );

--- a/tests/machine/x/rust/save_jsonl_stdout.out
+++ b/tests/machine/x/rust/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name":"Alice","age":30}
+{"name":"Bob","age":25}

--- a/tests/machine/x/rust/save_jsonl_stdout.rs
+++ b/tests/machine/x/rust/save_jsonl_stdout.rs
@@ -5,9 +5,8 @@ struct People {
     age: i32,
 }
 
-fn _save<T>(_src: &[T], _path: &str, _opts: std::collections::HashMap<String, String>) { }
-
 fn main() {
     let people = vec![People { name: "Alice", age: 30 }, People { name: "Bob", age: 25 }];
-    _save(&people, "-", { let mut m = std::collections::HashMap::new(); m.insert("format".to_string(), "jsonl".to_string()); m });
+    println!("{{\"name\":\"Alice\",\"age\":30}}
+{{\"name\":\"Bob\",\"age\":25}}");
 }

--- a/types/check.go
+++ b/types/check.go
@@ -1121,6 +1121,9 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type) error {
 					params = append(params, resolveTypeRef(f.Type, env))
 				}
 				env.SetFuncType(v.Name, FuncType{Params: params, Return: UnionType{Name: s.Type.Name, Variants: nil}})
+				if len(params) == 0 {
+					env.SetVar(v.Name, UnionType{Name: s.Type.Name, Variants: nil}, false)
+				}
 			}
 			env.SetUnion(s.Type.Name, ut)
 			env.types[s.Type.Name] = ut


### PR DESCRIPTION
## Summary
- add repoRoot helper to resolve dataset paths
- inline YAML data at compile-time in `compileLoadExpr`
- emit constant JSON when saving lists of structs
- escape braces in generated `println!`
- treat nullary union variants as constants
- regenerate Rust machine outputs

## Testing
- `go test ./compiler/x/rust -tags slow -run TestRustCompiler_VMValid_Golden/load_yaml -count=1`
- `go test ./compiler/x/rust -tags slow -run TestRustCompiler_VMValid_Golden/save_jsonl_stdout -count=1`
- `go test ./compiler/x/rust -tags slow -run TestRustCompiler_VMValid_Golden/tree_sum -count=1`
- `go test ./compiler/x/rust -tags slow -run TestRustCompiler_VMValid_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687926b02e348320b08e68ac68d8afc2