### PR TITLE
Add TypeScript Rosetta README updater

### DIFF
--- a/scripts/update_ts_rosetta_readme.go
+++ b/scripts/update_ts_rosetta_readme.go
@@ -1,0 +1,44 @@
+//go:build archive && slow
+
+package main
+
+import (
+    "bytes"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
+)
+
+func main() {
+    root := "."
+    srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+    outDir := filepath.Join(root, "tests", "rosetta", "out", "TypeScript")
+
+    files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+    total := len(files)
+    compiled := 0
+    var lines []string
+
+    for _, f := range files {
+        name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+        mark := "[ ]"
+        if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+            if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {
+                compiled++
+                mark = "[x]"
+            }
+        }
+        lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+    }
+
+    var buf bytes.Buffer
+    fmt.Fprintf(&buf, "# Rosetta TypeScript Output (%d/%d compiled and run)\n\n", compiled, total)
+    buf.WriteString("This directory holds TypeScript source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.\n\n")
+    buf.WriteString("## Program checklist\n")
+    buf.WriteString(strings.Join(lines, "\n"))
+    buf.WriteString("\n")
+
+    os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0644)
+}
+

--- a/tests/rosetta/out/TypeScript/README.md
+++ b/tests/rosetta/out/TypeScript/README.md
@@ -1,4 +1,4 @@
-# Rosetta TypeScript Output (4/216 compiled and run)
+# Rosetta TypeScript Output (4/238 compiled and run)
 
 This directory holds TypeScript source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -209,6 +209,28 @@ This directory holds TypeScript source code generated from the real Mochi progra
 - [ ] circles-of-given-radius-through-two-points
 - [ ] circular-primes
 - [ ] cistercian-numerals
+- [ ] compiler-virtual-machine-interpreter
+- [ ] concurrent-computing-1
+- [ ] concurrent-computing-2
+- [ ] concurrent-computing-3
+- [ ] conditional-structures-1
+- [ ] conditional-structures-10
+- [ ] conditional-structures-2
+- [ ] conditional-structures-3
+- [ ] conditional-structures-4
+- [ ] conditional-structures-5
+- [ ] conditional-structures-6
+- [ ] conditional-structures-7
+- [ ] conditional-structures-8
+- [ ] conditional-structures-9
+- [ ] consecutive-primes-with-ascending-or-descending-differences
+- [ ] constrained-genericity-1
+- [ ] constrained-genericity-2
+- [ ] constrained-genericity-3
+- [ ] constrained-genericity-4
+- [ ] constrained-random-points-on-a-circle-1
+- [ ] constrained-random-points-on-a-circle-2
+- [ ] continued-fraction
 - [ ] crc-32-1
 - [ ] crc-32-2
 - [ ] csv-data-manipulation
@@ -219,4 +241,3 @@ This directory holds TypeScript source code generated from the real Mochi progra
 - [ ] csv-to-html-translation-5
 - [ ] cusip
 - [ ] md5
-


### PR DESCRIPTION
## Summary
- regenerate the TypeScript Rosetta README using a new helper script
- provide `update_ts_rosetta_readme.go` for updating status

## Testing
- `go test ./compiler/x/ts -run Rosetta -tags slow -count=1`
- `go run -tags=archive,slow ./scripts/update_ts_rosetta_readme.go`

------
https://chatgpt.com/codex/tasks/task_e_687a1997e8f083209a603a23714d7f60