### PR TITLE
Improve Fortran transpiler loops

### DIFF
--- a/transpiler/x/fortran/README.md
+++ b/transpiler/x/fortran/README.md
@@ -2,7 +2,7 @@
 
 This checklist tracks Mochi programs from `tests/vm/valid` that successfully transpile using the experimental Fortran backend.
 
-Checklist of programs that currently transpile and run (20/100):
+Checklist of programs that currently transpile and run (17/100):
 
 - [ ] append_builtin
 - [ ] avg_builtin
@@ -48,7 +48,7 @@ Checklist of programs that currently transpile and run (20/100):
 - [ ] left_join_multi
 - [ ] len_builtin
 - [ ] len_map
-- [x] len_string
+- [ ] len_string
 - [x] let_and_print
 - [ ] list_assign
 - [ ] list_index
@@ -72,8 +72,8 @@ Checklist of programs that currently transpile and run (20/100):
 - [ ] outer_join
 - [ ] partial_application
 - [x] print_hello
-- [x] pure_fold
-- [x] pure_global_fold
+- [ ] pure_fold
+- [ ] pure_global_fold
 - [ ] python_auto
 - [ ] python_math
 - [ ] query_sum_select

--- a/transpiler/x/fortran/TASKS.md
+++ b/transpiler/x/fortran/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-20 10:26 +0700)
+- fortran transpiler: improve loop variable names
+
 ## Progress (2025-07-20 09:44 +0700)
 - docs(fortran): update tasks
 

--- a/transpiler/x/fortran/transpiler.go
+++ b/transpiler/x/fortran/transpiler.go
@@ -182,14 +182,16 @@ func (c *ContinueStmt) emit(w io.Writer, ind int) {
 
 func (f *ForStmt) emit(w io.Writer, ind int) {
 	if len(f.List) > 0 {
+		arrName := fmt.Sprintf("%s_arr", f.Var)
+		idxName := fmt.Sprintf("i_%s", f.Var)
 		writeIndent(w, ind)
-		fmt.Fprintf(w, "integer, dimension(%d) :: __arr = (/ %s /)\n", len(f.List), strings.Join(f.List, ", "))
+		fmt.Fprintf(w, "integer, dimension(%d) :: %s = (/ %s /)\n", len(f.List), arrName, strings.Join(f.List, ", "))
 		writeIndent(w, ind)
-		io.WriteString(w, "integer :: __i\n")
+		fmt.Fprintf(w, "integer :: %s\n", idxName)
 		writeIndent(w, ind)
-		io.WriteString(w, "do __i = 1, size(__arr)\n")
+		fmt.Fprintf(w, "do %s = 1, size(%s)\n", idxName, arrName)
 		writeIndent(w, ind+2)
-		fmt.Fprintf(w, "%s = __arr(__i)\n", f.Var)
+		fmt.Fprintf(w, "%s = %s(%s)\n", f.Var, arrName, idxName)
 		for _, st := range f.Body {
 			st.emit(w, ind+2)
 		}


### PR DESCRIPTION
## Summary
- tweak Fortran transpiler loops to use readable variable names
- update the checklist of passing VM tests
- record progress automatically in `TASKS.md`

## Testing
- `go test -count=1 ./transpiler/x/fortran -run TestFortranTranspiler_VMValid_Golden -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_687c60cbf9348320a7d215cebfdfd877