### PR TITLE
Improve Rust compiler const tracking

### DIFF
--- a/compiler/x/rust/TASKS.md
+++ b/compiler/x/rust/TASKS.md
@@ -41,8 +41,9 @@
   even when no explicit type is present.
 - 2025-08-07 - Inlined JSON printing for struct literals by tracking constant
   values in `let` and `var` declarations.
+- 2025-08-08 - Propagated constant JSON values through variable assignments so
+  `json` can print them without runtime helpers.
 ## Remaining Enhancements
-- [ ] Inline JSON printing for variables when values are known at compile time
 - [ ] Validate generated code for `tpc-h/q1.mochi`
 - [ ] Extend helper functions to support file I/O and dataset joins
 - [ ] Format emitted Rust code more like `rustfmt`

--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -928,6 +928,12 @@ func (c *Compiler) compileLet(l *parser.LetStmt) error {
 		if s, ok := c.structLiteralJSON(sl); ok {
 			c.constJSON[l.Name] = s
 		}
+	} else if id, ok := c.simpleIdent(l.Value); ok {
+		if s, ok2 := c.constJSON[id]; ok2 {
+			c.constJSON[l.Name] = s
+		} else if s, ok2 := c.constListJSON[id]; ok2 {
+			c.constListJSON[l.Name] = s
+		}
 	}
 	if c.lastListStruct != "" {
 		c.listVars[l.Name] = c.lastListStruct
@@ -1031,6 +1037,12 @@ func (c *Compiler) compileVar(v *parser.VarStmt) error {
 	} else if sl := tryStructLiteral(v.Value); sl != nil {
 		if s, ok := c.structLiteralJSON(sl); ok {
 			c.constJSON[v.Name] = s
+		}
+	} else if id, ok := c.simpleIdent(v.Value); ok {
+		if s, ok2 := c.constJSON[id]; ok2 {
+			c.constJSON[v.Name] = s
+		} else if s, ok2 := c.constListJSON[id]; ok2 {
+			c.constListJSON[v.Name] = s
 		}
 	}
 	if c.lastListStruct != "" {

--- a/tests/machine/x/rust/README.md
+++ b/tests/machine/x/rust/README.md
@@ -4,7 +4,7 @@ This directory contains Rust source code generated from the Mochi programs in `t
 
 Compiled programs: 100/100
 
-The compiler now inlines the `append`, `json`, and list set operations (`union`, `except`, `intersect`) when the element types are known. Lists inferred from prior `append` calls also avoid the helper. Constant list values are printed directly without calling runtime helpers. Struct literals assigned to variables are also tracked, allowing `json` to print them without using the runtime helper.
+The compiler now inlines the `append`, `json`, and list set operations (`union`, `except`, `intersect`) when the element types are known. Lists inferred from prior `append` calls also avoid the helper. Constant list values are printed directly without calling runtime helpers. Struct literals assigned to variables are also tracked, allowing `json` to print them without using the runtime helper. Variables that reference constant values now keep that information so `json` can inline them as well.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- propagate constant JSON info through variable assignments
- document new feature in Rust TASKS and README

## Testing
- `go test ./compiler/x/rust -run TestRustCompiler_VMValid_Golden -tags slow` *(fails: 78 passed, 22 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a1df2ea288320b760c8fe643463b1