### PR TITLE
Improve TypeScript min/max inference

### DIFF
--- a/compiler/x/ts/TASKS.md
+++ b/compiler/x/ts/TASKS.md
@@ -143,3 +143,6 @@
 - Sort expressions inline numeric, string, or boolean comparisons instead of calling the `_cmp` helper when the key type is known.
 ### 2025-10-12 00:00 UTC
 - Further refined `starts_with` compilation to inline `String.startsWith` when the receiver is known to be a string.
+### 2025-10-18 00:00 UTC
+- `min` and `max` now check the element type before using `Math.min`/`Math.max`.
+  Non-primitive lists fall back to the runtime helpers to avoid numeric coercion.

--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -2087,11 +2087,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "min":
 		if len(call.Args) == 1 {
 			t := underlyingType(c.inferExprType(call.Args[0]))
-			switch t.(type) {
+			switch tt := t.(type) {
 			case types.ListType:
-				return fmt.Sprintf("Math.min(...%s)", args[0]), nil
+				elem := underlyingType(tt.Elem)
+				if isNumericType(elem) || isStringType(elem) {
+					return fmt.Sprintf("Math.min(...%s)", args[0]), nil
+				}
 			case types.GroupType:
-				return fmt.Sprintf("Math.min(...%s.items)", args[0]), nil
+				elem := underlyingType(tt.Elem)
+				if isNumericType(elem) || isStringType(elem) {
+					return fmt.Sprintf("Math.min(...%s.items)", args[0]), nil
+				}
 			}
 		}
 		c.use("_min")
@@ -2099,11 +2105,17 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	case "max":
 		if len(call.Args) == 1 {
 			t := underlyingType(c.inferExprType(call.Args[0]))
-			switch t.(type) {
+			switch tt := t.(type) {
 			case types.ListType:
-				return fmt.Sprintf("Math.max(...%s)", args[0]), nil
+				elem := underlyingType(tt.Elem)
+				if isNumericType(elem) || isStringType(elem) {
+					return fmt.Sprintf("Math.max(...%s)", args[0]), nil
+				}
 			case types.GroupType:
-				return fmt.Sprintf("Math.max(...%s.items)", args[0]), nil
+				elem := underlyingType(tt.Elem)
+				if isNumericType(elem) || isStringType(elem) {
+					return fmt.Sprintf("Math.max(...%s.items)", args[0]), nil
+				}
 			}
 		}
 		c.use("_max")

--- a/tests/machine/x/ts/README.md
+++ b/tests/machine/x/ts/README.md
@@ -1,7 +1,7 @@
 # Mochi to TypeScript compilation status
 
 The TypeScript backend compiles Mochi programs from `tests/vm/valid` and executes them with Deno. The table below marks programs that compile and run successfully. Boolean values are printed as `1` or `0` for consistency with the reference outputs.
-Recent updates further shrink the runtime by inlining native operations whenever the input types are known. The `starts_with` builtin now emits `String.startsWith` when the argument types are strings. The compiler also recognizes method calls where the receiver is known to be a string and inlines `startsWith` directly.
+Recent updates further shrink the runtime by inlining native operations whenever the input types are known. The `starts_with` builtin now emits `String.startsWith` when the argument types are strings. The compiler also recognizes method calls where the receiver is known to be a string and inlines `startsWith` directly. Min/max now choose between `Math.min` and runtime helpers based on element types.
 
 ## Checklist
 - [x] append_builtin


### PR DESCRIPTION
## Summary
- refine `min` and `max` builtin handling
- document new behavior in TASKS and README

## Testing
- `go test ./compiler/x/ts -run TestTSCompiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6879ffc0f38c8320975b8d3deeac70d7