### PR TITLE
Fix Racket runtime helper dependencies

### DIFF
--- a/compiler/x/racket/compiler.go
+++ b/compiler/x/racket/compiler.go
@@ -79,6 +79,12 @@ func (c *Compiler) Compile(prog *parser.Program) ([]byte, error) {
 		out.WriteString("(require racket/function)\n")
 	}
 	if len(c.runtimeFuncs) > 0 {
+		if c.runtimeFuncs["_ge"] || c.runtimeFuncs["_max"] {
+			c.runtimeFuncs["_gt"] = true
+		}
+		if c.runtimeFuncs["_le"] || c.runtimeFuncs["_min"] {
+			c.runtimeFuncs["_lt"] = true
+		}
 		if c.runtimeFuncs["_gt"] || c.runtimeFuncs["_ge"] {
 			c.runtimeFuncs["_lt"] = true
 		}


### PR DESCRIPTION
## Summary
- ensure Racket backend emits `_gt` and `_lt` helpers when needed
- update build to keep runtime functions consistent

## Testing
- `go test ./compiler/x/racket -run TestRacketCompiler_Rosetta_Golden -count=1 -tags=slow -timeout=60s`

------
https://chatgpt.com/codex/tasks/task_e_687a7ae20470832083ff7a02572a633f