### PR TITLE
Improve Swift type inference

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,7 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-27 09:00 – list element types inferred from struct fields so numeric aggregates drop the `_avg` helper.
 - 2025-07-26 12:00 – struct literals now infer their concrete type so `_equal` helper is skipped when comparing typed lists.
 - 2025-07-25 09:30 – improved expression type detection for arithmetic chains so direct comparisons avoid `_equal` when possible
 - 2025-07-24 09:00 – arithmetic expressions now infer numeric types so expectation comparisons use `==` without the `_equal` helper when possible

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -1762,7 +1762,18 @@ func swiftTypeOf(t string) string {
 
 func listElemType(t string) string {
 	if strings.HasPrefix(t, "list_") {
-		return strings.TrimPrefix(t, "list_")
+		elem := strings.TrimPrefix(t, "list_")
+		switch elem {
+		case "Int":
+			return "int"
+		case "Double", "Float":
+			return "float"
+		case "String":
+			return "string"
+		case "Bool":
+			return "bool"
+		}
+		return elem
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- enhance list element type detection for aggregations
- document progress in TASKS.md

## Testing
- `go test ./compiler/x/swift -run TestSwiftCompiler_VMValid_Golden -tags slow -count=1` *(fails: output mismatch for group_by_sort.out)*

------
https://chatgpt.com/codex/tasks/task_e_6879368649c08320b6bfb3847a74eaa2