### PR TITLE
Add Mochi solution for Rosetta DNS-query task

### DIFF
--- a/tests/rosetta/x/Mochi/DNS-query.mochi
+++ b/tests/rosetta/x/Mochi/DNS-query.mochi
@@ -1,0 +1,10 @@
+import go "net" as net auto
+
+let res: list<any> = net.LookupHost("www.kame.net")
+let addrs = res[0]
+let err = res[1]
+if err == nil {
+  print(str(addrs))
+} else {
+  print(err)
+}


### PR DESCRIPTION
## Summary
- download task 238 from Rosetta Code to get the Go version
- implement equivalent Mochi program using Go FFI

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/DNS-query.mochi`

------
https://chatgpt.com/codex/tasks/task_e_687a6d4690cc83209e0450be020547e9