### PR TITLE
Add Mochi solution for Rosetta task 222 - Count the coins

### DIFF
--- a/tests/rosetta/x/Mochi/count-the-coins-1.mochi
+++ b/tests/rosetta/x/Mochi/count-the-coins-1.mochi
@@ -1,0 +1,24 @@
+// Mochi translation of Rosetta "Count the coins" task variant 1
+// Based on Go version in tests/rosetta/x/Go/count-the-coins-1.go
+
+fun countChange(amount: int): int {
+  return cc(amount, 4)
+}
+
+fun cc(amount: int, kindsOfCoins: int): int {
+  if amount == 0 { return 1 }
+  if amount < 0 || kindsOfCoins == 0 { return 0 }
+  return cc(amount, kindsOfCoins - 1) +
+         cc(amount - firstDenomination(kindsOfCoins), kindsOfCoins)
+}
+
+fun firstDenomination(kindsOfCoins: int): int {
+  if kindsOfCoins == 1 { return 1 }
+  if kindsOfCoins == 2 { return 5 }
+  if kindsOfCoins == 3 { return 10 }
+  if kindsOfCoins == 4 { return 25 }
+  return 0
+}
+
+let amount = 100
+print("amount, ways to make change: " + str(amount) + " " + str(countChange(amount)))

--- a/tests/rosetta/x/Mochi/count-the-coins-1.out
+++ b/tests/rosetta/x/Mochi/count-the-coins-1.out
@@ -1,0 +1,1 @@
+amount, ways to make change: 100 242

--- a/tests/rosetta/x/Mochi/count-the-coins-2.mochi
+++ b/tests/rosetta/x/Mochi/count-the-coins-2.mochi
@@ -1,0 +1,23 @@
+// Mochi translation of Rosetta "Count the coins" task variant 2
+// Based on Go version in tests/rosetta/x/Go/count-the-coins-2.go
+
+fun countChange(amount: int): int {
+  var ways: list<int> = []
+  var i = 0
+  while i <= amount {
+    ways = append(ways, 0)
+    i = i + 1
+  }
+  ways[0] = 1
+  for coin in [100, 50, 25, 10, 5, 1] {
+    var j = coin
+    while j <= amount {
+      ways[j] = ways[j] + ways[j - coin]
+      j = j + 1
+    }
+  }
+  return ways[amount]
+}
+
+let amount = 1000 * 100
+print("amount, ways to make change: " + str(amount) + " " + str(countChange(amount)))

--- a/tests/rosetta/x/Mochi/count-the-coins-2.out
+++ b/tests/rosetta/x/Mochi/count-the-coins-2.out
@@ -1,0 +1,1 @@
+amount, ways to make change: 100000 13398445413854501


### PR DESCRIPTION
## Summary
- implement Mochi translations for Rosetta "Count the coins" variants
- add expected outputs for both variants

## Testing
- `go test ./...`
- `go run tests/rosetta/x/Go/count-the-coins-1.go`
- `go run tests/rosetta/x/Go/count-the-coins-2.go`


------
https://chatgpt.com/codex/tasks/task_e_687a2b8c767483208164c201ab389253