### PR TITLE
Extend CS Rosetta tests

### DIFF
--- a/compiler/x/cs/rosetta_golden_test.go
+++ b/compiler/x/cs/rosetta_golden_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -104,7 +105,8 @@ func TestCSCompiler_Rosetta_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
-       max := 10
+	sort.Strings(files)
+	max := 20
 	if len(files) < max {
 		max = len(files)
 	}


### PR DESCRIPTION
## Summary
- run Rosetta golden tests for the first 20 tasks alphabetically

## Testing
- `go test ./compiler/x/cs -run Rosetta -tags slow -count=1` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687aed3a6e748320aa7b4f8321ae6514