### PR TITLE
Improve C# map inference

### DIFF
--- a/compiler/x/cs/TASKS.md
+++ b/compiler/x/cs/TASKS.md
@@ -1,4 +1,7 @@
 # C# Compiler TODO
+## Recent Updates (2025-07-28 12:00)
+- Prefer struct inference over map typing when both are possible. This
+  improves query results like `cross_join` by using typed records.
 ## Recent Updates (2025-07-28 00:00)
 - Improved type inference for datasets so `where` filters preserve struct field access.
 - Generated machine output for `dataset_sort_take_limit` and `dataset_where_filter` bringing totals to 34/100.

--- a/compiler/x/cs/compiler.go
+++ b/compiler/x/cs/compiler.go
@@ -720,12 +720,12 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 						listStruct = &st
 					}
 				} else if ml := mapLiteral(s.Let.Value); ml != nil {
-					if mt, ok := c.inferSimpleMap(ml); ok {
-						inferredT = mt
-					} else if st, ok := c.inferStructFromMap(ml, s.Let.Name); ok {
+					if st, ok := c.inferStructFromMap(ml, s.Let.Name); ok {
 						inferredT = st
 						c.env.SetStruct(st.Name, st)
 						c.compileStructType(st)
+					} else if mt, ok := c.inferSimpleMap(ml); ok {
+						inferredT = mt
 					}
 				} else if qe := s.Let.Value.Binary.Left.Value.Target.Query; qe != nil {
 					if ml := mapLiteral(qe.Select); ml != nil {
@@ -838,12 +838,12 @@ func (c *Compiler) compileStmt(s *parser.Statement) error {
 						c.compileStructType(st)
 					}
 				} else if ml := mapLiteral(s.Var.Value); ml != nil {
-					if mt, ok := c.inferSimpleMap(ml); ok {
-						inferredT = mt
-					} else if st, ok := c.inferStructFromMap(ml, s.Var.Name); ok {
+					if st, ok := c.inferStructFromMap(ml, s.Var.Name); ok {
 						inferredT = st
 						c.env.SetStruct(st.Name, st)
 						c.compileStructType(st)
+					} else if mt, ok := c.inferSimpleMap(ml); ok {
+						inferredT = mt
 					}
 				} else if qe := s.Var.Value.Binary.Left.Value.Target.Query; qe != nil {
 					if ml := mapLiteral(qe.Select); ml != nil {


### PR DESCRIPTION
## Summary
- favor struct inference over map typing in cs compiler
- note latest progress in TASKS

## Testing
- `gofmt -w compiler/x/cs/compiler.go`
- `go run -tags "slow compilecs" tools/compilecs.go tests/vm/valid/cross_join.mochi > /tmp/cross_join.cs`

------
https://chatgpt.com/codex/tasks/task_e_687a21807d988320b7cbbc25f471265c