### PR TITLE
Improve Python backend for Mochi Rosetta tasks

### DIFF
--- a/compiler/x/python/compiler.go
+++ b/compiler/x/python/compiler.go
@@ -638,6 +638,35 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 				continue
 			}
 
+			if p.Target.Selector != nil && len(p.Target.Selector.Tail) > 0 && len(op.Call.Args) == 0 {
+				last := p.Target.Selector.Tail[len(p.Target.Selector.Tail)-1]
+				baseSel := &parser.Primary{Selector: &parser.SelectorExpr{
+					Root: p.Target.Selector.Root,
+					Tail: p.Target.Selector.Tail[:len(p.Target.Selector.Tail)-1],
+				}}
+				baseExpr, err := c.compilePrimary(baseSel)
+				if err != nil {
+					return "", err
+				}
+				baseType := unwrapOption(c.inferPrimaryType(baseSel))
+				if mt, ok := baseType.(types.MapType); ok {
+					switch last {
+					case "keys":
+						expr = fmt.Sprintf("list(%s.keys())", baseExpr)
+						typ = types.ListType{Elem: mt.Key}
+						continue
+					case "values":
+						expr = fmt.Sprintf("list(%s.values())", baseExpr)
+						typ = types.ListType{Elem: mt.Value}
+						continue
+					case "items":
+						expr = fmt.Sprintf("list(%s.items())", baseExpr)
+						typ = types.ListType{Elem: types.AnyType{}}
+						continue
+					}
+				}
+			}
+
 			args := make([]string, len(op.Call.Args))
 			for i, a := range op.Call.Args {
 				v, err := c.compileExpr(a)

--- a/tests/rosetta/out/Python/DNS-query.error
+++ b/tests/rosetta/out/Python/DNS-query.error
@@ -1,0 +1,1 @@
+compile: unsupported import language: 0xc00039b350


### PR DESCRIPTION
## Summary
- support `map.keys`, `map.values` and `map.items` calls in the Python backend
- generate Python outputs for several additional Rosetta programs
- document progress in the generated checklist

## Testing
- `go run -tags='archive slow' ./scripts/update_python_rosetta_readme.go`

------
https://chatgpt.com/codex/tasks/task_e_687a8a34f1f88320bfa0a3dceea15486