### PR TITLE
Improve Elixir backend

### DIFF
--- a/compiler/x/ex/expr.go
+++ b/compiler/x/ex/expr.go
@@ -433,6 +433,11 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 						c.use("_avg")
 						res = fmt.Sprintf("_avg(%s)", argStr)
 					}
+				case "abs":
+					if len(args) != 1 {
+						return "", fmt.Errorf("abs expects 1 arg")
+					}
+					res = fmt.Sprintf("abs(%s)", args[0])
 				case "min":
 					if len(args) == 1 {
 						t := c.inferExprType(op.Call.Args[0])


### PR DESCRIPTION
## Summary
- add abs builtin in Elixir compiler
- run slow golden tests for Elixir backend

## Testing
- `go test ./compiler/x/ex -run TestExCompiler_Rosetta_Golden -tags=slow -v`


------
https://chatgpt.com/codex/tasks/task_e_687a21329a808320a0184680486e1ff1