### PR TITLE
Add Mochi solutions for Rosetta task 220

### DIFF
--- a/tests/rosetta/x/Mochi/count-in-octal-1.mochi
+++ b/tests/rosetta/x/Mochi/count-in-octal-1.mochi
@@ -1,0 +1,24 @@
+// Mochi translation of Rosetta "Count in octal" task variant 1
+// Based on Go version in tests/rosetta/x/Go/count-in-octal-1.go
+
+fun toOct(n: int): string {
+  if n == 0 { return "0" }
+  let digits = "01234567"
+  var out = ""
+  var v = n
+  while v > 0 {
+    let d = v % 8
+    out = digits[d:d+1] + out
+    v = v / 8
+  }
+  return out
+}
+
+fun main() {
+  // count from 0 to math.MaxInt8 (127)
+  for i in 0..128 {
+    print(toOct(i))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/count-in-octal-2.mochi
+++ b/tests/rosetta/x/Mochi/count-in-octal-2.mochi
@@ -1,0 +1,24 @@
+// Mochi translation of Rosetta "Count in octal" task variant 2
+// Based on Go version in tests/rosetta/x/Go/count-in-octal-2.go
+
+fun toOct(n: int): string {
+  if n == 0 { return "0" }
+  let digits = "01234567"
+  var out = ""
+  var v = n
+  while v > 0 {
+    let d = v % 8
+    out = digits[d:d+1] + out
+    v = v / 8
+  }
+  return out
+}
+
+fun main() {
+  // count from 0 to math.MaxUint16 (65535)
+  for i in 0..65536 {
+    print(toOct(i))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/count-in-octal-3.mochi
+++ b/tests/rosetta/x/Mochi/count-in-octal-3.mochi
@@ -1,0 +1,35 @@
+// Mochi translation of Rosetta "Count in octal" task variant 3
+// Based on Go version in tests/rosetta/x/Go/count-in-octal-3.go
+
+fun toOct(n: int): string {
+  if n == 0 { return "0" }
+  let digits = "01234567"
+  var out = ""
+  var v = n
+  while v > 0 {
+    let d = v % 8
+    out = digits[d:d+1] + out
+    v = v / 8
+  }
+  return out
+}
+
+fun main() {
+  var i = 0.0
+  while true {
+    print(toOct(i as int))
+    /* uncomment to produce example output
+    if i == 3.0 {
+      i = 9007199254740992.0 - 4.0  // skip to near the end
+      print("...")
+    }
+    */
+    let next = i + 1.0
+    if next == i {
+      break
+    }
+    i = next
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/count-in-octal-4.mochi
+++ b/tests/rosetta/x/Mochi/count-in-octal-4.mochi
@@ -1,0 +1,26 @@
+// Mochi translation of Rosetta "Count in octal" task variant 4
+// Based on Go version in tests/rosetta/x/Go/count-in-octal-4.go
+
+fun toOct(n: int): string {
+  if n == 0 { return "0" }
+  let digits = "01234567"
+  var out = ""
+  var v = n
+  while v > 0 {
+    let d = v % 8
+    out = digits[d:d+1] + out
+    v = v / 8
+  }
+  return out
+}
+
+fun main() {
+  // infinite loop counting with big integers until interrupted
+  var i = 0
+  while true {
+    print(toOct(i))
+    i = i + 1
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary
- download the Go sources for task 220 (Count-in-octal)
- implement the task in Mochi with four variants matching the Go code

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687a1f9c47c48320a3591b66be760d30