### PR TITLE
Improve PHP backend

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -37,3 +37,4 @@
 - 2025-07-21 12:30 - Avg builtin now uses full type inference so group queries
   may inline numeric averages without runtime helpers.
 - 2025-07-21 14:00 - Avg builtin now inlines PHP arithmetic for all list arguments, eliminating `_avg` helper.
+- 2025-07-21 15:00 - Left join queries compile to loops instead of using `_query` and `_group_by` helpers.

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -3,6 +3,7 @@
 This directory contains PHP code generated from the Mochi programs in `tests/vm/valid`. Each program was compiled using the PHP backend and executed with `php`. Successful runs have a `.out` file while failures produce a `.error` file.
 Printing now relies on PHP's built‑in `var_dump` so no `_print` helper is emitted.
 Average calculations inline PHP's numeric operations when types allow.
+Left join queries no longer emit the `_query` and `_group_by` helpers.
 
 Compiled programs: 100/100
 

--- a/tests/machine/x/php/group_by_left_join.out
+++ b/tests/machine/x/php/group_by_left_join.out
@@ -1,17 +1,10 @@
-Warning: Undefined array key "o" in /tmp/TestPHPCompiler_VMValid_GoldenX/001/group_by_left_join.php on line 23
-
-Warning: Undefined array key "o" in /tmp/TestPHPCompiler_VMValid_GoldenX/001/group_by_left_join.php on line 23
-
-Warning: Undefined array key "o" in /tmp/TestPHPCompiler_VMValid_GoldenX/001/group_by_left_join.php on line 23
-
-Warning: Undefined array key "o" in /tmp/TestPHPCompiler_VMValid_GoldenX/001/group_by_left_join.php on line 23
 --- Group Left Join ---
 string(5) "Alice"
 string(7) "orders:"
-int(0)
+int(2)
 string(3) "Bob"
 string(7) "orders:"
-int(0)
+int(1)
 string(7) "Charlie"
 string(7) "orders:"
 int(0)

--- a/tests/machine/x/php/group_by_left_join.php
+++ b/tests/machine/x/php/group_by_left_join.php
@@ -10,11 +10,26 @@ $orders = [
     ["id" => 102, "customerId" => 2]
 ];
 $stats = (function() use ($customers, $orders) {
-    $_rows = _query($customers, [['items'=>$orders, 'on'=>function($c, $o) use ($customers, $orders){return $o['customerId'] == $c['id'];}, 'left'=>true]], [ 'select' => function($c, $o) use ($customers, $orders){return [$c, $o];} ]);
-    $_groups = _group_by($_rows, function($c, $o) use ($customers, $orders){return $c['name'];});
+    $groups = [];
+    foreach ($customers as $c) {
+        $_found = false;
+        foreach ($orders as $o) {
+            if ($o['customerId'] == $c['id']) {
+                $_found = true;
+                $_k = json_encode($c['name']);
+                $groups[$_k][] = ["c" => $c, "o" => $o];
+            }
+        }
+        if (!$_found) {
+            $o = null;
+            $_k = json_encode($c['name']);
+            $groups[$_k][] = ["c" => $c, "o" => $o];
+        }
+    }
     $result = [];
-    foreach ($_groups as $__g) {
-        $g = $__g;
+    foreach ($groups as $_k => $__g) {
+        $_key = json_decode($_k, true);
+        $g = ['key'=>$_key,'items'=> $__g];
         $result[] = [
     "name" => $g['key'],
     "count" => count((function() use ($g) {
@@ -33,104 +48,5 @@ $stats = (function() use ($customers, $orders) {
 echo "--- Group Left Join ---", PHP_EOL;
 foreach ($stats as $s) {
     var_dump($s['name'], "orders:", $s['count']);
-}
-function _group_by($src, $keyfn) {
-    $groups = [];
-    $order = [];
-    foreach ($src as $it) {
-        $key = is_array($it) ? $keyfn(...$it) : $keyfn($it);
-        if (is_array($key)) $key = (object)$key;
-        $ks = json_encode($key);
-        if (!isset($groups[$ks])) { $groups[$ks] = ['key'=>$key,'items'=>[]]; $order[] = $ks; }
-        $groups[$ks]['items'][] = $it;
-    }
-    $res = [];
-    foreach ($order as $k) { $res[] = $groups[$k]; }
-    return $res;
-}
-
-function _query($src, $joins, $opts) {
-    $items = [];
-    foreach ($src as $v) { $items[] = [$v]; }
-    foreach ($joins as $j) {
-        $joined = [];
-        $jitems = $j['items'] ?? [];
-        if (($j['right'] ?? false) && ($j['left'] ?? false)) {
-            $matched = array_fill(0, count($jitems), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($jitems as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $row = $left; $row[] = $right;
-                    $joined[] = $row;
-                }
-                if (!$m) { $row = $left; $row[] = null; $joined[] = $row; }
-            }
-            foreach ($jitems as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $row = $undef; $row[] = $right; $joined[] = $row;
-                }
-            }
-        } elseif (($j['right'] ?? false)) {
-            foreach ($jitems as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $row = $left; $row[] = $right; $joined[] = $row;
-                }
-                if (!$m) { $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : []; $row = $undef; $row[] = $right; $joined[] = $row; }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($jitems as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $row = $left; $row[] = $right; $joined[] = $row;
-                }
-                if (($j['left'] ?? false) && !$m) { $row = $left; $row[] = null; $joined[] = $row; }
-            }
-        }
-        $items = $joined;
-    }
-    if (isset($opts['where'])) {
-        $fn = $opts['where'];
-        $items = array_values(array_filter($items, fn($r) => $fn(...$r)));
-    }
-    if (isset($opts['sortKey'])) {
-        $sk = $opts['sortKey'];
-        usort($items, function($a,$b) use($sk) {
-            $ak = $sk(...$a); $bk = $sk(...$b);
-            if (is_array($ak) || is_object($ak)) $ak = json_encode($ak);
-            if (is_array($bk) || is_object($bk)) $bk = json_encode($bk);
-            return $ak <=> $bk;
-        });
-    }
-    if (isset($opts['skip'])) {
-        $n = $opts['skip']; if ($n < 0) $n = 0; $items = array_slice($items, $n);
-    }
-    if (isset($opts['take'])) {
-        $n = $opts['take']; if ($n < 0) $n = 0; $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    $sel = $opts['select'];
-    foreach ($items as $r) { $res[] = $sel(...$r); }
-    return $res;
 }
 ?>

--- a/tests/machine/x/php/left_join.php
+++ b/tests/machine/x/php/left_join.php
@@ -15,97 +15,24 @@ $orders = [
         "total" => 80
     ]
 ];
-$result = _query($orders, [['items'=>$customers, 'on'=>function($o, $c) use ($customers, $orders){return $o['customerId'] == $c['id'];}, 'left'=>true]], [ 'select' => function($o, $c) use ($customers, $orders){return [
+$result = (function() use ($customers, $orders) {
+    $result = [];
+    foreach ($orders as $o) {
+        $_match = null;
+        foreach ($customers as $c) {
+            if ($o['customerId'] == $c['id']) { $_match = $c; break; }
+        }
+        $c = $_match;
+        $result[] = [
     "orderId" => $o['id'],
     "customer" => $c,
     "total" => $o['total']
-];} ]);
+];
+    }
+    return $result;
+})();
 echo "--- Left Join ---", PHP_EOL;
 foreach ($result as $entry) {
     var_dump("Order", $entry['orderId'], "customer", $entry['customer'], "total", $entry['total']);
-}
-function _query($src, $joins, $opts) {
-    $items = [];
-    foreach ($src as $v) { $items[] = [$v]; }
-    foreach ($joins as $j) {
-        $joined = [];
-        $jitems = $j['items'] ?? [];
-        if (($j['right'] ?? false) && ($j['left'] ?? false)) {
-            $matched = array_fill(0, count($jitems), false);
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($jitems as $ri => $right) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $matched[$ri] = true;
-                    $row = $left; $row[] = $right;
-                    $joined[] = $row;
-                }
-                if (!$m) { $row = $left; $row[] = null; $joined[] = $row; }
-            }
-            foreach ($jitems as $ri => $right) {
-                if (!$matched[$ri]) {
-                    $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : [];
-                    $row = $undef; $row[] = $right; $joined[] = $row;
-                }
-            }
-        } elseif (($j['right'] ?? false)) {
-            foreach ($jitems as $right) {
-                $m = false;
-                foreach ($items as $left) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $row = $left; $row[] = $right; $joined[] = $row;
-                }
-                if (!$m) { $undef = count($items) > 0 ? array_fill(0, count($items[0]), null) : []; $row = $undef; $row[] = $right; $joined[] = $row; }
-            }
-        } else {
-            foreach ($items as $left) {
-                $m = false;
-                foreach ($jitems as $right) {
-                    $keep = true;
-                    if (isset($j['on'])) {
-                        $args = $left; $args[] = $right;
-                        $keep = $j['on'](...$args);
-                    }
-                    if (!$keep) continue;
-                    $m = true; $row = $left; $row[] = $right; $joined[] = $row;
-                }
-                if (($j['left'] ?? false) && !$m) { $row = $left; $row[] = null; $joined[] = $row; }
-            }
-        }
-        $items = $joined;
-    }
-    if (isset($opts['where'])) {
-        $fn = $opts['where'];
-        $items = array_values(array_filter($items, fn($r) => $fn(...$r)));
-    }
-    if (isset($opts['sortKey'])) {
-        $sk = $opts['sortKey'];
-        usort($items, function($a,$b) use($sk) {
-            $ak = $sk(...$a); $bk = $sk(...$b);
-            if (is_array($ak) || is_object($ak)) $ak = json_encode($ak);
-            if (is_array($bk) || is_object($bk)) $bk = json_encode($bk);
-            return $ak <=> $bk;
-        });
-    }
-    if (isset($opts['skip'])) {
-        $n = $opts['skip']; if ($n < 0) $n = 0; $items = array_slice($items, $n);
-    }
-    if (isset($opts['take'])) {
-        $n = $opts['take']; if ($n < 0) $n = 0; $items = array_slice($items, 0, $n);
-    }
-    $res = [];
-    $sel = $opts['select'];
-    foreach ($items as $r) { $res[] = $sel(...$r); }
-    return $res;
 }
 ?>


### PR DESCRIPTION
## Summary
- inline PHP loops for simple left joins
- regenerate machine outputs for `left_join` and `group_by_left_join`
- document progress
- note improved join handling in PHP TASKS

## Testing
- `go test ./compiler/x/php -run TestPHPCompiler_VMValid_Golden/left_join$ -tags=slow -count=1`
- `go test ./compiler/x/php -run TestPHPCompiler_VMValid_Golden/group_by_left_join$ -tags=slow -count=1`
- `go test ./compiler/x/php -run TestPHPCompiler_VMValid_Golden -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6879b67d4f108320a1e9ff1ec66c1662