### PR TITLE
Fix Scala group key inference

### DIFF
--- a/compiler/x/scala/compiler.go
+++ b/compiler/x/scala/compiler.go
@@ -2270,6 +2270,10 @@ func (c *Compiler) compileQueryExpr(q *parser.QueryExpr) (string, error) {
 
 		groupEnv := types.NewEnv(c.env)
 		keyT := c.namedType(types.ExprType(q.Group.Exprs[0], child))
+		if st, ok := c.detectStructMap(q.Group.Exprs[0], child); ok {
+			st = c.ensureStructName(st)
+			keyT = st
+		}
 		groupEnv.SetVar(q.Group.Name, types.GroupType{Key: keyT, Elem: elem}, false)
 
 		if q.Sort != nil {
@@ -3131,7 +3135,11 @@ func (c *Compiler) querySelectEnv(q *parser.QueryExpr) *types.Env {
 		}
 	}
 	if q.Group != nil {
-		keyT := types.ExprType(q.Group.Exprs[0], env)
+		keyT := c.namedType(types.ExprType(q.Group.Exprs[0], env))
+		if st, ok := c.detectStructMap(q.Group.Exprs[0], env); ok {
+			st = c.ensureStructName(st)
+			keyT = st
+		}
 		g := types.NewEnv(env)
 		g.SetVar(q.Group.Name, types.GroupType{Key: keyT, Elem: types.AnyType{}}, false)
 		env = g


### PR DESCRIPTION
## Summary
- refine group-by typing so struct keys remain struct-typed

## Testing
- `go test ./...` *(fails: go tests require many dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a1de7a4d083209844293a06051567