### PR TITLE
Improve F# transpiler

### DIFF
--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,9 @@
+## Progress (2025-07-20 09:12 +0700)
+- Adjusted print formatting for booleans and header now uses git commit time
+
+## Progress (2025-07-20 09:12 +0700)
+- VM valid golden test results updated
+
 ## Progress (2025-07-20 08:47 +0700)
 - Refined F# emitter to produce cleaner code and improved type inference
 


### PR DESCRIPTION
## Summary
- tweak F# transpiler header to use git timestamps
- make boolean printing use `%b` for correct output
- update tasks log

## Testing
- `go test ./transpiler/x/fs`

------
https://chatgpt.com/codex/tasks/task_e_687c516da7c08320b8cfe84967fd191a