### PR TITLE
Fix nil printing in VM

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -7437,7 +7437,7 @@ func anyToValue(v any) Value { return FromAny(v) }
 func formatValue(v Value) string {
 	switch v.Tag {
 	case ValueNull:
-		return "null"
+		return "nil"
 	case ValueBool:
 		if v.Bool {
 			return "true"

--- a/tests/vm/valid/left_join.out
+++ b/tests/vm/valid/left_join.out
@@ -1,4 +1,4 @@
 --- Left Join ---
 Order 100 customer {"id": 1, "name": "Alice"} total 250
-Order 101 customer null total 80
+Order 101 customer nil total 80
 

--- a/tests/vm/valid/left_join_multi.out
+++ b/tests/vm/valid/left_join_multi.out
@@ -1,4 +1,4 @@
 --- Left Join Multi ---
 100 Alice {"orderId": 100, "sku": "a"}
-101 Bob null
+101 Bob nil
 

--- a/tests/vm/valid/map_literal_dynamic.out
+++ b/tests/vm/valid/map_literal_dynamic.out
@@ -1,1 +1,1 @@
-null null
+nil nil

--- a/tests/vm/valid/typed_let.out
+++ b/tests/vm/valid/typed_let.out
@@ -1,1 +1,1 @@
-null
+nil

--- a/tests/vm/valid/typed_var.out
+++ b/tests/vm/valid/typed_var.out
@@ -1,1 +1,1 @@
-null
+nil


### PR DESCRIPTION
## Summary
- ensure runtime VM prints `nil` for null values
- update golden tests for nil printing

## Testing
- `go test ./runtime/vm -tags slow -run TestVMValidPrograms -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687bd97952a08320ae58cbdf6b9cdb27