### PR TITLE
Add v0.10.31 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # 📦 CHANGELOG.md
+## [0.10.31] – 2025-07-19T10:21:06+07:00
+
+### Added
+
+* New Mochi examples such as Deconvolution-1D and Day-of-the-week
+* Rosetta golden tests expanded and sorted for determinism
+* TypeScript runtime `input` helper for Deno
+
+### Changed
+
+* Kotlin functions now return values
+* Scala and Swift handle return statements and list casts
+* Go manages top-level variables in `main`
+* C and C++ extend builtins and inference
+* Rust and Python improve constant handling and DNS lookup
+
+### Fixed
+
+* Go backend `len(any)` and global variable issues
+* Ruby and Java index inference bugs
+* READMEs refreshed across languages
 ## [0.10.30] – 2025-07-18T18:44:32+07:00
 
 ### Added

--- a/releases/v0.10.31.md
+++ b/releases/v0.10.31.md
@@ -1,0 +1,31 @@
+# Jul 2025 (v0.10.31)
+
+Released on Sat Jul 19 10:21:06 2025 +0700.
+
+Mochi v0.10.31 continues improving compiler features across languages and expands Rosetta task coverage with fresh examples and outputs.
+
+## Examples
+
+- Additional Mochi solutions such as Deconvolution-1D and Day-of-the-week
+- Rosetta golden tests extended and sorted for reproducibility
+- README and dataset outputs refreshed for multiple languages
+
+## Compilers
+
+- Kotlin functions can now return values
+- Scala handles return statements and list variables
+- Swift adds list casts and `upper` builtin
+- Go manages top-level variables in `main`
+- C and C++ support new builtins and improved type inference
+- Rust and Python address constant handling and DNS errors
+
+## Runtime
+
+- TypeScript runtime fixes `input` handling for Deno
+- Prolog flags runtime errors during execution
+
+## Documentation
+
+- Rosetta checklists updated across languages
+- Elixir and Python READMEs refreshed with compilation status
+


### PR DESCRIPTION
## Summary
- document v0.10.31 release notes
- update CHANGELOG for v0.10.31

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b153bc24083208410a15f79d20862