### PR TITLE
Fortran compiler precedence fix

### DIFF
--- a/tests/rosetta/out/Fortran/README.md
+++ b/tests/rosetta/out/Fortran/README.md
@@ -1,4 +1,4 @@
-# Rosetta Fortran Output (35/253 compiled and run)
+# Rosetta Fortran Output (37/271 compiled and run)
 
 This directory holds Fortran source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 


### PR DESCRIPTION
## Summary
- improve Fortran code generation by respecting operator precedence
- regenerate Rosetta README count for Fortran output

## Testing
- `go test ./compiler/x/fortran -run TestDummy -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_687a806158a0832099e4f952e07aa39f