### PR TITLE
Add v0.10.28 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,31 @@
 # 📦 CHANGELOG.md
+## [0.10.28] – 2025-07-18T08:39:31+07:00
+
+### Added
+
+* TPC-H dataset golden outputs regenerated across languages
+* Machine outputs for Zig, F#, Java and others
+* Deterministic `values` builtin for Go
+* `string_prefix_slice` support in Zig
+* JSON builtin for OCaml
+* Precomputed aggregates for constant lists in the C backend
+
+### Changed
+
+* Struct inference improved across C#, Kotlin, Scala and Rust
+* Go and Scala optimize joins and indexing
+* Lua, Pascal and Erlang refine printing and quoting
+* C backend handles map literal pair grouping
+* Inlined list operations across Prolog and Elixir
+* Scheme infers numeric assignments
+
+### Fixed
+
+* Fortran folds membership and length for constants
+* String list inference corrected in the C backend
+* Outer join handling fixed in Go
+* Machine README checklists updated
+
 ## [0.10.27] – 2025-07-16T22:58:30+07:00
 
 ### Added

--- a/releases/v0.10.28.md
+++ b/releases/v0.10.28.md
@@ -1,0 +1,32 @@
+# Jul 2025 (v0.10.28)
+
+Released on Fri Jul 18 08:39:31 2025 +0700.
+
+Mochi v0.10.28 refreshes dataset outputs and improves type inference across many
+languages while expanding machine examples and documentation.
+
+## Examples
+
+- TPC-H dataset golden outputs regenerated across languages
+- Machine outputs added for Zig, F#, Java and others
+- Deterministic `values()` builtin ensures reproducible examples
+
+## Compilers
+
+- Struct inference refined in C#, Kotlin, Scala and Rust
+- `string_prefix_slice` builtin output for Zig
+- Map literal pair grouping and constant aggregates in the C backend
+- List indexing and join generation optimized for Go and Scala
+- JSON builtin for OCaml with improved helpers
+- Printing and quoting improved for Lua, Pascal and Erlang
+
+## Runtime
+
+- Constant membership and length folded in Fortran
+- Deterministic values builtin available in the Go runtime
+- Precomputed counts for constant integer lists in the C backend
+- JSON helpers expanded across languages
+
+## Documentation
+
+- Machine READMEs updated with BigInt notes and new checklists


### PR DESCRIPTION
## Summary
- document release notes for v0.10.28
- update CHANGELOG for v0.10.28

## Testing
- `go test ./... -run ''` *(fails: command not found or heavy; truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6879a5c4a29c832091ca02b031376652