### PR TITLE
Add v0.10.29 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,30 @@
 # 📦 CHANGELOG.md
+## [0.10.29] – 2025-07-20T09:45:10+07:00
+
+### Added
+
+* Python bigint operations with new machine tests
+* Zig range index inference and direct substring slices
+* C# query map struct inference
+* Fortran TPC-H query 6 example
+* Dataset golden outputs refreshed across languages
+
+### Changed
+
+* Kotlin improves sort inference and map comparators
+* Go option field inference enhanced
+* F# compiler handles import modules and selector methods
+* OCaml inlines sum operations and refines union types
+* Lua runtime simplified with helper removal
+* C backend infers group keys and constant strings
+* Erlang tracks nested map fields
+
+### Fixed
+
+* Variant constant loops corrected in the C backend
+* Clojure outer join generation without query helper
+* Documentation updates for Fortran and Elixir
+
 ## [0.10.28] – 2025-07-18T08:39:31+07:00
 
 ### Added

--- a/releases/v0.10.29.md
+++ b/releases/v0.10.29.md
@@ -1,0 +1,35 @@
+# Jul 2025 (v0.10.29)
+
+Released on Sun Jul 20 09:45:10 2025 +0700.
+
+Mochi v0.10.29 continues dataset updates and introduces Python bigint support while refining compilers for Zig, Kotlin, C# and more.
+
+## Examples
+
+- Fortran TPC-H query 6 output and format
+- Dataset golden outputs refreshed for Kotlin, Java, C++, Go and others
+- Extended Python bigint machine test
+
+## Compilers
+
+- Zig compiler infers range indices and emits direct substring slices
+- Kotlin sort inference improved with map comparators
+- Go compiler enhances option field inference
+- F# compiler fixes import modules and selector methods
+- C# infers query map structs
+- OCaml inlines sum operations and refines union types
+- Lua runtime helpers removed
+- Erlang tracks nested map fields
+- C backend infers group keys and constant string lists
+
+## Runtime
+
+- Python runtime supports bigint operations
+- Zig substring builtin returns direct slices
+- Lua runtime simplified by dropping helpers
+- C backend fixes variant constant loops
+
+## Documentation
+
+- Fortran notes updated
+- Elixir README and other machine docs refreshed


### PR DESCRIPTION
## Summary
- document v0.10.29 changes in CHANGELOG
- add release notes for v0.10.29 under `releases/`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6879f784b0a8832084ce8600f0c8dba2