### PR TITLE
Improve Zig substring inference

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -44,3 +44,4 @@
 - 2025-07-21 improved substring builtin to emit direct slice when bounds are constant
 - 2025-07-21 infer range loop indices to avoid index helpers
 - 2025-07-22 compiled go_auto, python_auto, and python_math.mochi in Zig and updated machine README to 100/100.
+- 2025-07-23 improved substring inference when only one bound is constant, avoiding `_slice_string` helper.


### PR DESCRIPTION
## Summary
- enhance Zig compiler substring handling when one bound is constant
- note progress in TASKS

## Testing
- `go test -tags slow ./compiler/x/zig -run TPCH -v -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a005c8e58832080f279b7b61cb8d0