### PR TITLE
Add basic Fortran loop support

### DIFF
--- a/transpiler/x/fortran/TASKS.md
+++ b/transpiler/x/fortran/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-19 21:32 +07)
+- fortran transpiler: add for-loop, break and continue support
+
 ## Progress (2025-07-19 19:59 +07)
 - docs: update fortran progress
 


### PR DESCRIPTION
## Summary
- add `ForStmt`, `BreakStmt` and `ContinueStmt` to the Fortran transpiler
- implement emitting loops, break, and continue
- document current progress and add a progress entry

## Testing
- `go build ./transpiler/x/fortran`

------
https://chatgpt.com/codex/tasks/task_e_687ba915fcdc8320843193517d35e561