### PR TITLE
Add Mochi solution for Rosetta task 214

### DIFF
--- a/tests/rosetta/x/Mochi/convert-seconds-to-compound-duration.mochi
+++ b/tests/rosetta/x/Mochi/convert-seconds-to-compound-duration.mochi
@@ -1,0 +1,49 @@
+fun timeStr(sec: int): string {
+  var wks = sec / 604800
+  sec = sec % 604800
+  var ds = sec / 86400
+  sec = sec % 86400
+  var hrs = sec / 3600
+  sec = sec % 3600
+  var mins = sec / 60
+  sec = sec % 60
+
+  var res = ""
+  var comma = false
+  if wks != 0 {
+    res = res + str(wks) + " wk"
+    comma = true
+  }
+  if ds != 0 {
+    if comma {
+      res = res + ", "
+    }
+    res = res + str(ds) + " d"
+    comma = true
+  }
+  if hrs != 0 {
+    if comma {
+      res = res + ", "
+    }
+    res = res + str(hrs) + " hr"
+    comma = true
+  }
+  if mins != 0 {
+    if comma {
+      res = res + ", "
+    }
+    res = res + str(mins) + " min"
+    comma = true
+  }
+  if sec != 0 {
+    if comma {
+      res = res + ", "
+    }
+    res = res + str(sec) + " sec"
+  }
+  return res
+}
+
+print(timeStr(7259))
+print(timeStr(86400))
+print(timeStr(6000000))

--- a/tests/rosetta/x/Mochi/convert-seconds-to-compound-duration.out
+++ b/tests/rosetta/x/Mochi/convert-seconds-to-compound-duration.out
@@ -1,0 +1,3 @@
+2 hr, 59 sec
+1 d
+9 wk, 6 d, 10 hr, 40 min


### PR DESCRIPTION
## Summary
- add Mochi implementation for `Convert-seconds-to-compound-duration`
- include expected output for the new program

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/convert-seconds-to-compound-duration.mochi`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a1f8ecc608320ab7904a8849ccdef