### PR TITLE
Update Fortran tasks doc

### DIFF
--- a/compiler/x/fortran/TASKS.md
+++ b/compiler/x/fortran/TASKS.md
@@ -67,3 +67,4 @@
 - [x] Support query compilation with joins and group-by for TPC-H `q1.mochi`.
 - [x] Improve handling of automatic imports for external functions.
 - [ ] Continue refining generated code formatting.
+- [ ] Support list parameters without explicit declarations.


### PR DESCRIPTION
## Summary
- note remaining work to support list parameters without explicit type

## Testing
- `go test ./compiler/x/fortran -run Rosetta -tags slow -count=1` *(fails: gfortran missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a6c04d5d88320b54162aa9cc5e21f