### PR TITLE
Enhance Erlang backend

### DIFF
--- a/tests/rosetta/out/Erlang/README.md
+++ b/tests/rosetta/out/Erlang/README.md
@@ -14,8 +14,8 @@ This directory holds Erlang source code generated from the real Mochi programs i
 - [ ] 24-game-solve
 - [ ] 24-game
 - [ ] 4-rings-or-4-squares-puzzle
-- [ ] 9-billion-names-of-god-the-integer
-- [ ] 99-bottles-of-beer-2
+- [x] 9-billion-names-of-god-the-integer
+- [x] 99-bottles-of-beer-2
 - [x] 99-bottles-of-beer
 - [ ] DNS-query
 - [ ] a+b
@@ -26,10 +26,10 @@ This directory holds Erlang source code generated from the real Mochi programs i
 - [ ] abelian-sandpile-model-identity
 - [ ] abelian-sandpile-model
 - [ ] abstract-type
-- [ ] abundant-deficient-and-perfect-number-classifications
-- [ ] abundant-odd-numbers
+- [x] abundant-deficient-and-perfect-number-classifications
+- [x] abundant-odd-numbers
 - [ ] accumulator-factory
-- [ ] achilles-numbers
+- [x] achilles-numbers
 - [x] ackermann-function-2
 - [ ] ackermann-function-3
 - [ ] ackermann-function


### PR DESCRIPTION
## Summary
- support `map.keys()` in Erlang backend
- update Rosetta Erlang checklist for new working programs

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_687ae3abc228832080ad6c6e5b7f2503