### PR TITLE
Improve Swift compiler type inference

### DIFF
--- a/compiler/x/swift/compiler.go
+++ b/compiler/x/swift/compiler.go
@@ -202,6 +202,9 @@ func (c *compiler) analyzeStmt(s *parser.Statement) {
 			c.analyzeStmt(st)
 		}
 	case s.Fun != nil:
+		for _, p := range s.Fun.Params {
+			c.varTypes[p.Name] = inferTypeRef(p.Type)
+		}
 		for _, st := range s.Fun.Body {
 			c.analyzeStmt(st)
 		}


### PR DESCRIPTION
## Summary
- infer function parameter types during analysis for Swift compiler

## Testing
- `go test ./...` *(fails: cannot apply operator '<' to types null and int)*

------
https://chatgpt.com/codex/tasks/task_e_687a9496b8f88320896cb5b0caf10433