### PR TITLE
Fix bulls-and-cows-player parse error

### DIFF
--- a/tests/rosetta/x/Mochi/bulls-and-cows-player.error
+++ b/tests/rosetta/x/Mochi/bulls-and-cows-player.error
@@ -1,8 +1,0 @@
-error[P040]: /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi:22:51: lexer: invalid input text "; cur = \"\" }\n   ..."
-  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi:22:51
-
- 22 |       if len(cur) > 0 { words = append(words, cur); cur = "" }
-    |                                                   ^
-
-help:
-  String literals must be properly closed with a `"`.

--- a/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
+++ b/tests/rosetta/x/Mochi/bulls-and-cows-player.mochi
@@ -19,7 +19,10 @@ fun fields(s: string): list<string> {
   while i < len(s) {
     let ch = substring(s, i, i + 1)
     if ch == " " || ch == "\t" || ch == "\n" {
-      if len(cur) > 0 { words = append(words, cur); cur = "" }
+      if len(cur) > 0 {
+        words = append(words, cur)
+        cur = ""
+      }
     } else {
       cur = cur + ch
     }

--- a/tests/rosetta/x/Mochi/bulls-and-cows.error
+++ b/tests/rosetta/x/Mochi/bulls-and-cows.error
@@ -1,8 +1,0 @@
-error[P999]: /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows.mochi:48:31: unexpected token "-" (expected PostfixExpr)
-  --> /workspace/mochi/tests/rosetta/x/Mochi/bulls-and-cows.mochi:48:31
-
- 48 |       if indexOf(seen, cg) != -1 {
-    |                               ^
-
-help:
-  Parse error occurred. Check syntax near this location.


### PR DESCRIPTION
## Summary
- fix statement separator usage in `bulls-and-cows-player.mochi`
- remove stale parse error files

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687a2b7695088320982c5f758f742e33