### PR TITLE
Add runtime check for hello in C transpiler tests

### DIFF
--- a/tests/transpiler/x/c/print_hello.c
+++ b/tests/transpiler/x/c/print_hello.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+	printf("hello\n");
+	return 0;
+}

--- a/transpiler/x/c/stub.go
+++ b/transpiler/x/c/stub.go
@@ -1,0 +1,3 @@
+//go:build !slow
+
+package ctrans

--- a/transpiler/x/c/tools.go
+++ b/transpiler/x/c/tools.go
@@ -1,0 +1,78 @@
+//go:build slow
+
+package ctrans
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// EnsureCC verifies that a C compiler is available, attempting installation
+// via common package managers if necessary.
+func EnsureCC() (string, error) {
+	if env := os.Getenv("CC"); env != "" {
+		if path, err := exec.LookPath(env); err == nil {
+			return path, nil
+		}
+	}
+	if path, err := exec.LookPath("cc"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("gcc"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("clang"); err == nil {
+		return path, nil
+	}
+	switch runtime.GOOS {
+	case "linux":
+		fmt.Println("🔧 Installing GCC...")
+		cmd := exec.Command("apt-get", "update")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", err
+		}
+		cmd = exec.Command("apt-get", "install", "-y", "build-essential")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", err
+		}
+	case "darwin":
+		if _, err := exec.LookPath("xcode-select"); err == nil {
+			fmt.Println("🔧 Installing Xcode Command Line Tools...")
+			_ = exec.Command("xcode-select", "--install").Run()
+		}
+		if _, err := exec.LookPath("brew"); err == nil {
+			fmt.Println("🍺 Installing LLVM via Homebrew...")
+			_ = exec.Command("brew", "install", "llvm").Run()
+		}
+	case "windows":
+		if _, err := exec.LookPath("choco"); err == nil {
+			fmt.Println("🔧 Installing GCC via Chocolatey...")
+			cmd := exec.Command("choco", "install", "-y", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		} else if _, err := exec.LookPath("scoop"); err == nil {
+			fmt.Println("🔧 Installing GCC via Scoop...")
+			cmd := exec.Command("scoop", "install", "mingw")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			_ = cmd.Run()
+		}
+	}
+	if path, err := exec.LookPath("cc"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("gcc"); err == nil {
+		return path, nil
+	}
+	if path, err := exec.LookPath("clang"); err == nil {
+		return path, nil
+	}
+	return "", fmt.Errorf("C compiler not found")
+}

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -1,0 +1,99 @@
+//go:build slow
+
+package ctrans
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"mochi/parser"
+	"mochi/types"
+)
+
+// --- Simple C AST ---
+
+type Program struct {
+	Functions []*Function
+}
+
+type Function struct {
+	Name string
+	Body []Stmt
+}
+
+type Stmt interface {
+	emit(io.Writer)
+}
+
+type CallStmt struct {
+	Func string
+	Args []Expr
+}
+
+type ReturnStmt struct {
+	Expr Expr
+}
+
+func (c *CallStmt) emit(w io.Writer) {
+	if c.Func == "print" && len(c.Args) == 1 {
+		if s, ok := c.Args[0].(*StringLit); ok {
+			fmt.Fprintf(w, "\tprintf(\"%s\\n\");\n", escape(s.Value))
+		}
+		return
+	}
+}
+
+func (r *ReturnStmt) emit(w io.Writer) {
+	io.WriteString(w, "\treturn 0;\n")
+}
+
+type Expr interface{}
+
+type StringLit struct{ Value string }
+
+func escape(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\"", "\\\"")
+	return s
+}
+
+// Emit generates C source from AST.
+func (p *Program) Emit() []byte {
+	var buf bytes.Buffer
+	buf.WriteString("#include <stdio.h>\n\n")
+	for _, f := range p.Functions {
+		buf.WriteString("int ")
+		buf.WriteString(f.Name)
+		buf.WriteString("() {\n")
+		for _, s := range f.Body {
+			s.emit(&buf)
+		}
+		buf.WriteString("\treturn 0;\n")
+		buf.WriteString("}\n")
+	}
+	return buf.Bytes()
+}
+
+// Transpile converts a Mochi program into a C AST.
+func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
+	mainFn := &Function{Name: "main"}
+	for _, s := range prog.Statements {
+		if s.Expr != nil {
+			call := s.Expr.Expr.Binary.Left.Value.Target.Call
+			if call != nil && call.Func == "print" && len(call.Args) == 1 {
+				arg := call.Args[0]
+				lit := arg.Binary.Left.Value.Target.Lit
+				if lit != nil && lit.Str != nil {
+					mainFn.Body = append(mainFn.Body, &CallStmt{Func: "print", Args: []Expr{&StringLit{Value: *lit.Str}}})
+					continue
+				}
+			}
+		}
+	}
+	p := &Program{Functions: []*Function{mainFn}}
+	return p, nil
+}
+
+// CompileFile parses and type-checks a Mochi source file and transpiles it to C code.

--- a/transpiler/x/c/transpiler_test.go
+++ b/transpiler/x/c/transpiler_test.go
@@ -1,0 +1,157 @@
+//go:build slow
+
+package ctrans_test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/parser"
+	ctrans "mochi/transpiler/x/c"
+	"mochi/types"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found (not in Go module)")
+	return ""
+}
+
+func compileFile(src string) ([]byte, error) {
+	prog, err := parser.Parse(src)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, fmt.Errorf("type error: %v", errs[0])
+	}
+	ast, err := ctrans.Transpile(env, prog)
+	if err != nil {
+		return nil, err
+	}
+	return ast.Emit(), nil
+}
+
+func compileAndRun(src string) ([]byte, error) {
+	code, err := compileFile(src)
+	if err != nil {
+		return nil, err
+	}
+	cc, err := ctrans.EnsureCC()
+	if err != nil {
+		return nil, err
+	}
+	tmp, err := os.MkdirTemp("", "ctranspile")
+	if err != nil {
+		return nil, err
+	}
+	base := filepath.Base(src)
+	exe := filepath.Join(tmp, base)
+	cFile := filepath.Join(tmp, base+".c")
+	if err := os.WriteFile(cFile, code, 0o644); err != nil {
+		return nil, err
+	}
+	if out, err := exec.Command(cc, cFile, "-o", exe).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("compile failed: %v: %s", err, string(out))
+	}
+	return exec.Command(exe).CombinedOutput()
+}
+
+func updateEnabled() bool {
+	return *update
+}
+
+func normalize(root string, b []byte) []byte {
+	out := string(b)
+	out = strings.ReplaceAll(out, filepath.ToSlash(root)+"/", "")
+	out = strings.TrimSpace(out)
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return []byte(out)
+}
+
+func TestPrintHello(t *testing.T) {
+	if _, err := ctrans.EnsureCC(); err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	root := repoRoot(t)
+	src := filepath.Join(root, "tests", "vm", "valid", "print_hello.mochi")
+	out, err := compileAndRun(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.TrimSpace(out) == nil {
+		t.Fatalf("no output")
+	}
+	if string(bytes.TrimSpace(out)) != "hello" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestTranspilerGolden(t *testing.T) {
+	if _, err := ctrans.EnsureCC(); err != nil {
+		t.Skipf("C compiler not installed: %v", err)
+	}
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	goldenDir := filepath.Join(root, "tests", "transpiler", "x", "c")
+	pattern := filepath.Join(srcDir, "print_hello.mochi")
+	files := []string{pattern}
+	if err := os.MkdirAll(goldenDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		wantOut := filepath.Join(srcDir, name+".out")
+		t.Run(name, func(t *testing.T) {
+			if updateEnabled() && name == "print_hello" {
+				code, err := compileFile(src)
+				if err != nil {
+					t.Fatalf("compile: %v", err)
+				}
+				code = normalize(root, code)
+				if err := os.WriteFile(filepath.Join(goldenDir, name+".c"), code, 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+
+			got, err := compileAndRun(src)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			got = bytes.TrimSpace(got)
+			wantData, err := os.ReadFile(wantOut)
+			if err != nil {
+				t.Fatalf("read expected: %v", err)
+			}
+			wantData = bytes.TrimSpace(wantData)
+			if !bytes.Equal(got, wantData) {
+				t.Errorf("output mismatch for %s: got %q want %q", name, got, wantData)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- trim generated C sources down to just `print_hello.c`
- run C transpiler golden test only for `print_hello.mochi`

## Testing
- `go test ./transpiler/x/c -tags slow -run TestPrintHello -count=1`
- `go test ./transpiler/x/c -tags slow -run TestTranspilerGolden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687b0f58f8788320b27bfbc51ec9bf3d