### PR TITLE
Improve Fortran literal integer handling

### DIFF
--- a/compiler/x/fortran/compiler.go
+++ b/compiler/x/fortran/compiler.go
@@ -1855,7 +1855,8 @@ func literalIntPrimary(p *parser.Primary) *int {
 	if p == nil || p.Lit == nil || p.Lit.Int == nil {
 		return nil
 	}
-	return p.Lit.Int
+	v := int(*p.Lit.Int)
+	return &v
 }
 
 func literalIntUnary(u *parser.Unary) *int {
@@ -1863,7 +1864,8 @@ func literalIntUnary(u *parser.Unary) *int {
 		return nil
 	}
 	if u.Value.Target.Lit != nil && u.Value.Target.Lit.Int != nil {
-		return u.Value.Target.Lit.Int
+		v := int(*u.Value.Target.Lit.Int)
+		return &v
 	}
 	return nil
 }
@@ -1899,7 +1901,8 @@ func literalInt(e *parser.Expr) *int {
 		return nil
 	}
 	if u.Value.Target.Lit != nil && u.Value.Target.Lit.Int != nil {
-		return u.Value.Target.Lit.Int
+		v := int(*u.Value.Target.Lit.Int)
+		return &v
 	}
 	return nil
 }
@@ -1962,7 +1965,7 @@ func intList(l *parser.ListLiteral) ([]int, bool) {
 		if len(u.Ops) != 0 || u.Value == nil || u.Value.Target == nil || u.Value.Target.Lit == nil || u.Value.Target.Lit.Int == nil {
 			return nil, false
 		}
-		vals[i] = *u.Value.Target.Lit.Int
+		vals[i] = int(*u.Value.Target.Lit.Int)
 	}
 	return vals, true
 }
@@ -2355,7 +2358,7 @@ func (c *Compiler) constIntFromPostfix(pf *parser.PostfixExpr) (int, bool) {
 		return 0, false
 	}
 	if pf.Target.Lit != nil && pf.Target.Lit.Int != nil {
-		return *pf.Target.Lit.Int, true
+		return int(*pf.Target.Lit.Int), true
 	}
 	if pf.Target.Selector != nil && len(pf.Target.Selector.Tail) == 0 {
 		v, ok := c.constInts[pf.Target.Selector.Root]

--- a/tests/rosetta/out/Fortran/README.md
+++ b/tests/rosetta/out/Fortran/README.md
@@ -1,4 +1,4 @@
-# Rosetta Fortran Output (36/253 compiled and run)
+# Rosetta Fortran Output (36/278 compiled and run)
 
 This directory holds Fortran source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
@@ -17,6 +17,7 @@ This directory holds Fortran source code generated from the real Mochi programs 
 - [ ] 9-billion-names-of-god-the-integer
 - [ ] 99-bottles-of-beer-2
 - [x] 99-bottles-of-beer
+- [ ] DNS-query
 - [ ] a+b
 - [ ] abbreviations-automatic
 - [ ] abbreviations-easy
@@ -246,13 +247,37 @@ This directory holds Fortran source code generated from the real Mochi programs 
 - [ ] count-in-octal-2
 - [ ] count-in-octal-3
 - [ ] count-in-octal-4
+- [ ] count-occurrences-of-a-substring
+- [ ] count-the-coins-1
+- [ ] count-the-coins-2
+- [ ] cramers-rule
 - [ ] crc-32-1
 - [ ] crc-32-2
+- [ ] create-a-file-on-magnetic-tape
+- [ ] create-a-file
+- [ ] create-a-two-dimensional-array-at-runtime-1
+- [ ] create-an-html-table
+- [ ] create-an-object-at-a-given-address
 - [ ] csv-data-manipulation
 - [ ] csv-to-html-translation-1
 - [ ] csv-to-html-translation-2
 - [x] csv-to-html-translation-3
 - [x] csv-to-html-translation-4
 - [ ] csv-to-html-translation-5
+- [ ] cuban-primes
+- [ ] cullen-and-woodall-numbers
+- [ ] cumulative-standard-deviation
+- [ ] currency
+- [ ] currying
+- [ ] curzon-numbers
 - [ ] cusip
+- [ ] cyclops-numbers
+- [ ] damm-algorithm
+- [ ] date-format
+- [ ] date-manipulation
+- [ ] day-of-the-week
+- [ ] de-bruijn-sequences
+- [ ] deal-cards-for-freecell
+- [ ] death-star
+- [ ] deceptive-numbers
 - [ ] md5


### PR DESCRIPTION
## Summary
- fix Fortran generator helpers that return literal integers
- regenerate Rosetta README for Fortran

## Testing
- `go test ./...` *(fails: cannot apply operator '<' to types null and int)*

------
https://chatgpt.com/codex/tasks/task_e_687a93dba0f883208ba875add19328f4