### PR TITLE
Improve CS transpiler formatting

### DIFF
--- a/transpiler/x/cs/TASKS.md
+++ b/transpiler/x/cs/TASKS.md
@@ -1,6 +1,9 @@
 ## Progress (2025-07-20 01:31 +0000)
 - cs transpiler: add list set operations and clean imports (progress 59/100)
 
+## Progress (2025-07-20 01:45 UTC)
+- cs transpiler: improve formatting and remove linq inspection (progress 59/100)
+
 ## Progress (2025-07-19 18:52 +0000)
 - cs transpiler: improve code emission and type inference (progress 58/100)
 


### PR DESCRIPTION
## Summary
- improve readability for generated C# code
- always include `System.Linq` and remove linq inspection helpers
- avoid trailing semicolons on block statements
- update CS transpiler progress log

## Testing
- `go test ./transpiler/x/cs -c -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_687c48f554a883208f58adefd39a67de