### PR TITLE
Add input builtin to Swift compiler

### DIFF
--- a/tests/rosetta/out/Swift/README.md
+++ b/tests/rosetta/out/Swift/README.md
@@ -1,4 +1,4 @@
-# Rosetta Swift Output (56/216 programs run)
+# Rosetta Swift Output (58/216 programs run)
 
 This directory holds Swift source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -140,8 +140,8 @@ This directory holds Swift source code generated from the Mochi programs in `tes
 - [x] break-oo-privacy.mochi
 - [ ] brilliant-numbers.mochi
 - [ ] brownian-tree.mochi
-- [ ] bulls-and-cows-player.mochi
-- [ ] bulls-and-cows.mochi
+- [x] bulls-and-cows-player.mochi
+- [x] bulls-and-cows.mochi
 - [ ] burrows-wheeler-transform.mochi
 - [ ] caesar-cipher-1.mochi
 - [ ] caesar-cipher-2.mochi

--- a/tests/rosetta/x/Mochi/bulls-and-cows-player.error
+++ b/tests/rosetta/x/Mochi/bulls-and-cows-player.error
@@ -1,8 +1,0 @@
-error[P040]: /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi:22:51: lexer: invalid input text "; cur = \"\" }\n   ..."
-  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi:22:51
-
- 22 |       if len(cur) > 0 { words = append(words, cur); cur = "" }
-    |                                                   ^
-
-help:
-  String literals must be properly closed with a `"`.

--- a/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
+++ b/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
@@ -19,7 +19,10 @@ fun fields(s: string): list<string> {
   while i < len(s) {
     let ch = substring(s, i, i + 1)
     if ch == " " || ch == "\t" || ch == "\n" {
-      if len(cur) > 0 { words = append(words, cur); cur = "" }
+      if len(cur) > 0 {
+        words = append(words, cur)
+        cur = ""
+      }
     } else {
       cur = cur + ch
     }

--- a/tests/rosetta/x/Mochi/bulls-and-cows.error
+++ b/tests/rosetta/x/Mochi/bulls-and-cows.error
@@ -1,8 +1,0 @@
-error[P999]: /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows.mochi:48:31: unexpected token "-" (expected PostfixExpr)
-  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows.mochi:48:31
-
- 48 |       if indexOf(seen, cg) != -1 {
-    |                               ^
-
-help:
-  Parse error occurred. Check syntax near this location.


### PR DESCRIPTION
## Summary
- update Swift backend to emit helper for `input()` and import Foundation for `now()`
- fix bulls-and-cows-player Rosetta program syntax
- remove obsolete error logs
- refresh Swift Rosetta checklist for newly compiling tasks

## Testing
- `go test -tags=slow ./compiler/x/swift -run TestSwiftCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a2b5cd7f88320ba473ea261bbe138