### PR TITLE
Enhance ruby transpiler

### DIFF
--- a/transpiler/x/rb/transpiler.go
+++ b/transpiler/x/rb/transpiler.go
@@ -1798,6 +1798,16 @@ func (b *BlockStmt) emit(e *emitter) {
 	}
 }
 
+// BreakStmt represents a break statement.
+type BreakStmt struct{}
+
+func (b *BreakStmt) emit(w io.Writer) { io.WriteString(w, "break") }
+
+// ContinueStmt represents a continue/next statement.
+type ContinueStmt struct{}
+
+func (c *ContinueStmt) emit(w io.Writer) { io.WriteString(w, "next") }
+
 // FuncStmt represents a function definition.
 type FuncStmt struct {
 	Name   string


### PR DESCRIPTION
## Summary
- support `break` and `continue` in Ruby transpiler
- handle multi-argument `print` built‑in
- update generated Ruby test files
- mark `break_continue` test complete in README
- log latest progress in tasks

## Testing
- `go test ./transpiler/x/rb -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687b4c7d6dc0832090ff9f524fc47a13