### PR TITLE
Expand Dart rosetta coverage

### DIFF
--- a/compiler/x/dart/rosetta_golden_test.go
+++ b/compiler/x/dart/rosetta_golden_test.go
@@ -97,7 +97,7 @@ func TestDartCompiler_Rosetta_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
-	max := 3
+	max := 5
 	if len(files) < max {
 		max = len(files)
 	}

--- a/tests/rosetta/out/Dart/README.md
+++ b/tests/rosetta/out/Dart/README.md
@@ -2,7 +2,7 @@
 
 This directory holds Dart code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
-Compiled programs: 27/220
+Compiled programs: 27/238
 
 Checklist:
 - [ ] 100-doors-2
@@ -211,10 +211,28 @@ Checklist:
 - [ ] circles-of-given-radius-through-two-points
 - [ ] circular-primes
 - [ ] cistercian-numerals
+- [ ] compiler-virtual-machine-interpreter
+- [ ] concurrent-computing-1
+- [ ] concurrent-computing-2
+- [ ] concurrent-computing-3
+- [ ] conditional-structures-1
+- [ ] conditional-structures-10
+- [ ] conditional-structures-2
+- [ ] conditional-structures-3
+- [ ] conditional-structures-4
+- [ ] conditional-structures-5
+- [ ] conditional-structures-6
+- [ ] conditional-structures-7
+- [ ] conditional-structures-8
+- [ ] conditional-structures-9
+- [ ] consecutive-primes-with-ascending-or-descending-differences
 - [ ] constrained-genericity-1
 - [ ] constrained-genericity-2
 - [x] constrained-genericity-3
 - [ ] constrained-genericity-4
+- [ ] constrained-random-points-on-a-circle-1
+- [ ] constrained-random-points-on-a-circle-2
+- [ ] continued-fraction
 - [ ] crc-32-1
 - [ ] crc-32-2
 - [ ] csv-data-manipulation


### PR DESCRIPTION
## Summary
- compile more Rosetta programs with the Dart backend
- regenerate Dart Rosetta README to include new tasks

## Testing
- `go test ./compiler/x/dart -run TestDartCompiler_Rosetta_Golden -tags=slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_687a19a35de483208b4648267f30889d