### PR TITLE
Tag transpiler cross-language files as slow

### DIFF
--- a/transpiler/x/c/stub.go
+++ b/transpiler/x/c/stub.go
@@ -1,3 +1,3 @@
-//go:build !slow
+//go:build slow
 
 package ctrans

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljt
 
 import (

--- a/transpiler/x/clj/transpiler_test.go
+++ b/transpiler/x/clj/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cljt_test
 
 import (

--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cstranspiler
 
 import (

--- a/transpiler/x/cs/transpiler_test.go
+++ b/transpiler/x/cs/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cstranspiler_test
 
 import (

--- a/transpiler/x/py/transpiler.go
+++ b/transpiler/x/py/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package py
 
 import (

--- a/transpiler/x/py/transpiler_test.go
+++ b/transpiler/x/py/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package py_test
 
 import (


### PR DESCRIPTION
## Summary
- mark all files under `transpiler/x` with the `slow` build tag

## Testing
- `go test ./transpiler/... -run TestNonExist -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_687b1f8ad2f8832092c958102ea271db