### PR TITLE
Improve C++ compiler element inference

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -613,10 +613,10 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 	}
 	var elemHint string
 	if st.Type == nil {
-		if et := c.extractVectorElemType(exprStr); et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
+		if et := c.elemType[exprStr]; et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
 			typ = fmt.Sprintf("std::vector<%s>", et)
 			elemHint = et
-		} else if et := c.elemType[exprStr]; et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
+		} else if et := c.extractVectorElemType(exprStr); et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
 			typ = fmt.Sprintf("std::vector<%s>", et)
 			elemHint = et
 		}
@@ -696,10 +696,10 @@ func (c *Compiler) compileVar(st *parser.VarStmt) error {
 	}
 	var elemHint string
 	if st.Type == nil {
-		if et := c.extractVectorElemType(exprStr); et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
+		if et := c.elemType[exprStr]; et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
 			typ = fmt.Sprintf("std::vector<%s>", et)
 			elemHint = et
-		} else if et := c.elemType[exprStr]; et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
+		} else if et := c.extractVectorElemType(exprStr); et != "" && !strings.HasPrefix(exprStr, "std::unordered_map<") && !strings.HasPrefix(exprStr, "std::map<") {
 			typ = fmt.Sprintf("std::vector<%s>", et)
 			elemHint = et
 		} else if isEmptyListExpr(st.Value) {

--- a/tests/machine/x/cpp/README.md
+++ b/tests/machine/x/cpp/README.md
@@ -2,7 +2,7 @@
 
 Generated C++ code for the programs under `tests/vm/valid`. Each file here has a `.cpp` source produced by the compiler and an `.out` file with its runtime output. If compilation failed, a `.error` file captures the g++ output.
 
-Compiled programs: 92/100
+Compiled programs: 93/100
 
 ## Checklist
 - [x] append_builtin
@@ -60,7 +60,7 @@ Compiled programs: 92/100
 - [x] map_in_operator
  - [x] map_index
 - [x] map_int_key
-- [ ] map_literal_dynamic
+- [x] map_literal_dynamic
 - [x] map_membership
 - [x] map_nested_assign
 - [x] match_expr


### PR DESCRIPTION
## Summary
- prefer known element types before searching for inferred types
- mark `map_literal_dynamic` as compiled in C++ README

## Testing
- `go test -tags slow ./compiler/x/cpp -run TestCPPCompiler_VMValid_Golden -count=1` *(fails: golden mismatch for many cases)*

------
https://chatgpt.com/codex/tasks/task_e_687a217e3aa88320aa67923f566f06b5