### PR TITLE
Fix PHP compiler global vars

### DIFF
--- a/compiler/x/php/compiler.go
+++ b/compiler/x/php/compiler.go
@@ -168,6 +168,11 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 		params[i] = "$" + sanitizeName(p.Name)
 	}
 	c.writeln(fmt.Sprintf("function %s(%s) {", sanitizeName(fn.Name), strings.Join(params, ", ")))
+	c.indent++
+	capture := funStmtFreeVars(fn, c.env)
+	if len(capture) > 0 {
+		c.writeln(fmt.Sprintf("global %s;", strings.Join(capture, ", ")))
+	}
 	child := types.NewEnv(c.env)
 	for _, p := range fn.Params {
 		typ := resolveTypeRef(p.Type, c.env)
@@ -185,6 +190,7 @@ func (c *Compiler) compileFun(fn *parser.FunStmt) error {
 	if len(fn.Body) == 0 {
 		c.writeln("return;")
 	}
+	c.indent--
 	c.indent--
 	c.writeln("}")
 	c.env = origEnv

--- a/tests/rosetta/out/Php/24-game-solve.out
+++ b/tests/rosetta/out/Php/24-game-solve.out
@@ -1,39 +1,60 @@
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution
-
-Warning: Undefined variable $n_cards in /tmp/24-game-solve.php on line 126
+ 7
+ 7
+ 7
+ 7
 :  
 No solution

--- a/tests/rosetta/out/Php/24-game-solve.php
+++ b/tests/rosetta/out/Php/24-game-solve.php
@@ -5,165 +5,141 @@ $OP_SUB = 2;
 $OP_MUL = 3;
 $OP_DIV = 4;
 function newNum($n) {
-    return [
+    global $OP_NUM;
+        return [
     "op" => $OP_NUM,
     "value" => ["num" => $n, "denom" => 1]
 ];
 }
 function exprEval($x) {
-    if ($x["op"] == $OP_NUM) {
-        return $x["value"];
-    }
-    $l = exprEval($x["left"]);
-    $r = exprEval($x["right"]);
-    if ($x["op"] == $OP_ADD) {
-        return [
+    global $OP_ADD, $OP_MUL, $OP_NUM, $OP_SUB;
+        if ($x["op"] == $OP_NUM) {
+            return $x["value"];
+        }
+        $l = exprEval($x["left"]);
+        $r = exprEval($x["right"]);
+        if ($x["op"] == $OP_ADD) {
+            return [
     "num" => $l["num"] * $r["denom"] + $l["denom"] * $r["num"],
     "denom" => $l["denom"] * $r["denom"]
 ];
-    }
-    if ($x["op"] == $OP_SUB) {
-        return [
+        }
+        if ($x["op"] == $OP_SUB) {
+            return [
     "num" => $l["num"] * $r["denom"] - $l["denom"] * $r["num"],
     "denom" => $l["denom"] * $r["denom"]
 ];
-    }
-    if ($x["op"] == $OP_MUL) {
-        return [
+        }
+        if ($x["op"] == $OP_MUL) {
+            return [
     "num" => $l["num"] * $r["num"],
     "denom" => $l["denom"] * $r["denom"]
 ];
-    }
-    return [
+        }
+        return [
     "num" => $l["num"] * $r["denom"],
     "denom" => $l["denom"] * $r["num"]
 ];
 }
 function exprString($x) {
-    if ($x["op"] == $OP_NUM) {
-        return strval($x["value"]["num"]);
-    }
-    $ls = exprString($x["left"]);
-    $rs = exprString($x["right"]);
-    $opstr = "";
-    if ($x["op"] == $OP_ADD) {
-        $opstr = " + ";
-    } elseif ($x["op"] == $OP_SUB) {
-        $opstr = " - ";
-    } elseif ($x["op"] == $OP_MUL) {
-        $opstr = " * ";
-    }
-    return "(" . $ls . $opstr . $rs . ")";
+    global $OP_ADD, $OP_MUL, $OP_NUM, $OP_SUB;
+        if ($x["op"] == $OP_NUM) {
+            return (is_bool($x["value"]["num"]) ? ($x["value"]["num"] ? 'true' : 'false') : strval($x["value"]["num"]));
+        }
+        $ls = exprString($x["left"]);
+        $rs = exprString($x["right"]);
+        $opstr = "";
+        if ($x["op"] == $OP_ADD) {
+            $opstr = " + ";
+        } elseif ($x["op"] == $OP_SUB) {
+            $opstr = " - ";
+        } elseif ($x["op"] == $OP_MUL) {
+            $opstr = " * ";
+        }
+        return "(" . $ls . $opstr . $rs . ")";
 }
 $n_cards = 4;
 $goal = 24;
 $digit_range = 9;
 function solve($xs) {
-    if (count($xs) == 1) {
-        $f = exprEval($xs[0]);
-        if ($f["denom"] != 0 && $f["num"] == $f["denom"] * $goal) {
-            _print(exprString($xs[0]));
-            return true;
-        }
-        return false;
-    }
-    $i = 0;
-    while ($i < count($xs)) {
-        $j = $i + 1;
-        while ($j < count($xs)) {
-            $rest = [];
-            $k = 0;
-            while ($k < count($xs)) {
-                if ($k != $i && $k != $j) {
-                    $rest = array_merge($rest, [$xs[$k]]);
-                }
-                $k = $k + 1;
+    global $OP_ADD, $OP_DIV, $OP_MUL, $OP_SUB, $goal;
+        if (count($xs) == 1) {
+            $f = exprEval($xs[0]);
+            if ($f["denom"] != 0 && $f["num"] == $f["denom"] * $goal) {
+                echo exprString($xs[0]), PHP_EOL;
+                return true;
             }
-            $a = $xs[$i];
-            $b = $xs[$j];
-            foreach ([
+            return false;
+        }
+        $i = 0;
+        while ($i < count($xs)) {
+            $j = $i + 1;
+            while ($j < count($xs)) {
+                $rest = [];
+                $k = 0;
+                while ($k < count($xs)) {
+                    if ($k != $i && $k != $j) {
+                        $rest = array_merge($rest, [$xs[$k]]);
+                    }
+                    $k = $k + 1;
+                }
+                $a = $xs[$i];
+                $b = $xs[$j];
+                foreach ([
     $OP_ADD,
     $OP_SUB,
     $OP_MUL,
     $OP_DIV
 ] as $op) {
-                $node = [
+                    $node = [
     "op" => $op,
     "left" => $a,
     "right" => $b
 ];
-                if (solve(array_merge($rest, [$node]))) {
-                    return true;
+                    if (solve(array_merge($rest, [$node]))) {
+                        return true;
+                    }
                 }
-            }
-            $node = [
+                $node = [
     "op" => $OP_SUB,
     "left" => $b,
     "right" => $a
 ];
-            if (solve(array_merge($rest, [$node]))) {
-                return true;
-            }
-            $node = [
+                if (solve(array_merge($rest, [$node]))) {
+                    return true;
+                }
+                $node = [
     "op" => $OP_DIV,
     "left" => $b,
     "right" => $a
 ];
-            if (solve(array_merge($rest, [$node]))) {
-                return true;
+                if (solve(array_merge($rest, [$node]))) {
+                    return true;
+                }
+                $j = $j + 1;
             }
-            $j = $j + 1;
-        }
-        $i = $i + 1;
-    }
-    return false;
-}
-function main() {
-    $iter = 0;
-    while ($iter < 10) {
-        $cards = [];
-        $i = 0;
-        while ($i < $n_cards) {
-            $n = ($now() % ($digit_range - 1)) + 1;
-            $cards = array_merge($cards, [newNum($n)]);
-            _print(" " . strval($n));
             $i = $i + 1;
         }
-        _print(":  ");
-        if (!solve($cards)) {
-            _print("No solution");
+        return false;
+}
+function main() {
+    global $digit_range, $n_cards;
+        $iter = 0;
+        while ($iter < 10) {
+            $cards = [];
+            $i = 0;
+            while ($i < $n_cards) {
+                $n = (time() % ($digit_range - 1)) + 1;
+                $cards = array_merge($cards, [newNum($n)]);
+                echo " " . (is_bool($n) ? ($n ? 'true' : 'false') : strval($n)), PHP_EOL;
+                $i = $i + 1;
+            }
+            echo ":  ", PHP_EOL;
+            if (!solve($cards)) {
+                echo "No solution", PHP_EOL;
+            }
+            $iter = $iter + 1;
         }
-        $iter = $iter + 1;
-    }
 }
 main();
-function _print(...$args) {
-    $first = true;
-    foreach ($args as $a) {
-        if (!$first) echo ' ';
-        $first = false;
-        if (is_array($a)) {
-            if (array_is_list($a)) {
-                if ($a && is_array($a[0])) {
-                    $parts = [];
-                    foreach ($a as $sub) {
-                        if (is_array($sub)) {
-                            $parts[] = '[' . implode(' ', $sub) . ']';
-                        } else {
-                            $parts[] = strval($sub);
-                        }
-                    }
-                    echo implode(' ', $parts);
-                } else {
-                    echo '[' . implode(' ', array_map('strval', $a)) . ']';
-                }
-            } else {
-                echo json_encode($a);
-            }
-        } else {
-            echo strval($a);
-        }
-    }
-    echo PHP_EOL;
-}
 ?>


### PR DESCRIPTION
## Summary
- support using global variables inside functions for PHP backend
- regenerate PHP code for `24-game-solve` rosetta task

## Testing
- `go test -tags=slow ./compiler/x/php -run TestPHPCompiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687a9452d64c832092aab1edba05f58d