### PR TITLE
Fix panic in Rust backend for list-of-map literals

### DIFF
--- a/compiler/x/rust/compiler.go
+++ b/compiler/x/rust/compiler.go
@@ -3682,7 +3682,9 @@ func (c *Compiler) tryMapListStruct(varName string, list *parser.ListLiteral) (s
 			}
 			fields[j] = fmt.Sprintf("%s: %s", k, val)
 			if jVal, ok := c.simpleConstJSON(vexpr); ok {
-				jsonFields[j] = fmt.Sprintf("\"%s\":%s", k, jVal)
+				if jsonFields != nil {
+					jsonFields[j] = fmt.Sprintf("\"%s\":%s", k, jVal)
+				}
 			} else {
 				jsonFields = nil
 			}


### PR DESCRIPTION
## Summary
- prevent panic when generating structs from list-of-map literals

## Testing
- `go test ./compiler/...`


------
https://chatgpt.com/codex/tasks/task_e_687a7b326e848320b11f30f30e6b554f