### PR TITLE
Update Clojure compiler

### DIFF
--- a/compiler/x/clj/TASKS.md
+++ b/compiler/x/clj/TASKS.md
@@ -42,3 +42,4 @@ Remaining work:
 2025-07-22: Updated machine README to mark all examples passing. No outstanding tasks.
 2025-07-23: Added `_print` helper to mimic Mochi printing semantics and default
   initializers for typed variables. Regenerated machine outputs for updated tests.
+2025-07-24: Avoid unnecessary struct casts when expression type already matches.

--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -405,14 +405,20 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 	}
 	if st.Type != nil {
 		t := c.resolveTypeRef(st.Type)
-		switch tt := t.(type) {
-		case types.StructType:
-			c.use("_cast_struct")
-			expr = fmt.Sprintf("(_cast_struct #'%s %s)", sanitizeName(tt.Name), expr)
-		case types.ListType:
-			if stt, ok := tt.Elem.(types.StructType); ok {
-				c.use("_cast_struct_list")
-				expr = fmt.Sprintf("(_cast_struct_list #'%s %s)", sanitizeName(stt.Name), expr)
+		needCast := true
+		if st.Value != nil && equalTypes(t, c.exprType(st.Value)) {
+			needCast = false
+		}
+		if needCast {
+			switch tt := t.(type) {
+			case types.StructType:
+				c.use("_cast_struct")
+				expr = fmt.Sprintf("(_cast_struct #'%s %s)", sanitizeName(tt.Name), expr)
+			case types.ListType:
+				if stt, ok := tt.Elem.(types.StructType); ok {
+					c.use("_cast_struct_list")
+					expr = fmt.Sprintf("(_cast_struct_list #'%s %s)", sanitizeName(stt.Name), expr)
+				}
 			}
 		}
 	}
@@ -458,14 +464,20 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 	}
 	if st.Type != nil && expr != "nil" {
 		t := c.resolveTypeRef(st.Type)
-		switch tt := t.(type) {
-		case types.StructType:
-			c.use("_cast_struct")
-			expr = fmt.Sprintf("(_cast_struct #'%s %s)", sanitizeName(tt.Name), expr)
-		case types.ListType:
-			if stt, ok := tt.Elem.(types.StructType); ok {
-				c.use("_cast_struct_list")
-				expr = fmt.Sprintf("(_cast_struct_list #'%s %s)", sanitizeName(stt.Name), expr)
+		needCast := true
+		if st.Value != nil && equalTypes(t, c.exprType(st.Value)) {
+			needCast = false
+		}
+		if needCast {
+			switch tt := t.(type) {
+			case types.StructType:
+				c.use("_cast_struct")
+				expr = fmt.Sprintf("(_cast_struct #'%s %s)", sanitizeName(tt.Name), expr)
+			case types.ListType:
+				if stt, ok := tt.Elem.(types.StructType); ok {
+					c.use("_cast_struct_list")
+					expr = fmt.Sprintf("(_cast_struct_list #'%s %s)", sanitizeName(stt.Name), expr)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- avoid emitting `_cast_struct` and `_cast_struct_list` when the value already matches the target type
- document the optimization in TASKS

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879b65a24cc832090f470206870dc82