### PR TITLE
Improve Lua compiler

### DIFF
--- a/compiler/x/lua/TASKS.md
+++ b/compiler/x/lua/TASKS.md
@@ -100,3 +100,7 @@
 - `__print` now outputs plain strings without quoting when called with a single argument.
 - Updated golden outputs for VM valid suite after runtime changes.
 
+
+## Progress (2025-07-19 13:45)
+- Removed `__eq` and `__print` helpers by emitting direct Lua code for equality and printing.
+- Updated set operation helpers to use native comparisons.

--- a/compiler/x/lua/runtime.go
+++ b/compiler/x/lua/runtime.go
@@ -451,7 +451,7 @@ const (
 		"            for _, v in ipairs(lst) do\n" +
 		"                local dup = false\n" +
 		"                for _, w in ipairs(res) do\n" +
-		"                    if __eq(v, w) then dup = true break end\n" +
+		"                    if v == w then dup = true break end\n" +
 		"                end\n" +
 		"                if not dup then res[#res+1] = v end\n" +
 		"            end\n" +
@@ -468,7 +468,7 @@ const (
 		"            local found = false\n" +
 		"            if b then\n" +
 		"                for _, w in ipairs(b) do\n" +
-		"                    if __eq(v, w) then found = true break end\n" +
+		"                    if v == w then found = true break end\n" +
 		"                end\n" +
 		"            end\n" +
 		"            if not found then res[#res+1] = v end\n" +
@@ -482,9 +482,9 @@ const (
 		"    if a and b then\n" +
 		"        for _, v in ipairs(a) do\n" +
 		"            for _, w in ipairs(b) do\n" +
-		"                if __eq(v, w) then\n" +
+		"                if v == w then\n" +
 		"                    local dup = false\n" +
-		"                    for _, r in ipairs(res) do if __eq(r, v) then dup = true break end end\n" +
+		"                    for _, r in ipairs(res) do if r == v then dup = true break end end\n" +
 		"                    if not dup then res[#res+1] = v end\n" +
 		"                    break\n" +
 		"                end\n" +


### PR DESCRIPTION
## Summary
- inline print handling instead of `__print`
- remove `__eq` helper and use native equality checks
- adjust set operation helpers to compare values directly
- document progress in Lua TASKS

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6879bc1311908320b634d6f0bf4979cb