### PR TITLE
Improve Java transpiler output

### DIFF
--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,10 @@
-## Progress (2025-07-20 10:00 +0700)
+## Progress (2025-07-20 10:28 +0700)
+- java transpiler: simplify var types (717a1b129)
+
+- prolog: improve readability and remove style check (5d6f4afbd)
+
+- prolog: improve readability and remove style check (5d6f4afbd)
+
 - java transpiler: support string indexing and casts (6fbf9613a)
 - java transpiler: improve inference (1fc6f104a)
 - remove stale error files (ffbcf3bb2)

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -21,8 +21,10 @@ func javaType(t string) string {
 		return "boolean"
 	case "string":
 		return "String"
+	case "void":
+		return "void"
 	default:
-		return "Object"
+		return "int"
 	}
 }
 
@@ -188,15 +190,10 @@ func (s *LetStmt) emit(w io.Writer, indent string) {
 	if typ == "" && s.Expr != nil {
 		typ = inferType(s.Expr)
 	}
-	if typ != "" {
-		fmt.Fprint(w, javaType(typ)+" "+s.Name)
-	} else {
-		if indent == "    " {
-			fmt.Fprint(w, "int "+s.Name)
-		} else {
-			fmt.Fprint(w, "var "+s.Name)
-		}
+	if typ == "" {
+		typ = "int"
 	}
+	fmt.Fprint(w, javaType(typ)+" "+s.Name)
 	if s.Expr != nil {
 		fmt.Fprint(w, " = ")
 		s.Expr.emit(w)
@@ -219,15 +216,10 @@ func (s *VarStmt) emit(w io.Writer, indent string) {
 	if typ == "" && s.Expr != nil {
 		typ = inferType(s.Expr)
 	}
-	if typ != "" {
-		fmt.Fprint(w, javaType(typ)+" "+s.Name)
-	} else {
-		if indent == "    " {
-			fmt.Fprint(w, "int "+s.Name)
-		} else {
-			fmt.Fprint(w, "var "+s.Name)
-		}
+	if typ == "" {
+		typ = "int"
 	}
+	fmt.Fprint(w, javaType(typ)+" "+s.Name)
 	if s.Expr != nil {
 		fmt.Fprint(w, " = ")
 		s.Expr.emit(w)


### PR DESCRIPTION
## Summary
- simplify Java type inference defaults
- update Java transpiler progress log

## Testing
- `go test -tags=slow ./transpiler/x/java -run TestJavaTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c6106a66883208bd560d9b05864df