### PR TITLE
Run clj rosetta tests

### DIFF
--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -533,6 +533,9 @@ func (c *Compiler) compileImport(im *parser.ImportStmt) error {
 		if im.Auto {
 			c.goAuto[alias] = true
 		}
+		// also require the Go package so generated code compiles
+		mod := strings.ReplaceAll(path, "/", ".")
+		c.imports[alias] = mod
 		return nil
 	default:
 		return fmt.Errorf("unsupported import language: %s", *im.Lang)


### PR DESCRIPTION
## Summary
- require Go FFI packages when importing into Clojure

## Testing
- `go test ./compiler/x/clj -run Rosetta -tags=slow -count=1`
- `UPDATE=1 go test ./compiler/x/clj -run Rosetta -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687a1e50ca88832098e7f92a0a2dfbef