### PR TITLE
Add parseIntStr and indexOf support for Smalltalk compiler

### DIFF
--- a/tests/rosetta/out/Smalltalk/README.md
+++ b/tests/rosetta/out/Smalltalk/README.md
@@ -1,4 +1,4 @@
-# Rosetta Smalltalk Output (99/216 compiled and run)
+# Rosetta Smalltalk Output (100/216 compiled and run)
 
 This directory holds Smalltalk source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -217,5 +217,5 @@ This directory holds Smalltalk source code generated from the real Mochi program
 - [ ] csv-to-html-translation-3
 - [ ] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
-- [ ] cusip
+- [x] cusip
 - [ ] md5

--- a/types/check.go
+++ b/types/check.go
@@ -464,6 +464,11 @@ func Check(prog *parser.Program, env *Env) []error {
 		Return: StringType{},
 		Pure:   true,
 	}, false)
+	env.SetVar("parseIntStr", FuncType{
+		Params: []Type{StringType{}},
+		Return: IntType{},
+		Pure:   true,
+	}, false)
 	env.SetVar("int", FuncType{
 		Params: []Type{AnyType{}},
 		Return: IntType{},
@@ -2420,43 +2425,44 @@ func isNumeric(t Type) bool {
 }
 
 var builtinArity = map[string]int{
-	"now":       0,
-	"input":     0,
-	"json":      1,
-	"to_json":   1,
-	"str":       1,
-	"int":       1,
-	"upper":     1,
-	"lower":     1,
-	"reverse":   1,
-	"distinct":  1,
-	"trim":      1,
-	"contains":  2,
-	"split":     2,
-	"join":      2,
-	"eval":      1,
-	"len":       1,
-	"count":     1,
-	"exists":    1,
-	"avg":       1,
-	"abs":       1,
-	"ceil":      1,
-	"floor":     1,
-	"sum":       1,
-	"min":       1,
-	"max":       1,
-	"keys":      1,
-	"values":    1,
-	"reduce":    3,
-	"append":    2,
-	"push":      2,
-	"first":     1,
-	"substring": 3,
-	"padStart":  3,
-	"indexOf":   2,
-	"sha256":    1,
-	"num":       1,
-	"denom":     1,
+	"now":         0,
+	"input":       0,
+	"json":        1,
+	"to_json":     1,
+	"str":         1,
+	"parseIntStr": 1,
+	"int":         1,
+	"upper":       1,
+	"lower":       1,
+	"reverse":     1,
+	"distinct":    1,
+	"trim":        1,
+	"contains":    2,
+	"split":       2,
+	"join":        2,
+	"eval":        1,
+	"len":         1,
+	"count":       1,
+	"exists":      1,
+	"avg":         1,
+	"abs":         1,
+	"ceil":        1,
+	"floor":       1,
+	"sum":         1,
+	"min":         1,
+	"max":         1,
+	"keys":        1,
+	"values":      1,
+	"reduce":      3,
+	"append":      2,
+	"push":        2,
+	"first":       1,
+	"substring":   3,
+	"padStart":    3,
+	"indexOf":     2,
+	"sha256":      1,
+	"num":         1,
+	"denom":       1,
 }
 
 func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
@@ -2466,7 +2472,7 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 			return errArgCount(pos, name, 0, len(args))
 		}
 		return nil
-	case "json", "to_json", "str", "upper", "lower", "int", "eval":
+	case "json", "to_json", "str", "upper", "lower", "int", "eval", "parseIntStr":
 		if len(args) != 1 {
 			return errArgCount(pos, name, 1, len(args))
 		}
@@ -2481,6 +2487,12 @@ func checkBuiltinCall(name string, args []Type, pos lexer.Position) error {
 				// ok
 			default:
 				return fmt.Errorf("int() expects numeric or string")
+			}
+		case "parseIntStr":
+			if _, ok := args[0].(StringType); !ok {
+				if _, ok := args[0].(AnyType); !ok {
+					return errArgTypeMismatch(pos, 0, StringType{}, args[0])
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- update Smalltalk compiler to handle `parseIntStr` and `indexOf`
- adjust index operations and modulo operator
- mark `cusip` as compiled in Rosetta Smalltalk README
- register `parseIntStr` as builtin in type checker

## Testing
- `go vet ./...`
- `go test ./... -run=^$`

------
https://chatgpt.com/codex/tasks/task_e_687a6cc2b41c8320bf9efa3ce3badcb2