### PR TITLE
Enhance Java compiler with Set support

### DIFF
--- a/compiler/x/java/TASKS.md
+++ b/compiler/x/java/TASKS.md
@@ -42,3 +42,4 @@
 - 2025-07-17T09:15 - removed unused append helper by rewriting self-assignments
 - 2025-07-17T09:45 - replaced mapOfEntries helper with Map.ofEntries for map literals
 - 2025-07-17T12:27 - added struct membership inference to avoid inOp helper
+- 2025-07-18 08:09 - added Set generic handling and membership inference

--- a/compiler/x/java/compiler.go
+++ b/compiler/x/java/compiler.go
@@ -649,6 +649,12 @@ func (c *Compiler) typeName(t *parser.TypeRef) string {
 				return fmt.Sprintf("List<%s>", et)
 			}
 			return "List<?>"
+		case "set":
+			if len(t.Generic.Args) > 0 {
+				et := wrapperType(c.typeName(t.Generic.Args[0]))
+				return fmt.Sprintf("Set<%s>", et)
+			}
+			return "Set<?>"
 		case "map":
 			if len(t.Generic.Args) >= 2 {
 				kt := wrapperType(c.typeName(t.Generic.Args[0]))
@@ -2361,6 +2367,8 @@ func (c *Compiler) compileBinaryOp(left string, op *parser.BinaryOp, right strin
 		if typ == "String" {
 			return fmt.Sprintf("%s.contains(String.valueOf(%s))", right, left), nil
 		} else if strings.HasPrefix(typ, "List<") {
+			return fmt.Sprintf("%s.contains(%s)", right, left), nil
+		} else if strings.HasPrefix(typ, "Set<") {
 			return fmt.Sprintf("%s.contains(%s)", right, left), nil
 		} else if strings.HasPrefix(typ, "Map<") {
 			return fmt.Sprintf("%s.containsKey(%s)", right, left), nil


### PR DESCRIPTION
## Summary
- add Set generic handling in the Java compiler
- recognise Set membership with `in` operator
- log new improvement in `TASKS.md`

## Testing
- `go test ./compiler/x/java -run TestJavaCompiler_VM_Valid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a0033d0c883209fa640ac79092e11