### PR TITLE
Add Python transpiler golden runner and docs update

### DIFF
--- a/transpiler/x/py/TASKS.md
+++ b/transpiler/x/py/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-20 08:45 +0700)
+- Generated Python for 76/100 programs
+- Updated README checklist and outputs
+
 # Python Transpiler Tasks
 ## Recent Enhancements (2025-07-20 02:09 UTC+0700)
 

--- a/transpiler/x/py/transpiler.go
+++ b/transpiler/x/py/transpiler.go
@@ -1719,7 +1719,14 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				sumCall := &CallExpr{Func: &Name{Name: "sum"}, Args: []Expr{args[0]}}
 				lenCall := &CallExpr{Func: &Name{Name: "len"}, Args: []Expr{args[0]}}
 				div := &BinaryExpr{Left: sumCall, Op: "/", Right: lenCall}
-				return &CondExpr{Cond: args[0], Then: div, Else: &IntLit{Value: "0"}}, nil
+				zero := Expr(&IntLit{Value: "0"})
+				if currentEnv != nil {
+					t := types.ExprType(p.Call.Args[0], currentEnv)
+					if _, ok := t.(types.FloatType); ok {
+						zero = &FloatLit{Value: "0.0"}
+					}
+				}
+				return &CondExpr{Cond: args[0], Then: div, Else: zero}, nil
 			}
 		case "count":
 			if len(args) == 1 {

--- a/transpiler/x/py/vm_valid_golden_test.go
+++ b/transpiler/x/py/vm_valid_golden_test.go
@@ -1,0 +1,174 @@
+//go:build slow
+
+package py_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/golden"
+	"mochi/parser"
+	py "mochi/transpiler/x/py"
+	"mochi/types"
+)
+
+func ensurePython(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+}
+
+func TestPyTranspiler_VMValid_Golden(t *testing.T) {
+	ensurePython(t)
+	root := repoRoot(t)
+	outDir := filepath.Join(root, "tests", "transpiler", "x", "py")
+	os.MkdirAll(outDir, 0o755)
+
+	golden.RunWithSummary(t, "tests/vm/valid", ".mochi", ".out", func(src string) ([]byte, error) {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		codePath := filepath.Join(outDir, base+".py")
+		outPath := filepath.Join(outDir, base+".out")
+		errPath := filepath.Join(outDir, base+".error")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("parse: "+err.Error()), 0o644)
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			_ = os.WriteFile(errPath, []byte("type: "+errs[0].Error()), 0o644)
+			return nil, errs[0]
+		}
+		ast, err := py.Transpile(prog, env)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
+			return nil, err
+		}
+		var buf bytes.Buffer
+		if err := py.Emit(&buf, ast); err != nil {
+			_ = os.WriteFile(errPath, []byte("emit: "+err.Error()), 0o644)
+			return nil, err
+		}
+		if err := os.WriteFile(codePath, buf.Bytes(), 0o644); err != nil {
+			return nil, err
+		}
+		cmd := exec.Command("python3", codePath)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		got := bytes.TrimSpace(out)
+		if err != nil {
+			_ = os.WriteFile(errPath, append([]byte("run: "+err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		_ = os.Remove(errPath)
+		_ = os.WriteFile(outPath, got, 0o644)
+		return got, nil
+	})
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateReadme()
+	updateTasks()
+	os.Exit(code)
+}
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func updateReadme() {
+	root := repoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	outDir := filepath.Join(root, "tests", "transpiler", "x", "py")
+	readmePath := filepath.Join(root, "transpiler", "x", "py", "README.md")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	sort.Strings(files)
+	if len(files) > 100 {
+		files = files[:100]
+	}
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".py")); err == nil {
+			compiled++
+			mark = "[x]"
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+	}
+	var buf bytes.Buffer
+	buf.WriteString("# Transpiler Progress\n\n")
+	buf.WriteString("This checklist is auto-generated.\n")
+	buf.WriteString("Generated Python code from programs in `tests/vm/valid` lives in `tests/transpiler/x/py`.\n\n")
+	fmt.Fprintf(&buf, "## VM Golden Test Checklist (%d/%d)\n", compiled, total)
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n")
+	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
+}
+
+func updateTasks() {
+	root := repoRoot(&testing.T{})
+	taskFile := filepath.Join(root, "transpiler", "x", "py", "TASKS.md")
+	out, err := exec.Command("git", "log", "-1", "--format=%cI").Output()
+	ts := ""
+	if err == nil {
+		if t, perr := time.Parse(time.RFC3339, strings.TrimSpace(string(out))); perr == nil {
+			if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
+				ts = t.In(loc).Format("2006-01-02 15:04 -0700")
+			} else {
+				ts = t.Format("2006-01-02 15:04 MST")
+			}
+		}
+	}
+	srcDir := filepath.Join(root, "tests", "vm", "valid")
+	outDir := filepath.Join(root, "tests", "transpiler", "x", "py")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	sort.Strings(files)
+	if len(files) > 100 {
+		files = files[:100]
+	}
+	total := len(files)
+	compiled := 0
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		if _, err := os.Stat(filepath.Join(outDir, name+".py")); err == nil {
+			compiled++
+		}
+	}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("## Progress (%s)\n", ts))
+	fmt.Fprintf(&buf, "- Generated Python for %d/%d programs\n", compiled, total)
+	buf.WriteString("- Updated README checklist and outputs\n\n")
+	if data, err := os.ReadFile(taskFile); err == nil {
+		buf.Write(data)
+	}
+	_ = os.WriteFile(taskFile, buf.Bytes(), 0o644)
+}


### PR DESCRIPTION
## Summary
- create golden test runner for Python transpiler
- improve `avg` builtin handling to infer float type
- log progress in `TASKS.md`

## Testing
- `go test ./transpiler/x/py -run TestDoesNotExist -tags=slow`
- `go test ./transpiler/x/py -run TestTranspile_PrintHello -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_687c4a734a0c8320bdad824997a96724