### PR TITLE
Improve Any type detection for Haskell backend

### DIFF
--- a/compiler/x/hs/infer.go
+++ b/compiler/x/hs/infer.go
@@ -99,25 +99,7 @@ func (c *Compiler) isMapPostfix(p *parser.PostfixExpr) bool {
 
 // containsAny reports whether the type t or any nested component is AnyType.
 func containsAny(t types.Type) bool {
-	switch tt := t.(type) {
-	case types.AnyType:
-		return true
-	case types.ListType:
-		return containsAny(tt.Elem)
-	case types.MapType:
-		return containsAny(tt.Key) || containsAny(tt.Value)
-	case types.OptionType:
-		return containsAny(tt.Elem)
-	case types.GroupType:
-		return containsAny(tt.Key) || containsAny(tt.Elem)
-	case types.StructType:
-		for _, ft := range tt.Fields {
-			if containsAny(ft) {
-				return true
-			}
-		}
-	}
-	return false
+	return types.ContainsAny(t)
 }
 
 // local helpers

--- a/types/infercheck.go
+++ b/types/infercheck.go
@@ -29,6 +29,24 @@ func ContainsAny(t Type) bool {
 		return ContainsAny(tt.Elem)
 	case MapType:
 		return ContainsAny(tt.Key) || ContainsAny(tt.Value)
+	case OptionType:
+		return ContainsAny(tt.Elem)
+	case GroupType:
+		return ContainsAny(tt.Key) || ContainsAny(tt.Elem)
+	case StructType:
+		for _, ft := range tt.Fields {
+			if ContainsAny(ft) {
+				return true
+			}
+		}
+	case UnionType:
+		for _, v := range tt.Variants {
+			for _, ft := range v.Fields {
+				if ContainsAny(ft) {
+					return true
+				}
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- extend `types.ContainsAny` to walk through Option, Group, Struct and Union types
- delegate `compiler/x/hs` helper to the new `types.ContainsAny`

## Testing
- `go test ./compiler/x/hs -tags slow -run TestHSCompiler_VMValid_GoldenRun -count=1` *(fails: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_687933c9bba083209f13b445d1b5cf83