### PR TITLE
Fix Pascal compile imports

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -113,7 +113,7 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 	c.writeln(fmt.Sprintf("program %s;", name))
 	c.writeln("{$mode objfpc}")
 	c.writeln("{$modeswitch nestedprocvars}")
-	c.writeln("uses SysUtils, fgl, fphttpclient, Classes, Variants, fpjson, jsonparser, fpjsonrtti;")
+	c.writeln("uses SysUtils, fgl, Classes, Variants;")
 	c.writeln("")
 	c.writeln("type")
 	c.indent++

--- a/tests/rosetta/out/Pascal/README.md
+++ b/tests/rosetta/out/Pascal/README.md
@@ -1,4 +1,4 @@
-# Rosetta Pascal Output (4/253 compiled and run)
+# Rosetta Pascal Output (26/253 compiled and run)
 
 This directory holds Pascal source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -10,7 +10,7 @@ This directory holds Pascal source code generated from the Mochi programs in `te
 - [ ] 15-puzzle-game
 - [ ] 15-puzzle-solver
 - [ ] 2048
-- [x] 21-game
+- [ ] 21-game
 - [ ] 24-game-solve
 - [ ] 24-game
 - [ ] 4-rings-or-4-squares-puzzle


### PR DESCRIPTION
## Summary
- simplify Pascal `uses` clause to avoid missing units
- update Rosetta Pascal checklist

## Testing
- `go test ./compiler/x/pascal -tags=slow -run TestPascalCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a6c813738832080a137f60ddad260