### PR TITLE
Improve Fortran constant folding

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -59,6 +59,7 @@
   `count`, folding the length at compile time to remove unnecessary helper code.
 - 2025-07-17 12:45: String literals propagate through variables so `len` on constant strings is folded to a number at compile time.
 - 2025-07-18 00:30: Membership checks with literal strings or integers fold to constants at compile time.
+- 2025-07-18 01:00: Boolean and float lists propagate through variables so `len`, `count`, `append`, and set operations fold to constants when possible.
 
 ## Remaining Work
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.

--- a/tests/machine/x/fortran/README.md
+++ b/tests/machine/x/fortran/README.md
@@ -5,7 +5,7 @@ The Fortran backend compiles each Mochi program under `tests/vm/valid`. This dir
 List literal lengths are now computed at compile time so programs using `len` or
 `count` on constant arrays avoid runtime helper code. List set operations like
 `union` and `except` with constant integer lists are also folded at compile time.
-Append operations on constant integer lists stored in variables are resolved during compilation as well. The compiler now folds `len` and `count` for any constant list, `len` for literal strings, and membership checks for literal strings or integers, removing even more helper calls at runtime.
+Append operations on constant integer lists stored in variables are resolved during compilation as well. The compiler now folds `len` and `count` for any constant list, `len` for literal strings, and membership checks for literal strings or integers. Boolean and float lists are also propagated through variables so `len`, `count`, `append`, and set operations on them require no helper calls at runtime.
 
 Compiled programs: 100/100
 


### PR DESCRIPTION
## Summary
- extend the Fortran compiler with tracking for boolean and float list constants
- fold `len`, `count`, `append`, `union`, `union_all`, `except`, and `intersect` when applied to constant boolean or float lists
- expose helpers `literalBoolUnary`, `literalFloatUnary` and propagate literal bool/float expressions
- document the new optimisation in the Fortran README and TASKS

## Testing
- `go test -c ./compiler/x/fortran -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6879bbe43f988320873ee8bb5f2f1d9f