### PR TITLE
Improve Go transpiler type inference

### DIFF
--- a/transpiler/x/go/TASKS.md
+++ b/transpiler/x/go/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-20 10:43 +0700)
+- go transpiler: infer list type
+- Regenerated golden files - 56/100 vm valid programs passing
+
 ## Progress (2025-07-20 10:28 +0700)
 - go transpiler: improve type inference
 - Regenerated golden files - 56/100 vm valid programs passing


### PR DESCRIPTION
## Summary
- infer element type of list literals from static types
- document progress in tasks

## Testing
- `go test -tags slow ./transpiler/x/go -run TestGoTranspiler_VMValid_Golden`

------
https://chatgpt.com/codex/tasks/task_e_687c637166f88320906bf92b1b1e18b6