### PR TITLE
Add Mochi solution for Create-an-HTML-table

### DIFF
--- a/tests/rosetta/x/Mochi/create-an-html-table.mochi
+++ b/tests/rosetta/x/Mochi/create-an-html-table.mochi
@@ -1,0 +1,20 @@
+// Mochi translation of Go "Create an HTML table" example.
+// Generates a table with columns X, Y, Z and four rows of sequential numbers.
+
+fun main() {
+  var rows: list<list<int>> = []
+  for i in 0..4 {
+    rows = append(rows, [i*3, i*3+1, i*3+2])
+  }
+
+  print("<table>")
+  print("    <tr><th></th><th>X</th><th>Y</th><th>Z</th></tr>")
+  var idx = 0
+  for row in rows {
+    print("    <tr><td>" + str(idx) + "</td><td>" + str(row[0]) + "</td><td>" + str(row[1]) + "</td><td>" + str(row[2]) + "</td></tr>")
+    idx = idx + 1
+  }
+  print("</table>")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/create-an-html-table.out
+++ b/tests/rosetta/x/Mochi/create-an-html-table.out
@@ -1,0 +1,7 @@
+<table>
+    <tr><th></th><th>X</th><th>Y</th><th>Z</th></tr>
+    <tr><td>0</td><td>0</td><td>1</td><td>2</td></tr>
+    <tr><td>1</td><td>3</td><td>4</td><td>5</td></tr>
+    <tr><td>2</td><td>6</td><td>7</td><td>8</td></tr>
+    <tr><td>3</td><td>9</td><td>10</td><td>11</td></tr>
+</table>


### PR DESCRIPTION
## Summary
- implement Mochi version of the Rosetta "Create an HTML table" task
- add expected output for the task

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/create-an-html-table.mochi`
- `go test ./tools/rosetta -run TestMochiToGo -tags=slow -count=1` *(fails: duplicate case in compiler)*

------
https://chatgpt.com/codex/tasks/task_e_687a2b95565883209075c0a3e68375fe