### PR TITLE
Improve Lua transpiler

### DIFF
--- a/tests/algorithms/x/CS/data_structures/heap/min_heap.error
+++ b/tests/algorithms/x/CS/data_structures/heap/min_heap.error
@@ -1,1 +1,0 @@
-unsupported assignment

--- a/tests/algorithms/x/CS/data_structures/kd_tree/example/example_usage.error
+++ b/tests/algorithms/x/CS/data_structures/kd_tree/example/example_usage.error
@@ -1,1 +1,0 @@
-unsupported assignment

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -526,6 +526,24 @@ type BinaryExpr struct {
 	Op    string
 	Right Expr
 }
+type IndexExpr struct {
+	Target Expr
+	Index  Expr
+}
+type SliceExpr struct {
+	Target Expr
+	Start  Expr
+	End    Expr
+}
+type FieldExpr struct {
+	Target Expr
+	Name   string
+}
+type IndexAssignStmt struct {
+	Target Expr
+	Index  Expr
+	Value  Expr
+}
 
 type UnaryExpr struct {
 	Op    string


### PR DESCRIPTION
## Summary
- implement index and slice expressions in Lua transpiler
- handle method calls like `string.contains`
- support index assignment
- print lists nicely
- update golden outputs and documentation

## Testing
- `go test ./transpiler/x/lua -run VMValid -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687b963ee21483209ed5571b8c01ddc6