### PR TITLE
Improve Prolog backend

### DIFF
--- a/compiler/x/pl/TASKS.md
+++ b/compiler/x/pl/TASKS.md
@@ -33,3 +33,7 @@
 - Added short-circuit handling for `&&` and `||` in `buildBinary`.
 - Extended `isBoolExpr` to recognize expressions containing `->` or `;`.
 - Regenerated code for `bool_chain` using `go run ./cmd/mochix buildx -t pl`.
+
+## Progress (2025-07-28 00:00 UTC)
+- Added type-aware handling for indexing and slicing so lists and strings use native Prolog operations.
+- Helper predicates `get_item` and `slice` are now omitted when not required.

--- a/tests/machine/x/pl/short_circuit.error
+++ b/tests/machine/x/pl/short_circuit.error
@@ -1,0 +1,9 @@
+output mismatch
+-- got --
+boom
+false
+boom
+true
+-- want --
+0
+1

--- a/tests/machine/x/pl/slice.error
+++ b/tests/machine/x/pl/slice.error
@@ -1,0 +1,9 @@
+output mismatch
+-- got --
+[2,3]
+[1,2]
+ell
+-- want --
+2 3
+1 2
+ell

--- a/tests/machine/x/pl/string_compare.error
+++ b/tests/machine/x/pl/string_compare.error
@@ -1,0 +1,11 @@
+output mismatch
+-- got --
+true
+true
+true
+true
+-- want --
+1
+1
+1
+1

--- a/tests/machine/x/pl/string_contains.error
+++ b/tests/machine/x/pl/string_contains.error
@@ -1,0 +1,7 @@
+output mismatch
+-- got --
+true
+false
+-- want --
+1
+0

--- a/tests/machine/x/pl/string_in_operator.error
+++ b/tests/machine/x/pl/string_in_operator.error
@@ -1,0 +1,7 @@
+output mismatch
+-- got --
+true
+false
+-- want --
+1
+0

--- a/tests/machine/x/pl/string_prefix_slice.error
+++ b/tests/machine/x/pl/string_prefix_slice.error
@@ -1,0 +1,7 @@
+output mismatch
+-- got --
+true
+false
+-- want --
+1
+0

--- a/tests/machine/x/pl/substring_builtin.error
+++ b/tests/machine/x/pl/substring_builtin.error
@@ -1,0 +1,5 @@
+output mismatch
+-- got --
+moch
+-- want --
+och

--- a/tests/machine/x/pl/typed_var.error
+++ b/tests/machine/x/pl/typed_var.error
@@ -1,0 +1,3 @@
+run: exit status 2
+ERROR: /workspace/mochi/tests/machine/x/pl/typed_var.pl:6: user:main is/2: Arguments are not sufficiently instantiated
+

--- a/tests/machine/x/pl/values_builtin.error
+++ b/tests/machine/x/pl/values_builtin.error
@@ -1,0 +1,5 @@
+output mismatch
+-- got --
+[1,2,3]
+-- want --
+1 2 3


### PR DESCRIPTION
## Summary
- make Prolog compiler aware of list and string types
- inline indexing and slicing code for typed containers
- document the improvement in TASKS
- store current failures for some Prolog programs

## Testing
- `go test ./compiler/x/pl -tags slow -run TestPrologCompiler$ -count=1` *(fails: code mismatch for while_loop.pl.out)*

------
https://chatgpt.com/codex/tasks/task_e_687937aeb9788320bd85b56db06ca58d