### PR TITLE
Fix zig variable typing

### DIFF
--- a/compiler/x/zig/compiler.go
+++ b/compiler/x/zig/compiler.go
@@ -675,7 +675,9 @@ func (c *Compiler) compileGlobalDecls(prog *parser.Program) error {
 					if err != nil {
 						return err
 					}
-					if s.Var.Type == nil || canInferType(s.Var.Value, typ) {
+					if needsExplicitVarType(typ) {
+						c.writelnType(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), v), typ)
+					} else if s.Var.Type == nil || canInferType(s.Var.Value, typ) {
 						c.writelnType(fmt.Sprintf("var %s = %s;", name, v), typ)
 					} else {
 						c.writeln(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), v))
@@ -2375,7 +2377,9 @@ func (c *Compiler) compileVar(st *parser.VarStmt, inFun bool) error {
 			val = v
 		}
 	}
-	if st.Type == nil && st.Value != nil && canInferType(st.Value, typ) {
+	if needsExplicitVarType(typ) {
+		c.writelnType(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), val), typ)
+	} else if st.Type == nil && st.Value != nil && canInferType(st.Value, typ) {
 		c.writelnType(fmt.Sprintf("var %s = %s;", name, val), typ)
 	} else {
 		c.writelnType(fmt.Sprintf("var %s: %s = %s;", name, zigTypeOf(typ), val), typ)

--- a/compiler/x/zig/helpers.go
+++ b/compiler/x/zig/helpers.go
@@ -188,6 +188,15 @@ func zeroValue(t types.Type) string {
 	}
 }
 
+func needsExplicitVarType(t types.Type) bool {
+	switch t.(type) {
+	case types.IntType, types.Int64Type, types.FloatType, types.BoolType, types.StringType:
+		return true
+	default:
+		return false
+	}
+}
+
 func simpleStringKey(e *parser.Expr) (string, bool) {
 	if e == nil || len(e.Binary.Right) != 0 {
 		return "", false


### PR DESCRIPTION
## Summary
- fix zig backend to always emit explicit types for numeric variables

## Testing
- `go test ./compiler/x/zig -run Rosetta_Golden -tags=slow` *(fails: zig not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c6551088320a039c0d61ebcd120