### PR TITLE
Improve C compiler const list handling

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -144,3 +144,5 @@ should compile and run successfully.
   test blocks. `list_nested_assign.mochi` and `test_block.mochi` compile and run.
 - 2025-09-19 - Improved string list type inference and constant `in` evaluation;
   `sort_stable.mochi` now compiles and runs.
+ - 2025-09-20 - Computed `count` of constant integer lists at compile time to
+   avoid emitting list helpers. `count_builtin.mochi` now generates minimal C.

--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -5463,6 +5463,9 @@ func (c *Compiler) compilePrimary(p *parser.Primary) string {
 			}
 			return "0"
 		} else if p.Call.Func == "count" {
+			if vals, ok := c.evalListIntExpr(p.Call.Args[0]); ok {
+				return strconv.Itoa(len(vals))
+			}
 			t := c.exprType(p.Call.Args[0])
 			arg := c.compileExpr(p.Call.Args[0])
 			switch t.(type) {

--- a/tests/machine/x/c/README.md
+++ b/tests/machine/x/c/README.md
@@ -100,5 +100,5 @@ The C backend compiles Mochi programs in `tests/vm/valid`. The table below lists
  - [x] test_block
 - [ ] tree_sum
 - [ ] update_stmt
-- [ ] user_type_literal
+ - [x] user_type_literal
  - [x] values_builtin

--- a/tests/machine/x/c/count_builtin.c
+++ b/tests/machine/x/c/count_builtin.c
@@ -2,29 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-typedef struct {
-  int len;
-  int *data;
-} list_int;
-static list_int list_int_create(int len) {
-  list_int l;
-  l.len = len;
-  l.data = calloc(len, sizeof(int));
-  if (!l.data && len > 0) {
-    fprintf(stderr, "alloc failed\n");
-    exit(1);
-  }
-  return l;
-}
 int _mochi_main() {
-  list_int tmp1 = list_int_create(3);
-  tmp1.data[0] = 1;
-  tmp1.data[1] = 2;
-  tmp1.data[2] = 3;
-  list_int tmp2 = list_int_create(3);
-  tmp2.data[0] = 1;
-  tmp2.data[1] = 2;
-  tmp2.data[2] = 3;
   printf("%d\n", 3);
   return 0;
 }


### PR DESCRIPTION
## Summary
- optimize `count` calls on constant integer lists
- mark `user_type_literal.mochi` as compiling in the C README
- document constant-count optimization in TASKS
- update generated `count_builtin.c`

## Testing
- `go test ./compiler/x/c -run TestCCompiler_VMValid_Golden -tags slow -update -count=1` *(fails: 95 passed, 5 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68792bb1d054832099ccd9162d6bf67b