### PR TITLE
Improve Smalltalk compiler

### DIFF
--- a/compiler/x/smalltalk/vm_valid_golden_test.go
+++ b/compiler/x/smalltalk/vm_valid_golden_test.go
@@ -53,7 +53,7 @@ func TestSmalltalkCompiler_VMValid_Golden(t *testing.T) {
 			os.WriteFile(errPath, []byte(errs[0].Error()), 0644)
 			return nil, errs[0]
 		}
-		code, err := st.New().Compile(prog)
+		code, err := st.New(env).Compile(prog)
 		if err != nil {
 			os.WriteFile(errPath, []byte(err.Error()), 0644)
 			return nil, err

--- a/compiler/x/st/compiler_test.go
+++ b/compiler/x/st/compiler_test.go
@@ -68,7 +68,7 @@ func compileOne(t *testing.T, src, outDir, name, gstPath string) {
 		t.Skipf("type error: %v", errs[0])
 		return
 	}
-	code, err := st.New().Compile(prog)
+	code, err := st.New(env).Compile(prog)
 	if err != nil {
 		writeError(outDir, name, data, err)
 		t.Skipf("compile error: %v", err)

--- a/compiler/x/st/job_test.go
+++ b/compiler/x/st/job_test.go
@@ -34,7 +34,7 @@ func runJOBQuery(t *testing.T, base, gstPath string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := st.New().Compile(prog)
+	code, err := st.New(env).Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}

--- a/compiler/x/st/rosetta_golden_test.go
+++ b/compiler/x/st/rosetta_golden_test.go
@@ -44,7 +44,7 @@ func runRosettaTaskGolden(t *testing.T, name string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := st.New().Compile(prog)
+	code, err := st.New(env).Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}

--- a/compiler/x/st/tpcds_test.go
+++ b/compiler/x/st/tpcds_test.go
@@ -34,7 +34,7 @@ func runTPCDSQuery(t *testing.T, base, gstPath string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := st.New().Compile(prog)
+	code, err := st.New(env).Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}

--- a/compiler/x/st/tpch_test.go
+++ b/compiler/x/st/tpch_test.go
@@ -27,7 +27,7 @@ func runTPCHQuery(t *testing.T, base string, gstPath string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type error: %v", errs[0])
 	}
-	code, err := st.New().Compile(prog)
+	code, err := st.New(env).Compile(prog)
 	if err != nil {
 		t.Fatalf("compile error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add type environment to Smalltalk compiler
- fold list and string length at compile time
- handle `contains` calls and `in` expressions using type info
- update tests to pass environment to compiler

## Testing
- `go test -c -tags slow ./compiler/x/st`

------
https://chatgpt.com/codex/tasks/task_e_6879b6990f248320b833f0f970bb9eaf