### PR TITLE
Fix Go rosetta var init

### DIFF
--- a/compiler/x/go/README.md
+++ b/compiler/x/go/README.md
@@ -108,6 +108,33 @@ invoke the Go toolchain. Run them with:
 go test ./compile/go -tags slow
 ```
 
+## Rosetta Progress
+
+The Go backend is tested against the first 20 Mochi Rosetta programs. Results:
+
+| # | Program | Result |
+|---|---------|--------|
+| 1 | 100-doors-2 | ✅ |
+| 2 | 100-doors-3 | ✅ |
+| 3 | 100-doors | ✅ |
+| 4 | 100-prisoners | ❌ |
+| 5 | 15-puzzle-game | ❌ |
+| 6 | 15-puzzle-solver | ✅ |
+| 7 | 2048 | ❌ |
+| 8 | 21-game | ❌ |
+| 9 | 24-game-solve | ❌ |
+|10 | 24-game | ❌ |
+|11 | 4-rings-or-4-squares-puzzle | ✅ |
+|12 | 9-billion-names-of-god-the-integer | ❌ |
+|13 | 99-bottles-of-beer-2 | ❌ |
+|14 | 99-bottles-of-beer | ✅ |
+|15 | DNS-query | ✅ |
+|16 | a+b | ✅ |
+|17 | abbreviations-automatic | ✅ |
+|18 | abbreviations-easy | ✅ |
+|19 | abbreviations-simple | ✅ |
+|20 | abc-problem | ✅ |
+
 ## Notes
 
 The backend supports advanced Mochi features including streams, agents, dataset

--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -136,9 +136,8 @@ func (c *Compiler) compileMainFunc(prog *parser.Program) error {
 	// so we no longer emit explicit assignments here.
 	body := []*parser.Statement{}
 	for _, s := range prog.Statements {
-		if s.Fun != nil || s.Test != nil || s.Let != nil || s.Var != nil {
-			// Top-level functions, tests and variable declarations
-			// are handled elsewhere.
+		if s.Fun != nil || s.Test != nil {
+			// Top-level functions and tests are handled elsewhere.
 			continue
 		}
 		body = append(body, s)

--- a/tests/rosetta/out/Go/100-doors-2.error
+++ b/tests/rosetta/out/Go/100-doors-2.error
@@ -1,6 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:16:17: undefined: door
-/tmp/X/001/main.go:18:4: undefined: incrementer
-/tmp/X/001/main.go:19:4: undefined: door
-/tmp/X/001/main.go:19:25: undefined: incrementer

--- a/tests/rosetta/out/Go/100-doors-2.go
+++ b/tests/rosetta/out/Go/100-doors-2.go
@@ -11,6 +11,8 @@ import (
 type v map[string]any
 
 func main() {
+	var door int = 1
+	var incrementer int = 0
 	for current := 1; current < 101; current++ {
 		var line string = "Door " + fmt.Sprint(any(current)) + " "
 		if current == door {

--- a/tests/rosetta/out/Go/100-doors-3.error
+++ b/tests/rosetta/out/Go/100-doors-3.error
@@ -1,5 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:20:4: undefined: result
-/tmp/X/001/main.go:22:4: undefined: result
-/tmp/X/001/main.go:25:18: undefined: result

--- a/tests/rosetta/out/Go/100-doors-3.go
+++ b/tests/rosetta/out/Go/100-doors-3.go
@@ -11,6 +11,7 @@ import (
 type v map[string]any
 
 func main() {
+	var result string = ""
 	for i := 1; i < 101; i++ {
 		var j int = 1
 		for (j * j) < i {

--- a/tests/rosetta/out/Go/100-doors.error
+++ b/tests/rosetta/out/Go/100-doors.error
@@ -1,5 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:17:42: undefined: doors
-/tmp/X/001/main.go:22:4: undefined: doors
-/tmp/X/001/main.go:30:15: undefined: doors

--- a/tests/rosetta/out/Go/100-doors.go
+++ b/tests/rosetta/out/Go/100-doors.go
@@ -13,6 +13,7 @@ import (
 type v map[string]any
 
 func main() {
+	var doors []any = []any{}
 	for i := 0; i < 100; i++ {
 		doors = _toAnySlice(append(_toAnySlice(doors), any(false)))
 	}

--- a/tests/rosetta/out/Go/2048.go
+++ b/tests/rosetta/out/Go/2048.go
@@ -302,10 +302,16 @@ func has2048(b [][]int) bool {
 }
 
 func main() {
+	var SIZE int = 4
+	_ = SIZE
+	var board [][]int = newBoard()
+	var r map[string]any = spawnTile(board)
 	board = (((r["board"]).([][]int)).([][]int)).([][]int)
+	var full any = r["full"]
 	r = spawnTile(board)
 	board = (((r["board"]).([][]int)).([][]int)).([][]int)
 	full = r["full"]
+	var score int = 0
 	draw(board, score)
 	for {
 		fmt.Println(any("Move: "))

--- a/tests/rosetta/out/Go/24-game-solve.go
+++ b/tests/rosetta/out/Go/24-game-solve.go
@@ -148,6 +148,22 @@ func mainFn() {
 }
 
 func main() {
+	var OP_NUM int = 0
+	_ = OP_NUM
+	var OP_ADD int = 1
+	_ = OP_ADD
+	var OP_SUB int = 2
+	_ = OP_SUB
+	var OP_MUL int = 3
+	_ = OP_MUL
+	var OP_DIV int = 4
+	_ = OP_DIV
+	var n_cards int = 4
+	_ = n_cards
+	var goal int = 24
+	_ = goal
+	var digit_range int = 9
+	_ = digit_range
 	mainFn()
 }
 

--- a/tests/rosetta/out/Go/4-rings-or-4-squares-puzzle.error
+++ b/tests/rosetta/out/Go/4-rings-or-4-squares-puzzle.error
@@ -1,7 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:92:29: undefined: r1
-/tmp/X/001/main.go:93:14: undefined: r1
-/tmp/X/001/main.go:94:29: undefined: r2
-/tmp/X/001/main.go:95:14: undefined: r2
-/tmp/X/001/main.go:96:29: undefined: r3

--- a/tests/rosetta/out/Go/4-rings-or-4-squares-puzzle.go
+++ b/tests/rosetta/out/Go/4-rings-or-4-squares-puzzle.go
@@ -89,10 +89,13 @@ func getCombs(low int, high int, unique bool) map[string]any {
 }
 
 func main() {
+	var r1 map[string]any = getCombs(1, 7, true)
 	fmt.Println(any(fmt.Sprint(r1["count"]) + " unique solutions in 1 to 7"))
 	fmt.Println(r1["list"])
+	var r2 map[string]any = getCombs(3, 9, true)
 	fmt.Println(any(fmt.Sprint(r2["count"]) + " unique solutions in 3 to 9"))
 	fmt.Println(r2["list"])
+	var r3 map[string]any = getCombs(0, 9, false)
 	fmt.Println(any(fmt.Sprint(r3["count"]) + " non-unique solutions in 0 to 9"))
 }
 

--- a/tests/rosetta/out/Go/9-billion-names-of-god-the-integer.error
+++ b/tests/rosetta/out/Go/9-billion-names-of-god-the-integer.error
@@ -2,6 +2,3 @@ run: exit status 1
 # command-line-arguments
 /tmp/X/001/main.go:32:7: cannot use (float64(n) / float64(10)) (value of type float64) as int value in assignment
 /tmp/X/001/main.go:53:11: cannot use (float64(s) / float64(10)) (value of type float64) as int value in assignment
-/tmp/X/001/main.go:136:6: undefined: x
-/tmp/X/001/main.go:137:24: undefined: x
-/tmp/X/001/main.go:145:3: undefined: x

--- a/tests/rosetta/out/Go/9-billion-names-of-god-the-integer.go
+++ b/tests/rosetta/out/Go/9-billion-names-of-god-the-integer.go
@@ -133,6 +133,7 @@ func row(n int) []string {
 
 func main() {
 	fmt.Println(any("rows:"))
+	var x int = 1
 	for x < 11 {
 		var r []string = row(x)
 		var line string = ""

--- a/tests/rosetta/out/Go/DNS-query.error
+++ b/tests/rosetta/out/Go/DNS-query.error
@@ -1,5 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:16:12: undefined: err
-/tmp/X/001/main.go:17:30: undefined: addrs
-/tmp/X/001/main.go:19:15: undefined: err

--- a/tests/rosetta/out/Go/DNS-query.go
+++ b/tests/rosetta/out/Go/DNS-query.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	goffi "mochi/runtime/ffi/go"
 	"reflect"
 	"strings"
 )
@@ -13,6 +14,9 @@ import (
 type v map[string]any
 
 func main() {
+	var res []any = (func() any { v, _ := goffi.AttrAuto("net", "LookupHost", "www.kame.net"); return v }()).([]any)
+	var addrs any = res[0]
+	var err any = res[1]
 	if _equal(err, nil) {
 		fmt.Println(any(fmt.Sprint(addrs)))
 	} else {


### PR DESCRIPTION
## Summary
- handle top-level variable declarations when building main
- regenerate Go rosetta outputs
- note rosetta task status for Go backend

## Testing
- `ROSETTA_MAX=20 go test -run Rosetta -tags slow -v -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687b0741f3a48320a36dc6c95c3613ab