### PR TITLE
Improve PHP compiler printing

### DIFF
--- a/compiler/x/php/TASKS.md
+++ b/compiler/x/php/TASKS.md
@@ -30,6 +30,7 @@
 - 2025-07-17 01:10 - Marked VM golden tests with the "slow" build tag to avoid running during default test passes.
 
 ## July 2025 Progress
+- 2025-07-22 09:00 - Print with multiple scalar arguments now uses `echo` instead of `var_dump`.
 - 2025-07-19 13:20 - Verified that all 100 VM valid programs compile and run successfully with the PHP backend. Updated README checklist accordingly.
 - 2025-07-20 10:00 - Generated PHP machine outputs for all VM valid programs and added README checklist.
 - 2025-07-21 08:00 - Printing now uses `var_dump`; `_print` helper removed.

--- a/tests/machine/x/php/README.md
+++ b/tests/machine/x/php/README.md
@@ -5,6 +5,7 @@ Printing now relies on PHP's built‑in `var_dump` so no `_print` helper is emit
 Average calculations inline PHP's numeric operations when types allow.
 Left join queries no longer emit the `_query` and `_group_by` helpers.
 Right and outer joins also compile using plain loops without the `_query` helper.
+When all print arguments are simple scalars, `echo` is used instead of `var_dump`.
 
 Compiled programs: 100/100
 

--- a/tests/machine/x/php/break_continue.out
+++ b/tests/machine/x/php/break_continue.out
@@ -1,8 +1,4 @@
-string(11) "odd number:"
-int(1)
-string(11) "odd number:"
-int(3)
-string(11) "odd number:"
-int(5)
-string(11) "odd number:"
-int(7)
+odd number:1
+odd number:3
+odd number:5
+odd number:7

--- a/tests/machine/x/php/break_continue.php
+++ b/tests/machine/x/php/break_continue.php
@@ -17,6 +17,6 @@ foreach ($numbers as $n) {
     if ($n > 7) {
         break;
     }
-    var_dump("odd number:", $n);
+    echo "odd number:", $n, PHP_EOL;
 }
 ?>

--- a/tests/machine/x/php/cross_join.out
+++ b/tests/machine/x/php/cross_join.out
@@ -1,73 +1,10 @@
 --- Cross Join: All order-customer pairs ---
-string(5) "Order"
-int(100)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(250)
-string(13) ") paired with"
-string(5) "Alice"
-string(5) "Order"
-int(100)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(250)
-string(13) ") paired with"
-string(3) "Bob"
-string(5) "Order"
-int(100)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(250)
-string(13) ") paired with"
-string(7) "Charlie"
-string(5) "Order"
-int(101)
-string(12) "(customerId:"
-int(2)
-string(10) ", total: $"
-int(125)
-string(13) ") paired with"
-string(5) "Alice"
-string(5) "Order"
-int(101)
-string(12) "(customerId:"
-int(2)
-string(10) ", total: $"
-int(125)
-string(13) ") paired with"
-string(3) "Bob"
-string(5) "Order"
-int(101)
-string(12) "(customerId:"
-int(2)
-string(10) ", total: $"
-int(125)
-string(13) ") paired with"
-string(7) "Charlie"
-string(5) "Order"
-int(102)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(300)
-string(13) ") paired with"
-string(5) "Alice"
-string(5) "Order"
-int(102)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(300)
-string(13) ") paired with"
-string(3) "Bob"
-string(5) "Order"
-int(102)
-string(12) "(customerId:"
-int(1)
-string(10) ", total: $"
-int(300)
-string(13) ") paired with"
-string(7) "Charlie"
+Order100(customerId:1, total: $250) paired withAlice
+Order100(customerId:1, total: $250) paired withBob
+Order100(customerId:1, total: $250) paired withCharlie
+Order101(customerId:2, total: $125) paired withAlice
+Order101(customerId:2, total: $125) paired withBob
+Order101(customerId:2, total: $125) paired withCharlie
+Order102(customerId:1, total: $300) paired withAlice
+Order102(customerId:1, total: $300) paired withBob
+Order102(customerId:1, total: $300) paired withCharlie

--- a/tests/machine/x/php/cross_join.php
+++ b/tests/machine/x/php/cross_join.php
@@ -37,6 +37,6 @@ $result = (function() use ($customers, $orders) {
 })();
 echo "--- Cross Join: All order-customer pairs ---", PHP_EOL;
 foreach ($result as $entry) {
-    var_dump("Order", $entry['orderId'], "(customerId:", $entry['orderCustomerId'], ", total: $", $entry['orderTotal'], ") paired with", $entry['pairedCustomerName']);
+    echo "Order", $entry['orderId'], "(customerId:", $entry['orderCustomerId'], ", total: $", $entry['orderTotal'], ") paired with", $entry['pairedCustomerName'], PHP_EOL;
 }
 ?>

--- a/tests/machine/x/php/group_by.php
+++ b/tests/machine/x/php/group_by.php
@@ -44,25 +44,13 @@ $stats = (function() use ($people) {
         $result[] = [
     "city" => $g['key'],
     "count" => count($g['items']),
-    "avg_age" => count((function() use ($g) {
+    "avg_age" => _avg((function() use ($g) {
         $result = [];
         foreach ($g['items'] as $p) {
             $result[] = $p['age'];
         }
         return $result;
-    })()) ? array_sum((function() use ($g) {
-        $result = [];
-        foreach ($g['items'] as $p) {
-            $result[] = $p['age'];
-        }
-        return $result;
-    })()) / count((function() use ($g) {
-        $result = [];
-        foreach ($g['items'] as $p) {
-            $result[] = $p['age'];
-        }
-        return $result;
-    })()) : 0
+    })())
 ];
     }
     return $result;
@@ -70,5 +58,25 @@ $stats = (function() use ($people) {
 echo "--- People grouped by city ---", PHP_EOL;
 foreach ($stats as $s) {
     var_dump($s['city'], ": count =", $s['count'], ", avg_age =", $s['avg_age']);
+}
+function _avg($v) {
+    if (is_array($v) && array_key_exists('items', $v)) {
+        $v = $v['items'];
+    } elseif (is_object($v) && property_exists($v, 'items')) {
+        $v = $v->items;
+    }
+    if (!is_array($v)) {
+        throw new Exception('avg() expects list or group');
+    }
+    if (!$v) return 0;
+    $sum = 0;
+    foreach ($v as $it) {
+        if (is_int($it) || is_float($it)) {
+            $sum += $it;
+        } else {
+            throw new Exception('avg() expects numbers');
+        }
+    }
+    return $sum / count($v);
 }
 ?>

--- a/tests/machine/x/php/inner_join.out
+++ b/tests/machine/x/php/inner_join.out
@@ -1,19 +1,4 @@
 --- Orders with customer info ---
-string(5) "Order"
-int(100)
-string(2) "by"
-string(5) "Alice"
-string(3) "- $"
-int(250)
-string(5) "Order"
-int(101)
-string(2) "by"
-string(3) "Bob"
-string(3) "- $"
-int(125)
-string(5) "Order"
-int(102)
-string(2) "by"
-string(5) "Alice"
-string(3) "- $"
-int(300)
+Order100byAlice- $250
+Order101byBob- $125
+Order102byAlice- $300

--- a/tests/machine/x/php/inner_join.php
+++ b/tests/machine/x/php/inner_join.php
@@ -43,6 +43,6 @@ $result = (function() use ($customers, $orders) {
 })();
 echo "--- Orders with customer info ---", PHP_EOL;
 foreach ($result as $entry) {
-    var_dump("Order", $entry['orderId'], "by", $entry['customerName'], "- $", $entry['total']);
+    echo "Order", $entry['orderId'], "by", $entry['customerName'], "- $", $entry['total'], PHP_EOL;
 }
 ?>

--- a/tests/machine/x/php/load_yaml.php
+++ b/tests/machine/x/php/load_yaml.php
@@ -23,7 +23,7 @@ $adults = (function() use ($people) {
     return $result;
 })();
 foreach ($adults as $a) {
-    var_dump($a['name'], $a['email']);
+    echo $a['name'], $a['email'], PHP_EOL;
 }
 function _load($path = null, $opts = []) {
     $fmt = $opts['format'] ?? 'csv';

--- a/tests/machine/x/php/outer_join.out
+++ b/tests/machine/x/php/outer_join.out
@@ -1,31 +1,7 @@
 --- Outer Join using syntax ---
-string(5) "Order"
-int(100)
-string(2) "by"
-string(5) "Alice"
-string(3) "- $"
-int(250)
-string(5) "Order"
-int(101)
-string(2) "by"
-string(3) "Bob"
-string(3) "- $"
-int(125)
-string(5) "Order"
-int(102)
-string(2) "by"
-string(5) "Alice"
-string(3) "- $"
-int(300)
-string(5) "Order"
-int(103)
-string(2) "by"
-string(7) "Unknown"
-string(3) "- $"
-int(80)
-string(8) "Customer"
-string(7) "Charlie"
-string(13) "has no orders"
-string(8) "Customer"
-string(5) "Diana"
-string(13) "has no orders"
+Order100byAlice- $250
+Order101byBob- $125
+Order102byAlice- $300
+Order103byUnknown- $80
+CustomerCharliehas no orders
+CustomerDianahas no orders

--- a/tests/machine/x/php/outer_join.php
+++ b/tests/machine/x/php/outer_join.php
@@ -53,12 +53,12 @@ echo "--- Outer Join using syntax ---", PHP_EOL;
 foreach ($result as $row) {
     if ($row['order']) {
         if ($row['customer']) {
-            var_dump("Order", $row['order']['id'], "by", $row['customer']['name'], "- $", $row['order']['total']);
+            echo "Order", $row['order']['id'], "by", $row['customer']['name'], "- $", $row['order']['total'], PHP_EOL;
         } else {
-            var_dump("Order", $row['order']['id'], "by", "Unknown", "- $", $row['order']['total']);
+            echo "Order", $row['order']['id'], "by", "Unknown", "- $", $row['order']['total'], PHP_EOL;
         }
     } else {
-        var_dump("Customer", $row['customer']['name'], "has no orders");
+        echo "Customer", $row['customer']['name'], "has no orders", PHP_EOL;
     }
 }
 ?>

--- a/tests/machine/x/php/python_math.out
+++ b/tests/machine/x/php/python_math.out
@@ -1,10 +1,4 @@
-string(20) "Circle area with r ="
-int(3)
-string(2) "=>"
-float(28.274333882308138)
-string(18) "Square root of 49:"
-float(7)
-string(10) "sin(π/4):"
-float(0.7071067811865475)
-string(7) "log(e):"
-float(1)
+Circle area with r =3=>28.274333882308
+Square root of 49:7
+sin(π/4):0.70710678118655
+log(e):1

--- a/tests/machine/x/php/python_math.php
+++ b/tests/machine/x/php/python_math.php
@@ -12,8 +12,8 @@ $area = $math['pi'] * $math['pow']($r, 2);
 $root = $math['sqrt'](49);
 $sin45 = $math['sin']($math['pi'] / 4);
 $log_e = $math['log']($math['e']);
-var_dump("Circle area with r =", $r, "=>", $area);
-var_dump("Square root of 49:", $root);
-var_dump("sin(π/4):", $sin45);
-var_dump("log(e):", $log_e);
+echo "Circle area with r =", $r, "=>", $area, PHP_EOL;
+echo "Square root of 49:", $root, PHP_EOL;
+echo "sin(π/4):", $sin45, PHP_EOL;
+echo "log(e):", $log_e, PHP_EOL;
 ?>


### PR DESCRIPTION
## Summary
- improve PHP compiler so `print` with multiple scalars emits `echo`
- regenerate affected PHP machine outputs
- document behaviour in README and update tasks

## Testing
- `UPDATE=1 go test ./compiler/x/php -run TestPHPCompiler_VMValid_Golden -tags slow -count=1`
- `go test ./compiler/x/php -run TestPHPCompiler_VMValid_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a004163f48320ae295d0995d67c02