### PR TITLE
Update Swift compiler

### DIFF
--- a/compiler/x/swift/TASKS.md
+++ b/compiler/x/swift/TASKS.md
@@ -1,6 +1,8 @@
 # Swift Compiler Progress
 
 ## Recent Enhancements
+- 2025-07-30 10:00 – outer join queries mark both sides optional during type
+  inference so generated structs are reused across statements.
 - 2025-07-29 07:00 – optional field checks added and left join placeholders
   use typed optionals so complex joins compile and run.
 - 2025-07-28 08:00 – query expressions selecting numeric fields from groups now

--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -3515,6 +3515,19 @@ func (c *compiler) queryFieldTypes(q *parser.QueryExpr) map[string]string {
 				}
 				c.mapFields[j.Var] = f
 			}
+			if *j.Side == "outer" {
+				if t := c.varTypes[q.Var]; t != "" && !strings.HasSuffix(t, "?") {
+					c.varTypes[q.Var] = t + "?"
+				}
+				if f, ok := c.mapFields[q.Var]; ok {
+					for k, vt := range f {
+						if !strings.HasSuffix(vt, "?") {
+							f[k] = vt + "?"
+						}
+					}
+					c.mapFields[q.Var] = f
+				}
+			}
 		}
 	}
 	if q.Group != nil {


### PR DESCRIPTION
## Summary
- adjust outer join inference so both sides become optional
- document new improvement in Swift compiler task list

## Testing
- `go test -tags slow ./compiler/x/swift -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a1ddc56ec8320be2facf6c0698329