### PR TITLE
Improve F# transpiler

### DIFF
--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,12 +1,5 @@
-## Progress (2025-07-19 19:59 +0700)
-- VM valid golden test results updated
-
-## Progress (2025-07-19 12:44 UTC)
-- VM valid golden test results updated
-
-## Progress (2025-07-19 19:01 +0700)
-- Added lambda expression handling and index access.
-- 36 out of 100 VM valid tests pass.
+## Progress (2025-07-20 01:31 UTC)
+- Enhanced F# transpiler for readability and better inference
 
 # Transpiler Progress
 


### PR DESCRIPTION
## Summary
- simplify F# code generation header and remove version lookup
- add simple type inference for basic literals
- update progress log for F# transpiler

## Testing
- `go test ./transpiler/x/fs -run TestFSTranspiler_PrintHello -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687c471dd5cc8320ba2d7eaf6ca7d604