### PR TITLE
Update Go compiler helpers

### DIFF
--- a/compiler/x/go/TASKS.md
+++ b/compiler/x/go/TASKS.md
@@ -102,3 +102,5 @@ TPC-H progress:
 - 2025-07-21 18:00 - Expanded exists() and castExpr to avoid runtime helpers for common types
 - 2025-07-21 20:00 - Improved OptionType field inference for join keys; outer_join compiles without helpers
 - 2025-07-22 12:00 - Preserved OptionType fields when inferring structs and converted join sources to pointer slices so `left_join_multi` and `right_join` compile
+
+- 2025-07-23 00:00 - Skip slice cast helpers when converting nil values

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -235,6 +235,10 @@ func (c *Compiler) castExpr(expr string, from, to types.Type) string {
 	fromGo := goType(from)
 	toGo := goType(to)
 
+	if strings.TrimSpace(expr) == "nil" {
+		return "nil"
+	}
+
 	if toGo == "" {
 		return expr
 	}


### PR DESCRIPTION
## Summary
- skip slice cast helpers when converting `nil`
- document progress in Go compiler TASKS

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a1d4eac54832097c49de83d061219