### PR TITLE
Improve Erlang compiler

### DIFF
--- a/scripts/compile_rosetta_erlang.go
+++ b/scripts/compile_rosetta_erlang.go
@@ -97,6 +97,9 @@ func main() {
 			if bytes.HasPrefix(line, []byte("/tmp/")) {
 				continue
 			}
+			if bytes.Contains(line, []byte(".erl:")) && bytes.Contains(line, []byte("Warning:")) {
+				continue
+			}
 			if len(line) > 0 {
 				buf.Write(line)
 				buf.WriteByte('\n')


### PR DESCRIPTION
## Summary
- support chains of `if`/`return` statements in Erlang compiler
- filter compilation warnings in the Erlang Rosetta compile script

## Testing
- `go test ./...`
- `go test -tags=slow ./compiler/x/erlang -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a2b7882a8832098f8bebd0e049589