### PR TITLE
Fix interactive clojure tasks

### DIFF
--- a/scripts/compile_rosetta_clj.go
+++ b/scripts/compile_rosetta_clj.go
@@ -42,6 +42,11 @@ func main() {
 	outDir := filepath.Join(root, "tests", "rosetta", "out", "Clojure")
 	_ = os.MkdirAll(outDir, 0o755)
 
+	interactive := map[string]bool{
+		"15-puzzle-game": true,
+		"21-game":        true,
+	}
+
 	var tasks []string
 	if env := os.Getenv("TASKS"); env != "" {
 		for _, part := range strings.Split(env, ",") {
@@ -80,6 +85,12 @@ func main() {
 			fmt.Fprintln(os.Stderr, "write code", name, err)
 			continue
 		}
+		if interactive[name] {
+			os.Remove(filepath.Join(outDir, name+".error"))
+			os.Remove(filepath.Join(outDir, name+".out"))
+			continue
+		}
+
 		tmp := filepath.Join(os.TempDir(), name+".clj")
 		if err := os.WriteFile(tmp, code, 0o644); err != nil {
 			writeError(outDir, name, fmt.Sprintf("tmp write: %v", err))

--- a/tests/rosetta/out/Clojure/15-puzzle-game.error
+++ b/tests/rosetta/out/Clojure/15-puzzle-game.error
@@ -1,8 +1,0 @@
-parse: error[P999]: /workspace/mochi/tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18: unexpected token "!" (expected PostfixExpr)
-  --> /workspace/mochi/tests/rosetta/x/Mochi/15-puzzle-game.mochi:108:18
-
-108 |   while !quit && !isSolved() {
-    |                  ^
-
-help:
-  Parse error occurred. Check syntax near this location.

--- a/tests/rosetta/x/Mochi/15-puzzle-game.mochi
+++ b/tests/rosetta/x/Mochi/15-puzzle-game.mochi
@@ -105,7 +105,7 @@ fun playOneMove() {
 
 fun play() {
   print("Starting board:")
-  while (!quit && (!isSolved())) {
+  while !quit && isSolved() == false {
     print("")
     printBoard()
     playOneMove()


### PR DESCRIPTION
## Summary
- prevent Rosetta compilation script from running interactive tasks
- remove obsolete error file for 15-puzzle-game

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a7756aa7083208a3739e79e79bf43