### PR TITLE
Improve Python type hints for option types

### DIFF
--- a/compiler/x/python/TASKS.md
+++ b/compiler/x/python/TASKS.md
@@ -122,3 +122,5 @@
 - 2025-07-27 - Updated TPCH Python outputs to use compact JSON separators and regenerated golden files.
 - 2025-07-18 - List set operations now unwrap optional types so `_union`, `_except` and `_intersect` helpers are avoided when inputs are optional lists.
 - 2025-07-28 - Added bigint type support and golden tests for `tests/vm_extended/valid`.
+- 2025-07-29 - Option type hints propagate through `compileExprHint` and
+  `pyType` emits `typing.Optional` so optional lists avoid runtime helpers.

--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -1237,6 +1237,9 @@ func (c *Compiler) maybeFStringPrint(exprs []*parser.Expr) (string, bool, error)
 // literals that would otherwise default to `any`, such as empty list or map
 // literals. Hints are applied recursively for nested literals.
 func (c *Compiler) compileExprHint(e *parser.Expr, hint types.Type) (string, error) {
+	if ot, ok := hint.(types.OptionType); ok {
+		return c.compileExprHint(e, ot.Elem)
+	}
 	if lt, ok := hint.(types.ListType); ok {
 		if ll := e.Binary.Left.Value.Target.List; ll != nil {
 			elems := make([]string, len(ll.Elems))

--- a/compiler/x/python/helpers.go
+++ b/compiler/x/python/helpers.go
@@ -328,6 +328,8 @@ func pyType(t types.Type) string {
 		return "dict[" + pyType(tt.Key) + ", " + pyType(tt.Value) + "]"
 	case types.GroupType:
 		return "_Group[Any, " + pyType(tt.Elem) + "]"
+	case types.OptionType:
+		return "typing.Optional[" + pyType(tt.Elem) + "]"
 	case types.StructType:
 		return sanitizeName(tt.Name)
 	case types.UnionType:


### PR DESCRIPTION
## Summary
- support OptionType in compileExprHint and pyType
- log new progress in TASKS

## Testing
- `go test ./compiler/x/python -tags slow -run TestPyCompiler_SubsetPrograms -count=1` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6879ffc629788320a4053b7adb120904