### PR TITLE
Fix Kotlin compiler casts for floats

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1174,11 +1174,17 @@ func (c *Compiler) postfix(p *parser.PostfixExpr) (string, error) {
 				}
 			}
 			typ := c.typeName(op.Cast.Type)
-			if typ == "Int" {
+			switch typ {
+			case "Int":
 				val = fmt.Sprintf("(%s).toInt()", val)
-			} else if typ == "String" {
+			case "Double":
+				val = fmt.Sprintf("(%s).toDouble()", val)
+			case "String":
 				val = fmt.Sprintf("%s.toString()", val)
-			} else {
+			case "Boolean":
+				c.use("toBool")
+				val = fmt.Sprintf("toBool(%s)", val)
+			default:
 				val = fmt.Sprintf("%s as %s", val, typ)
 			}
 		default:
@@ -1456,7 +1462,7 @@ func (c *Compiler) builtinCall(call *parser.CallExpr, args []string) (string, bo
 		}
 	case "now":
 		if len(args) == 0 {
-			return "System.nanoTime().toInt()", true
+			return "kotlin.math.abs(System.nanoTime().toInt())", true
 		}
 	case "append":
 		if len(args) == 2 {

--- a/tests/rosetta/out/Kotlin/100-prisoners.error
+++ b/tests/rosetta/out/Kotlin/100-prisoners.error
@@ -1,7 +1,0 @@
-run: exit status 1
-Results from 1000 trials with 10 prisoners:
-
-Exception in thread "main" java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Double (java.lang.Integer and java.lang.Double are in module java.base of loader 'bootstrap')
-	at _100_prisonersKt.doTrials(100-prisoners.kt:93)
-	at _100_prisonersKt.main(100-prisoners.kt:105)
-	at _100_prisonersKt.main(100-prisoners.kt)

--- a/tests/rosetta/out/Kotlin/100-prisoners.kt
+++ b/tests/rosetta/out/Kotlin/100-prisoners.kt
@@ -15,7 +15,7 @@ fun shuffle(xs: MutableList<Int>): MutableList<Int> {
     var arr = xs
     var i = 99
     while (i > 0) {
-        val j = System.nanoTime().toInt() % (i + 1)
+        val j = kotlin.math.abs(System.nanoTime().toInt()) % (i + 1)
         val tmp = arr[i]
         arr[i] = arr[j]
         arr[j] = tmp
@@ -67,9 +67,9 @@ fun doTrials(trials: Int, np: Int, strategy: String): Unit {
                 }
                 var d = 0
                 while (d < 50) {
-                    var n = System.nanoTime().toInt() % 100
+                    var n = kotlin.math.abs(System.nanoTime().toInt()) % 100
                     while (opened[n]) {
-                        n = System.nanoTime().toInt() % 100
+                        n = kotlin.math.abs(System.nanoTime().toInt()) % 100
                     }
                     opened[n] = true
                     if (drawers[n] == p) {
@@ -90,7 +90,7 @@ fun doTrials(trials: Int, np: Int, strategy: String): Unit {
         }
         t = t + 1
     }
-    val rf = (pardoned as Double) / (trials as Double) * 100.0
+    val rf = ((pardoned).toDouble()) / ((trials).toDouble()) * 100.0
     println("  strategy = " + strategy + "  pardoned = " + pardoned.toString() + " relative frequency = " + rf.toString() + "%")
 }
 

--- a/tests/rosetta/out/Kotlin/100-prisoners.out
+++ b/tests/rosetta/out/Kotlin/100-prisoners.out
@@ -1,0 +1,8 @@
+Results from 1000 trials with 10 prisoners:
+
+  strategy = random  pardoned = 2 relative frequency = 0.2%
+  strategy = optimal  pardoned = 345 relative frequency = 34.5%
+Results from 1000 trials with 100 prisoners:
+
+  strategy = random  pardoned = 0 relative frequency = 0.0%
+  strategy = optimal  pardoned = 321 relative frequency = 32.1%

--- a/tests/rosetta/out/Kotlin/README.md
+++ b/tests/rosetta/out/Kotlin/README.md
@@ -5,13 +5,13 @@ programs in `tests/rosetta/x/Mochi`. Each file has the expected
 runtime output in a matching `.out` file. Compilation or runtime
 failures are stored in a corresponding `.error` file.
 
-Compiled programs: 17/216
+Compiled programs: 18/216
 
 ## Program checklist
 - [x] 100-doors-2
 - [x] 100-doors-3
 - [x] 100-doors
-- [ ] 100-prisoners
+- [x] 100-prisoners
 - [ ] 15-puzzle-game
 - [ ] 15-puzzle-solver
 - [ ] 2048


### PR DESCRIPTION
## Summary
- improve cast handling in the Kotlin backend
- ensure the `now()` builtin returns a non-negative value
- regenerate Rosetta Kotlin output for `100-prisoners`
- update progress in Rosetta Kotlin README

## Testing
- `go test -tags=slow ./compiler/x/kotlin -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a2b4593e483208bdb0b4c812de3ae