### PR TITLE
Improve C transpiler constant folding

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,6 +1,8 @@
-## Progress (2025-07-20 10:53 +0700)
-- Improved type inference for conditional expressions.
+## Progress (2025-07-20 11:04 +0700)
+- Enhanced constant folding for comparisons and logical operators.
+- Single-string print now uses `puts` for variables.
 - VM valid golden test results updated to 42/100
+
 
 ## Progress (2025-07-20 10:35 +0700)
 - VM valid golden test results updated to 42/100


### PR DESCRIPTION
## Summary
- refine C transpiler: evaluate boolean expressions and more constants
- simplify printing of single string variables
- record progress update in TASKS

## Testing
- `go test ./transpiler/x/c -tags=slow -run TestTranspilerGolden`

------
https://chatgpt.com/codex/tasks/task_e_687c6ae4581c83208e7e45636de0485a