### PR TITLE
Improve TS compiler starts_with inference

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -139,3 +139,5 @@
 
 ### 2025-10-10 00:00 UTC
 - Sort expressions inline numeric, string, or boolean comparisons instead of calling the `_cmp` helper when the key type is known.
+### 2025-10-12 00:00 UTC
+- Further refined `starts_with` compilation to inline `String.startsWith` when the receiver is known to be a string.

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -1677,9 +1677,20 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					typ = types.BoolType{}
 				} else if strings.HasSuffix(expr, ".starts_with") && len(args) == 1 {
 					recv := strings.TrimSuffix(expr, ".starts_with")
-					c.use("_starts_with")
-					expr = fmt.Sprintf("_starts_with(%s, %s)", recv, args[0])
-					typ = types.BoolType{}
+					recvTyp := underlyingType(c.inferPrimaryType(p.Target))
+					argTyp := underlyingType(c.inferExprType(op.Call.Args[0]))
+					if _, ok := recvTyp.(types.StringType); ok {
+						if _, ok := argTyp.(types.StringType); ok {
+							expr = fmt.Sprintf("%s.startsWith(%s)", recv, args[0])
+						} else {
+							expr = fmt.Sprintf("%s.startsWith(String(%s))", recv, args[0])
+						}
+						typ = types.BoolType{}
+					} else {
+						c.use("_starts_with")
+						expr = fmt.Sprintf("_starts_with(%s, %s)", recv, args[0])
+						typ = types.BoolType{}
+					}
 				} else {
 					expr = fmt.Sprintf("%s(%s)", expr, strings.Join(args, ", "))
 					typ = c.inferPostfixType(&parser.PostfixExpr{Target: &parser.Primary{Call: nil}})
@@ -1991,6 +2002,16 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "starts_with":
 		if len(args) != 2 {
 			return "", fmt.Errorf("starts_with expects 2 args")
+		}
+		if len(call.Args) == 2 {
+			leftType := underlyingType(c.inferExprType(call.Args[0]))
+			rightType := underlyingType(c.inferExprType(call.Args[1]))
+			if _, ok := leftType.(types.StringType); ok {
+				if _, ok := rightType.(types.StringType); ok {
+					return fmt.Sprintf("%s.startsWith(%s)", args[0], args[1]), nil
+				}
+				return fmt.Sprintf("%s.startsWith(String(%s))", args[0], args[1]), nil
+			}
 		}
 		c.use("_starts_with")
 		return fmt.Sprintf("_starts_with(%s, %s)", args[0], args[1]), nil

--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -1,7 +1,7 @@
 # Mochi to TypeScript compilation status
 
 The TypeScript backend compiles Mochi programs from `tests/vm/valid` and executes them with Deno. The table below marks programs that compile and run successfully. Boolean values are printed as `1` or `0` for consistency with the reference outputs.
-Recent updates further shrink the runtime by inlining native operations whenever the input types are known. The `starts_with` builtin now emits `String.startsWith` when the argument types are strings.
+Recent updates further shrink the runtime by inlining native operations whenever the input types are known. The `starts_with` builtin now emits `String.startsWith` when the argument types are strings. The compiler also recognizes method calls where the receiver is known to be a string and inlines `startsWith` directly.
 
 ## Checklist
 - [x] append_builtin


### PR DESCRIPTION
## Summary
- inline `starts_with` as `startsWith` when receiver is a string
- document new enhancement in ts TASKS
- mention the update in TypeScript backend README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68792be50ae08320a67ad60c9ad1a3a9