### PR TITLE
Update Kotlin transpiler docs and code

### DIFF
--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -69,3 +69,6 @@ _Last updated: 2025-07-20T09:17:42+07:00_
 - Added map indexing support for integer keys.
 - Generated Kotlin sources for `map_index` and `map_int_key`.
 - README progress updated to 48/100.
+
+## VM Golden Progress (2025-07-20T10:18:38+07:00)
+- Regenerated README checklist using git automation, progress remains 48/100.

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -215,11 +215,9 @@ type BinaryExpr struct {
 }
 
 func (b *BinaryExpr) emit(w io.Writer) {
-	io.WriteString(w, "(")
 	b.Left.emit(w)
 	io.WriteString(w, " "+b.Op+" ")
 	b.Right.emit(w)
-	io.WriteString(w, ")")
 }
 
 type LetStmt struct {


### PR DESCRIPTION
## Summary
- simplify Kotlin `BinaryExpr` emitting
- refresh Kotlin transpiler checklist
- note regeneration time in TASKS log

## Testing
- `go test -tags slow ./transpiler/x/kt -run TestTranspilePrograms -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c61117f348320a5e5c5a60db9231d