### PR TITLE
Improve Smalltalk compiler import handling

### DIFF
--- a/compiler/x/smalltalk/compiler.go
+++ b/compiler/x/smalltalk/compiler.go
@@ -111,6 +111,12 @@ func collectVars(st []*parser.Statement) []string {
 
 func (c *Compiler) compileStmt(s *parser.Statement) error {
 	switch {
+	case s.Import != nil:
+		// Ignore foreign import statements as the Smalltalk backend
+		// does not implement FFI yet. Programs that merely declare
+		// imports can still compile and run if the imported values are
+		// unused.
+		return nil
 	case s.Let != nil:
 		return c.compileLet(s.Let)
 	case s.Var != nil:

--- a/tests/rosetta/out/Smalltalk/README.md
+++ b/tests/rosetta/out/Smalltalk/README.md
@@ -1,4 +1,4 @@
-# Rosetta Smalltalk Output (100/216 compiled and run)
+# Rosetta Smalltalk Output (102/216 compiled and run)
 
 This directory holds Smalltalk source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -8,7 +8,7 @@ This directory holds Smalltalk source code generated from the real Mochi program
 - [x] 100-doors-3
 - [ ] 100-prisoners
 - [ ] 15-puzzle-game
-- [ ] 15-puzzle-solver
+- [x] 15-puzzle-solver
 - [ ] 2048
 - [ ] 21-game
 - [ ] 24-game
@@ -218,4 +218,4 @@ This directory holds Smalltalk source code generated from the real Mochi program
 - [ ] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
 - [x] cusip
-- [ ] md5
+- [x] md5


### PR DESCRIPTION
## Summary
- ignore foreign import statements in the Smalltalk backend
- mark new successes in Rosetta Smalltalk README

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687a7bced74c83209356c43cfeb0d46a