### PR TITLE
Fix Go compiler global vars in Rosetta tests

### DIFF
--- a/compiler/x/go/rosetta_golden_test.go
+++ b/compiler/x/go/rosetta_golden_test.go
@@ -82,7 +82,9 @@ func runRosettaTask(t *testing.T, name string) {
 	if err := os.WriteFile(file, code, 0644); err != nil {
 		t.Fatalf("write go: %v", err)
 	}
-	out, err := exec.Command("go", "run", file).CombinedOutput()
+	cmd := exec.Command("go", "run", file)
+	cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		writeErr(root, name, fmt.Errorf("run: %v\n%s", err, out))
 		t.Skipf("run error: %v", err)

--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -136,9 +136,8 @@ func (c *Compiler) compileMainFunc(prog *parser.Program) error {
 	// so we no longer emit explicit assignments here.
 	body := []*parser.Statement{}
 	for _, s := range prog.Statements {
-		if s.Fun != nil || s.Test != nil || s.Let != nil || s.Var != nil {
-			// Top-level functions, tests and variable declarations
-			// are handled elsewhere.
+		if s.Fun != nil || s.Test != nil {
+			// Top-level functions and test blocks are handled separately.
 			continue
 		}
 		body = append(body, s)

--- a/tests/rosetta/out/Go/100-doors-2.error
+++ b/tests/rosetta/out/Go/100-doors-2.error
@@ -1,6 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:16:17: undefined: door
-/tmp/X/001/main.go:18:4: undefined: incrementer
-/tmp/X/001/main.go:19:4: undefined: door
-/tmp/X/001/main.go:19:25: undefined: incrementer

--- a/tests/rosetta/out/Go/100-doors-2.go
+++ b/tests/rosetta/out/Go/100-doors-2.go
@@ -11,6 +11,8 @@ import (
 type v map[string]any
 
 func main() {
+	var door int = 1
+	var incrementer int = 0
 	for current := 1; current < 101; current++ {
 		var line string = "Door " + fmt.Sprint(any(current)) + " "
 		if current == door {

--- a/tests/rosetta/out/Go/100-doors-3.error
+++ b/tests/rosetta/out/Go/100-doors-3.error
@@ -1,5 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:20:4: undefined: result
-/tmp/X/001/main.go:22:4: undefined: result
-/tmp/X/001/main.go:25:18: undefined: result

--- a/tests/rosetta/out/Go/100-doors-3.go
+++ b/tests/rosetta/out/Go/100-doors-3.go
@@ -11,6 +11,7 @@ import (
 type v map[string]any
 
 func main() {
+	var result string = ""
 	for i := 1; i < 101; i++ {
 		var j int = 1
 		for (j * j) < i {

--- a/tests/rosetta/out/Go/100-doors.error
+++ b/tests/rosetta/out/Go/100-doors.error
@@ -1,5 +1,0 @@
-run: exit status 1
-# command-line-arguments
-/tmp/X/001/main.go:17:42: undefined: doors
-/tmp/X/001/main.go:22:4: undefined: doors
-/tmp/X/001/main.go:30:15: undefined: doors

--- a/tests/rosetta/out/Go/100-doors.go
+++ b/tests/rosetta/out/Go/100-doors.go
@@ -13,6 +13,7 @@ import (
 type v map[string]any
 
 func main() {
+	var doors []any = []any{}
 	for i := 0; i < 100; i++ {
 		doors = _toAnySlice(append(_toAnySlice(doors), any(false)))
 	}

--- a/tests/rosetta/out/Go/README.md
+++ b/tests/rosetta/out/Go/README.md
@@ -1,11 +1,11 @@
-# Rosetta Go Output (32/284 compiled and run)
+# Rosetta Go Output (35/284 compiled and run)
 
 This directory holds Go source code generated from the real Mochi programs in `tests/rosetta/x/Mochi`. Each file has the expected output in a matching `.out` file. Compilation or runtime failures are stored in a corresponding `.error` file.
 
 ## Program checklist
-- [ ] 100-doors-2
-- [ ] 100-doors-3
-- [ ] 100-doors
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
 - [x] 100-prisoners
 - [ ] 15-puzzle-game
 - [x] 15-puzzle-solver


### PR DESCRIPTION
## Summary
- handle top-level var/let declarations when generating Go code
- make Rosetta golden tests deterministic by setting `MOCHI_NOW_SEED`
- regenerate Go outputs for the first Rosetta programs and update README

## Testing
- `ROSETTA_MAX=3 go test ./compiler/x/go -tags slow -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687b075b13948320b81f9e016e371c01