### PR TITLE
Improve Pascal backend variable handling

### DIFF
--- a/scripts/update_pascal_rosetta_readme.go
+++ b/scripts/update_pascal_rosetta_readme.go
@@ -1,0 +1,43 @@
+//go:build archive && slow
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	root := "."
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	outDir := filepath.Join(root, "tests", "rosetta", "out", "Pascal")
+
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	total := len(files)
+	compiled := 0
+	var lines []string
+
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {
+				compiled++
+				mark = "[x]"
+			}
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+	}
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "# Rosetta Pascal Output (%d/%d compiled and run)\n\n", compiled, total)
+	buf.WriteString("This directory holds Pascal source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.\n\n")
+	buf.WriteString("## Program checklist\n")
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n")
+
+	os.WriteFile(filepath.Join(outDir, "README.md"), buf.Bytes(), 0644)
+}

--- a/tests/rosetta/out/Pascal/README.md
+++ b/tests/rosetta/out/Pascal/README.md
@@ -1,4 +1,4 @@
-# Rosetta Pascal Output (26/253 compiled and run)
+# Rosetta Pascal Output (25/264 compiled and run)
 
 This directory holds Pascal source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -246,13 +246,24 @@ This directory holds Pascal source code generated from the Mochi programs in `te
 - [ ] count-in-octal-2
 - [ ] count-in-octal-3
 - [ ] count-in-octal-4
+- [ ] count-occurrences-of-a-substring
+- [ ] count-the-coins-1
+- [ ] count-the-coins-2
+- [ ] cramers-rule
 - [ ] crc-32-1
 - [ ] crc-32-2
+- [ ] create-a-file-on-magnetic-tape
+- [ ] create-a-file
+- [ ] create-a-two-dimensional-array-at-runtime-1
+- [ ] create-an-html-table
+- [ ] create-an-object-at-a-given-address
 - [ ] csv-data-manipulation
 - [ ] csv-to-html-translation-1
 - [ ] csv-to-html-translation-2
 - [x] csv-to-html-translation-3
 - [x] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
+- [ ] cuban-primes
+- [ ] cullen-and-woodall-numbers
 - [ ] cusip
 - [ ] md5


### PR DESCRIPTION
## Summary
- update Pascal backend to register variables in the type environment as soon as they are declared
- treat function parameters separately when generating local variable declarations
- add a helper script to regenerate the Pascal Rosetta README
- regenerate the Pascal Rosetta README to reflect current compile status

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a7a4fe0508320a6afaf0121af32db