### PR TITLE
Sort rosetta golden test files

### DIFF
--- a/compiler/x/go/rosetta_golden_test.go
+++ b/compiler/x/go/rosetta_golden_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -111,6 +112,7 @@ func TestGoCompiler_Rosetta_Golden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
+	sort.Strings(files)
 	max := 3
 	if v := os.Getenv("ROSETTA_MAX"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {


### PR DESCRIPTION
## Summary
- sort file list before selecting Rosetta test cases

## Testing
- `ROSETTA_MAX=3 go test ./compiler/x/go -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687afdd069b0832093d354455d5f7b72