### PR TITLE
Improve Pascal backend with now() support

### DIFF
--- a/tests/rosetta/out/Pascal/README.md
+++ b/tests/rosetta/out/Pascal/README.md
@@ -1,0 +1,258 @@
+# Rosetta Pascal Output (3/253 compiled and run)
+
+This directory holds Pascal source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
+
+## Program checklist
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
+- [ ] 100-prisoners
+- [ ] 15-puzzle-game
+- [ ] 15-puzzle-solver
+- [ ] 2048
+- [ ] 21-game
+- [ ] 24-game-solve
+- [ ] 24-game
+- [ ] 4-rings-or-4-squares-puzzle
+- [ ] 9-billion-names-of-god-the-integer
+- [ ] 99-bottles-of-beer-2
+- [x] 99-bottles-of-beer
+- [ ] a+b
+- [ ] abbreviations-automatic
+- [ ] abbreviations-easy
+- [ ] abbreviations-simple
+- [ ] abc-problem
+- [ ] abelian-sandpile-model-identity
+- [ ] abelian-sandpile-model
+- [ ] abstract-type
+- [ ] abundant-deficient-and-perfect-number-classifications
+- [ ] abundant-odd-numbers
+- [ ] accumulator-factory
+- [ ] achilles-numbers
+- [ ] ackermann-function-2
+- [ ] ackermann-function-3
+- [ ] ackermann-function
+- [ ] active-directory-connect
+- [ ] active-directory-search-for-a-user
+- [ ] active-object
+- [ ] add-a-variable-to-a-class-instance-at-runtime
+- [ ] additive-primes
+- [x] address-of-a-variable
+- [ ] adfgvx-cipher
+- [ ] aks-test-for-primes
+- [ ] algebraic-data-types
+- [ ] align-columns
+- [ ] aliquot-sequence-classifications
+- [ ] almkvist-giullera-formula-for-pi
+- [ ] almost-prime
+- [ ] amb
+- [ ] amicable-pairs
+- [ ] anagrams-deranged-anagrams
+- [ ] anagrams
+- [ ] angle-difference-between-two-bearings-1
+- [ ] angle-difference-between-two-bearings-2
+- [ ] angles-geometric-normalization-and-conversion
+- [ ] animate-a-pendulum
+- [x] animation
+- [ ] anonymous-recursion-1
+- [ ] anonymous-recursion-2
+- [ ] anonymous-recursion
+- [ ] anti-primes
+- [ ] append-a-record-to-the-end-of-a-text-file
+- [x] apply-a-callback-to-an-array-1
+- [ ] apply-a-callback-to-an-array-2
+- [ ] apply-a-digital-filter-direct-form-ii-transposed-
+- [ ] approximate-equality
+- [ ] arbitrary-precision-integers-included-
+- [ ] archimedean-spiral
+- [ ] arena-storage-pool
+- [ ] arithmetic-complex
+- [ ] arithmetic-derivative
+- [ ] arithmetic-evaluation
+- [ ] arithmetic-geometric-mean-calculate-pi
+- [ ] arithmetic-geometric-mean
+- [x] arithmetic-integer-1
+- [x] arithmetic-integer-2
+- [ ] arithmetic-numbers
+- [ ] arithmetic-rational
+- [ ] array-concatenation
+- [ ] array-length
+- [ ] arrays
+- [ ] ascending-primes
+- [ ] ascii-art-diagram-converter
+- [x] assertions
+- [ ] associative-array-creation
+- [ ] associative-array-iteration
+- [ ] associative-array-merging
+- [ ] atomic-updates
+- [ ] attractive-numbers
+- [ ] average-loop-length
+- [ ] averages-arithmetic-mean
+- [ ] averages-mean-time-of-day
+- [ ] averages-median-1
+- [ ] averages-median-2
+- [ ] averages-median-3
+- [ ] averages-mode
+- [ ] averages-pythagorean-means
+- [ ] averages-root-mean-square
+- [ ] averages-simple-moving-average
+- [ ] avl-tree
+- [ ] b-zier-curves-intersections
+- [x] babbage-problem
+- [ ] babylonian-spiral
+- [ ] balanced-brackets
+- [ ] balanced-ternary
+- [ ] barnsley-fern
+- [ ] base64-decode-data
+- [ ] bell-numbers
+- [ ] benfords-law
+- [ ] bernoulli-numbers
+- [ ] best-shuffle
+- [ ] bifid-cipher
+- [ ] bin-given-limits
+- [x] binary-digits
+- [ ] binary-search
+- [ ] binary-strings
+- [x] bioinformatics-base-count
+- [ ] bioinformatics-global-alignment
+- [ ] bioinformatics-sequence-mutation
+- [ ] biorhythms
+- [ ] bitcoin-address-validation
+- [ ] bitmap-b-zier-curves-cubic
+- [ ] bitmap-b-zier-curves-quadratic
+- [ ] bitmap-bresenhams-line-algorithm
+- [ ] bitmap-flood-fill
+- [ ] bitmap-histogram
+- [ ] bitmap-midpoint-circle-algorithm
+- [ ] bitmap-ppm-conversion-through-a-pipe
+- [ ] bitmap-read-a-ppm-file
+- [ ] bitmap-read-an-image-through-a-pipe
+- [ ] bitmap-write-a-ppm-file
+- [ ] bitmap
+- [ ] bitwise-io-1
+- [ ] bitwise-io-2
+- [ ] bitwise-operations
+- [ ] blum-integer
+- [ ] boolean-values
+- [ ] box-the-compass
+- [ ] boyer-moore-string-search
+- [ ] brazilian-numbers
+- [ ] break-oo-privacy
+- [ ] brilliant-numbers
+- [ ] brownian-tree
+- [ ] bulls-and-cows-player
+- [ ] bulls-and-cows
+- [ ] burrows-wheeler-transform
+- [ ] caesar-cipher-1
+- [ ] caesar-cipher-2
+- [ ] calculating-the-value-of-e
+- [ ] calendar---for-real-programmers-1
+- [ ] calendar---for-real-programmers-2
+- [ ] calendar
+- [ ] calkin-wilf-sequence
+- [x] call-a-foreign-language-function
+- [ ] call-a-function-1
+- [ ] call-a-function-10
+- [ ] call-a-function-11
+- [ ] call-a-function-12
+- [ ] call-a-function-2
+- [ ] call-a-function-3
+- [ ] call-a-function-4
+- [x] call-a-function-5
+- [x] call-a-function-6
+- [ ] call-a-function-7
+- [ ] call-a-function-8
+- [ ] call-a-function-9
+- [ ] call-an-object-method-1
+- [ ] call-an-object-method-2
+- [ ] call-an-object-method-3
+- [ ] call-an-object-method
+- [ ] camel-case-and-snake-case
+- [ ] canny-edge-detector
+- [ ] canonicalize-cidr
+- [ ] cantor-set
+- [ ] carmichael-3-strong-pseudoprimes
+- [ ] cartesian-product-of-two-or-more-lists-1
+- [ ] cartesian-product-of-two-or-more-lists-2
+- [ ] cartesian-product-of-two-or-more-lists-3
+- [ ] cartesian-product-of-two-or-more-lists-4
+- [ ] case-sensitivity-of-identifiers
+- [ ] casting-out-nines
+- [ ] catalan-numbers-1
+- [ ] catalan-numbers-2
+- [ ] catalan-numbers-pascals-triangle
+- [ ] catamorphism
+- [ ] catmull-clark-subdivision-surface
+- [ ] chaocipher
+- [ ] chaos-game
+- [x] character-codes-1
+- [x] character-codes-2
+- [x] character-codes-3
+- [x] character-codes-4
+- [x] character-codes-5
+- [ ] chat-server
+- [ ] check-machin-like-formulas
+- [ ] check-that-file-exists
+- [x] checkpoint-synchronization-1
+- [ ] checkpoint-synchronization-2
+- [ ] checkpoint-synchronization-3
+- [x] checkpoint-synchronization-4
+- [ ] chernicks-carmichael-numbers
+- [ ] cheryls-birthday
+- [ ] chinese-remainder-theorem
+- [ ] chinese-zodiac
+- [ ] cholesky-decomposition-1
+- [ ] cholesky-decomposition
+- [ ] chowla-numbers
+- [ ] church-numerals-1
+- [ ] church-numerals-2
+- [ ] circles-of-given-radius-through-two-points
+- [ ] circular-primes
+- [ ] cistercian-numerals
+- [ ] compiler-virtual-machine-interpreter
+- [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
+- [ ] compound-data-type
+- [ ] concurrent-computing-1
+- [ ] concurrent-computing-2
+- [ ] concurrent-computing-3
+- [ ] conditional-structures-1
+- [ ] conditional-structures-10
+- [ ] conditional-structures-2
+- [ ] conditional-structures-3
+- [ ] conditional-structures-4
+- [ ] conditional-structures-5
+- [ ] conditional-structures-6
+- [ ] conditional-structures-7
+- [ ] conditional-structures-8
+- [ ] conditional-structures-9
+- [ ] consecutive-primes-with-ascending-or-descending-differences
+- [ ] constrained-genericity-1
+- [ ] constrained-genericity-2
+- [ ] constrained-genericity-3
+- [ ] constrained-genericity-4
+- [ ] constrained-random-points-on-a-circle-1
+- [ ] constrained-random-points-on-a-circle-2
+- [ ] continued-fraction
+- [ ] convert-decimal-number-to-rational
+- [ ] convert-seconds-to-compound-duration
+- [ ] convex-hull
+- [ ] conways-game-of-life
+- [ ] copy-a-string-1
+- [ ] copy-a-string-2
+- [ ] copy-stdin-to-stdout-1
+- [ ] copy-stdin-to-stdout-2
+- [ ] count-in-factors
+- [ ] count-in-octal-1
+- [ ] count-in-octal-2
+- [ ] count-in-octal-3
+- [ ] count-in-octal-4
+- [ ] crc-32-1
+- [ ] crc-32-2
+- [ ] csv-data-manipulation
+- [ ] csv-to-html-translation-1
+- [ ] csv-to-html-translation-2
+- [x] csv-to-html-translation-3
+- [x] csv-to-html-translation-4
+- [ ] csv-to-html-translation-5
+- [ ] cusip
+- [ ] md5


### PR DESCRIPTION
## Summary
- add Pascal backend handling for `now()` builtin
- fall back to integer mod when operands are float-like
- document available outputs for Pascal Rosetta programs

## Testing
- `go test -tags=slow ./compiler/x/pascal -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a2b4a1a3483208011d4f8ae488a18