### PR TITLE
Improve Rust compiler append inference

### DIFF
--- a/compiler/x/rust/TASKS.md
+++ b/compiler/x/rust/TASKS.md
@@ -37,6 +37,8 @@
 - 2025-08-01 - Added compile-time YAML loading and JSONL saving to eliminate runtime helpers. VM tests pass 100/100.
 - 2025-08-05 - Improved type inference for `append` and `json` builtins to inline
   operations when list and struct types are known. Updated VM golden outputs.
+- 2025-08-06 - Inlined `append` calls for lists tracked from previous operations
+  even when no explicit type is present.
 ## Remaining Enhancements
 - [ ] Inline JSON printing for variables when values are known at compile time
 - [ ] Validate generated code for `tpc-h/q1.mochi`

--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -3895,7 +3895,15 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 				}
 			}
 		}
+		haveList := false
 		if _, ok := types.TypeOfExpr(call.Args[0], c.env).(types.ListType); ok {
+			haveList = true
+		} else if name, ok := c.simpleIdent(call.Args[0]); ok {
+			if _, ok2 := c.listVars[name]; ok2 {
+				haveList = true
+			}
+		}
+		if haveList {
 			return fmt.Sprintf("{ let mut tmp = %s.clone(); tmp.push(%s); tmp }", args[0], args[1]), nil
 		}
 		c.helpers["append"] = true

--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -5,7 +5,7 @@ This directory contains Rust source code generated from the Mochi programs in `t
 Compiled programs: 100/100
 
 The compiler now inlines the `append`, `json`, and list set operations (`union`,
-`except`, `intersect`) when the element types are known. Constant list values
+`except`, `intersect`) when the element types are known. Lists inferred from prior `append` calls also avoid the helper. Constant list values
 are printed directly without calling runtime helpers.
 
 ## Checklist


### PR DESCRIPTION
## Summary
- inline append builtins when list variable is tracked even without explicit type
- update Rust machine output README about inline append inference
- log new compiler progress in TASKS

## Testing
- `go test -tags slow ./compiler/x/rust -run VM -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6879b68ec7d083208818222d6678c5f8