### PR TITLE
Improve Go backend variable handling

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -753,7 +753,7 @@ func compileProgram(lang string, env *types.Env, prog *parser.Program, root, src
 	case "smalltalk":
 		return smalltalkcode.New().Compile(prog)
 	case "st":
-		return stcode.New().Compile(prog)
+		return stcode.New(env).Compile(prog)
 	case "swift":
 		return swiftcode.New(env).Compile(prog)
 	case "zig":

--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4506,15 +4506,6 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	}
 
 	switch call.Func {
-	case "append":
-		if len(args) == 2 {
-			lt, ok1 := c.inferExprType(call.Args[0]).(types.ListType)
-			rt := c.inferExprType(call.Args[1])
-			if ok1 && equalTypes(lt.Elem, rt) && !isAny(lt.Elem) {
-				return fmt.Sprintf("append(%s, %s)", args[0], args[1]), nil
-			}
-		}
-		return fmt.Sprintf("append(%s)", argStr), nil
 	case "print":
 		c.imports["fmt"] = true
 		if len(call.Args) == 6 {

--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -194,6 +194,10 @@ func (c *Compiler) compileMainFunc(prog *parser.Program) error {
 // compileGlobalVarDecl emits a package-level variable declaration without
 // initialisation. The actual value will be assigned inside main.
 func (c *Compiler) compileGlobalVarDecl(s *parser.Statement) error {
+	oldBuf := c.buf
+	oldIndent := c.indent
+	c.buf = c.decls
+	c.indent = 0
 	switch {
 	case s.Let != nil:
 		name := sanitizeName(s.Let.Name)
@@ -262,6 +266,8 @@ func (c *Compiler) compileGlobalVarDecl(s *parser.Statement) error {
 			c.writeln(fmt.Sprintf("_ = %s", name))
 		}
 	}
+	c.buf = oldBuf
+	c.indent = oldIndent
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- write global var declarations in Go code using the declaration buffer
- fix build script to pass env into the ST compiler
- remove duplicate append case

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a2b750ba8832084511e0a046270d3