### PR TITLE
Improve optional types in Go backend

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -4909,6 +4909,11 @@ func (c *Compiler) compileCallExpr(call *parser.CallExpr) (string, error) {
 				return fmt.Sprintf("len([]rune(%s))", arg), nil
 			case types.GroupType:
 				return fmt.Sprintf("len(%s.Items)", arg), nil
+			case types.AnyType:
+				c.imports["mochi/runtime/data"] = true
+				c.imports["reflect"] = true
+				c.use("_count")
+				return fmt.Sprintf("_count(%s)", arg), nil
 			}
 			c.imports["mochi/runtime/data"] = true
 			c.imports["reflect"] = true

--- a/compiler/x/go/helpers.go
+++ b/compiler/x/go/helpers.go
@@ -136,6 +136,12 @@ func goType(t types.Type) string {
 		return "*data.Group"
 	case types.OptionType:
 		elem := goType(tt.Elem)
+		if isList(tt.Elem) || isMap(tt.Elem) || isStruct(tt.Elem) || isUnion(tt.Elem) || isString(tt.Elem) || isBoolLike(tt.Elem) || isNumeric(tt.Elem) {
+			if elem == "" {
+				elem = "any"
+			}
+			return elem
+		}
 		if elem == "" {
 			elem = "any"
 		}


### PR DESCRIPTION
## Summary
- handle lists, maps, and other built-in types in `OptionType` without pointers
- fall back to `_count` when `len` receives `any`

## Testing
- `go test ./compiler/x/go -run Rosetta -tags slow` *(fails: output mismatch for 100-prisoners.out)*

------
https://chatgpt.com/codex/tasks/task_e_687a935067148320bc8e6aa39752b42a