### PR TITLE
Improve OCaml compiler printing

### DIFF
--- a/compiler/x/ocaml/TASKS.md
+++ b/compiler/x/ocaml/TASKS.md
@@ -12,6 +12,9 @@
   numeric `sum` handling for float expressions.
 - [2025-07-30 00:00] Inlined numeric `sum` computations and inferred union
   types to avoid runtime helpers.
+- [2025-07-18] Improved `len` handling for string variables and added
+  primitive type detection in `print` to avoid generating the `__show`
+  helper when not needed.
 - [2025-07-22 00:00] Fixed `update` statement generation and reworked VM tests
   to use outputs under `tests/machine/x/ocaml`.
 - [2025-07-23 00:00] Handled casts inside `print` and sanitized OCaml field names

--- a/tests/machine/x/ocaml/README.md
+++ b/tests/machine/x/ocaml/README.md
@@ -2,7 +2,7 @@
 
 This directory contains OCaml code generated from the Mochi programs in `tests/vm/valid` using the OCaml compiler. Each program was compiled and executed with `ocamlc`. Successful runs produced an `.out` file while failures produced an `.error` file.
 
-Compiled programs: 81/100 successful.
+Compiled programs: 82/100 successful.
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
@@ -89,7 +89,7 @@ Compiled programs: 81/100 successful.
 - [x] string_contains.mochi
 - [x] string_in_operator.mochi
 - [x] string_index.mochi
-- [ ] string_prefix_slice.mochi
+- [x] string_prefix_slice.mochi
 - [x] substring_builtin.mochi
 - [x] sum_builtin.mochi
 - [x] tail_recursion.mochi


### PR DESCRIPTION
## Summary
- enhance print handling to convert ints, floats and bools without runtime helper
- detect string variables for `len` builtin
- record recent progress in OCaml TASKS
- regenerate OCaml machine README

## Testing
- `UPDATE=1 go test -tags slow ./compiler/x/ocaml -run VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6879f551443883208a3fba54671fd28b