### PR TITLE
Improve PHP int division

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -556,6 +556,15 @@ func (c *Compiler) compileBinary(b *parser.BinaryExpr) (string, error) {
 			} else {
 				leftType = types.AnyType{}
 			}
+		case "/":
+			if _, ok := leftType.(types.IntType); ok {
+				if _, ok := rightType.(types.IntType); ok {
+					res = fmt.Sprintf("intdiv(%s, %s)", res, r)
+					left = res
+					leftType = types.IntType{}
+					continue
+				}
+			}
 		default:
 			leftType = types.AnyType{}
 		}


### PR DESCRIPTION
## Summary
- handle integer division in the PHP backend

## Testing
- `go test ./compiler/x/php -run TestPHPCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a6c5c312c8320bee92ac63c2bb70f