### PR TITLE
Improve COBOL transpiler output

### DIFF
--- a/transpiler/x/cobol/TASKS.md
+++ b/transpiler/x/cobol/TASKS.md
@@ -3,12 +3,18 @@
 - Improved PIC inference for constant strings
 - Updated README checklist with progress 18/100
 
+## Progress (2025-07-20 09:20 GMT+7)
+- Simplified Display logic and updated numeric formatting
+- Regenerated COBOL sources; checklist still 18/100
+
 ## Progress (2025-07-20 01:47 +0700)
 - Updated README checklist with progress 18/100
 - Improved isDirectNumber for arithmetic detection
 
 
 # Transpiler Progress
+
+- 2025-07-20 09:20 GMT+7 - Refined display formatting using TMP-STR helper
 
 - 2025-07-20 01:32 +0700 - Simplified DISPLAY handling and removed TMP-STR helper; README checklist now 18/100
 - 2025-07-19 21:14 +0700 - Implemented boolean operators and generated golden files for `string_compare`; README checklist now 18/100

--- a/transpiler/x/cobol/transpiler.go
+++ b/transpiler/x/cobol/transpiler.go
@@ -560,7 +560,7 @@ func Emit(p *Program) []byte {
 	buf.WriteString(">>SOURCE FORMAT FREE\n")
 	buf.WriteString("IDENTIFICATION DIVISION.\n")
 	buf.WriteString("PROGRAM-ID. MAIN.\n")
-	if len(p.Vars) > 0 || p.NeedTmp {
+	if len(p.Vars) > 0 || p.NeedTmp || p.NeedStr {
 		buf.WriteString("\nDATA DIVISION.\n")
 		buf.WriteString("WORKING-STORAGE SECTION.\n")
 		for _, v := range p.Vars {


### PR DESCRIPTION
## Summary
- tweak display code to keep numeric formatting
- track `NeedStr` again for TMP-STR helper
- document recent progress

## Testing
- `go test ./transpiler/x/cobol -run TestTranspile_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c513c7c808320a39e7054cadac77f