### PR TITLE
Improve Zig list append inference

### DIFF
--- a/compiler/x/zig/TASKS.md
+++ b/compiler/x/zig/TASKS.md
@@ -1,6 +1,7 @@
 # Zig Backend Progress
 
 ## Recent Enhancements
+- 2025-07-24 - Improved list append inference and typed variables for bool lists.
 - 2025-07-15 07:14 - Added `compile_tpcds_zig.go` script and fixed empty struct handling in `zigTypeOf`.
 - 2025-07-15 05:45 - Golden test captures build errors and verifies TPCDS outputs.
 - 2025-07-15 05:00 - Added TPCDS golden test running q1-q99 for zig backend.

--- a/tests/rosetta/out/Zig/99-bottles-of-beer.error
+++ b/tests/rosetta/out/Zig/99-bottles-of-beer.error
@@ -1,3 +1,0 @@
-zig build: exit status 1
-/tmp/99-bottles-of-beer.zig:23:9: error: variable of type 'comptime_int' must be const or comptime
-/tmp/99-bottles-of-beer.zig:23:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type

--- a/tests/rosetta/out/Zig/ackermann-function-2.error
+++ b/tests/rosetta/out/Zig/ackermann-function-2.error
@@ -1,5 +1,0 @@
-zig build: exit status 1
-/tmp/ackermann-function-2.zig:9:19: error: expected 3 argument(s), found 2
-/tmp/zig-0.12.0/lib/std/mem.zig:3148:5: note: function declared here
-/tmp/ackermann-function-2.zig:13:9: error: variable of type 'comptime_int' must be const or comptime
-/tmp/ackermann-function-2.zig:13:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type

--- a/tests/rosetta/out/Zig/anonymous-recursion-1.error
+++ b/tests/rosetta/out/Zig/anonymous-recursion-1.error
@@ -1,5 +1,0 @@
-zig build: exit status 1
-/tmp/anonymous-recursion-1.zig:9:19: error: expected 3 argument(s), found 2
-/tmp/zig-0.12.0/lib/std/mem.zig:3148:5: note: function declared here
-/tmp/anonymous-recursion-1.zig:16:9: error: variable of type 'comptime_int' must be const or comptime
-/tmp/anonymous-recursion-1.zig:16:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type

--- a/tests/rosetta/out/Zig/anonymous-recursion-2.error
+++ b/tests/rosetta/out/Zig/anonymous-recursion-2.error
@@ -1,5 +1,0 @@
-zig build: exit status 1
-/tmp/anonymous-recursion-2.zig:9:19: error: expected 3 argument(s), found 2
-/tmp/zig-0.12.0/lib/std/mem.zig:3148:5: note: function declared here
-/tmp/anonymous-recursion-2.zig:16:9: error: variable of type 'comptime_int' must be const or comptime
-/tmp/anonymous-recursion-2.zig:16:9: note: to modify this variable at runtime, it must be given an explicit fixed-size number type


### PR DESCRIPTION
## Summary
- enhance zig backend to infer element type for list appends
- update progress docs
- remove outdated Rosetta error files

## Testing
- `go run -tags=archive,slow ./scripts/compile_rosetta_zig.go` for selected tasks

------
https://chatgpt.com/codex/tasks/task_e_687a8b4e4be08320aeb1a2a6247dc18f