### PR TITLE
Improve C# query struct inference

### DIFF
--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -1630,15 +1630,21 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 			}
 		}
 	}
-	if st, ok := resultT.(types.StructType); ok && st.Name == "" && q.Group == nil {
-		base := c.structHint
-		if base == "" {
-			base = "Item"
+	if st, ok := resultT.(types.StructType); ok && q.Group == nil {
+		if st.Name == "" {
+			base := c.structHint
+			if base == "" {
+				base = "Item"
+			}
+			if name, ok2 := c.findStructByFields(st); ok2 {
+				st.Name = name
+			} else {
+				st.Name = c.newStructName(base)
+				c.extraStructs = append(c.extraStructs, st)
+			}
 		}
-		st.Name = c.newStructName(base)
 		resultType = st.Name
 		resultT = st
-		c.extraStructs = append(c.extraStructs, st)
 	} else if lt, ok := resultT.(types.ListType); ok && q.Group == nil {
 		if st, ok2 := lt.Elem.(types.StructType); ok2 && st.Name == "" {
 			base := c.structHint


### PR DESCRIPTION
## Summary
- refine struct naming logic for LINQ query results in the C# compiler

## Testing
- `go run -tags slow /tmp/cscompile.go tests/vm/valid/cross_join.mochi /tmp/cross_join.cs`

------
https://chatgpt.com/codex/tasks/task_e_687a1dd8e30483209fbfa3c2f1bbab6b