### PR TITLE
Improve Haskell backend typed literals

### DIFF
--- a/compiler/x/hs/TASKS.md
+++ b/compiler/x/hs/TASKS.md
@@ -1,4 +1,7 @@
 # Haskell Backend Progress
+## Recent Updates (2025-08-30 05:00)
+- Added `compileExprHint` and `inferExprTypeHint` so typed list and map literals adopt declared types. Variable assignments and returns now use these hints, reducing `AnyValue` casts.
+
 ## Recent Updates (2025-08-20 05:00)
 - Split `_group_by` helper into a separate runtime chunk. Simple loops no longer
   import unused functions and `Data.Maybe` when grouping isn't used. The


### PR DESCRIPTION
## Summary
- support type hints for list, map and struct literals in Haskell compiler
- infer expression types using `inferExprTypeHint`
- update TASKS with latest progress

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a0039fd248320acbfd35564be48b7