### PR TITLE
Improve Zig compiler empty list handling

### DIFF
--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -482,7 +482,7 @@ func canInferType(e *parser.Expr, t types.Type) bool {
 		return false
 	}
 	if isIntLiteralExpr(e) || isFloatLiteralExpr(e) || isBoolLiteralExpr(e) || isStringLiteralExprRaw(e) {
-		if isInt(t) || isFloat(t) || isBool(t) || isString(t) {
+		if isInt(t) || isInt64(t) || isFloat(t) || isBool(t) || isString(t) {
 			return false
 		}
 	}

--- a/tests/rosetta/out/Zig/README.md
+++ b/tests/rosetta/out/Zig/README.md
@@ -1,4 +1,4 @@
-# Rosetta Zig Output (10/239 compiled and run)
+# Rosetta Zig Output (10/264 compiled and run)
 
 This directory holds Zig source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. A checkbox indicates the program compiled and executed successfully. Failing programs have a `.error` file.
 
@@ -211,6 +211,7 @@ This directory holds Zig source code generated from the real Mochi programs in `
 - [ ] cistercian-numerals
 - [ ] compiler-virtual-machine-interpreter
 - [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
+- [ ] compound-data-type
 - [ ] concurrent-computing-1
 - [ ] concurrent-computing-2
 - [ ] concurrent-computing-3
@@ -232,13 +233,37 @@ This directory holds Zig source code generated from the real Mochi programs in `
 - [ ] constrained-random-points-on-a-circle-1
 - [ ] constrained-random-points-on-a-circle-2
 - [ ] continued-fraction
+- [ ] convert-decimal-number-to-rational
+- [ ] convert-seconds-to-compound-duration
+- [ ] convex-hull
+- [ ] conways-game-of-life
+- [ ] copy-a-string-1
+- [ ] copy-a-string-2
+- [ ] copy-stdin-to-stdout-1
+- [ ] copy-stdin-to-stdout-2
+- [ ] count-in-factors
+- [ ] count-in-octal-1
+- [ ] count-in-octal-2
+- [ ] count-in-octal-3
+- [ ] count-in-octal-4
+- [ ] count-occurrences-of-a-substring
+- [ ] count-the-coins-1
+- [ ] count-the-coins-2
+- [ ] cramers-rule
 - [ ] crc-32-1
 - [ ] crc-32-2
+- [ ] create-a-file-on-magnetic-tape
+- [ ] create-a-file
+- [ ] create-a-two-dimensional-array-at-runtime-1
+- [ ] create-an-html-table
+- [ ] create-an-object-at-a-given-address
 - [ ] csv-data-manipulation
 - [ ] csv-to-html-translation-1
 - [ ] csv-to-html-translation-2
 - [x] csv-to-html-translation-3
 - [x] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
+- [ ] cuban-primes
+- [ ] cullen-and-woodall-numbers
 - [ ] cusip
 - [ ] md5


### PR DESCRIPTION
## Summary
- allow `canInferType` to consider int64 literals so variables get explicit types
- generate valid slice literals using `[_]` syntax for empty lists
- regenerate Zig Rosetta README checklist

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a6cdfc1c08320a805ad9a28e03617