### PR TITLE
Add slow tag for transpiler drivers

### DIFF
--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dartt
 
 import (

--- a/transpiler/x/dart/transpiler_test.go
+++ b/transpiler/x/dart/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dartt_test
 
 import (

--- a/transpiler/x/erl/transpiler.go
+++ b/transpiler/x/erl/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erl
 
 import (

--- a/transpiler/x/erl/transpiler_test.go
+++ b/transpiler/x/erl/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package erl_test
 
 import (

--- a/transpiler/x/ex/transpiler.go
+++ b/transpiler/x/ex/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ex
 
 import (

--- a/transpiler/x/ex/transpiler_test.go
+++ b/transpiler/x/ex/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ex_test
 
 import (

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fstrans
 
 import (

--- a/transpiler/x/fs/transpiler_test.go
+++ b/transpiler/x/fs/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fstrans_test
 
 import (

--- a/transpiler/x/hs/transpiler.go
+++ b/transpiler/x/hs/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hs
 
 import (

--- a/transpiler/x/hs/transpiler_test.go
+++ b/transpiler/x/hs/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package hs_test
 
 import (

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package javatr
 
 import (

--- a/transpiler/x/java/transpiler_test.go
+++ b/transpiler/x/java/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package javatr_test
 
 import (

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kt
 
 import (

--- a/transpiler/x/kt/transpiler_test.go
+++ b/transpiler/x/kt/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package kt_test
 
 import (

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package lua
 
 import (

--- a/transpiler/x/lua/transpiler_test.go
+++ b/transpiler/x/lua/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package lua_test
 
 import (

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php
 
 import (

--- a/transpiler/x/php/transpiler_test.go
+++ b/transpiler/x/php/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php_test
 
 import (

--- a/transpiler/x/pl/transpiler.go
+++ b/transpiler/x/pl/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pl
 
 import (

--- a/transpiler/x/pl/transpiler_test.go
+++ b/transpiler/x/pl/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package pl_test
 
 import (

--- a/transpiler/x/rb/transpiler.go
+++ b/transpiler/x/rb/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rb
 
 import (

--- a/transpiler/x/rb/transpiler_test.go
+++ b/transpiler/x/rb/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rb_test
 
 import (

--- a/transpiler/x/rkt/transpiler.go
+++ b/transpiler/x/rkt/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rkt
 
 import (

--- a/transpiler/x/rkt/transpiler_test.go
+++ b/transpiler/x/rkt/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rkt_test
 
 import (

--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rs
 
 import (

--- a/transpiler/x/rs/transpiler_test.go
+++ b/transpiler/x/rs/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rs_test
 
 import (

--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scalat
 
 import (

--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/transpiler/x/scheme/transpiler_test.go
+++ b/transpiler/x/scheme/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme_test
 
 import (

--- a/transpiler/x/st/transpiler.go
+++ b/transpiler/x/st/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st
 
 import (

--- a/transpiler/x/st/transpiler_test.go
+++ b/transpiler/x/st/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package st_test
 
 import (

--- a/transpiler/x/swift/transpiler.go
+++ b/transpiler/x/swift/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swifttrans
 
 import (

--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigt
 
 import (

--- a/transpiler/x/zig/transpiler_test.go
+++ b/transpiler/x/zig/transpiler_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zigt_test
 
 import (


### PR DESCRIPTION
## Summary
- add `//go:build slow` to each transpiler driver in `transpiler/x`

## Testing
- `make lint` *(fails: build constraints exclude all Go files in transpiler/x/fs)*

------
https://chatgpt.com/codex/tasks/task_e_687b3cb0fb70832096f4ed8c0ca9b034