### PR TITLE
Improve Java transpiler inference

### DIFF
--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,6 @@
-## Progress (2025-07-20 08:59 +0700)
+## Progress (2025-07-20 09:17 +0700)
+- remove stale error files (ffbcf3bb2)
+
 - java transpiler: clean emit and improve inference (6c82586e5)
 
 - java transpiler: improve type inference and globals (7e8eb605a)


### PR DESCRIPTION
## Summary
- improve Java transpiler variable type inference using a map
- update progress log for latest work

## Testing
- `go test ./transpiler/x/java -tags slow -run TestJavaTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c51ce92948320b232d863f07013e9