### PR TITLE
Add list-int string helper to C backend

### DIFF
--- a/compiler/x/c/compiler.go
+++ b/compiler/x/c/compiler.go
@@ -6177,8 +6177,13 @@ func (c *Compiler) compilePrimary(p *parser.Primary) string {
 		} else if p.Call.Func == "str" {
 			arg := c.compileExpr(p.Call.Args[0])
 			name := c.newTemp()
-			c.need(needStr)
-			c.writeln(fmt.Sprintf("char* %s = _str(%s);", name, arg))
+			if isListIntExpr(p.Call.Args[0], c.env) {
+				c.need(needStrListInt)
+				c.writeln(fmt.Sprintf("char* %s = _str_list_int(%s);", name, arg))
+			} else {
+				c.need(needStr)
+				c.writeln(fmt.Sprintf("char* %s = _str(%s);", name, arg))
+			}
 			return name
 		} else if p.Call.Func == "int" {
 			arg := c.compileExpr(p.Call.Args[0])

--- a/compiler/x/c/needs.go
+++ b/compiler/x/c/needs.go
@@ -5,6 +5,7 @@ package ccode
 // Helper requirement keys used by the compiler.
 const (
 	needStr                  = "str"
+	needStrListInt           = "str_list_int"
 	needInput                = "input"
 	needIndexString          = "index_string"
 	needIndexOfString        = "index_of_string"

--- a/compiler/x/c/runtime.go
+++ b/compiler/x/c/runtime.go
@@ -549,6 +549,19 @@ static list_int _sha256_list(list_int v) {
     return buf;
 }
 `
+	helperStrListInt = `static char* _str_list_int(list_int v) {
+    int cap = v.len * 12 + 2;
+    char* buf = (char*)malloc(cap);
+    int pos = 0;
+    buf[pos++] = '[';
+    for (int i = 0; i < v.len; i++) {
+        if (i) buf[pos++] = ',';
+        pos += sprintf(buf+pos, "%d", v.data[i]);
+    }
+    buf[pos++] = ']';
+    buf[pos] = '\\0';
+    return buf;
+}`
 	helperLower = `static char* _lower(char* s) {
     int len = strlen(s);
     char* buf = (char*)malloc(len + 1);
@@ -828,6 +841,7 @@ var helperCode = map[string]string{
 	needInMapIntString:       helperMapIntString,
 	needInput:                helperInput,
 	needStr:                  helperStr,
+	needStrListInt:           helperStrListInt,
 	needLower:                helperLower,
 	needUpper:                helperUpper,
 	needFloat:                helperFloat,
@@ -919,6 +933,7 @@ var helperOrder = []string{
 	needInMapIntString,
 	needInput,
 	needStr,
+	needStrListInt,
 	needLower,
 	needUpper,
 	needFloat,

--- a/tests/rosetta/out/C/README.md
+++ b/tests/rosetta/out/C/README.md
@@ -1,28 +1,28 @@
-# Rosetta C Output (85/271 compiled and run)
+# Rosetta C Output (87/284 compiled and run)
 
 This directory holds C source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
 ## Program checklist
-1. [x] 100-doors-2
-2. [x] 100-doors-3
-3. [x] 100-doors
-4. [x] 100-prisoners
-5. [ ] 15-puzzle-game
-6. [ ] 15-puzzle-solver
-7. [ ] 2048
-8. [ ] 21-game
-9. [ ] 24-game-solve
-10. [x] 24-game
-11. [ ] 4-rings-or-4-squares-puzzle
-12. [ ] 9-billion-names-of-god-the-integer
-13. [x] 99-bottles-of-beer-2
-14. [x] 99-bottles-of-beer
-15. [ ] DNS-query
-16. [x] a+b
-17. [ ] abbreviations-automatic
-18. [ ] abbreviations-easy
-19. [ ] abbreviations-simple
-20. [ ] abc-problem
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
+- [x] 100-prisoners
+- [ ] 15-puzzle-game
+- [ ] 15-puzzle-solver
+- [ ] 2048
+- [ ] 21-game
+- [ ] 24-game-solve
+- [x] 24-game
+- [ ] 4-rings-or-4-squares-puzzle
+- [ ] 9-billion-names-of-god-the-integer
+- [x] 99-bottles-of-beer-2
+- [x] 99-bottles-of-beer
+- [ ] DNS-query
+- [x] a+b
+- [ ] abbreviations-automatic
+- [ ] abbreviations-easy
+- [ ] abbreviations-simple
+- [ ] abc-problem
 - [ ] abelian-sandpile-model-identity
 - [x] abelian-sandpile-model
 - [ ] abstract-type
@@ -52,7 +52,7 @@ This directory holds C source code generated from the real Mochi programs in `te
 - [ ] anagrams
 - [ ] angle-difference-between-two-bearings-1
 - [ ] angle-difference-between-two-bearings-2
- - [x] angles-geometric-normalization-and-conversion
+- [x] angles-geometric-normalization-and-conversion
 - [x] animate-a-pendulum
 - [x] animation
 - [x] anonymous-recursion-1
@@ -210,6 +210,7 @@ This directory holds C source code generated from the real Mochi programs in `te
 - [ ] circles-of-given-radius-through-two-points
 - [ ] circular-primes
 - [ ] cistercian-numerals
+- [ ] comma-quibbling
 - [ ] compiler-virtual-machine-interpreter
 - [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
 - [ ] compound-data-type
@@ -273,4 +274,16 @@ This directory holds C source code generated from the real Mochi programs in `te
 - [ ] cusip
 - [ ] cyclops-numbers
 - [ ] damm-algorithm
+- [ ] date-format
+- [ ] date-manipulation
+- [ ] day-of-the-week
+- [ ] de-bruijn-sequences
+- [ ] deal-cards-for-freecell
+- [ ] death-star
+- [ ] deceptive-numbers
+- [ ] deconvolution-1d-2
+- [ ] deconvolution-1d-3
+- [ ] deconvolution-1d
+- [ ] deepcopy-1
+- [ ] define-a-primitive-data-type
 - [ ] md5


### PR DESCRIPTION
## Summary
- add `str_list_int` requirement for C compiler
- implement `_str_list_int` runtime helper and integrate with compiler
- update Rosetta C status README

## Testing
- `go build ./...` *(fails: signal killed? actually success with no output)*

------
https://chatgpt.com/codex/tasks/task_e_687b06cad8a883208bbf47e99fa59a01