### PR TITLE
Improve Pascal type inference

### DIFF
--- a/compiler/x/pascal/compiler.go
+++ b/compiler/x/pascal/compiler.go
@@ -1813,6 +1813,7 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 		}
 		if p.Lit.Str != nil {
 			s := strings.ReplaceAll(*p.Lit.Str, "'", "''")
+			s = strings.ReplaceAll(s, "\n", "\\n")
 			return fmt.Sprintf("'%s'", s), nil
 		}
 		if p.Lit.Null {

--- a/compiler/x/pascal/helpers.go
+++ b/compiler/x/pascal/helpers.go
@@ -490,6 +490,14 @@ func (c *Compiler) listElemType(p *parser.Primary) string {
 	if lt, ok := t.(types.ListType); ok {
 		return typeString(lt.Elem)
 	}
+	if p.Selector != nil && c.varTypes != nil {
+		if vt, ok := c.varTypes[p.Selector.Root]; ok {
+			if strings.HasPrefix(vt, "specialize TArray<") {
+				inner := strings.TrimSuffix(strings.TrimPrefix(vt, "specialize TArray<"), ">")
+				return inner
+			}
+		}
+	}
 	return "integer"
 }
 


### PR DESCRIPTION
## Summary
- improve unary inference in `TypeOfPostfixBasic`
- escape newlines for Pascal string literals
- infer list element types from tracked variable types

## Testing
- `go test -tags=slow ./compiler/x/pascal -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687aedf459f4832099738cfe7b10852f