### PR TITLE
Improve Pascal transpiler and docs

### DIFF
--- a/transpiler/x/pas/README.md
+++ b/transpiler/x/pas/README.md
@@ -1,9 +1,9 @@
 # Pascal Transpiler
 
 This folder contains the experimental Pascal transpiler.
-The checklist below tracks which example programs from `tests/vm/valid` have been successfully transpiled.
-Progress: **27/100**
+Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 
+## VM Golden Test Checklist (27/100)
 - [ ] append_builtin.mochi
 - [ ] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -80,17 +80,17 @@ Progress: **27/100**
 - [ ] record_assign.mochi
 - [ ] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
- - [x] short_circuit.mochi
+- [x] short_circuit.mochi
 - [ ] slice.mochi
 - [ ] sort_stable.mochi
 - [ ] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
- - [x] string_contains.mochi
+- [x] string_contains.mochi
 - [x] string_in_operator.mochi
 - [x] string_index.mochi
 - [x] string_prefix_slice.mochi
- - [x] substring_builtin.mochi
+- [x] substring_builtin.mochi
 - [ ] sum_builtin.mochi
 - [ ] tail_recursion.mochi
 - [ ] test_block.mochi

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,11 +1,11 @@
 # Transpiler Tasks
 
-## Progress (2025-07-19 12:53 +0000)
-- Added list literal and array indexing support.
-- Added tests `len_builtin` and `list_index`.
-- Updated README progress to 27/100.
+## Progress (2025-07-20 08:31 +0700)
+- Improved code generation formatting and added basic type inference for auto-declared variables.
+- Updated README checklist with 27/100 tests.
 
 ## Recent Updates
+- [2025-07-20T08:31:52+07:00] Improved formatting and added variable inference.
 - [2025-07-19T12:53:18Z] Added list literal support and new tests; progress to 27/100
 - [2025-07-19T12:29:49Z] Added short_circuit test and progress to 25/100
 - [2025-07-19T11:43:36+00:00] Added substring and contains features; progress to 24/100


### PR DESCRIPTION
## Summary
- update Pascal README with golden test checklist
- log new progress in TASKS with git timestamp
- add simple variable type inference and improved code emission

## Testing
- `go test ./transpiler/x/pas -tags slow`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c475c5c4c832082194cf2b1d6ce20