### PR TITLE
Fix Elixir module attribute casing

### DIFF
--- a/compiler/x/ex/TASKS.md
+++ b/compiler/x/ex/TASKS.md
@@ -76,3 +76,7 @@ fails if any `.error` file is present.
 - `len` and `exists` now handle `option` values without relying on `_length`
   or `_exists`. When the underlying type is known the compiler emits direct
   Elixir code with a `nil` check.
+
+## Rosetta Improvements (2025-07-18 15:56)
+- Module attribute names are now lowercased. This fixes compilation errors for
+  tasks defining constants like `SIZE` or `THRESHOLD`.

--- a/compiler/x/ex/expr.go
+++ b/compiler/x/ex/expr.go
@@ -564,8 +564,8 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 				}
 			}
 		}
-		if _, ok := c.attrs[p.Selector.Root]; ok {
-			name = "@" + name
+		if _, ok := c.attrs[attrName(p.Selector.Root)]; ok {
+			name = "@" + attrName(p.Selector.Root)
 		}
 		if len(p.Selector.Tail) > 0 {
 			name += "." + strings.Join(p.Selector.Tail, ".")


### PR DESCRIPTION
## Summary
- lower case module attribute names in Elixir backend
- document Rosetta improvement in tasks list

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a6baa3c7883208a2430b4c7d92823