### PR TITLE
Improve list append type inference

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -940,6 +940,9 @@ func checkStmt(s *parser.Statement, env *Env, expectedReturn Type) error {
 		if !unify(lhsType, rhsType, nil) {
 			return errCannotAssign(s.Assign.Pos, rhsType, s.Assign.Name, lhsType)
 		}
+		if len(s.Assign.Index) == 0 && len(s.Assign.Field) == 0 {
+			env.SetVar(s.Assign.Name, rhsType, true)
+		}
 		return nil
 
 	case s.Fetch != nil:

--- a/types/infer.go
+++ b/types/infer.go
@@ -460,7 +460,9 @@ func inferPrimaryType(env *Env, p *parser.Primary) Type {
 				if lt, ok := t.(ListType); ok {
 					elem := lt.Elem
 					argT := ExprType(p.Call.Args[1], env)
-					if !equalTypes(elem, argT) {
+					if _, ok := elem.(AnyType); ok {
+						elem = argT
+					} else if !equalTypes(elem, argT) {
 						elem = AnyType{}
 					}
 					return ListType{Elem: elem}


### PR DESCRIPTION
## Summary
- refine type inference for `append` builtin to adopt element type when list element is unknown
- update type checker to refresh variable types on assignment

## Testing
- `go test ./compiler/x/zig -run TestZigCompiler_Rosetta_Golden -count=1 -tags=slow -v` *(fails: zig run failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a923da01083208cf0f06e06fde41c