### PR TITLE
Fix build by adding C# transpiler stub

### DIFF
--- a/transpiler/x/cs/stub.go
+++ b/transpiler/x/cs/stub.go
@@ -1,0 +1,22 @@
+//go:build !slow
+
+package cstranspiler
+
+import (
+	"mochi/parser"
+	"mochi/types"
+)
+
+// Program is a minimal placeholder used when the real implementation is
+// excluded by build tags.
+type Program struct{}
+
+// Transpile returns a placeholder program and no error so that packages can
+// compile without the slow implementation.
+func Transpile(_ *parser.Program, _ *types.Env) (*Program, error) {
+	return &Program{}, nil
+}
+
+// Emit returns nil output. It is a no-op replacement when the real
+// implementation is not included.
+func Emit(_ *Program) []byte { return nil }


### PR DESCRIPTION
## Summary
- add a stub implementation for the C# transpiler so builds without the `slow` build tag succeed

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687b7886b9bc8320bfffd923e9fa57bc