### PR TITLE
Add deterministic now() to TypeScript compiler

### DIFF
--- a/compiler/x/ts/compiler.go
+++ b/compiler/x/ts/compiler.go
@@ -2184,10 +2184,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 		}
 		return fmt.Sprintf("(%s)[0]", argStr), nil
 	case "now":
-		// performance.now() returns milliseconds as a float. Multiply
-		// by 1e6 so that `now()` is consistent with Go's UnixNano()
-		// and the interpreter which return nanoseconds.
-		return "performance.now() * 1000000", nil
+		// Use helper so tests can seed deterministic timestamps via
+		// the MOCHI_NOW_SEED environment variable, matching the
+		// behaviour of the Go runtime.
+		c.use("_now")
+		return "_now()", nil
 	case "json":
 		c.use("_json")
 		return fmt.Sprintf("console.log(_json(%s))", argStr), nil

--- a/compiler/x/ts/rosetta_golden_test.go
+++ b/compiler/x/ts/rosetta_golden_test.go
@@ -3,125 +3,124 @@
 package tscode_test
 
 import (
-    "bytes"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
-    "testing"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 
-    tscode "mochi/compiler/x/ts"
-    "mochi/parser"
-    "mochi/types"
+	tscode "mochi/compiler/x/ts"
+	"mochi/parser"
+	"mochi/types"
 )
 
 func shouldUpdateRosetta() bool {
-    if v, ok := os.LookupEnv("UPDATE"); ok && (v == "1" || v == "true") {
-        return true
-    }
-    return false
+	if v, ok := os.LookupEnv("UPDATE"); ok && (v == "1" || v == "true") {
+		return true
+	}
+	return false
 }
 
 func findRepoRoot(t *testing.T) string {
-    dir, err := os.Getwd()
-    if err != nil {
-        t.Fatal(err)
-    }
-    for i := 0; i < 10; i++ {
-        if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-            return dir
-        }
-        parent := filepath.Dir(dir)
-        if parent == dir {
-            break
-        }
-        dir = parent
-    }
-    t.Fatal("go.mod not found")
-    return ""
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
 }
 
 func runRosettaTaskGolden(t *testing.T, name string) {
-    if err := tscode.EnsureDeno(); err != nil {
-        t.Skipf("deno not installed: %v", err)
-    }
-    root := findRepoRoot(t)
-    script := exec.Command("go", "run", "-tags=archive,slow", "./scripts/compile_rosetta_ts.go")
-    script.Env = append(os.Environ(), "GOTOOLCHAIN=local", "TASKS="+name)
-    script.Dir = root
-    if out, err := script.CombinedOutput(); err != nil {
-        t.Fatalf("compile script error: %v\n%s", err, out)
-    }
+	if err := tscode.EnsureDeno(); err != nil {
+		t.Skipf("deno not installed: %v", err)
+	}
+	root := findRepoRoot(t)
+	script := exec.Command("go", "run", "-tags=archive,slow", "./scripts/compile_rosetta_ts.go")
+	script.Env = append(os.Environ(), "GOTOOLCHAIN=local", "MOCHI_NOW_SEED=1", "TASKS="+name)
+	script.Dir = root
+	if out, err := script.CombinedOutput(); err != nil {
+		t.Fatalf("compile script error: %v\n%s", err, out)
+	}
 
-    errFile := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".error")
-    if b, err := os.ReadFile(errFile); err == nil {
-        t.Skipf("typescript run failed:\n%s", b)
-        return
-    }
+	errFile := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".error")
+	if b, err := os.ReadFile(errFile); err == nil {
+		t.Skipf("typescript run failed:\n%s", b)
+		return
+	}
 
-    src := filepath.Join(root, "tests", "rosetta", "x", "Mochi", name+".mochi")
-    prog, err := parser.Parse(src)
-    if err != nil {
-        t.Fatalf("parse error: %v", err)
-    }
-    env := types.NewEnv(nil)
-    if errs := types.Check(prog, env); len(errs) > 0 {
-        t.Fatalf("type error: %v", errs[0])
-    }
-    c := tscode.New(env, root)
-    code, err := c.Compile(prog)
-    if err != nil {
-        t.Fatalf("compile error: %v", err)
-    }
-    codeWant := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".ts")
-    if shouldUpdateRosetta() {
-        _ = os.WriteFile(codeWant, code, 0644)
-    } else if _, err := os.Stat(codeWant); err != nil {
-        t.Fatalf("read golden: %v", err)
-    }
+	src := filepath.Join(root, "tests", "rosetta", "x", "Mochi", name+".mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type error: %v", errs[0])
+	}
+	c := tscode.New(env, root)
+	code, err := c.Compile(prog)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	codeWant := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".ts")
+	if shouldUpdateRosetta() {
+		_ = os.WriteFile(codeWant, code, 0644)
+	} else if _, err := os.Stat(codeWant); err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
 
-    dir := t.TempDir()
-    file := filepath.Join(dir, "main.ts")
-    if err := os.WriteFile(file, code, 0644); err != nil {
-        t.Fatalf("write error: %v", err)
-    }
-    cmd := exec.Command("deno", "run", "--quiet", "--allow-net", "--allow-read", file)
-    cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
-    if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi")+".in"); err == nil {
-        cmd.Stdin = bytes.NewReader(data)
-    }
-    out, err := cmd.CombinedOutput()
-    if err != nil {
-        t.Skipf("run error: %v\n%s", err, out)
-        return
-    }
-    gotOut := bytes.TrimSpace(out)
-    outWant := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".out")
-    if shouldUpdateRosetta() {
-        _ = os.WriteFile(outWant, append(gotOut, '\n'), 0644)
-    } else if wantOut, err := os.ReadFile(outWant); err == nil {
-        if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
-            t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", name, gotOut, bytes.TrimSpace(wantOut))
-        }
-    }
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.ts")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	cmd := exec.Command("deno", "run", "--quiet", "--allow-net", "--allow-read", file)
+	cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system", "MOCHI_NOW_SEED=1")
+	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+		cmd.Stdin = bytes.NewReader(data)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("run error: %v\n%s", err, out)
+		return
+	}
+	gotOut := bytes.TrimSpace(out)
+	outWant := filepath.Join(root, "tests", "rosetta", "out", "TypeScript", name+".out")
+	if shouldUpdateRosetta() {
+		_ = os.WriteFile(outWant, append(gotOut, '\n'), 0644)
+	} else if wantOut, err := os.ReadFile(outWant); err == nil {
+		if !bytes.Equal(gotOut, bytes.TrimSpace(wantOut)) {
+			t.Errorf("output mismatch for %s.out\n\n--- Got ---\n%s\n\n--- Want ---\n%s", name, gotOut, bytes.TrimSpace(wantOut))
+		}
+	}
 }
 
 func TestTSCompiler_Rosetta_Golden(t *testing.T) {
-    if err := tscode.EnsureDeno(); err != nil {
-        t.Skip("deno not installed")
-    }
-    root := findRepoRoot(t)
-    files, err := filepath.Glob(filepath.Join(root, "tests", "rosetta", "x", "Mochi", "*.mochi"))
-    if err != nil {
-        t.Fatalf("glob: %v", err)
-    }
-    max := 3
-    if len(files) < max {
-        max = len(files)
-    }
-    for _, f := range files[:max] {
-        name := strings.TrimSuffix(filepath.Base(f), ".mochi")
-        t.Run(name, func(t *testing.T) { runRosettaTaskGolden(t, name) })
-    }
+	if err := tscode.EnsureDeno(); err != nil {
+		t.Skip("deno not installed")
+	}
+	root := findRepoRoot(t)
+	files, err := filepath.Glob(filepath.Join(root, "tests", "rosetta", "x", "Mochi", "*.mochi"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	max := 3
+	if len(files) < max {
+		max = len(files)
+	}
+	for _, f := range files[:max] {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		t.Run(name, func(t *testing.T) { runRosettaTaskGolden(t, name) })
+	}
 }
-

--- a/compiler/x/ts/runtime.go
+++ b/compiler/x/ts/runtime.go
@@ -174,6 +174,19 @@ const (
 		"  return v as Iterable<T>;\n" +
 		"}\n"
 
+	helperNow = "let _nowSeed = 0;\n" +
+		"let _nowSeeded = false;\n" +
+		"{ const s = Deno.env.get('MOCHI_NOW_SEED');\n" +
+		"  if (s) { const v = parseInt(s, 10);\n" +
+		"    if (!isNaN(v)) { _nowSeed = v; _nowSeeded = true; } } }\n" +
+		"function _now(): number {\n" +
+		"  if (_nowSeeded) {\n" +
+		"    _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647;\n" +
+		"    return _nowSeed;\n" +
+		"  }\n" +
+		"  return performance.now() * 1000000;\n" +
+		"}\n"
+
 	helperGenText = "function _gen_text(prompt: string, model: string | null, params: unknown | null): string {\n" +
 		"  // TODO: integrate with your preferred LLM\n" +
 		"  return prompt;\n" +
@@ -561,6 +574,7 @@ var helperMap = map[string]string{
 	"_values":      helperValues,
 	"_input":       helperInput,
 	"_iter":        helperIter,
+	"_now":         helperNow,
 	"_gen_text":    helperGenText,
 	"_gen_embed":   helperGenEmbed,
 	"_gen_struct":  helperGenStruct,

--- a/scripts/compile_rosetta_ts.go
+++ b/scripts/compile_rosetta_ts.go
@@ -3,111 +3,110 @@
 package main
 
 import (
-    "bytes"
-    "fmt"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
-    tscode "mochi/compiler/x/ts"
-    "mochi/parser"
-    "mochi/types"
+	tscode "mochi/compiler/x/ts"
+	"mochi/parser"
+	"mochi/types"
 )
 
 func repoRoot() string {
-    dir, _ := os.Getwd()
-    for i := 0; i < 10; i++ {
-        if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-            return dir
-        }
-        p := filepath.Dir(dir)
-        if p == dir {
-            break
-        }
-        dir = p
-    }
-    return dir
+	dir, _ := os.Getwd()
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		p := filepath.Dir(dir)
+		if p == dir {
+			break
+		}
+		dir = p
+	}
+	return dir
 }
 
 func writeError(dir, name, msg string) {
-    _ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, name+".error"), []byte(msg), 0o644)
 }
 
 func main() {
-    os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
-    defer os.Unsetenv("MOCHI_HEADER_TIME")
+	os.Setenv("MOCHI_HEADER_TIME", "2006-01-02T15:04:05Z")
+	defer os.Unsetenv("MOCHI_HEADER_TIME")
 
-    if err := tscode.EnsureDeno(); err != nil {
-        fmt.Fprintln(os.Stderr, err)
-        os.Exit(1)
-    }
+	if err := tscode.EnsureDeno(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
-    root := repoRoot()
-    outDir := filepath.Join(root, "tests", "rosetta", "out", "TypeScript")
-    _ = os.MkdirAll(outDir, 0o755)
+	root := repoRoot()
+	outDir := filepath.Join(root, "tests", "rosetta", "out", "TypeScript")
+	_ = os.MkdirAll(outDir, 0o755)
 
-    var tasks []string
-    if env := os.Getenv("TASKS"); env != "" {
-        for _, part := range strings.Split(env, ",") {
-            n := strings.TrimSpace(part)
-            if n != "" {
-                tasks = append(tasks, n)
-            }
-        }
-    } else {
-        pattern := filepath.Join(root, "tests", "rosetta", "x", "Mochi", "*.mochi")
-        files, _ := filepath.Glob(pattern)
-        for _, f := range files {
-            tasks = append(tasks, strings.TrimSuffix(filepath.Base(f), ".mochi"))
-        }
-    }
+	var tasks []string
+	if env := os.Getenv("TASKS"); env != "" {
+		for _, part := range strings.Split(env, ",") {
+			n := strings.TrimSpace(part)
+			if n != "" {
+				tasks = append(tasks, n)
+			}
+		}
+	} else {
+		pattern := filepath.Join(root, "tests", "rosetta", "x", "Mochi", "*.mochi")
+		files, _ := filepath.Glob(pattern)
+		for _, f := range files {
+			tasks = append(tasks, strings.TrimSuffix(filepath.Base(f), ".mochi"))
+		}
+	}
 
-    for _, name := range tasks {
-        src := filepath.Join(root, "tests", "rosetta", "x", "Mochi", name+".mochi")
-        prog, err := parser.Parse(src)
-        if err != nil {
-            writeError(outDir, name, fmt.Sprintf("parse: %v", err))
-            continue
-        }
-        env := types.NewEnv(nil)
-        if errs := types.Check(prog, env); len(errs) > 0 {
-            writeError(outDir, name, fmt.Sprintf("type: %v", errs[0]))
-            continue
-        }
-        c := tscode.New(env, root)
-        code, err := c.Compile(prog)
-        if err != nil {
-            writeError(outDir, name, fmt.Sprintf("compile: %v", err))
-            continue
-        }
-        codeFile := filepath.Join(outDir, name+".ts")
-        if err := os.WriteFile(codeFile, code, 0o644); err != nil {
-            fmt.Fprintln(os.Stderr, "write code", name, err)
-            continue
-        }
-        tmp := filepath.Join(os.TempDir(), name+".ts")
-        if err := os.WriteFile(tmp, code, 0o644); err != nil {
-            writeError(outDir, name, fmt.Sprintf("tmp write: %v", err))
-            os.Remove(filepath.Join(outDir, name+".out"))
-            continue
-        }
-        cmd := exec.Command("deno", "run", "--quiet", "--allow-net", "--allow-read", tmp)
-        cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system")
-        if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi")+".in"); err == nil {
-            cmd.Stdin = bytes.NewReader(data)
-        }
-        out, err := cmd.CombinedOutput()
-        if err != nil {
-            writeError(outDir, name, fmt.Sprintf("run: %v\n%s", err, out))
-            os.Remove(filepath.Join(outDir, name+".out"))
-            continue
-        }
-        os.Remove(filepath.Join(outDir, name+".error"))
-        cleaned := append(bytes.TrimSpace(out), '\n')
-        if err := os.WriteFile(filepath.Join(outDir, name+".out"), cleaned, 0o644); err != nil {
-            fmt.Fprintln(os.Stderr, "write out", name, err)
-        }
-    }
+	for _, name := range tasks {
+		src := filepath.Join(root, "tests", "rosetta", "x", "Mochi", name+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			writeError(outDir, name, fmt.Sprintf("parse: %v", err))
+			continue
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			writeError(outDir, name, fmt.Sprintf("type: %v", errs[0]))
+			continue
+		}
+		c := tscode.New(env, root)
+		code, err := c.Compile(prog)
+		if err != nil {
+			writeError(outDir, name, fmt.Sprintf("compile: %v", err))
+			continue
+		}
+		codeFile := filepath.Join(outDir, name+".ts")
+		if err := os.WriteFile(codeFile, code, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write code", name, err)
+			continue
+		}
+		tmp := filepath.Join(os.TempDir(), name+".ts")
+		if err := os.WriteFile(tmp, code, 0o644); err != nil {
+			writeError(outDir, name, fmt.Sprintf("tmp write: %v", err))
+			os.Remove(filepath.Join(outDir, name+".out"))
+			continue
+		}
+		cmd := exec.Command("deno", "run", "--quiet", "--allow-net", "--allow-read", tmp)
+		cmd.Env = append(os.Environ(), "DENO_TLS_CA_STORE=system", "MOCHI_NOW_SEED=1")
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			writeError(outDir, name, fmt.Sprintf("run: %v\n%s", err, out))
+			os.Remove(filepath.Join(outDir, name+".out"))
+			continue
+		}
+		os.Remove(filepath.Join(outDir, name+".error"))
+		cleaned := append(bytes.TrimSpace(out), '\n')
+		if err := os.WriteFile(filepath.Join(outDir, name+".out"), cleaned, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write out", name, err)
+		}
+	}
 }
-

--- a/tests/rosetta/out/TypeScript/README.md
+++ b/tests/rosetta/out/TypeScript/README.md
@@ -1,4 +1,4 @@
-# Rosetta TypeScript Output (8/239 compiled and run)
+# Rosetta TypeScript Output (11/239 compiled and run)
 
 This directory holds TypeScript source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -11,9 +11,9 @@ This directory holds TypeScript source code generated from the real Mochi progra
 - [x] 15-puzzle-solver
 - [x] 2048
 - [ ] 21-game
-- [ ] 24-game-solve
-- [ ] 24-game
-- [ ] 4-rings-or-4-squares-puzzle
+- [x] 24-game-solve
+- [x] 24-game
+- [x] 4-rings-or-4-squares-puzzle
 - [x] 9-billion-names-of-god-the-integer
 - [ ] 99-bottles-of-beer-2
 - [ ] 99-bottles-of-beer


### PR DESCRIPTION
## Summary
- implement `_now` helper and MOCHI_NOW_SEED support
- compile `now()` calls using the helper
- ensure Rosetta tests pass `MOCHI_NOW_SEED`
- forward the env var in the TypeScript Rosetta compile script
- document additional passing programs in TypeScript Rosetta README

## Testing
- `go test ./compiler/x/ts -run TestTSCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a44be60ac8320ba614415bdf0800a