### PR TITLE
Improve Python compiler inference

### DIFF
--- a/compiler/x/python/TASKS.md
+++ b/compiler/x/python/TASKS.md
@@ -1,3 +1,6 @@
+## Recent Enhancements (2025-07-29 00:00)
+- Optional collections now inline `len(x or [])` and `(len(x or []) > 0)` so the `_count` and `_exists` helpers are avoided when possible.
+
 ## Recent Enhancements (2025-07-22 00:00)
 - Typed variables without initializers now default to zero values.
 - `_fmt` now uses `repr(v)` for floats, ensuring `3.14` and `27.333333333333332` print exactly as in the VM.

--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -974,6 +974,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) == 1 {
 			t := c.inferExprType(call.Args[0])
 			if isListLike(t) || isMapLike(t) || isStringLike(t) {
+				if _, ok := t.(types.OptionType); ok {
+					return fmt.Sprintf("len(%s or [])", args[0]), nil
+				}
 				return fmt.Sprintf("len(%s)", args[0]), nil
 			}
 			if _, ok := t.(types.GroupType); ok {
@@ -986,6 +989,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		if len(args) == 1 {
 			t := c.inferExprType(call.Args[0])
 			if isListLike(t) || isMapLike(t) || isStringLike(t) {
+				if _, ok := t.(types.OptionType); ok {
+					return fmt.Sprintf("(len(%s or []) > 0)", args[0]), nil
+				}
 				return fmt.Sprintf("(len(%s) > 0)", args[0]), nil
 			}
 			if _, ok := t.(types.GroupType); ok {


### PR DESCRIPTION
## Summary
- refine helper usage in Python backend
- document optional collection handling in TASKS

## Testing
- `go test ./compiler/x/python -run TestVM -tags slow -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6879f75379288320b5a60e6ba0ae6506