### PR TITLE
Improve Kotlin compiler builtins

### DIFF
--- a/compiler/x/kotlin/compiler.go
+++ b/compiler/x/kotlin/compiler.go
@@ -1027,6 +1027,9 @@ func (c *Compiler) binaryOp(left string, lType types.Type, op string, right stri
 		c.use("intersect")
 		return fmt.Sprintf("intersect(%s.toMutableList(), %s.toMutableList())", left, right), types.ListType{}, nil
 	case "+", "-", "*", "/", "%":
+		if types.IsListType(lType) && types.IsListType(rType) && op == "+" {
+			return fmt.Sprintf("%s.toMutableList().apply { addAll(%s) }", left, right), types.ListType{}, nil
+		}
 		if _, ok := lType.(types.IntType); ok {
 			if _, rok := rType.(types.FloatType); rok {
 				left = fmt.Sprintf("(%s).toDouble()", left)


### PR DESCRIPTION
## Summary
- add `upper`, `lower` and fallback `len` support in Kotlin runtime
- allow list concatenation with `+`
- regenerate Rosetta Kotlin output for `abbreviations-easy`
- update Kotlin Rosetta README

## Testing
- `go test -tags slow ./compiler/x/kotlin -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a814f283c8320a856204b7fe33071