### PR TITLE
Improve Go backend var typing

### DIFF
--- a/compiler/x/go/compiler.go
+++ b/compiler/x/go/compiler.go
@@ -473,7 +473,7 @@ func (c *Compiler) compileLet(s *parser.LetStmt) error {
 		c.writeln(fmt.Sprintf("var %s %s", name, typStr))
 		c.writeln(fmt.Sprintf("%s = %s", name, value))
 	} else if s.Type == nil && c.indent > 0 {
-		c.writeln(fmt.Sprintf("%s := %s", name, value))
+		c.writeln(fmt.Sprintf("var %s %s = %s", name, typStr, value))
 	} else {
 		c.writeln(fmt.Sprintf("var %s %s = %s", name, typStr, value))
 	}
@@ -599,7 +599,7 @@ func (c *Compiler) compileVar(s *parser.VarStmt) error {
 		c.writeln(fmt.Sprintf("var %s %s", name, typStr))
 		c.writeln(fmt.Sprintf("%s = %s", name, value))
 	} else if s.Type == nil && c.indent > 0 {
-		c.writeln(fmt.Sprintf("%s := %s", name, value))
+		c.writeln(fmt.Sprintf("var %s %s = %s", name, typStr, value))
 	} else {
 		c.writeln(fmt.Sprintf("var %s %s = %s", name, typStr, value))
 	}
@@ -727,7 +727,7 @@ func (c *Compiler) compileAssign(s *parser.AssignStmt) error {
 	if finalTyp != nil {
 		exprGo := goType(exprT)
 		typGo := goType(finalTyp)
-		if typGo != "" && typGo != exprGo && (isAny(exprT) || !equalTypes(finalTyp, exprT)) {
+		if typGo != "" && typGo != exprGo {
 			value = c.castExpr(value, exprT, finalTyp)
 		}
 	}

--- a/compiler/x/go/runtime.go
+++ b/compiler/x/go/runtime.go
@@ -269,12 +269,12 @@ const (
 		"        }\n" +
 		"    }\n" +
 		"}\n" +
-		"func _now() int {\n" +
+		"func _now() int64 {\n" +
 		"    if seededNow {\n" +
 		"        nowSeed = (nowSeed*1664525 + 1013904223) % 2147483647\n" +
-		"        return int(nowSeed)\n" +
+		"        return nowSeed\n" +
 		"    }\n" +
-		"    return int(time.Now().UnixNano())\n" +
+		"    return time.Now().UnixNano()\n" +
 		"}\n"
 
 	helperGenText = "func _genText(prompt string, model string, params map[string]any) string {\n" +


### PR DESCRIPTION
## Summary
- make Go runtime now() return int64
- declare variables with explicit types inside blocks
- always cast assignments when Go types differ

## Testing
- `ROSETTA_MAX=20 go test -tags=slow -run Rosetta_Golden ./compiler/x/go -count=1` *(fails: output mismatch for 100-prisoners)*

------
https://chatgpt.com/codex/tasks/task_e_687afdc84c888320adc4ae540edcecb3