### PR TITLE
Fix duplicate case in go compiler

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4506,15 +4506,6 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 	}
 
 	switch call.Func {
-	case "append":
-		if len(args) == 2 {
-			lt, ok1 := c.inferExprType(call.Args[0]).(types.ListType)
-			rt := c.inferExprType(call.Args[1])
-			if ok1 && equalTypes(lt.Elem, rt) && !isAny(lt.Elem) {
-				return fmt.Sprintf("append(%s, %s)", args[0], args[1]), nil
-			}
-		}
-		return fmt.Sprintf("append(%s)", argStr), nil
 	case "print":
 		c.imports["fmt"] = true
 		if len(call.Args) == 6 {


### PR DESCRIPTION
## Summary
- remove duplicated `append` case from Go compiler

## Testing
- `go test -tags slow -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a2b7219e48320806e3427bedc3064