### PR TITLE
Improve PHP compiler integer handling

### DIFF
--- a/archived/compiler/x/fs/util.go
+++ b/archived/compiler/x/fs/util.go
@@ -295,7 +295,7 @@ func intLiteral(e *parser.Expr) (int, bool) {
 	if len(p.Ops) != 0 || p.Target.Lit == nil || p.Target.Lit.Int == nil {
 		return 0, false
 	}
-	v := *p.Target.Lit.Int
+	v := int(*p.Target.Lit.Int)
 	if negate {
 		v = -v
 	}

--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -974,6 +974,11 @@ func (c *Compiler) compileCall(call *parser.CallExpr) (string, error) {
 			return "", fmt.Errorf("substring expects 3 args")
 		}
 		return fmt.Sprintf("substr(%s, %s, %s)", args[0], args[1], args[2]), nil
+	case "indexOf":
+		if len(args) != 2 {
+			return "", fmt.Errorf("indexOf expects 2 args")
+		}
+		return fmt.Sprintf("strpos(%s, %s)", args[0], args[1]), nil
 	case "str":
 		if len(args) != 1 {
 			return "", fmt.Errorf("str expects 1 arg")

--- a/compiler/x/php/helpers.go
+++ b/compiler/x/php/helpers.go
@@ -14,6 +14,8 @@ import (
 var reservedNames = map[string]struct{}{
 	"shuffle": {},
 	"this":    {},
+	"ord":     {},
+	"chr":     {},
 }
 
 func sanitizeName(name string) string {

--- a/tests/rosetta/out/Php/README.md
+++ b/tests/rosetta/out/Php/README.md
@@ -1,4 +1,4 @@
-# Rosetta PHP Output (8/253 compiled and run)
+# Rosetta PHP Output (8/264 compiled and run)
 
 This directory holds PHP source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -246,13 +246,24 @@ This directory holds PHP source code generated from the real Mochi programs in `
 - [ ] count-in-octal-2
 - [ ] count-in-octal-3
 - [ ] count-in-octal-4
+- [ ] count-occurrences-of-a-substring
+- [ ] count-the-coins-1
+- [ ] count-the-coins-2
+- [ ] cramers-rule
 - [ ] crc-32-1
 - [ ] crc-32-2
+- [ ] create-a-file-on-magnetic-tape
+- [ ] create-a-file
+- [ ] create-a-two-dimensional-array-at-runtime-1
+- [ ] create-an-html-table
+- [ ] create-an-object-at-a-given-address
 - [ ] csv-data-manipulation
 - [ ] csv-to-html-translation-1
 - [ ] csv-to-html-translation-2
 - [ ] csv-to-html-translation-3
 - [ ] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
+- [ ] cuban-primes
+- [ ] cullen-and-woodall-numbers
 - [ ] cusip
 - [ ] md5

--- a/tests/rosetta/out/Php/bitwise-io-1.error
+++ b/tests/rosetta/out/Php/bitwise-io-1.error
@@ -1,0 +1,7 @@
+run: exit status 255
+
+Fatal error: Uncaught Error: Cannot use object of type Writer as array in /tmp/bitwise-io-1.php:106
+Stack trace:
+#0 /tmp/bitwise-io-1.php(108): ExampleWriter_WriteBits()
+#1 {main}
+  thrown in /tmp/bitwise-io-1.php on line 106

--- a/tests/rosetta/out/Php/bitwise-io-1.php
+++ b/tests/rosetta/out/Php/bitwise-io-1.php
@@ -1,0 +1,109 @@
+<?php
+function pow2($n) {
+    $v = 1;
+    $i = 0;
+    while ($i < $n) {
+        $v = $v * 2;
+        $i = $i + 1;
+    }
+    return $v;
+}
+function lshift($x, $n) {
+    return $x * pow2($n);
+}
+function rshift($x, $n) {
+    return intdiv($x, pow2($n));
+}
+class Writer {
+    public $order;
+    public $bits;
+    public $nbits;
+    public $data;
+    public function __construct($fields = []) {
+        $this->order = $fields['order'] ?? null;
+        $this->bits = $fields['bits'] ?? null;
+        $this->nbits = $fields['nbits'] ?? null;
+        $this->data = $fields['data'] ?? null;
+    }
+}
+function NewWriter($order) {
+    return new Writer([
+    'order' => $order,
+    'bits' => 0,
+    'nbits' => 0,
+    'data' => []
+]);
+}
+function writeBitsLSB($w, $c, $width) {
+    $w->bits = $w->bits + lshift($c, $w->nbits);
+    $w->nbits = $w->nbits + $width;
+    while ($w->nbits >= 8) {
+        $b = $w->bits % 256;
+        $w->data = array_merge($w->data, [$b]);
+        $w->bits = rshift($w->bits, 8);
+        $w->nbits = $w->nbits - 8;
+    }
+    return $w;
+}
+function writeBitsMSB($w, $c, $width) {
+    $w->bits = $w->bits + lshift($c, 32 - $width - $w->nbits);
+    $w->nbits = $w->nbits + $width;
+    while ($w->nbits >= 8) {
+        $b = rshift($w->bits, 24) % 256;
+        $w->data = array_merge($w->data, [$b]);
+        $w->bits = ($w->bits % pow2(24)) * 256;
+        $w->nbits = $w->nbits - 8;
+    }
+    return $w;
+}
+function WriteBits($w, $c, $width) {
+    if ($w->order == "LSB") {
+        return writeBitsLSB($w, $c, $width);
+    }
+    return writeBitsMSB($w, $c, $width);
+}
+function CloseWriter($w) {
+    if ($w->nbits > 0) {
+        if ($w->order == "MSB") {
+            $w->bits = rshift($w->bits, 24);
+        }
+        $w->data = array_merge($w->data, [$w->bits % 256]);
+    }
+    $w->bits = 0;
+    $w->nbits = 0;
+    return $w;
+}
+function toBinary($n, $bits) {
+    $b = "";
+    $val = $n;
+    $i = 0;
+    while ($i < $bits) {
+        $b = strval($val % 2) . $b;
+        $val = $val / 2;
+        $i = $i + 1;
+    }
+    return $b;
+}
+function bytesToBits($bs) {
+    $out = "[";
+    $i = 0;
+    while ($i < count($bs)) {
+        $out = $out . toBinary($bs[$i], 8);
+        if ($i + 1 < count($bs)) {
+            $out = $out . " ";
+        }
+        $i = $i + 1;
+    }
+    $out = $out . "]";
+    return $out;
+}
+function ExampleWriter_WriteBits() {
+    $bw = NewWriter("MSB");
+    $bw = WriteBits($bw, 15, 4);
+    $bw = WriteBits($bw, 0, 1);
+    $bw = WriteBits($bw, 19, 5);
+    $bw = CloseWriter($bw);
+    var_dump(bytesToBits($bw['data']));
+}
+ExampleWriter_WriteBits();
+?>

--- a/tests/rosetta/out/Php/bitwise-io-2.error
+++ b/tests/rosetta/out/Php/bitwise-io-2.error
@@ -1,8 +1,215 @@
-type: error[T008]: type mismatch: expected int, got float
-  --> /workspace/mochi/tests/rosetta/x/Mochi/bitwise-io-2.mochi:10:42
+run: exit status 255
+"This is a test." as bytes: 84 65 65 65 65 65 65 65 65 65 65 65 65 65 65
 
- 10 | fun rshift(x: int, n: int): int { return x / pow2(n) }
-    |                                          ^
+Deprecated: Implicit conversion from float 10.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
 
-help:
-  Change the value to match the expected type.
+Deprecated: Implicit conversion from float 5.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.3125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.65625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 32.5 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 16.25 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 8.125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 4.0625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 2.03125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 1.015625 to int loses precision in /tmp/bitwise-io-2.php on line 141
+
+Deprecated: Implicit conversion from float 0.5078125 to int loses precision in /tmp/bitwise-io-2.php on line 141
+    original bits: [01010100 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001 01000001]
+
+Fatal error: Uncaught Error: Cannot use object of type Writer as array in /tmp/bitwise-io-2.php:252
+Stack trace:
+#0 /tmp/bitwise-io-2.php(268): Example()
+#1 {main}
+  thrown in /tmp/bitwise-io-2.php on line 252

--- a/tests/rosetta/out/Php/bitwise-io-2.php
+++ b/tests/rosetta/out/Php/bitwise-io-2.php
@@ -1,0 +1,284 @@
+<?php
+function pow2($n) {
+    $v = 1;
+    $i = 0;
+    while ($i < $n) {
+        $v = $v * 2;
+        $i = $i + 1;
+    }
+    return $v;
+}
+function lshift($x, $n) {
+    return $x * pow2($n);
+}
+function rshift($x, $n) {
+    return intdiv($x, pow2($n));
+}
+class Writer {
+    public $order;
+    public $bits;
+    public $nbits;
+    public $data;
+    public function __construct($fields = []) {
+        $this->order = $fields['order'] ?? null;
+        $this->bits = $fields['bits'] ?? null;
+        $this->nbits = $fields['nbits'] ?? null;
+        $this->data = $fields['data'] ?? null;
+    }
+}
+function NewWriter($order) {
+    return new Writer([
+    'order' => $order,
+    'bits' => 0,
+    'nbits' => 0,
+    'data' => []
+]);
+}
+function writeBitsLSB($w, $c, $width) {
+    $w->bits = $w->bits + lshift($c, $w->nbits);
+    $w->nbits = $w->nbits + $width;
+    while ($w->nbits >= 8) {
+        $b = $w->bits % 256;
+        $w->data = array_merge($w->data, [$b]);
+        $w->bits = rshift($w->bits, 8);
+        $w->nbits = $w->nbits - 8;
+    }
+    return $w;
+}
+function writeBitsMSB($w, $c, $width) {
+    $w->bits = $w->bits + lshift($c, 32 - $width - $w->nbits);
+    $w->nbits = $w->nbits + $width;
+    while ($w->nbits >= 8) {
+        $b = rshift($w->bits, 24) % 256;
+        $w->data = array_merge($w->data, [$b]);
+        $w->bits = ($w->bits % pow2(24)) * 256;
+        $w->nbits = $w->nbits - 8;
+    }
+    return $w;
+}
+function WriteBits($w, $c, $width) {
+    if ($w->order == "LSB") {
+        return writeBitsLSB($w, $c, $width);
+    }
+    return writeBitsMSB($w, $c, $width);
+}
+function CloseWriter($w) {
+    if ($w->nbits > 0) {
+        if ($w->order == "MSB") {
+            $w->bits = rshift($w->bits, 24);
+        }
+        $w->data = array_merge($w->data, [$w->bits % 256]);
+    }
+    $w->bits = 0;
+    $w->nbits = 0;
+    return $w;
+}
+class Reader {
+    public $order;
+    public $data;
+    public $idx;
+    public $bits;
+    public $nbits;
+    public function __construct($fields = []) {
+        $this->order = $fields['order'] ?? null;
+        $this->data = $fields['data'] ?? null;
+        $this->idx = $fields['idx'] ?? null;
+        $this->bits = $fields['bits'] ?? null;
+        $this->nbits = $fields['nbits'] ?? null;
+    }
+}
+function NewReader($data, $order) {
+    return new Reader([
+    'order' => $order,
+    'data' => $data,
+    'idx' => 0,
+    'bits' => 0,
+    'nbits' => 0
+]);
+}
+function readBitsLSB($r, $width) {
+    while ($r->nbits < $width) {
+        if ($r->idx >= count($r->data)) {
+            return ["val" => 0, "eof" => true];
+        }
+        $b = $r->data[$r->idx];
+        $r->idx = $r->idx + 1;
+        $r->bits = $r->bits + lshift($b, $r->nbits);
+        $r->nbits = $r->nbits + 8;
+    }
+    $mask = pow2($width) - 1;
+    $out = $r->bits % ($mask + 1);
+    $r->bits = rshift($r->bits, $width);
+    $r->nbits = $r->nbits - $width;
+    return ["val" => $out, "eof" => false];
+}
+function readBitsMSB($r, $width) {
+    while ($r->nbits < $width) {
+        if ($r->idx >= count($r->data)) {
+            return ["val" => 0, "eof" => true];
+        }
+        $b = $r->data[$r->idx];
+        $r->idx = $r->idx + 1;
+        $r->bits = $r->bits + lshift($b, 24 - $r->nbits);
+        $r->nbits = $r->nbits + 8;
+    }
+    $out = rshift($r->bits, 32 - $width);
+    $r->bits = ($r->bits * pow2($width)) % pow2(32);
+    $r->nbits = $r->nbits - $width;
+    return ["val" => $out, "eof" => false];
+}
+function ReadBits($r, $width) {
+    if ($r->order == "LSB") {
+        return readBitsLSB($r, $width);
+    }
+    return readBitsMSB($r, $width);
+}
+function toBinary($n, $bits) {
+    $b = "";
+    $val = $n;
+    $i = 0;
+    while ($i < $bits) {
+        $b = strval($val % 2) . $b;
+        $val = $val / 2;
+        $i = $i + 1;
+    }
+    return $b;
+}
+function bytesToBits($bs) {
+    $out = "[";
+    $i = 0;
+    while ($i < count($bs)) {
+        $out = $out . toBinary($bs[$i], 8);
+        if ($i + 1 < count($bs)) {
+            $out = $out . " ";
+        }
+        $i = $i + 1;
+    }
+    $out = $out . "]";
+    return $out;
+}
+function bytesToHex($bs) {
+    $digits = "0123456789ABCDEF";
+    $out = "";
+    $i = 0;
+    while ($i < count($bs)) {
+        $b = $bs[$i];
+        $hi = $b / 16;
+        $lo = $b % 16;
+        $out = $out + array_slice($digits, $hi, $hi + 1 - $hi) + array_slice($digits, $lo, $lo + 1 - $lo);
+        if ($i + 1 < count($bs)) {
+            $out = $out . " ";
+        }
+        $i = $i + 1;
+    }
+    return $out;
+}
+function _ord($ch) {
+    $upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    $lower = "abcdefghijklmnopqrstuvwxyz";
+    $idx = strpos($upper, $ch);
+    if ($idx >= 0) {
+        return 65 + $idx;
+    }
+    $idx = strpos($lower, $ch);
+    if ($idx >= 0) {
+        return 97 + $idx;
+    }
+    if ($ch >= "0" && $ch <= "9") {
+        return 48 + parseIntStr($ch);
+    }
+    if ($ch == " ") {
+        return 32;
+    }
+    if ($ch == ".") {
+        return 46;
+    }
+    return 0;
+}
+function _chr($n) {
+    $upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    $lower = "abcdefghijklmnopqrstuvwxyz";
+    if ($n >= 65 && $n < 91) {
+        return array_slice($upper, $n - 65, $n - 64 - $n - 65);
+    }
+    if ($n >= 97 && $n < 123) {
+        return array_slice($lower, $n - 97, $n - 96 - $n - 97);
+    }
+    if ($n >= 48 && $n < 58) {
+        $digits = "0123456789";
+        return array_slice($digits, $n - 48, $n - 47 - $n - 48);
+    }
+    if ($n == 32) {
+        return " ";
+    }
+    if ($n == 46) {
+        return ".";
+    }
+    return "?";
+}
+function bytesOfStr($s) {
+    $bs = [];
+    $i = 0;
+    while ($i < strlen($s)) {
+        $bs = array_merge($bs, [_ord(substr($s, $i, $i + 1 - $i))]);
+        $i = $i + 1;
+    }
+    return $bs;
+}
+function bytesToDec($bs) {
+    $out = "";
+    $i = 0;
+    while ($i < count($bs)) {
+        $out = $out . strval($bs[$i]);
+        if ($i + 1 < count($bs)) {
+            $out = $out . " ";
+        }
+        $i = $i + 1;
+    }
+    return $out;
+}
+function Example() {
+    $message = "This is a test.";
+    $msgBytes = bytesOfStr($message);
+    echo "\"" . $message . "\" as bytes: " . bytesToDec($msgBytes), PHP_EOL;
+    echo "    original bits: " . bytesToBits($msgBytes), PHP_EOL;
+    $bw = NewWriter("MSB");
+    $i = 0;
+    while ($i < _len($msgBytes)) {
+        $bw = WriteBits($bw, $msgBytes[$i], 7);
+        $i = $i + 1;
+    }
+    $bw = CloseWriter($bw);
+    echo "Written bitstream: " . bytesToBits($bw['data']), PHP_EOL;
+    echo "Written bytes: " . bytesToHex($bw['data']), PHP_EOL;
+    $br = NewReader($bw['data'], "MSB");
+    $result = "";
+    while (true) {
+        $r = ReadBits($br, 7);
+        if ($r["eof"]) {
+            break;
+        }
+        $v = (int)($r["val"]);
+        if ($v != 0) {
+            $result = $result . _chr($v);
+        }
+    }
+    echo "Read back as \"" . $result . "\"", PHP_EOL;
+}
+Example();
+function _len($v) {
+    if (is_array($v) && array_key_exists('items', $v)) {
+        return count($v['items']);
+    }
+    if (is_object($v) && property_exists($v, 'items')) {
+        return count($v->items);
+    }
+    if (is_array($v)) {
+        return count($v);
+    }
+    if (is_string($v)) {
+        return strlen($v);
+    }
+    return 0;
+}
+?>

--- a/types/check.go
+++ b/types/check.go
@@ -1377,7 +1377,7 @@ func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, err
 		switch {
 		case isNumeric(left) && isNumeric(right):
 			if op == "/" && unify(left, IntType{}, nil) && unify(right, IntType{}, nil) {
-				return FloatType{}, nil
+				return IntType{}, nil
 			}
 			if unify(left, FloatType{}, nil) || unify(right, FloatType{}, nil) {
 				return FloatType{}, nil

--- a/types/infer.go
+++ b/types/infer.go
@@ -114,7 +114,7 @@ func inferBinaryType(env *Env, b *parser.BinaryExpr) Type {
 				switch ops[i] {
 				case "+", "-", "*", "/", "%":
 					if ops[i] == "/" && isInt(left) && isInt(right) {
-						res = FloatType{}
+						res = IntType{}
 						break
 					}
 					if (isInt64(left) && (isInt64(right) || isInt(right))) ||

--- a/types/pure.go
+++ b/types/pure.go
@@ -25,7 +25,8 @@ func IsLiteralExpr(e *parser.Expr) bool {
 func AnyToLiteral(v any) *parser.Literal {
 	switch t := v.(type) {
 	case int:
-		return &parser.Literal{Int: &t}
+		il := parser.IntLit(t)
+		return &parser.Literal{Int: &il}
 	case float64:
 		return &parser.Literal{Float: &t}
 	case string:


### PR DESCRIPTION
## Summary
- allow hexadecimal and binary literals in parser
- infer int result for int division in type checker
- expose IntLit for numeric literals
- sanitize more PHP reserved names
- compile indexOf to PHP `strpos`
- update generated rosetta outputs

## Testing
- `go vet ./...`
- `TASKS=bitwise-io-2,bitwise-io-1 go run -tags=archive,slow ./scripts/compile_rosetta_php.go`

------
https://chatgpt.com/codex/tasks/task_e_687a7995b8d0832094a09b6fac9a9628