### PR TITLE
Fix OCaml `any` type mapping

### DIFF
--- a/compiler/x/ocaml/compiler.go
+++ b/compiler/x/ocaml/compiler.go
@@ -2455,7 +2455,7 @@ func (c *Compiler) typeRef(t *parser.TypeRef) string {
 		return strings.Join(parts, " -> ")
 	}
 	if t.Simple != nil {
-		switch *t.Simple {
+		switch strings.ToLower(*t.Simple) {
 		case "int":
 			return "int"
 		case "float":
@@ -2464,6 +2464,8 @@ func (c *Compiler) typeRef(t *parser.TypeRef) string {
 			return "bool"
 		case "string":
 			return "string"
+		case "any":
+			return "Obj.t"
 		default:
 			return strings.ToLower(*t.Simple)
 		}


### PR DESCRIPTION
## Summary
- handle `any` type in OCaml backend so programs using it compile

## Testing
- `go test -tags=slow ./compiler/x/ocaml -run TestOCamlCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687a94207e6c83208ce71dfc65ac902c