### PR TITLE
Improve Zig compiler list var handling

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -46,3 +46,4 @@
 - 2025-07-22 compiled go_auto, python_auto, and python_math.mochi in Zig and updated machine README to 100/100.
 - 2025-07-23 improved substring inference when only one bound is constant, avoiding `_slice_string` helper.
 - 2025-07-23 optimized sum/avg over simple queries to use direct loops instead of temporary lists
+- 2025-07-24 avoid reference slices for list variables to allow mutation

--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -512,7 +512,7 @@ func (c *Compiler) compileGlobalDecls(prog *parser.Program) error {
 				if ll := extractListLiteral(s.Let.Value); ll != nil && len(ll.Elems) > 0 && s.Let.Type == nil {
 					if extractMapLiteral(ll.Elems[0]) != nil {
 						structName := pascalCase(name) + "Item"
-						decl, init, err := c.compileNamedListLiteral(ll, true, structName)
+						decl, init, err := c.compileNamedListLiteral(ll, false, structName)
 						if err == nil {
 							if !c.structs[structName] {
 								c.writeln(decl)
@@ -2296,7 +2296,7 @@ func (c *Compiler) compileVar(st *parser.VarStmt, inFun bool) error {
 		if ll := extractListLiteral(st.Value); ll != nil && len(ll.Elems) > 0 && st.Type == nil {
 			if ml := extractMapLiteral(ll.Elems[0]); ml != nil {
 				if known, ok := c.matchStructFromMapLiteral(ml); ok {
-					v, err := c.compileListLiteral(ll, true)
+					v, err := c.compileListLiteral(ll, false)
 					if err == nil {
 						if c.env != nil {
 							if stype, ok2 := c.env.GetStruct(known); ok2 {
@@ -2308,7 +2308,7 @@ func (c *Compiler) compileVar(st *parser.VarStmt, inFun bool) error {
 					}
 				}
 				structName := pascalCase(name) + "Item"
-				decl, init, err := c.compileNamedListLiteral(ll, true, structName)
+				decl, init, err := c.compileNamedListLiteral(ll, false, structName)
 				if err == nil {
 					if !c.structs[structName] {
 						c.writeln(decl)


### PR DESCRIPTION
## Summary
- fix `compileVar` to use value arrays for list literals
- update global compile path for list literals
- document improvement in `TASKS.md`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a208f469483209051d9985458417e