### PR TITLE
Pascal compiler tweaks

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -1034,6 +1034,8 @@ func (c *Compiler) typeRef(t *parser.TypeRef) string {
 			return "string"
 		case "bool":
 			return "boolean"
+		case "any":
+			return "Variant"
 		}
 	}
 	if t.Fun != nil {

--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -427,6 +427,8 @@ func parsePasType(s string) types.Type {
 		return types.BoolType{}
 	case "char":
 		return types.StringType{}
+	case "Variant":
+		return types.AnyType{}
 	}
 	if strings.HasPrefix(s, "specialize TArray<") && strings.HasSuffix(s, ">") {
 		inner := strings.TrimSuffix(strings.TrimPrefix(s, "specialize TArray<"), ">")

--- a/tests/rosetta/out/Pascal/2048.error
+++ b/tests/rosetta/out/Pascal/2048.error
@@ -7,8 +7,6 @@ Compiling /tmp/2048.pas
 fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,System.Variant>.IndexOf(const AKey:ShortString):LongInt;" marked as inline is not inlined
 2048.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
 2048.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
-2048.pas(69,98) Error: Identifier not found "any"
-2048.pas(69,101) Error: Type identifier expected
 2048.pas(87,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(94,11) Error: Incompatible types: got "TArray$1$crc9F312717" expected "TArray$1$crc90DE1C48"
 2048.pas(97,5) Error: Incompatible types: got "TArray$1$crc9F312717" expected "QWord"
@@ -20,29 +18,19 @@ fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,Sys
 2048.pas(147,29) Error: Incompatible type for arg no. 1: Got "TArray$1$crc90DE1C48", expected "LongInt"
 2048.pas(164,10) Error: Illegal qualifier
 2048.pas(167,51) Error: Illegal qualifier
-2048.pas(174,81) Error: Identifier not found "any"
-2048.pas(174,84) Error: Type identifier expected
 2048.pas(197,50) Error: Incompatible types: got "Int64" expected "TArray$1$crc90DE1C48"
 2048.pas(198,26) Error: Incompatible types: got "LongInt" expected "ShortString"
 2048.pas(199,52) Error: Incompatible type for arg no. 2: Got "TArray$1$crc90DE1C48", expected "LongInt"
-2048.pas(218,113) Error: Identifier not found "any"
-2048.pas(218,116) Error: Type identifier expected
 2048.pas(232,13) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
 2048.pas(237,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(237,137) Error: Incompatible type for arg no. 1: Got "LongInt", expected "ShortString"
 2048.pas(238,31) Error: Incompatible type for arg no. 1: Got "LongInt", expected "ShortString"
-2048.pas(251,114) Error: Identifier not found "any"
-2048.pas(251,117) Error: Type identifier expected
 2048.pas(272,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(295,154) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
-2048.pas(314,111) Error: Identifier not found "any"
-2048.pas(314,114) Error: Type identifier expected
 2048.pas(330,13) Error: Incompatible types: got "Variant" expected "TFPGMap<System.ShortString,System.Variant>"
 2048.pas(335,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(335,137) Error: Incompatible type for arg no. 1: Got "LongInt", expected "ShortString"
 2048.pas(336,31) Error: Incompatible type for arg no. 1: Got "LongInt", expected "ShortString"
-2048.pas(349,113) Error: Identifier not found "any"
-2048.pas(349,116) Error: Type identifier expected
 2048.pas(370,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(395,116) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"
 2048.pas(396,136) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9F312717", expected "TArray$1$crc90DE1C48"

--- a/tests/rosetta/out/Pascal/2048.pas
+++ b/tests/rosetta/out/Pascal/2048.pas
@@ -32,7 +32,7 @@ end;
 
 var
   SIZE: integer;
-  board: specialize TArray<specialize TArray<integer>>;
+  board: Variant;
   cmd: Variant;
   full: specialize TFPGMap<string, Variant>;
   m: Variant;
@@ -66,7 +66,7 @@ begin
   exit;
 end;
 
-function spawnTile(b: specialize TArray<specialize TArray<integer>>): specialize TFPGMap<string, any>;
+function spawnTile(b: specialize TArray<specialize TArray<integer>>): specialize TFPGMap<string, Variant>;
 var
   _tmp0: specialize TFPGMap<string, Variant>;
   _tmp1: specialize TFPGMap<string, Variant>;
@@ -171,7 +171,7 @@ begin
   exit;
 end;
 
-function slideLeft(row: specialize TArray<integer>): specialize TFPGMap<string, any>;
+function slideLeft(row: specialize TArray<integer>): specialize TFPGMap<string, Variant>;
 var
   _tmp2: specialize TFPGMap<string, Variant>;
   gain: integer;
@@ -215,7 +215,7 @@ begin
   exit;
 end;
 
-function moveLeft(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, any>;
+function moveLeft(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, Variant>;
 var
   _tmp3: specialize TFPGMap<string, Variant>;
   moved: boolean;
@@ -248,7 +248,7 @@ begin
   exit;
 end;
 
-function moveRight(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, any>;
+function moveRight(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, Variant>;
 var
   _tmp4: specialize TFPGMap<string, Variant>;
   moved: boolean;
@@ -311,7 +311,7 @@ begin
   end;
 end;
 
-function moveUp(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, any>;
+function moveUp(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, Variant>;
 var
   _tmp5: specialize TFPGMap<string, Variant>;
   col: specialize TArray<integer>;
@@ -346,7 +346,7 @@ begin
   exit;
 end;
 
-function moveDown(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, any>;
+function moveDown(b: specialize TArray<specialize TArray<integer>>; score: integer): specialize TFPGMap<string, Variant>;
 var
   _tmp6: specialize TFPGMap<string, Variant>;
   col: specialize TArray<integer>;

--- a/tests/rosetta/out/Pascal/24-game-solve.error
+++ b/tests/rosetta/out/Pascal/24-game-solve.error
@@ -4,52 +4,31 @@ Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /tmp/24-game-solve.pas
 24-game-solve.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
-24-game-solve.pas(43,57) Error: Identifier not found "any"
-24-game-solve.pas(43,60) Error: Type identifier expected
 24-game-solve.pas(53,36) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.Variant>", expected "Variant"
-24-game-solve.pas(58,49) Error: Identifier not found "any"
-24-game-solve.pas(58,52) Error: Type identifier expected
-24-game-solve.pas(67,9) Error: Illegal qualifier
-24-game-solve.pas(68,19) Error: Illegal qualifier
-24-game-solve.pas(69,19) Error: Illegal qualifier
-24-game-solve.pas(70,9) Error: Illegal qualifier
-24-game-solve.pas(71,9) Error: Illegal qualifier
-24-game-solve.pas(72,9) Error: Illegal qualifier
+24-game-solve.pas(68,34) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+24-game-solve.pas(69,35) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
 24-game-solve.pas(74,31) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(74,42) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(75,33) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(75,46) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(76,13) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.ShortString,System.LongInt>"
-24-game-solve.pas(80,51) Error: Identifier not found "any"
-24-game-solve.pas(80,54) Error: Type identifier expected
-24-game-solve.pas(86,9) Error: Illegal qualifier
-24-game-solve.pas(87,22) Error: Illegal qualifier
-24-game-solve.pas(88,22) Error: Illegal qualifier
-24-game-solve.pas(90,9) Error: Illegal qualifier
-24-game-solve.pas(93,18) Error: Illegal qualifier
-24-game-solve.pas(96,18) Error: Illegal qualifier
-24-game-solve.pas(107,65) Error: Identifier not found "any"
-24-game-solve.pas(107,68) Error: Type identifier expected
-24-game-solve.pas(107,69) Error: Type identifier expected
-24-game-solve.pas(122,7) Error: Type mismatch
-24-game-solve.pas(124,52) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "TArray$1$crc9F312717"
+24-game-solve.pas(87,37) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+24-game-solve.pas(88,38) Error: Incompatible type for arg no. 1: Got "Variant", expected "TFPGMap<System.ShortString,System.Variant>"
+24-game-solve.pas(124,52) Error: Incompatible type for arg no. 1: Got "TArray$1$crcEC9BFAAE", expected "TArray$1$crc9F312717"
 24-game-solve.pas(125,12) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(125,34) Error: Incompatible types: got "Constant String" expected "LongInt"
 24-game-solve.pas(125,45) Error: Incompatible types: got "Constant String" expected "LongInt"
-24-game-solve.pas(127,59) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "TArray$1$crc9F312717"
-24-game-solve.pas(135,14) Error: Type mismatch
-24-game-solve.pas(138,16) Error: Type mismatch
-24-game-solve.pas(142,18) Error: Type mismatch
-24-game-solve.pas(147,45) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "TArray$1$crc9F312717"
-24-game-solve.pas(148,45) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "TArray$1$crc9F312717"
+24-game-solve.pas(127,59) Error: Incompatible type for arg no. 1: Got "TArray$1$crcEC9BFAAE", expected "TArray$1$crc9F312717"
+24-game-solve.pas(147,45) Error: Incompatible type for arg no. 1: Got "TArray$1$crcEC9BFAAE", expected "TArray$1$crc9F312717"
+24-game-solve.pas(148,45) Error: Incompatible type for arg no. 1: Got "TArray$1$crcEC9BFAAE", expected "TArray$1$crc9F312717"
 24-game-solve.pas(155,17) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.Variant,System.Variant>"
-24-game-solve.pas(156,60) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "Variant"
+24-game-solve.pas(156,88) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
 24-game-solve.pas(162,15) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.Variant,System.Variant>"
-24-game-solve.pas(163,58) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "Variant"
+24-game-solve.pas(163,86) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
 24-game-solve.pas(168,15) Error: Incompatible types: got "TFPGMap<System.ShortString,System.Variant>" expected "TFPGMap<System.Variant,System.Variant>"
-24-game-solve.pas(169,58) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "Variant"
-24-game-solve.pas(193,64) Error: Incompatible type for arg no. 2: Got "<erroneous type>", expected "Variant"
-24-game-solve.pas(198,23) Error: Incompatible type for arg no. 1: Got "TArray$1$crcE41905E8", expected "<erroneous type>"
-24-game-solve.pas(214) Fatal: There were 46 errors compiling module, stopping
+24-game-solve.pas(169,86) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.Variant,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
+24-game-solve.pas(193,92) Error: Incompatible type for arg no. 2: Got "TFPGMap<System.ShortString,System.Variant>", expected "TFPGMap<System.ShortString,System.LongInt>"
+24-game-solve.pas(198,23) Error: Incompatible type for arg no. 1: Got "TArray$1$crc9B9CCA38", expected "TArray$1$crcEC9BFAAE"
+24-game-solve.pas(214) Fatal: There were 25 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/out/Pascal/24-game-solve.pas
+++ b/tests/rosetta/out/Pascal/24-game-solve.pas
@@ -40,7 +40,7 @@ var
   goal: integer;
   n_cards: integer;
 
-function newNum(n: integer): specialize TFPGMap<string, any>;
+function newNum(n: integer): specialize TFPGMap<string, Variant>;
 var
   _tmp0: specialize TFPGMap<string, Variant>;
   _tmp1: specialize TFPGMap<string, Variant>;
@@ -55,7 +55,7 @@ begin
   exit;
 end;
 
-function exprEval(x: specialize TFPGMap<string, any>): specialize TFPGMap<string, integer>;
+function exprEval(x: specialize TFPGMap<string, Variant>): specialize TFPGMap<string, integer>;
 var
   _tmp2: specialize TFPGMap<string, Variant>;
   _tmp3: specialize TFPGMap<string, Variant>;
@@ -77,7 +77,7 @@ begin
   exit;
 end;
 
-function exprString(x: specialize TFPGMap<string, any>): string;
+function exprString(x: specialize TFPGMap<string, Variant>): string;
 var
   ls: Variant;
   opstr: string;
@@ -104,7 +104,7 @@ begin
   exit;
 end;
 
-function solve(xs: specialize TArray<specialize TFPGMap<string, any>>): boolean;
+function solve(xs: specialize TArray<specialize TFPGMap<string, Variant>>): boolean;
 var
   _tmp6: specialize TFPGMap<string, Variant>;
   _tmp7: specialize TFPGMap<string, Variant>;
@@ -117,7 +117,7 @@ var
   k: integer;
   node: specialize TFPGMap<Variant, Variant>;
   op: Variant;
-  rest: specialize TArray<Variant>;
+  rest: specialize TArray<specialize TFPGMap<string, integer>>;
 begin
   if (Length(xs) = 1) then
   begin
@@ -137,7 +137,7 @@ begin
     j := i + 1;
     while (j < Length(xs)) do
     begin
-      rest := specialize TArray<Variant>([]);
+      rest := specialize TArray<specialize TFPGMap<string, integer>>([]);
       k := 0;
       while (k < Length(xs)) do
       begin
@@ -153,20 +153,20 @@ begin
         _tmp6.AddOrSetData('left', a);
         _tmp6.AddOrSetData('right', b);
         node := _tmp6;
-        if solve(specialize _appendList<Variant>(rest, node)) then ;
+        if solve(specialize _appendList<specialize TFPGMap<string, integer>>(rest, node)) then ;
       end;
       _tmp7 := specialize TFPGMap<string, Variant>.Create;
       _tmp7.AddOrSetData('op', OP_SUB);
       _tmp7.AddOrSetData('left', b);
       _tmp7.AddOrSetData('right', a);
       node := _tmp7;
-      if solve(specialize _appendList<Variant>(rest, node)) then ;
+      if solve(specialize _appendList<specialize TFPGMap<string, integer>>(rest, node)) then ;
       _tmp8 := specialize TFPGMap<string, Variant>.Create;
       _tmp8.AddOrSetData('op', OP_DIV);
       _tmp8.AddOrSetData('left', b);
       _tmp8.AddOrSetData('right', a);
       node := _tmp8;
-      if solve(specialize _appendList<Variant>(rest, node)) then ;
+      if solve(specialize _appendList<specialize TFPGMap<string, integer>>(rest, node)) then ;
       j := j + 1;
     end;
     i := i + 1;
@@ -177,7 +177,7 @@ end;
 
 procedure main();
 var
-  cards: specialize TArray<Variant>;
+  cards: specialize TArray<specialize TFPGMap<string, integer>>;
   i: integer;
   iter: integer;
   n: Variant;
@@ -185,12 +185,12 @@ begin
   iter := 0;
   while (iter < 10) do
   begin
-    cards := specialize TArray<Variant>([]);
+    cards := specialize TArray<specialize TFPGMap<string, integer>>([]);
     i := 0;
     while (i < n_cards) do
     begin
       n := _now() mod digit_range - 1 + 1;
-      cards := specialize _appendList<Variant>(cards, newNum(n));
+      cards := specialize _appendList<specialize TFPGMap<string, integer>>(cards, newNum(n));
       writeln(' ' + IntToStr(n));
       i := i + 1;
     end;

--- a/tests/rosetta/out/Pascal/4-rings-or-4-squares-puzzle.error
+++ b/tests/rosetta/out/Pascal/4-rings-or-4-squares-puzzle.error
@@ -20,8 +20,6 @@ fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,Sys
 4-rings-or-4-squares-puzzle.pas(54,54) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
 4-rings-or-4-squares-puzzle.pas(54,57) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
 4-rings-or-4-squares-puzzle.pas(61,10) Note: Call to subroutine "operator =(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
-4-rings-or-4-squares-puzzle.pas(70,93) Error: Identifier not found "any"
-4-rings-or-4-squares-puzzle.pas(70,96) Error: Type identifier expected
 4-rings-or-4-squares-puzzle.pas(85,12) Error: Incompatible types: got "ShortInt" expected "<procedure variable type of function(Variant):LongInt is nested;Register>"
 4-rings-or-4-squares-puzzle.pas(86,7) Error: Ordinal expression expected
 4-rings-or-4-squares-puzzle.pas(88,9) Error: Ordinal expression expected
@@ -31,6 +29,6 @@ fgl.pp(1668,8) Note: Call to subroutine "function TFPGMap<System.ShortString,Sys
 4-rings-or-4-squares-puzzle.pas(106,30) Error: Operator is not overloaded: "<procedure variable type of function(Variant):LongInt is nested;Register>" + "ShortInt"
 4-rings-or-4-squares-puzzle.pas(114,36) Error: Incompatible type for arg no. 2: Got "<procedure variable type of function(Variant):LongInt is nested;Register>", expected "Variant"
 4-rings-or-4-squares-puzzle.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
-4-rings-or-4-squares-puzzle.pas(130) Fatal: There were 10 errors compiling module, stopping
+4-rings-or-4-squares-puzzle.pas(130) Fatal: There were 8 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/out/Pascal/4-rings-or-4-squares-puzzle.pas
+++ b/tests/rosetta/out/Pascal/4-rings-or-4-squares-puzzle.pas
@@ -67,7 +67,7 @@ begin
   exit;
 end;
 
-function getCombs(low: integer; high: integer; unique: boolean): specialize TFPGMap<string, any>;
+function getCombs(low: integer; high: integer; unique: boolean): specialize TFPGMap<string, Variant>;
 var
   _tmp0: specialize TFPGMap<string, Variant>;
   a: Variant;

--- a/tests/rosetta/out/Pascal/9-billion-names-of-god-the-integer.error
+++ b/tests/rosetta/out/Pascal/9-billion-names-of-god-the-integer.error
@@ -4,29 +4,41 @@ Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /tmp/9-billion-names-of-god-the-integer.pas
 9-billion-names-of-god-the-integer.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
-9-billion-names-of-god-the-integer.pas(53,8) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(54,10) Note: Call to subroutine "operator >(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(54,13) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(54,62) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(54,62) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(54,59) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(56,52) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(56,52) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(56,49) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(57,12) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(57,12) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
-9-billion-names-of-god-the-integer.pas(76,13) Error: Incompatible types: got "TArray$1$crcE41905E8" expected "TArray$1$crc9F312717"
+9-billion-names-of-god-the-integer.pas(58,8) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(59,10) Note: Call to subroutine "operator >(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(59,13) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(59,62) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(59,62) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(59,59) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(61,52) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(61,52) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(61,49) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(62,12) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(62,12) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
 9-billion-names-of-god-the-integer.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
-9-billion-names-of-god-the-integer.pas(103,24) Error: Incompatible type for arg no. 1: Got "TArray$1$crcE41905E8", expected "TArray$1$crc9F312717"
-9-billion-names-of-god-the-integer.pas(136,24) Error: Incompatible type for arg no. 1: Got "TArray$1$crcE41905E8", expected "TArray$1$crc9F312717"
-9-billion-names-of-god-the-integer.pas(181,74) Error: Incompatible types: got "TArray$1$crcF9AFD986" expected "<procedure variable type of function(LongInt):{Dynamic} Array Of ShortString is nested;Register>"
-9-billion-names-of-god-the-integer.pas(186,62) Error: Illegal qualifier
-9-billion-names-of-god-the-integer.pas(186,62) Error: Type mismatch
-9-billion-names-of-god-the-integer.pas(189,56) Error: Incompatible type for arg no. 2: Got "<procedure variable type of function(LongInt):{Dynamic} Array Of ShortString is nested;Register>", expected "Variant"
-9-billion-names-of-god-the-integer.pas(212,13) Error: Incompatible types: got "TArray$1$crcE41905E8" expected "TArray$1$crc862A1656"
-9-billion-names-of-god-the-integer.pas(236,18) Error: Incompatible type for arg no. 1: Got "<procedure variable type of function(Variant):LongInt is nested;Register>", expected "LongInt"
-9-billion-names-of-god-the-integer.pas(237,25) Error: Incompatible type for arg no. 1: Got "<procedure variable type of function(Variant):LongInt is nested;Register>", expected "QWord"
-9-billion-names-of-god-the-integer.pas(234,7) Error: Incompatible types: got "LongInt" expected "<procedure variable type of function(Variant):LongInt is nested;Register>"
-9-billion-names-of-god-the-integer.pas(240) Fatal: There were 11 errors compiling module, stopping
+9-billion-names-of-god-the-integer.pas(126,11) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(129,21) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(129,21) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(129,16) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(129,21) Note: Call to subroutine "operator :=(const source:LongInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(130,8) Note: Call to subroutine "operator <(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(130,14) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(132,20) Note: Call to subroutine "operator +(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(132,20) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(138,53) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(151,18) Note: Call to subroutine "operator :=(const source:Int64):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(152,9) Note: Call to subroutine "operator >=(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(152,12) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(154,58) Note: Call to subroutine "operator :=(const source:Variant):LongInt;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(155,12) Note: Call to subroutine "operator -(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(155,12) Note: Call to subroutine "operator :=(const source:ShortInt):Variant;" marked as inline is not inlined
+9-billion-names-of-god-the-integer.pas(190,165) Error: Incompatible type for arg no. 1: Got "TArray$1$crc47A4C996", expected "TArray$1$crcDEAD982C"
+9-billion-names-of-god-the-integer.pas(191,196) Error: Incompatible type for arg no. 2: Got "TArray$1$crcDEAD982C", expected "TArray$1$crc9F312717"
+9-billion-names-of-god-the-integer.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
+9-billion-names-of-god-the-integer.pas(13,19) Warning: function result variable of a managed type does not seem to be initialized
+9-billion-names-of-god-the-integer.pas(241,18) Error: Incompatible type for arg no. 1: Got "<procedure variable type of function(Variant):LongInt is nested;Register>", expected "LongInt"
+9-billion-names-of-god-the-integer.pas(242,25) Error: Incompatible type for arg no. 1: Got "<procedure variable type of function(Variant):LongInt is nested;Register>", expected "QWord"
+9-billion-names-of-god-the-integer.pas(239,7) Error: Incompatible types: got "LongInt" expected "<procedure variable type of function(Variant):LongInt is nested;Register>"
+9-billion-names-of-god-the-integer.pas(245) Fatal: There were 5 errors compiling module, stopping
 Fatal: Compilation aborted
 Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/out/Pascal/9-billion-names-of-god-the-integer.pas
+++ b/tests/rosetta/out/Pascal/9-billion-names-of-god-the-integer.pas
@@ -16,6 +16,11 @@ begin
   Result[n] := val;
 end;
 
+generic function _countList<T>(arr: specialize TArray<T>): integer;
+begin
+  Result := Length(arr);
+end;
+
 generic function _indexList<T>(arr: specialize TArray<T>; i: integer): T;
 begin
   if i < 0 then i := Length(arr) + i;
@@ -40,7 +45,7 @@ end;
 
 
 var
-  i: Variant;
+  i: integer;
   line: string;
   num: function(p0: Variant): integer is nested;
   r: Variant;
@@ -62,15 +67,15 @@ end;
 
 function bigFromInt(x: integer): specialize TArray<integer>;
 var
-  digits: specialize TArray<Variant>;
-  n: Variant;
+  digits: specialize TArray<integer>;
+  n: integer;
 begin
   if (x = 0) then ;
-  digits := specialize TArray<Variant>([]);
+  digits := specialize TArray<integer>([]);
   n := x;
   while (n > 0) do
   begin
-    digits := specialize _appendList<Variant>(digits, n mod 10);
+    digits := specialize _appendList<integer>(digits, n mod 10);
     n := n div 10;
   end;
   result := digits;
@@ -83,10 +88,10 @@ var
   bv: integer;
   carry: integer;
   i: integer;
-  res: specialize TArray<Variant>;
+  res: specialize TArray<integer>;
   s: integer;
 begin
-  res := specialize TArray<Variant>([]);
+  res := specialize TArray<integer>([]);
   carry := 0;
   i := 0;
   while (((i < Length(a)) or (i < Length(b))) or (carry > 0)) do
@@ -96,7 +101,7 @@ begin
     bv := 0;
     if (i < Length(b)) then ;
     s := av + bv + carry;
-    res := specialize _appendList<Variant>(res, s mod 10);
+    res := specialize _appendList<integer>(res, s mod 10);
     carry := s div 10;
     i := i + 1;
   end;
@@ -111,9 +116,9 @@ var
   bv: integer;
   diff: Variant;
   i: integer;
-  res: specialize TArray<Variant>;
+  res: specialize TArray<integer>;
 begin
-  res := specialize TArray<Variant>([]);
+  res := specialize TArray<integer>([]);
   borrow := 0;
   i := 0;
   while (i < Length(a)) do
@@ -130,7 +135,7 @@ begin
     begin
       borrow := 0;
     end;
-    res := specialize _appendList<Variant>(res, diff);
+    res := specialize _appendList<integer>(res, diff);
     i := i + 1;
   end;
   result := bigTrim(res);
@@ -168,13 +173,13 @@ end;
 
 function cumu(n: integer): specialize TArray<specialize TArray<integer>>;
 var
-  cache: specialize TArray<Variant>;
-  row: function(p0: integer): specialize TArray<string> is nested;
-  val: specialize TArray<Variant>;
+  cache: specialize TArray<specialize TArray<specialize TArray<integer>>>;
+  row: specialize TArray<specialize TArray<integer>>;
+  val: specialize TArray<specialize TArray<specialize TArray<integer>>>;
   x: integer;
   y: integer;
 begin
-  cache := specialize TArray<Variant>([specialize TArray<specialize TArray<integer>>([bigFromInt(1)])]);
+  cache := specialize TArray<specialize TArray<specialize TArray<integer>>>([specialize TArray<specialize TArray<integer>>([bigFromInt(1)])]);
   y := 1;
   while (y <= n) do
   begin
@@ -182,14 +187,14 @@ begin
     x := 1;
     while (x <= y) do
     begin
-      val := specialize _indexList<Variant>(specialize _indexList<Variant>(cache, y - x), minInt(x, y - x));
-      row := specialize _appendList<Variant>(row, bigAdd(row[Length(row) - 1], val));
+      val := specialize _indexList<specialize TArray<specialize TArray<integer>>>(specialize _indexList<specialize TArray<specialize TArray<integer>>>(cache, y - x), minInt(x, y - x));
+      row := specialize _appendList<specialize TArray<integer>>(row, bigAdd(specialize _indexList<specialize TArray<integer>>(row, specialize _countList<specialize TArray<integer>>(row) - 1), val));
       x := x + 1;
     end;
-    cache := specialize _appendList<Variant>(cache, row);
+    cache := specialize _appendList<specialize TArray<specialize TArray<integer>>>(cache, row);
     y := y + 1;
   end;
-  result := specialize _indexList<Variant>(cache, n);
+  result := specialize _indexList<specialize TArray<specialize TArray<integer>>>(cache, n);
   exit;
 end;
 
@@ -197,16 +202,16 @@ function row(n: integer): specialize TArray<string>;
 var
   diff: Variant;
   e: Variant;
-  i: Variant;
-  out: specialize TArray<Variant>;
+  i: integer;
+  out: specialize TArray<string>;
 begin
   e := cumu(n);
-  out := specialize TArray<Variant>([]);
+  out := specialize TArray<string>([]);
   i := 0;
   while (i < n) do
   begin
     diff := bigSub(e[i + 1], e[i]);
-    out := specialize _appendList<Variant>(out, bigToString(diff));
+    out := specialize _appendList<string>(out, bigToString(diff));
     i := i + 1;
   end;
   result := out;

--- a/tests/rosetta/out/Pascal/99-bottles-of-beer-2.pas
+++ b/tests/rosetta/out/Pascal/99-bottles-of-beer-2.pas
@@ -55,9 +55,9 @@ var
   ch: Variant;
   cur: string;
   i: integer;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
-  words := specialize TArray<Variant>([]);
+  words := specialize TArray<string>([]);
   cur := '';
   i := 0;
   while (i < Length(s)) do
@@ -68,7 +68,7 @@ begin
     begin
       if (Length(cur) > 0) then
       begin
-        words := specialize _appendList<Variant>(words, cur);
+        words := specialize _appendList<string>(words, cur);
         cur := '';
       end;
     end else
@@ -144,22 +144,22 @@ end;
 
 function slur(p: string; d: integer): string;
 var
-  a: specialize TArray<Variant>;
+  a: specialize TArray<string>;
   i: integer;
   idx: Variant;
   j: Variant;
   k: integer;
   s: Variant;
   seed: Variant;
-  tmp: specialize TArray<Variant>;
+  tmp: specialize TArray<string>;
   w: Variant;
 begin
   if (Length(p) <= 2) then ;
-  a := specialize TArray<Variant>([]);
+  a := specialize TArray<string>([]);
   i := 1;
   while (i < Length(p) - 1) do
   begin
-    a := specialize _appendList<Variant>(a, _sliceString(p, i, i + i + 1));
+    a := specialize _appendList<string>(a, _sliceString(p, i, i + i + 1));
     i := i + 1;
   end;
   idx := Length(a) - 1;
@@ -170,8 +170,8 @@ begin
     if (seed mod 100 >= d) then
     begin
       j := seed mod idx + 1;
-      tmp := specialize _indexList<Variant>(a, idx);
-      a[idx] := specialize _indexList<Variant>(a, j);
+      tmp := specialize _indexList<string>(a, idx);
+      a[idx] := specialize _indexList<string>(a, j);
       a[j] := tmp;
     end;
     idx := idx - 1;
@@ -180,7 +180,7 @@ begin
   k := 0;
   while (k < Length(a)) do
   begin
-    s := s + specialize _indexList<Variant>(a, k);
+    s := s + specialize _indexList<string>(a, k);
     k := k + 1;
   end;
   s := s + _sliceString(p, Length(p) - 1, Length(p) - 1 + Length(p));

--- a/tests/rosetta/out/Pascal/README.md
+++ b/tests/rosetta/out/Pascal/README.md
@@ -2,27 +2,27 @@
 
 This directory holds Pascal source code generated from the Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
-## Program checklist
-- [x] 100-doors-2
-- [x] 100-doors-3
-- [x] 100-doors
-- [ ] 100-prisoners
-- [ ] 15-puzzle-game
-- [ ] 15-puzzle-solver
-- [ ] 2048
-- [ ] 21-game
-- [ ] 24-game-solve
-- [ ] 24-game
-- [ ] 4-rings-or-4-squares-puzzle
-- [ ] 9-billion-names-of-god-the-integer
-- [ ] 99-bottles-of-beer-2
-- [x] 99-bottles-of-beer
-- [ ] DNS-query
-- [ ] a+b
-- [ ] abbreviations-automatic
-- [ ] abbreviations-easy
-- [ ] abbreviations-simple
-- [ ] abc-problem
+-## Program checklist
+1. [x] 100-doors-2
+2. [x] 100-doors-3
+3. [x] 100-doors
+4. [ ] 100-prisoners
+5. [ ] 15-puzzle-game
+6. [ ] 15-puzzle-solver
+7. [ ] 2048
+8. [ ] 21-game
+9. [ ] 24-game-solve
+10. [ ] 24-game
+11. [ ] 4-rings-or-4-squares-puzzle
+12. [ ] 9-billion-names-of-god-the-integer
+13. [ ] 99-bottles-of-beer-2
+14. [x] 99-bottles-of-beer
+15. [ ] DNS-query
+16. [ ] a+b
+17. [ ] abbreviations-automatic
+18. [ ] abbreviations-easy
+19. [ ] abbreviations-simple
+20. [ ] abc-problem
 - [ ] abelian-sandpile-model-identity
 - [ ] abelian-sandpile-model
 - [ ] abstract-type

--- a/tests/rosetta/out/Pascal/abbreviations-automatic.pas
+++ b/tests/rosetta/out/Pascal/abbreviations-automatic.pas
@@ -44,9 +44,9 @@ var
   ch: Variant;
   cur: string;
   i: integer;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
-  words := specialize TArray<Variant>([]);
+  words := specialize TArray<string>([]);
   cur := '';
   i := 0;
   while (i < Length(s)) do
@@ -57,7 +57,7 @@ begin
     begin
       if (Length(cur) > 0) then
       begin
-        words := specialize _appendList<Variant>(words, cur);
+        words := specialize _appendList<string>(words, cur);
         cur := '';
       end;
     end else
@@ -92,13 +92,13 @@ function distinct(xs: specialize TArray<string>): specialize TArray<string>;
 var
   _tmp0: specialize TFPGMap<string, integer>;
   i: integer;
-  m: specialize TFPGMap<Variant, Variant>;
-  out: specialize TArray<Variant>;
+  m: specialize TFPGMap<string, boolean>;
+  out: specialize TArray<string>;
   x: Variant;
 begin
   _tmp0 := specialize TFPGMap<string, integer>.Create;
   m := _tmp0;
-  out := specialize TArray<Variant>([]);
+  out := specialize TArray<string>([]);
   i := 0;
   while (i < Length(xs)) do
   begin
@@ -106,7 +106,7 @@ begin
     if not (m.IndexOf(x) >= 0) then
     begin
       m.KeyData[x] := True;
-      out := specialize _appendList<Variant>(out, x);
+      out := specialize _appendList<string>(out, x);
     end;
     i := i + 1;
   end;
@@ -116,7 +116,7 @@ end;
 
 function abbrevLen(words: specialize TArray<string>): integer;
 var
-  abbrs: specialize TArray<Variant>;
+  abbrs: specialize TArray<string>;
   i: integer;
   l: integer;
   size: Variant;
@@ -125,11 +125,11 @@ begin
   l := 1;
   while True do
   begin
-    abbrs := specialize TArray<Variant>([]);
+    abbrs := specialize TArray<string>([]);
     i := 0;
     while (i < size) do
     begin
-      abbrs := specialize _appendList<Variant>(abbrs, takeRunes(specialize _indexList<Variant>(words, i), l));
+      abbrs := specialize _appendList<string>(abbrs, takeRunes(specialize _indexList<string>(words, i), l));
       i := i + 1;
     end;
     if (Length(distinct(abbrs)) = size) then ;
@@ -154,7 +154,7 @@ var
   i: integer;
   l: Variant;
   lines: specialize TArray<Variant>;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
   lines := specialize TArray<Variant>(['Sunday Monday Tuesday Wednesday Thursday Friday Saturday', 'Sondag Maandag Dinsdag Woensdag Donderdag Vrydag Saterdag', 'E_djelë E_hënë E_martë E_mërkurë E_enjte E_premte E_shtunë', 'Ehud Segno Maksegno Erob Hamus Arbe Kedame', 'Al_Ahad Al_Ithinin Al_Tholatha''a Al_Arbia''a Al_Kamis Al_Gomia''a Al_Sabit', 'Guiragui Yergou_shapti Yerek_shapti Tchorek_shapti Hink_shapti Ourpat Shapat', 'domingu llunes martes miércoles xueves vienres sábadu', 'Bazar_gÜnÜ Birinci_gÜn Çkinci_gÜn ÜçÜncÜ_gÜn DÖrdÜncÜ_gÜn Bes,inci_gÜn Altòncò_gÜn', 'Igande Astelehen Astearte Asteazken Ostegun Ostiral Larunbat', 'Robi_bar Shom_bar Mongal_bar Budhh_bar BRihashpati_bar Shukro_bar Shoni_bar', 'Nedjelja Ponedeljak Utorak Srijeda Cxetvrtak Petak Subota', 'Disul Dilun Dimeurzh Dimerc''her Diriaou Digwener Disadorn', 'nedelia ponedelnik vtornik sriada chetvartak petak sabota', 'sing_kei_yaht sing_kei_yat sing_kei_yee sing_kei_saam sing_kei_sie sing_kei_ng sing_kei_luk', 'Diumenge Dilluns Dimarts Dimecres Dijous Divendres Dissabte', 'Dzeenkk-eh Dzeehn_kk-ehreh Dzeehn_kk-ehreh_nah_kay_dzeeneh Tah_neesee_dzeehn_neh Deehn_ghee_dzee-neh Tl-oowey_tts-el_dehlee Dzeentt-ahzee', 'dy_Sul dy_Lun dy_Meurth dy_Mergher dy_You dy_Gwener dy_Sadorn', 'Dimanch Lendi Madi Mèkredi Jedi Vandredi Samdi', 'nedjelja ponedjeljak utorak srijeda cxetvrtak petak subota', 'nede^le ponde^lí úterÿ str^eda c^tvrtek pátek sobota', 'Sondee Mondee Tiisiday Walansedee TOOsedee Feraadee Satadee', 's0ndag mandag tirsdag onsdag torsdag fredag l0rdag', 'zondag maandag dinsdag woensdag donderdag vrijdag zaterdag', 'Diman^co Lundo Mardo Merkredo ^Jaùdo Vendredo Sabato', 'pÜhapäev esmaspäev teisipäev kolmapäev neljapäev reede laupäev', 'Diu_prima Diu_sequima Diu_tritima Diu_quartima Diu_quintima Diu_sextima Diu_sabbata', 'sunnudagur mánadagur tÿsdaguy mikudagur hósdagur friggjadagur leygardagur', 'Yek_Sham''beh Do_Sham''beh Seh_Sham''beh Cha''har_Sham''beh Panj_Sham''beh Jom''eh Sham''beh', 'sunnuntai maanantai tiistai keskiviiko torsktai perjantai lauantai', 'dimanche lundi mardi mercredi jeudi vendredi samedi', 'Snein Moandei Tiisdei Woansdei Tonersdei Freed Sneon', 'Domingo Segunda_feira Martes Mércores Joves Venres Sábado', 'k''vira orshabati samshabati otkhshabati khutshabati p''arask''evi shabati', 'Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Samstag', 'Kiriaki'' Defte''ra Tri''ti Teta''rti Pe''mpti Paraskebi'' Sa''bato', 'ravivaar somvaar mangalvaar budhvaar guruvaar shukravaar shanivaar', 'pópule pó`akahi pó`alua pó`akolu pó`ahá pó`alima pó`aono', 'Yom_rishon Yom_sheni Yom_shlishi Yom_revi''i Yom_chamishi Yom_shishi Shabat', 'ravivara somavar mangalavar budhavara brahaspativar shukravara shanivar', 'vasárnap hétfö kedd szerda csütörtök péntek szombat', 'Sunnudagur Mánudagur ╞riδjudagur Miδvikudagar Fimmtudagur FÖstudagur Laugardagur', 'sundio lundio mardio merkurdio jovdio venerdio saturdio', 'Minggu Senin Selasa Rabu Kamis Jumat Sabtu', 'Dominica Lunedi Martedi Mercuridi Jovedi Venerdi Sabbato', 'Dé_Domhnaigh Dé_Luain Dé_Máirt Dé_Ceadaoin Dé_ardaoin Dé_hAoine Dé_Sathairn', 'domenica lunedí martedí mercoledí giovedí venerdí sabato', 'Nichiyou_bi Getzuyou_bi Kayou_bi Suiyou_bi Mokuyou_bi Kin''you_bi Doyou_bi', 'Il-yo-il Wol-yo-il Hwa-yo-il Su-yo-il Mok-yo-il Kum-yo-il To-yo-il', 'Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni', 'sve-tdien pirmdien otrdien tresvdien ceturtdien piektdien sestdien', 'Sekmadienis Pirmadienis Antradienis Trec^iadienis Ketvirtadienis Penktadienis S^es^tadienis', 'Wangu Kazooba Walumbe Mukasa Kiwanuka Nnagawonye Wamunyi', 'xing-_qi-_rì xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù', 'Jedoonee Jelune Jemayrt Jecrean Jardaim Jeheiney Jesam', 'Jabot Manre Juje Wonje Taije Balaire Jarere', 'geminrongo minòmishi mártes mièrkoles misheushi bèrnashi mishábaro', 'Ahad Isnin Selasa Rabu Khamis Jumaat Sabtu', 'sφndag mandag tirsdag onsdag torsdag fredag lφrdag', 'lo_dimenge lo_diluns lo_dimarç lo_dimèrcres lo_dijòus lo_divendres lo_dissabte', 'djadomingo djaluna djamars djarason djaweps djabièrna djasabra', 'Niedziela Poniedzial/ek Wtorek S,roda Czwartek Pia,tek Sobota', 'Domingo segunda-feire terça-feire quarta-feire quinta-feire sexta-feira såbado', 'Domingo Lunes martes Miercoles Jueves Viernes Sabado', 'Duminicª Luni Mart''i Miercuri Joi Vineri Sâmbªtª', 'voskresenie ponedelnik vtornik sreda chetverg pyatnitsa subbota', 'Sunday Di-luain Di-màirt Di-ciadain Di-ardaoin Di-haoine Di-sathurne', 'nedjelja ponedjeljak utorak sreda cxetvrtak petak subota', 'Sontaha Mmantaha Labobedi Laboraro Labone Labohlano Moqebelo', 'Iridha- Sandhudha- Anga.haruwa-dha- Badha-dha- Brahaspa.thindha- Sikura-dha- Sena.sura-dha-', 'nedel^a pondelok utorok streda s^tvrtok piatok sobota', 'Nedelja Ponedeljek Torek Sreda Cxetrtek Petek Sobota', 'domingo lunes martes miércoles jueves viernes sábado', 'sonde mundey tude-wroko dride-wroko fode-wroko freyda Saturday', 'Jumapili Jumatatu Jumanne Jumatano Alhamisi Ijumaa Jumamosi', 'söndag måndag tisdag onsdag torsdag fredag lordag', 'Linggo Lunes Martes Miyerkoles Huwebes Biyernes Sabado', 'Lé-pài-jít Pài-it Pài-jï Pài-sañ Pài-sì Pài-gÖ. Pài-lák', 'wan-ar-tit wan-tjan wan-ang-kaan wan-phoet wan-pha-ru-hat-sa-boh-die wan-sook wan-sao', 'Tshipi Mosupologo Labobedi Laboraro Labone Labotlhano Matlhatso', 'Pazar Pazartesi Sali Çar,samba Per,sembe Cuma Cumartesi', 'nedilya ponedilok vivtorok sereda chetver pyatnytsya subota', 'Chu?_Nhâ.t Thú*_Hai Thú*_Ba Thú*_Tu* Thú*_Na''m Thú*_Sáu Thú*_Ba?y', 'dydd_Sul dyds_Llun dydd_Mawrth dyds_Mercher dydd_Iau dydd_Gwener dyds_Sadwrn', 'Dibeer Altine Talaata Allarba Al_xebes Aljuma Gaaw', 'iCawa uMvulo uLwesibini uLwesithathu uLuwesine uLwesihlanu uMgqibelo', 'zuntik montik dinstik mitvokh donershtik fraytik shabes', 'iSonto uMsombuluko uLwesibili uLwesithathu uLwesine uLwesihlanu uMgqibelo', 'Dies_Dominica Dies_Lunæ Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Saturni', 'Bazar_gÜnÜ Bazar_ærtæsi Çærs,ænbæ_axs,amò Çærs,ænbæ_gÜnÜ CÜmæ_axs,amò CÜmæ_gÜnÜ CÜmæ_Senbæ', 'Sun Moon Mars Mercury Jove Venus Saturn', 'zondag maandag dinsdag woensdag donderdag vrijdag zaterdag', 'KoseEraa GyoOraa BenEraa Kuoraa YOwaaraa FeEraa Memenaa', 'Sonntag Montag Dienstag Mittwoch Donnerstag Freitag Sonnabend', 'Domingo Luns Terza_feira Corta_feira Xoves Venres Sábado', 'Dies_Solis Dies_Lunae Dies_Martis Dies_Mercurii Dies_Iovis Dies_Veneris Dies_Sabbatum', 'xing-_qi-_tiàn xing-_qi-_yi-. xing-_qi-_èr xing-_qi-_san-. xing-_qi-_sì xing-_qi-_wuv. xing-_qi-_liù', 'djadomingu djaluna djamars djarason djaweps djabièrnè djasabra', 'Killachau Atichau Quoyllurchau Illapachau Chaskachau Kuychichau Intichau']);
   i := 0;

--- a/tests/rosetta/out/Pascal/abbreviations-easy.pas
+++ b/tests/rosetta/out/Pascal/abbreviations-easy.pas
@@ -55,9 +55,9 @@ var
   ch: Variant;
   cur: string;
   i: integer;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
-  words := specialize TArray<Variant>([]);
+  words := specialize TArray<string>([]);
   cur := '';
   i := 0;
   while (i < Length(s)) do
@@ -68,7 +68,7 @@ begin
     begin
       if (Length(cur) > 0) then
       begin
-        words := specialize _appendList<Variant>(words, cur);
+        words := specialize _appendList<string>(words, cur);
         cur := '';
       end;
     end else
@@ -100,7 +100,7 @@ end;
 
 function join(xs: specialize TArray<string>; sep: string): string;
 var
-  i: Variant;
+  i: integer;
   res: string;
 begin
   res := '';
@@ -121,18 +121,18 @@ var
   ci: integer;
   cmd: Variant;
   found: boolean;
-  results: specialize TArray<Variant>;
-  w: specialize TArray<Variant>;
+  results: specialize TArray<string>;
+  w: specialize TArray<string>;
   wi: integer;
   wlen: Variant;
   ww: Variant;
 begin
-  results := specialize TArray<Variant>([]);
+  results := specialize TArray<string>([]);
   if (Length(words) = 0) then ;
   wi := 0;
   while (wi < Length(words)) do
   begin
-    w := specialize _indexList<Variant>(words, wi);
+    w := specialize _indexList<string>(words, wi);
     found := False;
     wlen := Length(w);
     ci := 0;
@@ -145,7 +145,7 @@ begin
         ww := UpperCase(w);
         if (_sliceString(c, 0, 0 + wlen) = ww) then
         begin
-          results := specialize _appendList<Variant>(results, c);
+          results := specialize _appendList<string>(results, c);
           found := True;
           break;
         end;
@@ -165,19 +165,19 @@ var
   cmd: Variant;
   commands: Variant;
   count: function(p0: Variant): integer is nested;
-  i: Variant;
+  i: integer;
   j: integer;
   k: integer;
-  mins: specialize TArray<Variant>;
+  mins: specialize TArray<integer>;
   out1: string;
-  results: specialize TArray<Variant>;
+  results: specialize TArray<string>;
   sentence: string;
   table: string;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
   table := 'Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy ' + 'COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find ' + 'NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput ' + ' Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO ' + 'MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT ' + 'READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT ' + 'RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp ';
   commands := fields(table);
-  mins := specialize TArray<Variant>([]);
+  mins := specialize TArray<integer>([]);
   i := 0;
   while (i < Length(commands)) do
   begin
@@ -190,7 +190,7 @@ begin
       if ((ch >= 'A') and (ch <= 'Z')) then ;
       j := j + 1;
     end;
-    mins := specialize _appendList<Variant>(mins, count);
+    mins := specialize _appendList<integer>(mins, count);
     i := i + 1;
   end;
   sentence := 'riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin';
@@ -200,7 +200,7 @@ begin
   k := 0;
   while (k < Length(words)) do
   begin
-    out1 := out1 + padRight(specialize _indexList<Variant>(words, k), Length(specialize _indexList<Variant>(results, k))) + ' ';
+    out1 := out1 + padRight(specialize _indexList<string>(words, k), Length(specialize _indexList<string>(results, k))) + ' ';
     k := k + 1;
   end;
   writeln(out1);

--- a/tests/rosetta/out/Pascal/abbreviations-simple.pas
+++ b/tests/rosetta/out/Pascal/abbreviations-simple.pas
@@ -55,9 +55,9 @@ var
   ch: Variant;
   cur: string;
   i: integer;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
-  words := specialize TArray<Variant>([]);
+  words := specialize TArray<string>([]);
   cur := '';
   i := 0;
   while (i < Length(s)) do
@@ -68,7 +68,7 @@ begin
     begin
       if (Length(cur) > 0) then
       begin
-        words := specialize _appendList<Variant>(words, cur);
+        words := specialize _appendList<string>(words, cur);
         cur := '';
       end;
     end else
@@ -100,7 +100,7 @@ end;
 
 function join(xs: specialize TArray<string>; sep: string): string;
 var
-  i: Variant;
+  i: integer;
   res: string;
 begin
   res := '';
@@ -119,7 +119,7 @@ function parseIntStr(str: string): integer;
 var
   _tmp0: specialize TFPGMap<string, integer>;
   digits: specialize TFPGMap<Variant, Variant>;
-  i: Variant;
+  i: integer;
   n: integer;
   neg: boolean;
 begin
@@ -156,7 +156,7 @@ end;
 function isDigits(s: string): boolean;
 var
   ch: Variant;
-  i: Variant;
+  i: integer;
 begin
   if (Length(s) = 0) then ;
   i := 0;
@@ -170,20 +170,20 @@ begin
   exit;
 end;
 
-function readTable(table: string): specialize TFPGMap<string, any>;
+function readTable(table: string): specialize TFPGMap<string, Variant>;
 var
-  _tmp1: specialize TFPGMap<string, specialize TArray<Variant>>;
+  _tmp1: specialize TFPGMap<string, Variant>;
   cmd: Variant;
-  cmds: specialize TArray<Variant>;
-  i: Variant;
+  cmds: specialize TArray<string>;
+  i: integer;
   minlen: Variant;
-  mins: specialize TArray<Variant>;
+  mins: specialize TArray<integer>;
   num: function(p0: Variant): integer is nested;
   toks: Variant;
 begin
   toks := fields(table);
-  cmds := specialize TArray<Variant>([]);
-  mins := specialize TArray<Variant>([]);
+  cmds := specialize TArray<string>([]);
+  mins := specialize TArray<integer>([]);
   i := 0;
   while (i < Length(toks)) do
   begin
@@ -199,10 +199,10 @@ begin
         i := i + 1;
       end;
     end;
-    cmds := specialize _appendList<Variant>(cmds, cmd);
-    mins := specialize _appendList<Variant>(mins, minlen);
+    cmds := specialize _appendList<string>(cmds, cmd);
+    mins := specialize _appendList<integer>(mins, minlen);
   end;
-  _tmp1 := specialize TFPGMap<string, specialize TArray<Variant>>.Create;
+  _tmp1 := specialize TFPGMap<string, Variant>.Create;
   _tmp1.AddOrSetData('commands', cmds);
   _tmp1.AddOrSetData('mins', mins);
   result := _tmp1;
@@ -215,30 +215,30 @@ var
   ci: integer;
   cmd: Variant;
   found: boolean;
-  results: specialize TArray<Variant>;
-  w: specialize TArray<Variant>;
+  results: specialize TArray<string>;
+  w: specialize TArray<string>;
   wi: integer;
   wlen: Variant;
   ww: Variant;
 begin
-  results := specialize TArray<Variant>([]);
+  results := specialize TArray<string>([]);
   wi := 0;
   while (wi < Length(words)) do
   begin
-    w := specialize _indexList<Variant>(words, wi);
+    w := specialize _indexList<string>(words, wi);
     found := False;
     wlen := Length(w);
     ci := 0;
     while (ci < Length(commands)) do
     begin
       cmd := specialize _indexList<integer>(commands, ci);
-      if (((specialize _indexList<Variant>(mins, ci) <> 0) and (wlen >= specialize _indexList<Variant>(mins, ci))) and (wlen <= Length(cmd))) then
+      if (((specialize _indexList<integer>(mins, ci) <> 0) and (wlen >= specialize _indexList<integer>(mins, ci))) and (wlen <= Length(cmd))) then
       begin
         c := UpperCase(cmd);
         ww := UpperCase(w);
         if (_sliceString(c, 0, 0 + wlen) = ww) then
         begin
-          results := specialize _appendList<Variant>(results, c);
+          results := specialize _appendList<string>(results, c);
           found := True;
           break;
         end;
@@ -256,13 +256,13 @@ procedure main();
 var
   commands: specialize TArray<string>;
   k: integer;
-  mins: specialize TArray<Variant>;
+  mins: specialize TArray<integer>;
   out1: string;
-  results: specialize TArray<Variant>;
+  results: specialize TArray<string>;
   sentence: string;
   table: string;
   tbl: Variant;
-  words: specialize TArray<Variant>;
+  words: specialize TArray<string>;
 begin
   table := '' + 'add 1  alter 3  backup 2  bottom 1  Cappend 2  change 1  Schange  Cinsert 2  Clast 3 ' + 'compress 4 copy 2 count 3 Coverlay 3 cursor 3  delete 3 Cdelete 2  down 1  duplicate ' + '3 xEdit 1 expand 3 extract 3  find 1 Nfind 2 Nfindup 6 NfUP 3 Cfind 2 findUP 3 fUP 2 ' + 'forward 2  get  help 1 hexType 4  input 1 powerInput 3  join 1 split 2 spltJOIN load ' + 'locate 1 Clocate 2 lowerCase 3 upperCase 3 Lprefix 2  macro  merge 2 modify 3 move 2 ' + 'msg  next 1 overlay 1 parse preserve 4 purge 3 put putD query 1 quit  read recover 3 ' + 'refresh renum 3 repeat 3 replace 1 Creplace 2 reset 3 restore 4 rgtLEFT right 2 left ' + '2  save  set  shift 2  si  sort  sos  stack 3 status 4 top  transfer 3  type 1  up 1 ';
   sentence := 'riG   rePEAT copies  put mo   rest    types   fup.    6
@@ -279,10 +279,10 @@ poweRin';
     out1 := out1 + ' ';
     if (k < Length(words) - 1) then
     begin
-      out1 := out1 + padRight(specialize _indexList<Variant>(words, k), Length(specialize _indexList<Variant>(results, k)));
+      out1 := out1 + padRight(specialize _indexList<string>(words, k), Length(specialize _indexList<string>(results, k)));
     end else
     begin
-      out1 := out1 + specialize _indexList<Variant>(words, k);
+      out1 := out1 + specialize _indexList<string>(words, k);
     end;
     k := k + 1;
   end;

--- a/tests/rosetta/out/Pascal/abc-problem.error
+++ b/tests/rosetta/out/Pascal/abc-problem.error
@@ -4,10 +4,14 @@ Copyright (c) 1993-2021 by Florian Klaempfl and others
 Target OS: Linux for x86-64
 Compiling /tmp/abc-problem.pas
 abc-problem.pas(16,19) Warning: function result variable of a managed type does not seem to be initialized
-abc-problem.pas(72,13) Error: Incompatible types: got "TArray$1$crcE41905E8" expected "TArray$1$crc862A1656"
 abc-problem.pas(16,19) Warning: function result variable of a managed type does not seem to be initialized
+abc-problem.pas(57,10) Note: Call to subroutine "operator :=(const source:ShortString):Variant;" marked as inline is not inlined
+abc-problem.pas(58,8) Note: Call to subroutine "operator =(const op1:Variant;const op2:Variant):Boolean;" marked as inline is not inlined
+abc-problem.pas(58,11) Note: Call to subroutine "operator :=(const source:Char):Variant;" marked as inline is not inlined
+abc-problem.pas(67,18) Note: Call to subroutine "operator :=(const source:Variant):ShortString;" marked as inline is not inlined
+abc-problem.pas(67,18) Note: Call to subroutine "operator +(const op1:Variant;const op2:Variant):Variant;" marked as inline is not inlined
+abc-problem.pas(67,18) Note: Call to subroutine "operator :=(const source:ShortString):Variant;" marked as inline is not inlined
 abc-problem.pas(89,45) Error: Incompatible type for arg no. 1: Got "TArray$1$crc862A1656", expected "TArray$1$crc9F312717"
-abc-problem.pas(99,60) Error: Incompatible type for arg no. 2: Got "TArray$1$crcE41905E8", expected "TArray$1$crc862A1656"
 abc-problem.pas(127,9) Error: Incompatible types: got "<procedure variable type of function(ShortString):Boolean is nested;Register>" expected "Variant"
 abc-problem.pas(130,37) Fatal: Syntax error, ")" expected but "(" found
 Fatal: Compilation aborted

--- a/tests/rosetta/out/Pascal/abc-problem.pas
+++ b/tests/rosetta/out/Pascal/abc-problem.pas
@@ -47,9 +47,9 @@ var
   c: Variant;
   cur: string;
   i: integer;
-  res: specialize TArray<Variant>;
+  res: specialize TArray<string>;
 begin
-  res := specialize TArray<Variant>([]);
+  res := specialize TArray<string>([]);
   cur := '';
   i := 0;
   while (i < Length(s)) do
@@ -59,7 +59,7 @@ begin
     begin
       if (Length(cur) > 0) then
       begin
-        res := specialize _appendList<Variant>(res, cur);
+        res := specialize _appendList<string>(res, cur);
         cur := '';
       end;
     end else
@@ -79,7 +79,7 @@ var
   c: Variant;
   i: integer;
   j: integer;
-  rest: specialize TArray<Variant>;
+  rest: specialize TArray<string>;
 begin
   if (Length(word) = 0) then ;
   c := LowerCase(_sliceString(word, 0, 1));
@@ -89,7 +89,7 @@ begin
     b := specialize _indexList<integer>(blks, i);
     if ((c = LowerCase(Copy(b, 1, 1 - 0))) or (c = LowerCase(Copy(b, 1 + 1, 2 - 1)))) then
     begin
-      rest := specialize TArray<Variant>([]);
+      rest := specialize TArray<string>([]);
       j := 0;
       while (j < Length(blks)) do
       begin


### PR DESCRIPTION
## Summary
- support Pascal `any` by translating to Variant
- regenerate Pascal Rosetta outputs
- number the first 20 tasks in the Pascal Rosetta README

## Testing
- `go test -tags=slow ./compiler/x/pascal -run TestPascalCompiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687ae4819bc083208b00235dc0e551b5