### PR TITLE
Improve F# transpiler variable inference

### DIFF
--- a/tests/transpiler/x/fs/avg_builtin.fs
+++ b/tests/transpiler/x/fs/avg_builtin.fs
@@ -1,4 +1,4 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:08:36 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-printfn "%s" (string (Seq.averageBy float [1; 2; 3]))
+printfn "%s" (string (List.averageBy float [1; 2; 3]))

--- a/tests/transpiler/x/fs/basic_compare.fs
+++ b/tests/transpiler/x/fs/basic_compare.fs
@@ -1,8 +1,8 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:08:38 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let a = 10 - 3
-let b = 2 + 2
+let a: int = 10 - 3
+let b: int = 2 + 2
 printfn "%s" (string a)
-printfn "%s" (string (a = 7))
-printfn "%s" (string (b < 5))
+printfn "%b" (a = 7)
+printfn "%b" (b < 5)

--- a/tests/transpiler/x/fs/bool_chain.fs
+++ b/tests/transpiler/x/fs/bool_chain.fs
@@ -1,9 +1,9 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:08:42 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
 let rec boom =
     printfn "%s" (string "boom")
     true
-printfn "%s" (string (((1 < 2) && (2 < 3)) && (3 < 4)))
-printfn "%s" (string (((1 < 2) && (2 > 3)) && (boom)))
-printfn "%s" (string ((((1 < 2) && (2 < 3)) && (3 > 4)) && (boom)))
+printfn "%b" (((1 < 2) && (2 < 3)) && (3 < 4))
+printfn "%b" (((1 < 2) && (2 > 3)) && (boom))
+printfn "%b" ((((1 < 2) && (2 < 3)) && (3 > 4)) && (boom))

--- a/tests/transpiler/x/fs/if_else.fs
+++ b/tests/transpiler/x/fs/if_else.fs
@@ -1,7 +1,7 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:08:56 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let x = 5
+let x: int = 5
 if x > 3 then
 printfn "%s" (string "big")
 else

--- a/tests/transpiler/x/fs/if_then_else.fs
+++ b/tests/transpiler/x/fs/if_then_else.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:08:58 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let x = 12
-let msg = if x > 10 then "yes" else "no"
+let x: int = 12
+let msg: string = if x > 10 then "yes" else "no"
 printfn "%s" (string msg)

--- a/tests/transpiler/x/fs/if_then_else_nested.fs
+++ b/tests/transpiler/x/fs/if_then_else_nested.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:00 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let x = 8
-let msg = if x > 10 then "big" else (if x > 5 then "medium" else "small")
+let x: int = 8
+let msg: string = if x > 10 then "big" else (if x > 5 then "medium" else "small")
 printfn "%s" (string msg)

--- a/tests/transpiler/x/fs/in_operator.fs
+++ b/tests/transpiler/x/fs/in_operator.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:01 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
 let xs = [1; 2; 3]
-printfn "%s" (string (xs.Contains(2)))
-printfn "%s" (string (not (xs.Contains(5))))
+printfn "%b" (List.contains 2 xs)
+printfn "%b" (not (List.contains 5 xs))

--- a/tests/transpiler/x/fs/len_builtin.fs
+++ b/tests/transpiler/x/fs/len_builtin.fs
@@ -1,4 +1,4 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:02 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-printfn "%s" (string (Seq.length [1; 2; 3]))
+printfn "%s" (string (List.length [1; 2; 3]))

--- a/tests/transpiler/x/fs/len_string.fs
+++ b/tests/transpiler/x/fs/len_string.fs
@@ -1,4 +1,4 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:04 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-printfn "%s" (string (Seq.length "mochi"))
+printfn "%s" (string (String.length "mochi"))

--- a/tests/transpiler/x/fs/let_and_print.fs
+++ b/tests/transpiler/x/fs/let_and_print.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:05 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let a = 10
+let a: int = 10
 let b: int = 20
 printfn "%s" (string (a + b))

--- a/tests/transpiler/x/fs/membership.fs
+++ b/tests/transpiler/x/fs/membership.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:11 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
 let nums = [1; 2; 3]
-printfn "%s" (string (nums.Contains(2)))
-printfn "%s" (string (nums.Contains(4)))
+printfn "%b" (List.contains 2 nums)
+printfn "%b" (List.contains 4 nums)

--- a/tests/transpiler/x/fs/pure_global_fold.fs
+++ b/tests/transpiler/x/fs/pure_global_fold.fs
@@ -1,7 +1,7 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:19 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let k = 2
+let k: int = 2
 let rec inc x =
     x + k
 printfn "%s" (string (inc 3))

--- a/tests/transpiler/x/fs/short_circuit.fs
+++ b/tests/transpiler/x/fs/short_circuit.fs
@@ -1,8 +1,8 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:21 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
 let rec boom a b =
     printfn "%s" (string "boom")
     true
-printfn "%s" (string (false && (boom 1 2)))
-printfn "%s" (string (true || (boom 1 2)))
+printfn "%b" (false && (boom 1 2))
+printfn "%b" (true || (boom 1 2))

--- a/tests/transpiler/x/fs/string_compare.fs
+++ b/tests/transpiler/x/fs/string_compare.fs
@@ -1,7 +1,7 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:25 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-printfn "%s" (string ("a" < "b"))
-printfn "%s" (string ("a" <= "a"))
-printfn "%s" (string ("b" > "a"))
-printfn "%s" (string ("b" >= "b"))
+printfn "%b" ("a" < "b")
+printfn "%b" ("a" <= "a")
+printfn "%b" ("b" > "a")
+printfn "%b" ("b" >= "b")

--- a/tests/transpiler/x/fs/string_in_operator.error
+++ b/tests/transpiler/x/fs/string_in_operator.error
@@ -1,7 +1,0 @@
-exit status 1
-F# Compiler for F# 4.0 (Open Source Edition)
-Freely distributed under the Apache 2.0 Open Source License
-
-/workspace/mochi/tests/transpiler/x/fs/string_in_operator.fs(5,34): error FS0001: The type 'string' is not compatible with the type 'seq<string>'
-
-/workspace/mochi/tests/transpiler/x/fs/string_in_operator.fs(6,34): error FS0001: The type 'string' is not compatible with the type 'seq<string>'

--- a/tests/transpiler/x/fs/string_in_operator.fs
+++ b/tests/transpiler/x/fs/string_in_operator.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:28 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let s = "catch"
-printfn "%s" (string (s.Contains("cat")))
-printfn "%s" (string (s.Contains("dog")))
+let s: string = "catch"
+printfn "%b" (s.Contains("cat"))
+printfn "%b" (s.Contains("dog"))

--- a/tests/transpiler/x/fs/string_in_operator.out
+++ b/tests/transpiler/x/fs/string_in_operator.out
@@ -1,2 +1,2 @@
-True
-False
+true
+false

--- a/tests/transpiler/x/fs/string_index.fs
+++ b/tests/transpiler/x/fs/string_index.fs
@@ -1,5 +1,5 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:30 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let s = "mochi"
+let s: string = "mochi"
 printfn "%s" (string (s.[1]))

--- a/tests/transpiler/x/fs/string_prefix_slice.fs
+++ b/tests/transpiler/x/fs/string_prefix_slice.fs
@@ -1,8 +1,8 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:32 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let prefix = "fore"
-let s1 = "forest"
-printfn "%s" (string ((s1.Substring(0, (Seq.length prefix) - 0)) = prefix))
-let s2 = "desert"
-printfn "%s" (string ((s2.Substring(0, (Seq.length prefix) - 0)) = prefix))
+let prefix: string = "fore"
+let s1: string = "forest"
+printfn "%b" ((s1.Substring(0, (String.length prefix) - 0)) = prefix)
+let s2: string = "desert"
+printfn "%b" ((s2.Substring(0, (String.length prefix) - 0)) = prefix)

--- a/tests/transpiler/x/fs/sum_builtin.fs
+++ b/tests/transpiler/x/fs/sum_builtin.fs
@@ -1,4 +1,4 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:35 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-printfn "%s" (string (Seq.sum [1; 2; 3]))
+printfn "%s" (string (List.sum [1; 2; 3]))

--- a/tests/transpiler/x/fs/two-sum.fs
+++ b/tests/transpiler/x/fs/two-sum.fs
@@ -1,8 +1,8 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:38 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
 let rec twoSum nums target =
-    let n = Seq.length nums
+    let n: int = Seq.length nums
     for i in 0 .. (n - 1) do
 for j in i + 1 .. (n - 1) do
 if ((nums.[i]) + (nums.[j])) = target then

--- a/tests/transpiler/x/fs/var_assignment.fs
+++ b/tests/transpiler/x/fs/var_assignment.fs
@@ -1,6 +1,6 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:44 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let mutable x = 1
+let mutable x: int = 1
 x <- 2
 printfn "%s" (string x)

--- a/tests/transpiler/x/fs/while_loop.fs
+++ b/tests/transpiler/x/fs/while_loop.fs
@@ -1,7 +1,7 @@
-// Mochi 0.10.31 - generated 2025-07-19 13:09:46 UTC
+// Generated 2025-07-20 10:18 +0700
 open System
 
-let mutable i = 0
+let mutable i: int = 0
 while i < 3 do
 printfn "%s" (string i)
 i <- i + 1

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-20 10:18 +0700)
+- VM valid golden test results updated
+- Basic variable type tracking improves inference
+
 ## Progress (2025-07-20 09:43 +0700)
 - Improved `in` operator handling for lists and strings
 - Built-in `len`, `sum`, and `avg` use `List` functions when possible


### PR DESCRIPTION
## Summary
- track inferred variable types while transpiling
- use the tracked types for better inference
- update golden F# examples and outputs
- note progress in TASKS

## Testing
- `go test ./transpiler/x/fs -run VMValid -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687c60c0f0ac8320a6405e5669254e32