### PR TITLE
Add Mochi implementation for Rosetta task 243

### DIFF
--- a/tests/rosetta/x/Mochi/de-bruijn-sequences.mochi
+++ b/tests/rosetta/x/Mochi/de-bruijn-sequences.mochi
@@ -1,0 +1,148 @@
+fun dbRec(k: int, n: int, t: int, p: int, a: list<int>, seq: list<int>): list<int> {
+  if t > n {
+    if n % p == 0 {
+      var j = 1
+      while j <= p {
+        seq = append(seq, a[j])
+        j = j + 1
+      }
+    }
+  } else {
+    a[t] = a[t-p]
+    seq = dbRec(k, n, t+1, p, a, seq)
+    var j = a[t-p] + 1
+    while j < k {
+      a[t] = j
+      seq = dbRec(k, n, t+1, t, a, seq)
+      j = j + 1
+    }
+  }
+  return seq
+}
+
+fun deBruijn(k: int, n: int): string {
+  let digits = "0123456789"
+  var alphabet = digits
+  if k < 10 { alphabet = digits[0:k] }
+  var a: list<int> = []
+  var i = 0
+  while i < k*n { a = append(a, 0); i = i + 1 }
+  var seq: list<int> = []
+  seq = dbRec(k, n, 1, 1, a, seq)
+  var b = ""
+  var idx = 0
+  while idx < len(seq) {
+    b = b + alphabet[seq[idx]]
+    idx = idx + 1
+  }
+  b = b + b[0:n-1]
+  return b
+}
+
+fun allDigits(s: string): bool {
+  var i = 0
+  while i < len(s) {
+    let ch = s[i:i+1]
+    if ch < "0" || ch > "9" { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun parseIntStr(str: string): int {
+  var n = 0
+  var i = 0
+  while i < len(str) {
+    n = n * 10 + (str[i:i+1] as int)
+    i = i + 1
+  }
+  return n
+}
+
+fun validate(db: string) {
+  let le = len(db)
+  var found: list<int> = []
+  var i = 0
+  while i < 10000 {
+    found = append(found, 0)
+    i = i + 1
+  }
+  var j = 0
+  while j < le - 3 {
+    let s = db[j:j + 4]
+    if allDigits(s) {
+      let n = parseIntStr(s)
+      found[n] = found[n] + 1
+    }
+    j = j + 1
+  }
+  var errs: list<string> = []
+  var k = 0
+  while k < 10000 {
+    if found[k] == 0 {
+      errs = append(errs, "    PIN number " + padLeft(k, 4) + " missing")
+    } else if found[k] > 1 {
+      errs = append(errs, "    PIN number " + padLeft(k, 4) + " occurs " + str(found[k]) + " times")
+    }
+    k = k + 1
+  }
+  let lerr = len(errs)
+  if lerr == 0 {
+    print("  No errors found")
+  } else {
+    var pl = "s"
+    if lerr == 1 { pl = "" }
+    print("  " + str(lerr) + " error" + pl + " found:")
+    let msg = joinStr(errs, "\n")
+    print(msg)
+  }
+}
+
+fun padLeft(n: int, width: int): string {
+  var s = str(n)
+  while len(s) < width { s = "0" + s }
+  return s
+}
+
+fun joinStr(xs: list<string>, sep: string): string {
+  var res = ""
+  var i = 0
+  while i < len(xs) {
+    if i > 0 { res = res + sep }
+    res = res + xs[i]
+    i = i + 1
+  }
+  return res
+}
+
+fun reverse(s: string): string {
+  var out = ""
+  var i = len(s) - 1
+  while i >= 0 {
+    out = out + s[i:i + 1]
+    i = i - 1
+  }
+  return out
+}
+
+fun main() {
+  var db = deBruijn(10, 4)
+  let le = len(db)
+  print("The length of the de Bruijn sequence is " + str(le))
+  print("\nThe first 130 digits of the de Bruijn sequence are:")
+  print(db[0:130])
+  print("\nThe last 130 digits of the de Bruijn sequence are:")
+  print(db[le-130:])
+  print("\nValidating the de Bruijn sequence:")
+  validate(db)
+
+  print("\nValidating the reversed de Bruijn sequence:")
+  let dbr = reverse(db)
+  validate(dbr)
+
+  db = db[0:4443] + "." + db[4444:len(db)]
+  print("\nValidating the overlaid de Bruijn sequence:")
+  validate(db)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/de-bruijn-sequences.out
+++ b/tests/rosetta/x/Mochi/de-bruijn-sequences.out
@@ -1,0 +1,20 @@
+The length of the de Bruijn sequence is 10003
+
+The first 130 digits of the de Bruijn sequence are:
+0000100020003000400050006000700080009001100120013001400150016001700180019002100220023002400250026002700280029003100320033003400350
+
+The last 130 digits of the de Bruijn sequence are:
+6898689969697769786979698769886989699769986999777787779778877897798779978787978887889789878997979887989799879998888988998989999000
+
+Validating the de Bruijn sequence:
+  No errors found
+
+Validating the reversed de Bruijn sequence:
+  No errors found
+
+Validating the overlaid de Bruijn sequence:
+  4 errors found:
+    PIN number 1459 missing
+    PIN number 4591 missing
+    PIN number 5814 missing
+    PIN number 8145 missing


### PR DESCRIPTION
## Summary
- implement `deBruijn` algorithm in Mochi
- add output verification for the De‑Bruijn sequences task

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/de-bruijn-sequences.mochi > /tmp/mochi_full.out`

------
https://chatgpt.com/codex/tasks/task_e_687a7ccc20e08320af82186077998089