### PR TITLE
Update Dart compiler to skip blank expressions

### DIFF
--- a/compiler/x/dart/compiler.go
+++ b/compiler/x/dart/compiler.go
@@ -388,6 +388,11 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 		c.writeln("")
 		return nil
 	case s.Expr != nil:
+		// Ignore blank expression statements which may arise from
+		// trailing newlines in source files.
+		if s.Expr.Expr == nil || s.Expr.Expr.Binary == nil {
+			return nil
+		}
 		expr, err := c.compileExpr(s.Expr.Expr)
 		if err != nil {
 			return err
@@ -831,7 +836,9 @@ func (c *Compiler) compileUpdate(u *parser.UpdateStmt) error {
 
 func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 	if e == nil || e.Binary == nil {
-		return "", fmt.Errorf("empty expression")
+		// Gracefully handle missing expressions which may occur due to
+		// trailing semicolons by emitting Dart `null`.
+		return "null", nil
 	}
 	return c.compileBinary(e.Binary)
 }

--- a/tests/machine/x/dart/README.md
+++ b/tests/machine/x/dart/README.md
@@ -2,8 +2,6 @@
 
 This directory contains Dart code generated from Mochi programs. Successful runs have a .out file, failures a .error file.
 
-Helper functions are now emitted only when referenced, so generated code is closer to the human examples.
-
 Compiled programs: 100/100
 
 Checklist:

--- a/tests/rosetta/out/Dart/README.md
+++ b/tests/rosetta/out/Dart/README.md
@@ -2,7 +2,7 @@
 
 This directory holds Dart code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
-Compiled programs: 27/238
+Compiled programs: 27/239
 
 Checklist:
 - [ ] 100-doors-2
@@ -212,6 +212,7 @@ Checklist:
 - [ ] circular-primes
 - [ ] cistercian-numerals
 - [ ] compiler-virtual-machine-interpreter
+- [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
 - [ ] concurrent-computing-1
 - [ ] concurrent-computing-2
 - [ ] concurrent-computing-3


### PR DESCRIPTION
## Summary
- handle trailing blank expression statements in Dart backend
- treat missing expressions as `null`
- regenerate Dart README files for machine and Rosetta outputs

## Testing
- `go test ./compiler/x/dart -run Rosetta -tags=slow,archive -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a1e4f15808320bc0a2aba0409feab