### PR TITLE
Improve Dart transpiler progress

### DIFF
--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,26 +1,10 @@
-## Recent Enhancements (2025-07-20 09:12 +0700)
+## Recent Enhancements (2025-07-20 09:35 +0700)
 - Improved variable declarations with basic type inference.
 - Simplified `avg` builtin emission using list methods.
 - Updated README checklist with progress summary.
 
-- Refined boolean operator emission.
-- Added string concatenation type inference.
-- Simplified main emitter for readability.
-- Regenerated README progress (48/100).
-
-- Updated README checklist to include all golden tests.
-- Enhanced type inference for lists and maps.
-- Removed version/time helpers for simpler output.
-
-- Added support for map literals and method calls.
-- Generated golden outputs for `len_map` and `string_contains`.
-
-- Added support for `break` and `continue` statements.
-- Implemented `if ... then ... else` expressions.
-- Added list indexing support and `substring` builtin.
-- Implemented `append` and `avg` builtins.
-- Added list and string `in` operator support.
-- Refactored `avg` builtin to use a simple loop for clarity.
+## Progress (2025-07-20 09:35 +0700)
+- VM valid 48/100
 
 # Dart Transpiler Tasks
 - Added boolean literals and logical operators.

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -759,17 +759,21 @@ func inferType(e Expr) string {
 			if lt == "String" || rt == "String" {
 				return "String"
 			}
-			return "int"
+			return "num"
 		case "-", "*", "/", "%":
-			return "int"
+			return "num"
 		case "<", "<=", ">", ">=", "==", "!=", "&&", "||":
 			return "bool"
 		default:
-			return "var"
+			return "dynamic"
 		}
 	case *UnaryExpr:
 		if ex.Op == "-" {
-			return "int"
+			t := inferType(ex.X)
+			if t == "int" || t == "num" {
+				return t
+			}
+			return "num"
 		}
 		return inferType(ex.X)
 	case *CondExpr:


### PR DESCRIPTION
## Summary
- refine type inference for math operations in the Dart transpiler
- keep only permanent task notes and track VM valid progress
- generate timestamped progress section in TASKS

## Testing
- `go test -tags slow ./transpiler/x/dart -c`

------
https://chatgpt.com/codex/tasks/task_e_687c55f8f9448320b7316739fb2eb06a