### PR TITLE
Fix group count and equality in Go compiler

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4554,13 +4554,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "count":
 		if len(call.Args) == 1 {
 			at := c.inferExprType(call.Args[0])
+			arg := args[0]
+			if strings.HasPrefix(arg, "any(") && strings.HasSuffix(arg, ")") {
+				arg = strings.TrimSuffix(strings.TrimPrefix(arg, "any("), ")")
+			}
 			switch at.(type) {
 			case types.ListType, types.MapType:
-				return fmt.Sprintf("len(%s)", args[0]), nil
+				return fmt.Sprintf("len(%s)", arg), nil
 			case types.StringType:
-				return fmt.Sprintf("len([]rune(%s))", args[0]), nil
+				return fmt.Sprintf("len([]rune(%s))", arg), nil
 			case types.GroupType:
-				return fmt.Sprintf("len(%s.Items)", args[0]), nil
+				return fmt.Sprintf("len(%s.Items)", arg), nil
 			}
 		}
 		c.imports["mochi/runtime/data"] = true

--- a/compiler/x/go/runtime.go
+++ b/compiler/x/go/runtime.go
@@ -660,6 +660,20 @@ const (
 	helperEqual = "func _equal(a, b any) bool {\n" +
 		"    av := reflect.ValueOf(a)\n" +
 		"    bv := reflect.ValueOf(b)\n" +
+		"    if av.Kind() == reflect.Struct && bv.Kind() == reflect.Map {\n" +
+		"        am := map[string]any{}\n" +
+		"        _copyToMap(am, a)\n" +
+		"        bm := map[string]any{}\n" +
+		"        _copyToMap(bm, b)\n" +
+		"        return _equal(am, bm)\n" +
+		"    }\n" +
+		"    if av.Kind() == reflect.Map && bv.Kind() == reflect.Struct {\n" +
+		"        am := map[string]any{}\n" +
+		"        _copyToMap(am, a)\n" +
+		"        bm := map[string]any{}\n" +
+		"        _copyToMap(bm, b)\n" +
+		"        return _equal(am, bm)\n" +
+		"    }\n" +
 		"    if av.Kind() == reflect.Slice && bv.Kind() == reflect.Slice {\n" +
 		"        if av.Len() != bv.Len() { return false }\n" +
 		"        for i := 0; i < av.Len(); i++ {\n" +
@@ -1008,6 +1022,10 @@ func (c *Compiler) use(name string) {
 		c.imports["strings"] = true
 		c.imports["reflect"] = true
 		c.helpers["_equal"] = true
+	}
+	if name == "_equal" {
+		c.imports["reflect"] = true
+		c.use("_copyToMap")
 	}
 	if name == "_minOrdered" || name == "_maxOrdered" || name == "_avgOrdered" || name == "_sumOrdered" {
 		c.imports["golang.org/x/exp/constraints"] = true


### PR DESCRIPTION
## Summary
- handle `count` on groups without unnecessary `any()` cast
- allow struct-vs-map comparison in runtime `_equal`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687932d6be888320b24d699092955973