### PR TITLE
Add Rosetta Date-format task

### DIFF
--- a/runtime/ffi/go/testpkg/timefmt.go
+++ b/runtime/ffi/go/testpkg/timefmt.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "time"
+
+func TodayISO() string {
+	return time.Now().Format("2006-01-02")
+}
+
+func TodayLong() string {
+	return time.Now().Format("Monday, January 2, 2006")
+}

--- a/tests/rosetta/x/Mochi/date-format.mochi
+++ b/tests/rosetta/x/Mochi/date-format.mochi
@@ -1,0 +1,4 @@
+import go "mochi/runtime/ffi/go/testpkg" as testpkg auto
+
+print(testpkg.TodayISO())
+print(testpkg.TodayLong())


### PR DESCRIPTION
## Summary
- add FFI helpers in testpkg for date formatting
- implement Rosetta `Date-format` task in Mochi using Go FFI

## Testing
- `go vet ./runtime/ffi/go/testpkg/...`
- `go test ./runtime/ffi/go/testpkg -run TestDummy`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/date-format.mochi`

------
https://chatgpt.com/codex/tasks/task_e_687a6d61c844832094fc1fa4173eb9bd