### PR TITLE
Improve C transpiler loops

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-20 03:33 UTC)
+- Improved constant list loops with string element detection.
+- VM valid golden test results updated to 41/100
 ## Progress (2025-07-20 09:48 +0700)
 - VM valid golden test results updated to 41/100
 

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -20,7 +20,7 @@ var (
 	constStrings map[string]string
 )
 
-const version = "0.10.32"
+const version = "0.10.33"
 
 // --- Simple C AST ---
 
@@ -249,10 +249,21 @@ func (f *ForStmt) emit(w io.Writer, indent int) {
 	if len(f.List) > 0 {
 		arrName := fmt.Sprintf("%s_arr", f.Var)
 		lenName := fmt.Sprintf("%s_len", f.Var)
+		elemType := "int"
+		allString := true
+		for _, e := range f.List {
+			if !exprIsString(e) {
+				allString = false
+				break
+			}
+		}
+		if allString {
+			elemType = "const char*"
+		}
 		writeIndent(w, indent)
 		io.WriteString(w, "{\n")
 		writeIndent(w, indent+1)
-		fmt.Fprintf(w, "int %s[] = {", arrName)
+		fmt.Fprintf(w, "%s %s[] = {", elemType, arrName)
 		for i, e := range f.List {
 			if i > 0 {
 				io.WriteString(w, ", ")
@@ -267,7 +278,7 @@ func (f *ForStmt) emit(w io.Writer, indent int) {
 		io.WriteString(w, lenName)
 		io.WriteString(w, "; i++) {\n")
 		writeIndent(w, indent+2)
-		fmt.Fprintf(w, "int %s = %s[i];\n", f.Var, arrName)
+		fmt.Fprintf(w, "%s %s = %s[i];\n", elemType, f.Var, arrName)
 		for _, s := range f.Body {
 			s.emit(w, indent+2)
 		}


### PR DESCRIPTION
## Summary
- enhance `ForStmt` emission to detect string element lists for more idiomatic C output
- document progress in C `TASKS.md`

## Testing
- `go test ./transpiler/x/c -tags slow -run TestTranspilerGolden -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_687c61e655f08320a5d718c90477a0d9