### PR TITLE
Enhance Erlang compiler inference

### DIFF
--- a/compiler/x/erlang/TASKS.md
+++ b/compiler/x/erlang/TASKS.md
@@ -3,6 +3,7 @@
 ## Recent updates
 - [2025-07-17 16:26] Added group variable type inference so group_by programs no longer use mochi_get. Regenerated machine outputs.
 - [2025-07-18 00:10] Added map field tracking so known fields use `maps:get/2` without defaults. Removed unused mochi_get in simple programs.
+- [2025-07-18 08:15] Recognized selector paths and propagated group item fields so more joins and group iterations use `maps:get` directly.
 - [2025-07-17 13:05] Regenerated `cross_join`, `cross_join_filter`, and
   `dataset_sort_take_limit` with refined type inference so `maps:get` replaces
   `mochi_get`.

--- a/compiler/x/erlang/helpers.go
+++ b/compiler/x/erlang/helpers.go
@@ -12,8 +12,15 @@ func identName(e *parser.Expr) (string, bool) {
 	if len(u.Ops) != 0 || u.Value == nil || len(u.Value.Ops) != 0 {
 		return "", false
 	}
-	if sel := u.Value.Target.Selector; sel != nil && len(sel.Tail) == 0 {
-		return sel.Root, true
+	if sel := u.Value.Target.Selector; sel != nil {
+		name := sel.Root
+		for _, part := range sel.Tail {
+			if !identifierRegex.MatchString(part) {
+				return "", false
+			}
+			name += "." + part
+		}
+		return name, true
 	}
 	return "", false
 }
@@ -89,6 +96,9 @@ func listMapLiteralFields(e *parser.Expr) []string {
 func queryResultFields(q *parser.QueryExpr) []string {
 	if q == nil {
 		return nil
+	}
+	if q.Group != nil && selectIsVar(q.Select, q.Group.Name) {
+		return []string{"key", "items"}
 	}
 	return mapLiteralFields(q.Select)
 }


### PR DESCRIPTION
## Summary
- improve selector recognition in Erlang helper functions
- propagate group item fields and recognize grouped query result types
- update TASKS for Erlang compiler

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6879ffd6ba408320b19c4ebee4794e69