### PR TITLE
Improve Zig compiler query optimizations

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -45,3 +45,4 @@
 - 2025-07-21 infer range loop indices to avoid index helpers
 - 2025-07-22 compiled go_auto, python_auto, and python_math.mochi in Zig and updated machine README to 100/100.
 - 2025-07-23 improved substring inference when only one bound is constant, avoiding `_slice_string` helper.
+- 2025-07-23 optimized sum/avg over simple queries to use direct loops instead of temporary lists


### PR DESCRIPTION
## Summary
- optimize sum and avg for simple queries
- document optimization in Zig TASKS

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a1de005508320ac68ba168642aaad