### PR TITLE
Improve C++ backend

### DIFF
--- a/compiler/x/cpp/compiler.go
+++ b/compiler/x/cpp/compiler.go
@@ -639,7 +639,7 @@ func (c *Compiler) compileLet(st *parser.LetStmt) error {
 			if err != nil {
 				return err
 			}
-			exprStr = fmt.Sprintf("std::vector<%s>{}", elem)
+			exprStr = "{}"
 			elemHint = elem
 			typ = fmt.Sprintf("std::vector<%s>", elem)
 		}

--- a/compiler/x/cpp/job_golden_test.go
+++ b/compiler/x/cpp/job_golden_test.go
@@ -61,7 +61,7 @@ func TestCPPCompiler_JOBQueries(t *testing.T) {
 				t.Fatalf("write error: %v", err)
 			}
 			bin := filepath.Join(dir, "prog")
-			if out, err := exec.Command("g++", file, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+			if out, err := exec.Command("g++", file, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 				t.Skipf("g++ error: %v\n%s", err, out)
 				return
 			}

--- a/compiler/x/cpp/rosetta_golden_test.go
+++ b/compiler/x/cpp/rosetta_golden_test.go
@@ -88,7 +88,7 @@ func runRosettaTaskGolden(t *testing.T, name string) {
 		t.Fatalf("write error: %v", err)
 	}
 	bin := filepath.Join(dir, "prog")
-	if out, err := exec.Command("g++", file, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+	if out, err := exec.Command("g++", file, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 		t.Skipf("g++ error: %v\n%s", err, out)
 		return
 	}

--- a/compiler/x/cpp/tpcds_golden_test.go
+++ b/compiler/x/cpp/tpcds_golden_test.go
@@ -70,7 +70,7 @@ func TestCPPCompiler_TPCDSQueries(t *testing.T) {
 				t.Fatalf("write error: %v", err)
 			}
 			bin := filepath.Join(dir, "prog")
-			if out, err := exec.Command("g++", file, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+			if out, err := exec.Command("g++", file, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 				if shouldUpdate() {
 					_ = os.WriteFile(errPath, out, 0644)
 				}

--- a/compiler/x/cpp/tpch_golden_test.go
+++ b/compiler/x/cpp/tpch_golden_test.go
@@ -76,7 +76,7 @@ func TestCPPCompiler_TPCHQueries(t *testing.T) {
 				t.Fatalf("write error: %v", err)
 			}
 			bin := filepath.Join(dir, "prog")
-			if out, err := exec.Command("g++", file, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+			if out, err := exec.Command("g++", file, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 				if shouldUpdate() {
 					_ = os.WriteFile(errPath, out, 0644)
 				}

--- a/compiler/x/cpp/vm_golden_test.go
+++ b/compiler/x/cpp/vm_golden_test.go
@@ -53,7 +53,7 @@ func TestCPPCompiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		bin := filepath.Join(outDir, name)
-		if out, err := exec.Command("g++", codePath, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+		if out, err := exec.Command("g++", codePath, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 			_ = os.WriteFile(errPath, out, 0644)
 			return nil, fmt.Errorf("g++ error: %w", err)
 		}

--- a/scripts/compile_rosetta_cpp.go
+++ b/scripts/compile_rosetta_cpp.go
@@ -90,7 +90,7 @@ func main() {
 			continue
 		}
 		bin := filepath.Join(tmpDir, name)
-		if out, err := exec.Command("g++", srcTmp, "-std=c++17", "-o", bin).CombinedOutput(); err != nil {
+		if out, err := exec.Command("g++", srcTmp, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
 			writeError(outDir, name, fmt.Sprintf("g++: %v\n%s", err, out))
 			os.Remove(filepath.Join(outDir, name+".out"))
 			continue

--- a/tests/rosetta/out/cpp/README.md
+++ b/tests/rosetta/out/cpp/README.md
@@ -1,6 +1,6 @@
 # Rosetta C++ Output (7/253 compiled and run)
 
-This directory holds C++ source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
+This directory holds C++ source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file. Generated programs are now compiled with `-std=c++20` to support modern language features used by some tasks.
 
 ## Program checklist
 - [x] 100-doors-2


### PR DESCRIPTION
## Summary
- compile generated C++ code using `-std=c++20`
- adjust helper to emit `{}` for typed empty lists
- note updated compilation flag in C++ Rosetta README

## Testing
- `go test -tags=slow ./compiler/x/cpp -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a939d5d4c83208ebb9a534dcbe94f