### PR TITLE
Fix go build/test

### DIFF
--- a/scripts/gen_ex_golden.go
+++ b/scripts/gen_ex_golden.go
@@ -1,3 +1,5 @@
+//go:build archive && slow
+
 package main
 
 import (

--- a/scripts/update_dart_transpiler_readme.go
+++ b/scripts/update_dart_transpiler_readme.go
@@ -1,3 +1,5 @@
+//go:build archive && slow
+
 package main
 
 import (

--- a/scripts/update_st_transpiler_readme.go
+++ b/scripts/update_st_transpiler_readme.go
@@ -1,3 +1,5 @@
+//go:build archive && slow
+
 package main
 
 import (

--- a/scripts/update_st_transpiler_tasks.go
+++ b/scripts/update_st_transpiler_tasks.go
@@ -1,3 +1,5 @@
+//go:build archive && slow
+
 package main
 
 import (

--- a/transpiler/x/erl/transpiler_test.go
+++ b/transpiler/x/erl/transpiler_test.go
@@ -59,11 +59,19 @@ func runGolden(t *testing.T, name string) {
 	}
 	cmd := exec.Command("escript", erlFile)
 	out, err := cmd.CombinedOutput()
-	got := bytes.TrimSpace(out)
 	if err != nil {
 		_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
 		t.Fatalf("run: %v", err)
 	}
+	lines := bytes.Split(out, []byte{'\n'})
+	filtered := lines[:0]
+	for _, l := range lines {
+		if bytes.Contains(l, []byte("Warning:")) || bytes.HasPrefix(l, []byte("%")) {
+			continue
+		}
+		filtered = append(filtered, l)
+	}
+	got := bytes.TrimSpace(bytes.Join(filtered, []byte{'\n'}))
 	_ = os.Remove(filepath.Join(outDir, name+".error"))
 	wantPath := filepath.Join(outDir, name+".out")
 	want, err := os.ReadFile(wantPath)


### PR DESCRIPTION
## Summary
- add build tags to dev scripts so they don't build by default
- ignore Erlang warnings in tests

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b38e7816c83209ce823e11dd40fd4