### PR TITLE
Improve F# compiler capabilities

### DIFF
--- a/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
+++ b/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
@@ -19,7 +19,10 @@ fun fields(s: string): list<string> {
   while i < len(s) {
     let ch = substring(s, i, i + 1)
     if ch == " " || ch == "\t" || ch == "\n" {
-      if len(cur) > 0 { words = append(words, cur); cur = "" }
+      if len(cur) > 0 {
+        words = append(words, cur)
+        cur = ""
+      }
     } else {
       cur = cur + ch
     }


### PR DESCRIPTION
## Summary
- support `return` without a value
- handle `input()` and `int()` builtins
- use string length when `len` argument is a string
- annotate parameter types in generated F# functions
- fix bulls and cows player source

## Testing
- `go run -tags slow /tmp/runfs.go`

------
https://chatgpt.com/codex/tasks/task_e_687a2b39b21083208f5e17e96a207c8e