### PR TITLE
Add loop support to Smalltalk transpiler

### DIFF
--- a/tests/algorithms/x/CS/web_programming/fetch_github_info.error
+++ b/tests/algorithms/x/CS/web_programming/fetch_github_info.error
@@ -1,1 +1,1 @@
-unsupported primary
+unsupported expression

--- a/transpiler/x/st/transpiler.go
+++ b/transpiler/x/st/transpiler.go
@@ -1157,6 +1157,16 @@ func evalPrimary(p *parser.Primary, vars map[string]value) (value, error) {
 		if p.Lit.Str != nil {
 			return value{kind: valString, s: *p.Lit.Str}, nil
 		}
+	case p.List != nil:
+		elems := make([]value, 0, len(p.List.Elems))
+		for _, e := range p.List.Elems {
+			v, err := evalExpr(e, vars)
+			if err != nil {
+				return value{}, err
+			}
+			elems = append(elems, v)
+		}
+		return value{kind: valList, list: elems}, nil
 	case p.Selector != nil:
 		if v, ok := vars[p.Selector.Root]; ok {
 			for _, f := range p.Selector.Tail {


### PR DESCRIPTION
## Summary
- support lists and for/while loops in `transpiler/x/st`
- update generated Smalltalk files for new golden tests
- regenerate README and TASKS progress with git timestamp

## Testing
- `go test ./transpiler/x/st -tags slow -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687b75468dec8320b19c043d5da3c3a6