### PR TITLE
Improve Clojure Rosetta determinism

### DIFF
--- a/compiler/x/clj/compiler.go
+++ b/compiler/x/clj/compiler.go
@@ -1452,7 +1452,8 @@ func (c *Compiler) compilePostfix(p *parser.PostfixExpr) (string, error) {
 					expr = fmt.Sprintf("(_json %s)", args[0])
 				}
 			case "now":
-				expr = "(System/nanoTime)"
+				c.use("_now")
+				expr = "(_now)"
 			case "str":
 				expr = fmt.Sprintf("(str %s)", strings.Join(args, " "))
 			case "upper":
@@ -1735,7 +1736,8 @@ func (c *Compiler) compilePrimary(p *parser.Primary) (string, error) {
 			}
 		case "now":
 			if len(args) == 0 {
-				return "(System/nanoTime)", nil
+				c.use("_now")
+				return "(_now)", nil
 			}
 		case "json":
 			if len(args) == 1 {

--- a/compiler/x/clj/rosetta_golden_test.go
+++ b/compiler/x/clj/rosetta_golden_test.go
@@ -23,22 +23,22 @@ func shouldUpdateRosetta() bool {
 }
 
 func runRosettaTaskGolden(t *testing.T, name string) {
-       interactive := map[string]bool{
-               "15-puzzle-game": true,
-               "15-puzzle-solver": true,
-               "2048":           true,
-               "21-game":        true,
-               "24-game":        true,
-               "a+b":            true,
-               "adfgvx-cipher":  true,
-               "amb":            true,
-               "9-billion-names-of-god-the-integer": true,
-               "DNS-query":      true,
-               "abc-problem":    true,
-       }
-       root := repoRoot(t)
+	interactive := map[string]bool{
+		"15-puzzle-game":                     true,
+		"15-puzzle-solver":                   true,
+		"2048":                               true,
+		"21-game":                            true,
+		"24-game":                            true,
+		"a+b":                                true,
+		"adfgvx-cipher":                      true,
+		"amb":                                true,
+		"9-billion-names-of-god-the-integer": true,
+		"DNS-query":                          true,
+		"abc-problem":                        true,
+	}
+	root := repoRoot(t)
 	script := exec.Command("go", "run", "-tags=archive,slow", "./scripts/compile_rosetta_clj.go")
-	script.Env = append(os.Environ(), "GOTOOLCHAIN=local", "TASKS="+name, "SOURCE_DATE_EPOCH=0")
+	script.Env = append(os.Environ(), "GOTOOLCHAIN=local", "TASKS="+name, "SOURCE_DATE_EPOCH=0", "MOCHI_NOW_SEED=1")
 	script.Dir = root
 	if out, err := script.CombinedOutput(); err != nil {
 		t.Fatalf("compile script error: %v\n%s", err, out)
@@ -69,15 +69,15 @@ func runRosettaTaskGolden(t *testing.T, name string) {
 	}
 
 	dir := t.TempDir()
-       file := filepath.Join(dir, "main.clj")
-       if err := os.WriteFile(file, code, 0644); err != nil {
-               t.Fatalf("write error: %v", err)
-       }
-       if interactive[name] {
-               t.Skip("interactive program")
-       }
-       cmd := exec.Command("clojure", file)
-	cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
+	file := filepath.Join(dir, "main.clj")
+	if err := os.WriteFile(file, code, 0644); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	if interactive[name] {
+		t.Skip("interactive program")
+	}
+	cmd := exec.Command("clojure", file)
+	cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar", "MOCHI_NOW_SEED=1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Skipf("run error: %v\n%s", err, out)
@@ -122,7 +122,7 @@ func TestClojureCompiler_Rosetta_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
-       max := 20
+	max := 20
 	if len(files) < max {
 		max = len(files)
 	}

--- a/compiler/x/clj/runtime.go
+++ b/compiler/x/clj/runtime.go
@@ -258,6 +258,20 @@ const (
     (sequential? col) (some #(= item %) col)
     :else false))`
 
+	helperNow = `(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))`
+
 	helperUnionAll = `(defn _union_all [a b]
   (vec (concat a b)))`
 
@@ -420,6 +434,7 @@ var helperMap = map[string]string{
 	"_print":            helperPrint,
 	"_sort_key":         helperSortKey,
 	"_in":               helperIn,
+	"_now":              helperNow,
 	"_union_all":        helperUnionAll,
 	"_union":            helperUnion,
 	"_except":           helperExcept,
@@ -455,6 +470,7 @@ var helperOrder = []string{
 	"_print",
 	"_sort_key",
 	"_in",
+	"_now",
 	"_union_all",
 	"_union",
 	"_except",

--- a/scripts/compile_rosetta_clj.go
+++ b/scripts/compile_rosetta_clj.go
@@ -42,19 +42,19 @@ func main() {
 	outDir := filepath.Join(root, "tests", "rosetta", "out", "Clojure")
 	_ = os.MkdirAll(outDir, 0o755)
 
-       interactive := map[string]bool{
-               "15-puzzle-game": true,
-               "15-puzzle-solver": true,
-               "2048":           true,
-               "21-game":        true,
-               "24-game":        true,
-               "a+b":            true,
-               "adfgvx-cipher":  true,
-               "amb":            true,
-               "9-billion-names-of-god-the-integer": true,
-               "DNS-query":      true,
-               "abc-problem":    true,
-       }
+	interactive := map[string]bool{
+		"15-puzzle-game":                     true,
+		"15-puzzle-solver":                   true,
+		"2048":                               true,
+		"21-game":                            true,
+		"24-game":                            true,
+		"a+b":                                true,
+		"adfgvx-cipher":                      true,
+		"amb":                                true,
+		"9-billion-names-of-god-the-integer": true,
+		"DNS-query":                          true,
+		"abc-problem":                        true,
+	}
 
 	var tasks []string
 	if env := os.Getenv("TASKS"); env != "" {
@@ -107,7 +107,7 @@ func main() {
 			continue
 		}
 		cmd := exec.Command("clojure", tmp)
-		cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar")
+		cmd.Env = append(os.Environ(), "CLASSPATH=/usr/share/java/data.json.jar:/usr/share/java/snakeyaml-engine.jar", "MOCHI_NOW_SEED=1")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			writeError(outDir, name, fmt.Sprintf("run: %v\n%s", err, out))

--- a/tests/rosetta/out/Clojure/100-prisoners.clj
+++ b/tests/rosetta/out/Clojure/100-prisoners.clj
@@ -20,6 +20,19 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 ;; Function shuffle takes [xs: list of int] and returns list of int
 (defn shuffle [xs]
   (try
@@ -28,7 +41,7 @@
     (loop []
       (when (> shuffle_i 0)
         (let [r (try
-          (def shuffle_j (mod (System/nanoTime) (+ shuffle_i 1))) ;; int
+          (def shuffle_j (mod (_now) (+ shuffle_i 1))) ;; int
           (def shuffle_tmp (_indexList shuffle_arr shuffle_i)) ;; int
           (def shuffle_arr (assoc shuffle_arr shuffle_i (_indexList shuffle_arr shuffle_j))) ;; int
           (def shuffle_arr (assoc shuffle_arr shuffle_j shuffle_tmp)) ;; int
@@ -151,11 +164,11 @@
   (loop []
     (when (< doTrials_d 50)
       (let [r (try
-        (def doTrials_n (mod (System/nanoTime) 100)) ;; int
+        (def doTrials_n (mod (_now) 100)) ;; int
         (loop []
           (when (_indexList doTrials_opened doTrials_n)
             (let [r (try
-              (def doTrials_n (mod (System/nanoTime) 100)) ;; int
+              (def doTrials_n (mod (_now) 100)) ;; int
               :next
             (catch clojure.lang.ExceptionInfo e
               (cond

--- a/tests/rosetta/out/Clojure/100-prisoners.out
+++ b/tests/rosetta/out/Clojure/100-prisoners.out
@@ -1,9 +1,9 @@
 WARNING: shuffle already refers to: #'clojure.core/shuffle in namespace: main, being replaced by: #'main/shuffle
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0.0%
-  strategy = optimal  pardoned = 309 relative frequency = 30.9%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0.0%
-  strategy = optimal  pardoned = 341 relative frequency = 34.1%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%

--- a/tests/rosetta/out/Clojure/15-puzzle-game.clj
+++ b/tests/rosetta/out/Clojure/15-puzzle-game.clj
@@ -26,12 +26,25 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 (declare board solved empty moves quit)
 
 ;; Function randMove returns int
 (defn randMove []
   (try
-    (throw (ex-info "return" {:value (mod (System/nanoTime) 4)}))
+    (throw (ex-info "return" {:value (mod (_now) 4)}))
   (catch clojure.lang.ExceptionInfo e
     (if (= (.getMessage e) "return")
       (:value (ex-data e))

--- a/tests/rosetta/out/Clojure/2048.clj
+++ b/tests/rosetta/out/Clojure/2048.clj
@@ -38,6 +38,19 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 (declare SIZE board r full score)
 
 ;; Function newBoard returns list of list of int
@@ -145,10 +158,10 @@
 (when (= (count spawnTile_empty) 0)
 (throw (ex-info "return" {:value {"board" b "full" true}}))
 )
-(def spawnTile_idx (mod (System/nanoTime) (count spawnTile_empty))) ;; int
+(def spawnTile_idx (mod (_now) (count spawnTile_empty))) ;; int
 (def spawnTile_cell (_indexList spawnTile_empty spawnTile_idx)) ;; list of int
 (def spawnTile_val 4) ;; int
-(when (< (mod (System/nanoTime) 10) 9)
+(when (< (mod (_now) 10) 9)
 (def spawnTile_val 2) ;; int
 )
 (def b (assoc-in b [(_indexList spawnTile_cell 1) (_indexList spawnTile_cell 0)] spawnTile_val)) ;; int

--- a/tests/rosetta/out/Clojure/21-game.clj
+++ b/tests/rosetta/out/Clojure/21-game.clj
@@ -20,6 +20,19 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 ;; Function parseIntStr takes [str: string] and returns int
 (defn parseIntStr [str]
   (try
@@ -66,7 +79,7 @@
 (defn main []
 (try
 (def main_total 0) ;; int
-(def main_computer (= (mod (System/nanoTime) 2) 0)) ;; bool
+(def main_computer (= (mod (_now) 2) 0)) ;; bool
 (_print "Enter q to quit at any time\n")
 (if main_computer
   (do
@@ -93,7 +106,7 @@
                 (def main_choice 0) ;; int
                 (if (< main_total 18)
                   (do
-                    (def main_choice (+ (mod (System/nanoTime) 3) 1)) ;; int
+                    (def main_choice (+ (mod (_now) 3) 1)) ;; int
                   )
 
                 (do

--- a/tests/rosetta/out/Clojure/24-game-solve.clj
+++ b/tests/rosetta/out/Clojure/24-game-solve.clj
@@ -32,6 +32,19 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 (declare OP_NUM OP_ADD OP_SUB OP_MUL OP_DIV n_cards goal digit_range)
 
 ;; Function newNum takes [n: int] and returns map of string to any
@@ -237,7 +250,7 @@
 (loop []
 (when (< main_i n_cards)
 (let [r (try
-(def main_n (+ (mod (System/nanoTime) (- digit_range 1)) 1)) ;; int
+(def main_n (+ (mod (_now) (- digit_range 1)) 1)) ;; int
 (def main_cards (conj main_cards (newNum main_n))) ;; list of map of string to any
 (_print (str " " (str main_n)))
 (def main_i (+ main_i 1)) ;; int

--- a/tests/rosetta/out/Clojure/24-game-solve.out
+++ b/tests/rosetta/out/Clojure/24-game-solve.out
@@ -1,60 +1,60 @@
-6
+5
+ 8
+ 6
+ 1
+:  
+No solution
+ 7
+ 5
+ 7
+ 7
+:  
+No solution
+ 1
+ 3
  4
- 3
- 3
+ 2
+:  
+(4 * (4 + 2))
+ 5
+ 1
+ 8
+ 6
+:  
+No solution
+ 5
+ 7
+ 4
+ 4
 :  
 No solution
  8
- 7
- 5
- 4
-:  
-No solution
- 5
- 6
- 7
- 3
-:  
-No solution
- 5
- 3
- 3
- 6
-:  
-No solution
  1
- 1
- 6
  5
-:  
-No solution
- 5
- 3
- 3
- 3
-:  
-No solution
- 5
- 4
- 2
- 5
-:  
-No solution
- 1
- 4
- 6
- 7
-:  
-No solution
- 6
  8
- 2
- 2
 :  
 No solution
+ 4
  2
+ 5
+ 6
+:  
+No solution
+ 4
+ 8
+ 8
+ 8
+:  
+(8 + (8 + 8))
+ 6
+ 6
+ 4
+ 4
+:  
+No solution
  4
  7
- 2
+ 7
+ 7
 :  
 No solution

--- a/tests/rosetta/out/Clojure/24-game.clj
+++ b/tests/rosetta/out/Clojure/24-game.clj
@@ -26,10 +26,23 @@
       (when (> i 0) (print " "))
       (pv a))
     (println)))
+(def ^:dynamic _now_seeded (atom false))
+  (def ^:dynamic _now_seed (atom 0))
+  (defn _now []
+    (when-not @_now_seeded
+      (let [s (System/getenv "MOCHI_NOW_SEED")]
+        (when (and s (re-matches #"\d+" s))
+          (reset! _now_seed (Long/parseLong s))
+          (reset! _now_seeded true))))
+    (if @_now_seeded
+      (do
+        (swap! _now_seed #(mod (+ (* % 1664525) 1013904223) 2147483647))
+        @_now_seed)
+      (System/nanoTime)))
 ;; Function randDigit returns int
 (defn randDigit []
   (try
-    (throw (ex-info "return" {:value (+ (mod (System/nanoTime) 9) 1)}))
+    (throw (ex-info "return" {:value (+ (mod (_now) 9) 1)}))
   (catch clojure.lang.ExceptionInfo e
     (if (= (.getMessage e) "return")
       (:value (ex-data e))

--- a/tests/rosetta/out/Clojure/README.md
+++ b/tests/rosetta/out/Clojure/README.md
@@ -3,25 +3,26 @@
 This directory holds Clojure source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected runtime output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
 ## Program checklist
-- [x] 100-doors-2
-- [x] 100-doors-3
-- [x] 100-doors
-- [x] 100-prisoners
-- [ ] 15-puzzle-game
-- [ ] 15-puzzle-solver
-- [ ] 2048
-- [ ] 21-game
-- [x] 24-game-solve
-- [ ] 24-game
-- [x] 4-rings-or-4-squares-puzzle
-- [ ] 9-billion-names-of-god-the-integer
-- [x] 99-bottles-of-beer-2
-- [x] 99-bottles-of-beer
-- [ ] a+b
-- [x] abbreviations-automatic
-- [x] abbreviations-easy
-- [x] abbreviations-simple
-- [ ] abc-problem
+1. [x] 100-doors-2
+2. [x] 100-doors-3
+3. [x] 100-doors
+4. [x] 100-prisoners
+5. [ ] 15-puzzle-game
+6. [ ] 15-puzzle-solver
+7. [ ] 2048
+8. [ ] 21-game
+9. [x] 24-game-solve
+10. [ ] 24-game
+11. [x] 4-rings-or-4-squares-puzzle
+12. [ ] 9-billion-names-of-god-the-integer
+13. [x] 99-bottles-of-beer-2
+14. [x] 99-bottles-of-beer
+15. [ ] DNS-query
+16. [ ] a+b
+17. [x] abbreviations-automatic
+18. [x] abbreviations-easy
+19. [x] abbreviations-simple
+20. [ ] abc-problem
 - [ ] abelian-sandpile-model-identity
 - [ ] abelian-sandpile-model
 - [ ] abstract-type


### PR DESCRIPTION
## Summary
- implement deterministic `_now` helper in Clojure runtime
- use `MOCHI_NOW_SEED` in Clojure rosetta tests and compile script
- regenerate Clojure Rosetta outputs
- enumerate first 20 Rosetta tasks in README

## Testing
- `go test ./compiler/x/clj -run Rosetta_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687afa829ca483208d4a558cb686eae1