### PR TITLE
Add Mochi translation for Copy-a-string Rosetta task

### DIFF
--- a/tests/rosetta/x/Mochi/copy-a-string-1.mochi
+++ b/tests/rosetta/x/Mochi/copy-a-string-1.mochi
@@ -1,0 +1,2 @@
+var src = "Hello"
+var dst = src

--- a/tests/rosetta/x/Mochi/copy-a-string-2.mochi
+++ b/tests/rosetta/x/Mochi/copy-a-string-2.mochi
@@ -1,0 +1,12 @@
+var creature = "shark"
+var pointer = [creature]
+
+print("creature = " + creature)
+print("pointer = 0")
+print("*pointer = " + pointer[0])
+
+pointer[0] = "jellyfish"
+creature = pointer[0]
+
+print("*pointer = " + pointer[0])
+print("creature = " + creature)

--- a/tests/rosetta/x/Mochi/copy-a-string-2.out
+++ b/tests/rosetta/x/Mochi/copy-a-string-2.out
@@ -1,0 +1,5 @@
+creature = shark
+pointer = 0
+*pointer = shark
+*pointer = jellyfish
+creature = jellyfish


### PR DESCRIPTION
## Summary
- implement `copy-a-string` examples in Mochi
- include expected outputs for both programs

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/copy-a-string-2.mochi`

------
https://chatgpt.com/codex/tasks/task_e_687a1f95e3148320a086b0155c1c4724