### PR TITLE
Improve Kotlin transpiler

### DIFF
--- a/tests/transpiler/x/kt/append_builtin.kt
+++ b/tests/transpiler/x/kt/append_builtin.kt
@@ -1,4 +1,4 @@
 fun main() {
     val a: MutableList<Int> = mutableListOf(1, 2)
-    println(a + mutableListOf(3))
+    println(a + 3)
 }

--- a/tests/transpiler/x/kt/map_nested_assign.error
+++ b/tests/transpiler/x/kt/map_nested_assign.error
@@ -1,7 +1,7 @@
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/transpiler/x/kt/map_nested_assign.kt:4:5: error: only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type MutableMap<String, Int>?
+/workspace/mochi/tests/transpiler/x/kt/map_nested_assign.kt:3:5: error: only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type MutableMap<String, Int>?
     data["outer"]["inner"] = 2
     ^
-/workspace/mochi/tests/transpiler/x/kt/map_nested_assign.kt:5:13: error: only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type MutableMap<String, Int>?
+/workspace/mochi/tests/transpiler/x/kt/map_nested_assign.kt:4:13: error: only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type MutableMap<String, Int>?
     println(data["outer"]["inner"])
             ^

--- a/tests/transpiler/x/kt/slice.error
+++ b/tests/transpiler/x/kt/slice.error
@@ -1,4 +1,0 @@
-OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/transpiler/x/kt/slice.kt:5:21: error: unresolved reference: subList
-    println("hello".subList(1, 4))
-                    ^

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **46/100**
+Completed golden tests: **46/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,6 +1,6 @@
 # Kotlin Transpiler Tasks
 
-_Last updated: 2025-07-20 01:31 UTC_
+_Last updated: 2025-07-20T09:17:42+07:00_
 
 - Basic programs using `print` are supported.
 - Added integer and list literals.
@@ -59,3 +59,8 @@ _Last updated: 2025-07-20 01:31 UTC_
 - Improved Kotlin emitter with indentation for all statements.
 - README checklist regenerated directly from `tests/vm/valid` with 46/100 passing.
 - Documented progress using git timestamp.
+
+## VM Golden Progress (2025-07-20T09:17:42+07:00)
+- Append operations use Kotlin `+` for lists.
+- Function return types inferred from the environment.
+- README progress regenerated showing 46/100 passing.

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -503,9 +503,8 @@ type AppendExpr struct {
 
 func (a *AppendExpr) emit(w io.Writer) {
 	a.List.emit(w)
-	io.WriteString(w, " + mutableListOf(")
+	io.WriteString(w, " + ")
 	a.Elem.emit(w)
-	io.WriteString(w, ")")
 }
 
 type MinExpr struct{ Value Expr }
@@ -699,6 +698,13 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 				params = append(params, fmt.Sprintf("%s: %s", p0.Name, typ))
 			}
 			ret := kotlinType(st.Fun.Return)
+			if ret == "" {
+				if t, ok := env.Types()[st.Fun.Name]; ok {
+					if ft, ok := t.(types.FuncType); ok {
+						ret = kotlinTypeFromType(ft.Return)
+					}
+				}
+			}
 			p.Funcs = append(p.Funcs, &FuncDef{Name: st.Fun.Name, Params: params, Ret: ret, Body: body})
 		case st.If != nil:
 			stmt, err := convertIfStmt(env, st.If)


### PR DESCRIPTION
## Summary
- update Kotlin README auto-generated checklist
- document progress for Kotlin transpiler
- infer Kotlin function return types
- simplify list append expression
- update generated Kotlin output

## Testing
- `go test -tags slow ./transpiler/x/kt -run TestTranspilePrograms -count=1` *(fails: output mismatch and kotlinc error)*

------
https://chatgpt.com/codex/tasks/task_e_687c51d8946083209d4e0577c1bf9866