### PR TITLE
Enhance Go transpiler type inference

### DIFF
--- a/transpiler/x/go/TASKS.md
+++ b/transpiler/x/go/TASKS.md
@@ -1,3 +1,83 @@
+## Progress (2025-07-20 09:33 +0700)
+- go transpiler: improve variable type inference
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:25 +0700)
+- go transpiler: inline helpers
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:12 +0700)
+- php transpiler: add func support and update golden
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:12 +0700)
+- php transpiler: add func support and update golden
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:12 +0700)
+- php transpiler: add func support and update golden
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:12 +0700)
+- php transpiler: add func support and update golden
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 09:12 +0700)
+- php transpiler: add func support and update golden
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 08:43 +0700)
+- update go transpiler tasks
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 08:41 +0700)
+- go transpiler: handle string contains
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 08:32 +0700)
+- Add unary not handling to Go transpiler
+- Regenerated golden files - 53/100 vm valid programs passing
+
+## Progress (2025-07-20 08:19 +0700)
+- go transpiler: support function literals
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 08:10 +0700)
+- go transpiler: update golden files
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 02:22 +0700)
+- go transpiler: simpler loops
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 02:08 +0700)
+- go transpiler: handle map iteration
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 01:49 +0700)
+- docs(go): update VM checklist and tasks
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 01:38 +0700)
+- regenerate go golden files
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 01:34 +0700)
+- refine Go transpiler types
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 01:30 +0700)
+- Applying previous commit.
+- Regenerated golden files - 52/100 vm valid programs passing
+
+## Progress (2025-07-20 01:26 +0700)
+- Refined "in" operator to return booleans
+- Regenerated golden files - 43/100 vm valid programs passing
+
+## Progress (2025-07-20 01:14 +0700)
+- Added map literal and map indexing support
+- Improved type inference for variable and function declarations
+- Regenerated golden files - 40/100 vm valid programs passing
 ## Progress (2025-07-20 09:25 +0700)
 - go transpiler: inline helpers
 - Regenerated golden files - 53/100 vm valid programs passing

--- a/transpiler/x/go/transpiler.go
+++ b/transpiler/x/go/transpiler.go
@@ -656,6 +656,9 @@ func compileStmt(st *parser.Statement, env *types.Env) (Stmt, error) {
 					}
 				}
 			}
+			if typ == "" {
+				typ = inferGoType(st.Let.Value, env)
+			}
 			return &VarDecl{Name: st.Let.Name, Type: typ, Value: e}, nil
 		}
 		return &VarDecl{Name: st.Let.Name, Type: typ}, nil
@@ -678,6 +681,9 @@ func compileStmt(st *parser.Statement, env *types.Env) (Stmt, error) {
 						ml.ValueType = toGoTypeFromType(mt.Value)
 					}
 				}
+			}
+			if typ == "" {
+				typ = inferGoType(st.Var.Value, env)
 			}
 			return &VarDecl{Name: st.Var.Name, Type: typ, Value: e}, nil
 		}
@@ -1275,6 +1281,13 @@ func toGoTypeFromType(t types.Type) string {
 		return fmt.Sprintf("map[%s]%s", toGoTypeFromType(tt.Key), toGoTypeFromType(tt.Value))
 	}
 	return "any"
+}
+
+func inferGoType(e *parser.Expr, env *types.Env) string {
+	if e == nil {
+		return ""
+	}
+	return toGoTypeFromType(types.TypeOfExprBasic(e, env))
 }
 
 func isBoolExpr(e *parser.Expr) bool { return isBoolBinary(e.Binary) }


### PR DESCRIPTION
## Summary
- improve Go transpiler variable declarations by inferring type from assigned value
- document progress for the Go transpiler

## Testing
- `go test -tags slow ./transpiler/x/go -run VMValid -count=1` *(fails: unsupported primary)*

------
https://chatgpt.com/codex/tasks/task_e_687c540561ec8320b6fbcc5986555ff6