### PR TITLE
Enhance Zig backend inference

### DIFF
--- a/compiler/x/zig/builtins.go
+++ b/compiler/x/zig/builtins.go
@@ -385,7 +385,8 @@ func (c *Compiler) writeBuiltins() {
 	if c.needsConcatString {
 		c.writeln("fn _concat_string(a: []const u8, b: []const u8) []const u8 {")
 		c.indent++
-		c.writeln("return std.mem.concat(u8, &[_][]const u8{ a, b })" + c.catchHandler() + ";")
+		c.writeln("const alloc = std.heap.page_allocator;")
+		c.writeln("return std.mem.concat(u8, &[_][]const u8{ a, b }, alloc)" + c.catchHandler() + ";")
 		c.indent--
 		c.writeln("}")
 		c.writeln("")

--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -4554,6 +4554,50 @@ func (c *Compiler) listElemTypePostfix(p *parser.PostfixExpr) string {
 	return "i32"
 }
 
+func isIntLiteralExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || u.Value.Target == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Int != nil
+}
+
+func isFloatLiteralExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || u.Value.Target == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Float != nil
+}
+
+func isBoolLiteralExpr(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || u.Value.Target == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Bool != nil
+}
+
+func isStringLiteralExprRaw(e *parser.Expr) bool {
+	if e == nil || e.Binary == nil || len(e.Binary.Right) > 0 {
+		return false
+	}
+	u := e.Binary.Left
+	if len(u.Ops) > 0 || u.Value == nil || u.Value.Target == nil || len(u.Value.Ops) > 0 {
+		return false
+	}
+	return u.Value.Target.Lit != nil && u.Value.Target.Lit.Str != nil
+}
+
 var zigReserved = map[string]bool{
 	"fn": true, "var": true, "const": true, "pub": true, "return": true,
 	"for": true, "while": true, "if": true, "else": true,

--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -481,6 +481,11 @@ func canInferType(e *parser.Expr, t types.Type) bool {
 	if _, ok := t.(types.AnyType); ok {
 		return false
 	}
+	if isIntLiteralExpr(e) || isFloatLiteralExpr(e) || isBoolLiteralExpr(e) || isStringLiteralExprRaw(e) {
+		if isInt(t) || isFloat(t) || isBool(t) || isString(t) {
+			return false
+		}
+	}
 	return true
 }
 

--- a/compiler/x/zig/rosetta_golden_test.go
+++ b/compiler/x/zig/rosetta_golden_test.go
@@ -116,11 +116,7 @@ func TestZigCompiler_Rosetta_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
-	max := 10
-	if len(files) < max {
-		max = len(files)
-	}
-	for _, f := range files[:max] {
+	for _, f := range files {
 		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
 		t.Run(name, func(t *testing.T) { runRosettaTaskGolden(t, name) })
 	}


### PR DESCRIPTION
## Summary
- improve `_concat_string` built-in to use an allocator
- avoid relying on Zig's comptime inference for mutable variables
- expose literal helpers and adjust type inference
- run all Rosetta tests in zig golden test

## Testing
- `go test ./compiler/x/zig -run TestZigCompiler_Rosetta_Golden -tags=slow -count=1` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687a1e3941748320ab09b5eff20c12ec