### PR TITLE
Enhance Racket backend builtins

### DIFF
--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -334,9 +334,11 @@ func (c *Compiler) compileExpr(e *parser.Expr) (string, error) {
 			if ls || rs {
 				expr = fmt.Sprintf("(string-append %s %s)", l, r)
 				outStr = true
-			} else {
+			} else if ln && rn {
 				expr = fmt.Sprintf("(+ %s %s)", l, r)
-				outNum = ln && rn
+				outNum = true
+			} else {
+				expr = fmt.Sprintf("(if (and (string? %s) (string? %s)) (string-append %s %s) (+ %s %s))", l, r, l, r, l, r)
 			}
 		case "-", "*", "/":
 			expr = fmt.Sprintf("(%s %s %s)", op.op, l, r)
@@ -629,11 +631,21 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				return "", fmt.Errorf("str expects 1 arg")
 			}
 			return fmt.Sprintf("(number->string %s)", args[0]), nil
+		case "input":
+			if len(args) != 0 {
+				return "", fmt.Errorf("input expects no arg")
+			}
+			return "(read-line)", nil
 		case "exists":
 			if len(args) != 1 {
 				return "", fmt.Errorf("exists expects 1 arg")
 			}
 			return fmt.Sprintf("(not (null? %s))", args[0]), nil
+		case "now":
+			if len(args) != 0 {
+				return "", fmt.Errorf("now expects no arg")
+			}
+			return "(inexact->exact (round (* (current-inexact-milliseconds) 1000000)))", nil
 		case "json":
 			if len(args) != 1 {
 				return "", fmt.Errorf("json expects 1 arg")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,7 +31,7 @@ var mochiLexer = lexer.MustSimple([]lexer.SimpleRule{
 	{Name: "Int", Pattern: `\d+`},
 	{Name: "String", Pattern: `"(?:\\.|[^"])*"`},
 	{Name: "Punct", Pattern: `==|!=|<=|>=|&&|\|\||=>|:-|\.\.|[-+*/%=<>!|{}\[\](),.:]`},
-	{Name: "Whitespace", Pattern: `[ \t\n\r]+`},
+	{Name: "Whitespace", Pattern: `[ \t\n\r;]+`},
 })
 
 // --- Program Structure ---

--- a/scripts/compile_rosetta_racket.go
+++ b/scripts/compile_rosetta_racket.go
@@ -67,7 +67,19 @@ func main() {
 
 	for _, name := range tasks {
 		src := filepath.Join(root, "tests", "rosetta", "x", "Mochi", name+".mochi")
-		prog, err := parser.Parse(src)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			writeError(outDir, name, fmt.Sprintf("read: %v", err))
+			continue
+		}
+		// replace semicolons with newlines for simple statement separation
+		clean := bytes.ReplaceAll(data, []byte(";"), []byte("\n"))
+		tmpSrc := filepath.Join(os.TempDir(), name+".mochi")
+		if err := os.WriteFile(tmpSrc, clean, 0o644); err != nil {
+			writeError(outDir, name, fmt.Sprintf("tmp write: %v", err))
+			continue
+		}
+		prog, err := parser.Parse(tmpSrc)
 		if err != nil {
 			writeError(outDir, name, fmt.Sprintf("parse: %v", err))
 			continue


### PR DESCRIPTION
## Summary
- implement `now` and `input` builtins for the Racket backend
- allow dynamic string concatenation when the operand types are unknown
- treat `;` as whitespace in the parser
- pre-process rosetta tasks to replace `;` with newlines before parsing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a2b539b4c83208486704589054c27