### PR TITLE
Update zig backend slicing

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -35,3 +35,4 @@
 - 2025-07-17 compiled list_index.mochi and string_index.mochi in Zig
 - 2025-07-17 improved slice and index inference to remove runtime helpers
 - 2025-07-17 enhanced int constant folding and dynamic slice ranges
+- 2025-07-18 refined skip/take slicing to use direct range expressions

--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -1682,7 +1682,6 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 		b.WriteString("for (" + itemsVar + ".items) |" + sanitizeName(q.Group.Name) + "| { " + resVar + ".append(" + sel + ")" + c.catchHandler() + "; }")
 		b.WriteString(" const " + resVar + "Slice = " + resVar + ".toOwnedSlice()" + c.catchHandler() + ";")
 		if skipExpr != "" || takeExpr != "" {
-			c.needsSlice = true
 			start := "0"
 			if skipExpr != "" {
 				start = skipExpr
@@ -1695,7 +1694,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 					end = takeExpr
 				}
 			}
-			b.WriteString(" var " + resVar + "Sliced = _slice_list(" + resElem + ", " + resVar + "Slice, " + start + ", " + end + ", 1);")
+			startU := toUSize(start)
+			endU := toUSize(end)
+			b.WriteString(" var " + resVar + "Sliced = " + resVar + "Slice[" + startU + ".." + endU + "];")
 			b.WriteString(" break :" + lbl + " " + resVar + "Sliced; }")
 		} else {
 			b.WriteString(" break :" + lbl + " " + resVar + "Slice; }")
@@ -2154,7 +2155,6 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 	resVar := c.newTmp()
 	if skipExpr != "" || takeExpr != "" {
 		b.WriteString(" var " + resVar + " = " + tmp + ".toOwnedSlice()" + c.catchHandler() + ";")
-		c.needsSlice = true
 		start := "0"
 		if skipExpr != "" {
 			start = skipExpr
@@ -2167,7 +2167,9 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 				end = takeExpr
 			}
 		}
-		b.WriteString(" " + resVar + " = _slice_list(" + elem + ", " + resVar + ", " + start + ", " + end + ", 1);")
+		startU := toUSize(start)
+		endU := toUSize(end)
+		b.WriteString(" " + resVar + " = " + resVar + "[" + startU + ".." + endU + "];")
 	} else {
 		b.WriteString(" const " + resVar + " = " + tmp + ".toOwnedSlice()" + c.catchHandler() + ";")
 	}

--- a/tests/machine/x/zig/dataset_sort_take_limit.zig
+++ b/tests/machine/x/zig/dataset_sort_take_limit.zig
@@ -5,26 +5,6 @@ fn handleError(err: anyerror) noreturn {
     std.debug.panic("{any}", .{err});
 }
 
-fn _slice_list(comptime T: type, v: []const T, start: i32, end: i32, step: i32) []T {
-    var s = start;
-    var e = end;
-    var st = step;
-    const n: i32 = @as(i32, @intCast(v.len));
-    if (s < 0) s += n;
-    if (e < 0) e += n;
-    if (st == 0) st = 1;
-    if (s < 0) s = 0;
-    if (e > n) e = n;
-    if (st > 0 and e < s) e = s;
-    if (st < 0 and e > s) e = s;
-    var res = std.ArrayList(T).init(std.heap.page_allocator);
-    defer res.deinit();
-    var i: i32 = s;
-    while ((st > 0 and i < e) or (st < 0 and i > e)) : (i += st) {
-        res.append(v[@as(usize, @intCast(i))]) catch |err| handleError(err);
-    }
-    return res.toOwnedSlice() catch |err| handleError(err);
-}
 
 const ProductsItem = struct {
     name: []const u8,
@@ -82,7 +62,7 @@ pub fn main() void {
             _tmp1.append(p.item) catch |err| handleError(err);
         }
         var _tmp2 = _tmp1.toOwnedSlice() catch |err| handleError(err);
-        _tmp2 = _slice_list(ProductsItem, _tmp2, 1, (1 + 3), 1);
+        _tmp2 = _tmp2[1..(1 + 3)];
         break :blk0 _tmp2;
     };
     std.debug.print("--- Top products (excluding most expensive) ---\n", .{});


### PR DESCRIPTION
## Summary
- generate direct range slices instead of runtime helper
- update dataset_sort_take_limit machine code
- document the change in TASKS

## Testing
- `go test -tags slow -run VMValid` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6879a5938a28832084cd2f1a14923ab4