### PR TITLE
Improve COBOL transpiler

### DIFF
--- a/transpiler/x/cobol/README.md
+++ b/transpiler/x/cobol/README.md
@@ -1,10 +1,10 @@
-# COBOL Transpiler Output
+# COBOL Transpiler
 
-Generated COBOL code from Mochi programs in `tests/vm/valid`. Each test is compiled with `cobc`.
+This directory stores COBOL code generated from Mochi programs in `tests/vm/valid`.
+Each program is transpiled and the resulting `.cob` sources are compiled with `cobc` during testing.
 
-This checklist is auto-generated.
+Checklist of programs that currently transpile and run (18/100):
 
-## VM Golden Test Checklist (18/100)
 - [ ] append_builtin
 - [ ] avg_builtin
 - [x] basic_compare

--- a/transpiler/x/cobol/TASKS.md
+++ b/transpiler/x/cobol/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-20 10:18 +0700)
+- Refined TMP-STR detection so simple numeric displays no longer allocate it
+- Regenerated README checklist (18/100)
+
 ## Progress (2025-07-20 09:32 +0700)
 - Generated more idiomatic DISPLAY output without TMP-STR
 - Updated README checklist via script (18/100)

--- a/transpiler/x/cobol/transpiler.go
+++ b/transpiler/x/cobol/transpiler.go
@@ -80,7 +80,13 @@ func stmtNeedsTmp(s Stmt) bool {
 func needsStr(s Stmt) bool {
 	switch st := s.(type) {
 	case *DisplayStmt:
-		return !st.IsString
+		if st.IsString {
+			return false
+		}
+		if st.Temp {
+			return true
+		}
+		return !isDirectNumber(st.Expr)
 	case *IfStmt:
 		for _, t := range st.Then {
 			if needsStr(t) {


### PR DESCRIPTION
## Summary
- refine TMP-STR detection logic so numeric displays only allocate it when required
- regenerate COBOL transpiler checklist
- log the refinement in TASKS

## Testing
- `go test ./transpiler/x/cobol -run TestTranspile_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687c608ca4748320a420fb290c9a65c3