### PR TITLE
Improve Prolog compiler len inference

### DIFF
--- a/archived/compiler/x/pl_simple/compiler_test.go
+++ b/archived/compiler/x/pl_simple/compiler_test.go
@@ -45,7 +45,7 @@ func compileAndRun(t *testing.T, src, outDir, name string) {
 		writeError(outDir, name, string(data), err)
 		t.Fatalf("parse error: %v", err)
 	}
-	code, err := pl.New().Compile(prog)
+	code, err := pl.New(nil).Compile(prog)
 	if err != nil {
 		writeError(outDir, name, string(data), err)
 		t.Fatalf("compile error: %v", err)

--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -739,7 +739,7 @@ func compileProgram(lang string, env *types.Env, prog *parser.Program, root, src
 	case "php":
 		return phpcode.New(env).Compile(prog)
 	case "pl", "prolog":
-		return plcode.New().Compile(prog)
+		return plcode.New(env).Compile(prog)
 	case "racket", "rkt":
 		return racketcode.New().Compile(prog)
 	case "rb", "ruby":

--- a/compiler/x/pl/compiler_test.go
+++ b/compiler/x/pl/compiler_test.go
@@ -41,7 +41,7 @@ func TestPrologCompiler_GoldenOutput(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("\u274c parse error: %w", err)
 		}
-		code, err := pl.New().Compile(prog)
+		code, err := pl.New(nil).Compile(prog)
 		if err != nil {
 			return nil, fmt.Errorf("\u274c compile error: %w", err)
 		}
@@ -86,7 +86,7 @@ func compileAndRun(t *testing.T, src, outDir, name string) {
 		writeError(outDir, name, string(data), err)
 		return
 	}
-	code, err := pl.New().Compile(prog)
+	code, err := pl.New(nil).Compile(prog)
 	if err != nil {
 		writeError(outDir, name, string(data), err)
 		return

--- a/compiler/x/pl/job_golden_test.go
+++ b/compiler/x/pl/job_golden_test.go
@@ -40,7 +40,7 @@ func TestPrologCompiler_JOB_Golden(t *testing.T) {
 			if errs := types.Check(prog, env); len(errs) > 0 {
 				t.Fatalf("type error: %v", errs[0])
 			}
-			code, err := pl.New().Compile(prog)
+			code, err := pl.New(env).Compile(prog)
 			if err != nil {
 				t.Fatalf("compile error: %v", err)
 			}

--- a/compiler/x/pl/rosetta_golden_test.go
+++ b/compiler/x/pl/rosetta_golden_test.go
@@ -70,7 +70,7 @@ func runRosettaTaskGolden(t *testing.T, name string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := pl.New().Compile(prog)
+	code, err := pl.New(env).Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}

--- a/compiler/x/pl/tpcds_golden_test.go
+++ b/compiler/x/pl/tpcds_golden_test.go
@@ -58,7 +58,7 @@ func TestPrologCompiler_TPCDSQueries(t *testing.T) {
 			if errs := types.Check(prog, env); len(errs) > 0 {
 				t.Fatalf("type error: %v", errs[0])
 			}
-			code, err := pl.New().Compile(prog)
+			code, err := pl.New(env).Compile(prog)
 			if err != nil {
 				t.Fatalf("compile error: %v", err)
 			}

--- a/scripts/compile_prolog.go
+++ b/scripts/compile_prolog.go
@@ -28,7 +28,7 @@ func main() {
 			os.Remove(filepath.Join(outDir, name+".pl"))
 			continue
 		}
-		code, err := pl.New().Compile(prog)
+		code, err := pl.New(nil).Compile(prog)
 		if err != nil {
 			ioutil.WriteFile(errPath, []byte(err.Error()), 0644)
 			os.Remove(filepath.Join(outDir, name+".pl"))

--- a/scripts/compile_rosetta_pl.go
+++ b/scripts/compile_rosetta_pl.go
@@ -70,7 +70,7 @@ func main() {
 			writeError(outDir, name, fmt.Sprintf("type: %v", errs[0]))
 			continue
 		}
-		code, err := pl.New().Compile(prog)
+		code, err := pl.New(env).Compile(prog)
 		if err != nil {
 			writeError(outDir, name, fmt.Sprintf("compile: %v", err))
 			continue

--- a/scripts/compile_tpcds_pl.go
+++ b/scripts/compile_tpcds_pl.go
@@ -76,7 +76,7 @@ func main() {
 			os.Remove(outPath)
 			continue
 		}
-		code, err := pl.New().Compile(prog)
+		code, err := pl.New(env).Compile(prog)
 		if err != nil {
 			os.WriteFile(errPath, []byte("compile: "+err.Error()), 0o644)
 			os.Remove(codePath)


### PR DESCRIPTION
## Summary
- add type-aware environment to Prolog compiler
- infer argument type in `len` builtin and avoid `len_any` helper
- propagate types through let/var/assign
- wire environment through tests and scripts

## Testing
- `go test ./compiler/x/pl -run TestPrologCompiler_GoldenOutput -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687933e64dc08320bbb5109efa56288c