### PR TITLE
Fix global var init for Go compiler

### DIFF
--- a/compiler/x/go/usage.go
+++ b/compiler/x/go/usage.go
@@ -132,8 +132,27 @@ func (c *Compiler) compileMainFunc(prog *parser.Program) error {
 			c.writeln(fmt.Sprintf("if _, ok := extern.Get(%q); !ok { panic(\"extern object not registered: %s\") }", name, name))
 		}
 	}
+	// Initialise global variables inside main before executing the rest of
+	// the program. Package level declarations were emitted above.
+	for _, s := range prog.Statements {
+		switch {
+		case s.Let != nil:
+			if s.Let.Value != nil {
+				if err := c.compileAssign(&parser.AssignStmt{Pos: s.Let.Pos, Name: s.Let.Name, Value: s.Let.Value}); err != nil {
+					return err
+				}
+			}
+		case s.Var != nil:
+			if s.Var.Value != nil {
+				if err := c.compileAssign(&parser.AssignStmt{Pos: s.Var.Pos, Name: s.Var.Name, Value: s.Var.Value}); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	// Variable initialisation happens as part of the statement list
-	// so we no longer emit explicit assignments here.
+	// for remaining statements.
 	body := []*parser.Statement{}
 	for _, s := range prog.Statements {
 		if s.Fun != nil || s.Test != nil || s.Let != nil || s.Var != nil {


### PR DESCRIPTION
## Summary
- initialize global variables in main for Go backend

## Testing
- `go test ./compiler/x/go -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687b0769a42c8320bb92322334dae09d