### PR TITLE
Improve C compiler constant contains

### DIFF
--- a/compiler/x/c/TASKS.md
+++ b/compiler/x/c/TASKS.md
@@ -154,3 +154,4 @@ should compile and run successfully.
   now compiles.
 - 2025-09-25 - Evaluated count on constant float lists and fixed union tag naming; tree_sum.mochi now compiles.
 - 2025-09-26 - Added constant evaluation for string list literals so len/count/min/max avoid runtime helpers.
+- 2025-09-27 - Evaluated `in` operations on constant string and float lists at compile time to eliminate contains helpers.

--- a/tests/machine/x/c/group_items_iteration.out
+++ b/tests/machine/x/c/group_items_iteration.out
@@ -1,1 +1,1 @@
-map[tag:600375314 total:3] map[tag:600375316 total:3]
+map[tag:-714100718 total:3] map[tag:-714100716 total:3]


### PR DESCRIPTION
## Summary
- optimize "in" expressions on constant lists in C backend
- update generated group_items_iteration output
- note new improvement in TASKS log

## Testing
- `go test ./compiler/x/c -run TestCCompiler_VMValid_Golden -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_6879c4ca3a7083209eede654999d6e21