### PR TITLE
Improve C transpiler membership handling

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-20 01:35 UTC)
+- VM valid golden test results updated to 37/100
+
 ## Progress (2025-07-20 08:20 +0700)
 - VM valid golden test results updated to 37/100
 ## Progress (2025-07-19 19:14 UTC)

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -429,6 +429,33 @@ func (b *BinaryExpr) emitExpr(w io.Writer) {
 		io.WriteString(w, ") != NULL")
 		return
 	}
+	if b.Op == "in" {
+		if list, ok := evalList(b.Right); ok {
+			io.WriteString(w, "(")
+			if len(list.Elems) == 0 {
+				io.WriteString(w, "0")
+			} else {
+				for i, e := range list.Elems {
+					if i > 0 {
+						io.WriteString(w, " || ")
+					}
+					if exprIsString(b.Left) || exprIsString(e) {
+						io.WriteString(w, "strcmp(")
+						b.Left.emitExpr(w)
+						io.WriteString(w, ", ")
+						e.emitExpr(w)
+						io.WriteString(w, ") == 0")
+					} else {
+						b.Left.emitExpr(w)
+						io.WriteString(w, " == ")
+						e.emitExpr(w)
+					}
+				}
+			}
+			io.WriteString(w, ")")
+			return
+		}
+	}
 	if (exprIsString(b.Left) || exprIsString(b.Right)) &&
 		(b.Op == "==" || b.Op == "!=" || b.Op == "<" || b.Op == "<=" || b.Op == ">" || b.Op == ">=") {
 		io.WriteString(w, "strcmp(")


### PR DESCRIPTION
## Summary
- enhance the C transpiler to inline membership checks for constant lists
- record latest progress in TASKS.md

## Testing
- `go test -tags slow ./transpiler/x/c`


------
https://chatgpt.com/codex/tasks/task_e_687c466956608320a5e2dc01e47ecaf2