### PR TITLE
Improve Go compiler print handling

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -1863,27 +1863,27 @@ func (c *Compiler) compileBinaryOp(left string, leftType types.Type, op string, 
 				expr = fmt.Sprintf("append(append([]any{}, %s...), %s...)", left, right)
 				next = types.ListType{Elem: types.AnyType{}}
 			}
-case op == "+" && isString(leftType) && isString(rightType):
-expr = fmt.Sprintf("%s + %s", left, right)
-next = types.StringType{}
-case op == "+" && isList(leftType) && isString(rightType):
-if lt, ok := leftType.(types.ListType); ok {
-if _, ok2 := lt.Elem.(types.StringType); ok2 {
-c.imports["strings"] = true
-expr = fmt.Sprintf("strings.Join(%s, \"\") + %s", left, right)
-next = types.StringType{}
-break
-}
-}
-case op == "+" && isString(leftType) && isList(rightType):
-if rt, ok := rightType.(types.ListType); ok {
-if _, ok2 := rt.Elem.(types.StringType); ok2 {
-c.imports["strings"] = true
-expr = fmt.Sprintf("%s + strings.Join(%s, \"\")", left, right)
-next = types.StringType{}
-break
-}
-}
+		case op == "+" && isString(leftType) && isString(rightType):
+			expr = fmt.Sprintf("%s + %s", left, right)
+			next = types.StringType{}
+		case op == "+" && isList(leftType) && isString(rightType):
+			if lt, ok := leftType.(types.ListType); ok {
+				if _, ok2 := lt.Elem.(types.StringType); ok2 {
+					c.imports["strings"] = true
+					expr = fmt.Sprintf("strings.Join(%s, \"\") + %s", left, right)
+					next = types.StringType{}
+					break
+				}
+			}
+		case op == "+" && isString(leftType) && isList(rightType):
+			if rt, ok := rightType.(types.ListType); ok {
+				if _, ok2 := rt.Elem.(types.StringType); ok2 {
+					c.imports["strings"] = true
+					expr = fmt.Sprintf("%s + strings.Join(%s, \"\")", left, right)
+					next = types.StringType{}
+					break
+				}
+			}
 		case op == "+" && isInt(leftType) && isAny(rightType):
 			left = fmt.Sprintf("float64(%s)", left)
 			right = c.castExpr(right, rightType, types.FloatType{})
@@ -4523,6 +4523,9 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				if isBool(at) {
 					args[i] = fmt.Sprintf("func() int { if %s { return 1 }; return 0 }()", args[i])
 				}
+			}
+			if len(args) == 1 {
+				return fmt.Sprintf("fmt.Println(%s)", args[0]), nil
 			}
 			c.imports["strings"] = true
 			return fmt.Sprintf("fmt.Println(strings.TrimSuffix(fmt.Sprintln(%s), \"\\n\"))", strings.Join(args, ", ")), nil


### PR DESCRIPTION
## Summary
- allow Go backend to emit a direct `fmt.Println` when a print call has a single simple argument

## Testing
- `go test ./compiler/x/go -tags slow -run VMValid_Golden/print_hello -update`

------
https://chatgpt.com/codex/tasks/task_e_687a2070bd2883208812c86f10bbcbc9