### PR TITLE
Improve Fortran transpiler output

### DIFF
--- a/tests/transpiler/x/fortran/basic_compare.f90
+++ b/tests/transpiler/x/fortran/basic_compare.f90
@@ -1,8 +1,9 @@
 program main
   implicit none
-  integer :: a = (10 - 3)
-  integer :: b = (2 + 2)
+  integer :: a = 10 - 3
+  integer :: b = 2 + 2
+
   print '(I0)', a
-  print *, merge('true','false', (a == 7))
-  print *, merge('true','false', (b < 5))
+  print *, merge('true ','false', a == 7)
+  print *, merge('true ','false', b < 5)
 end program main

--- a/tests/transpiler/x/fortran/basic_compare.out
+++ b/tests/transpiler/x/fortran/basic_compare.out
@@ -1,3 +1,3 @@
 7
- true
+ true 
  true

--- a/tests/transpiler/x/fortran/binary_precedence.f90
+++ b/tests/transpiler/x/fortran/binary_precedence.f90
@@ -1,7 +1,7 @@
 program main
   implicit none
-  print '(I0)', (1 + (2 * 3))
-  print '(I0)', (((1 + 2)) * 3)
-  print '(I0)', ((2 * 3) + 1)
-  print '(I0)', (2 * ((3 + 1)))
+  print '(I0)', 1 + 2 * 3
+  print '(I0)', (1 + 2) * 3
+  print '(I0)', 2 * 3 + 1
+  print '(I0)', 2 * (3 + 1)
 end program main

--- a/tests/transpiler/x/fortran/bool_chain.f90
+++ b/tests/transpiler/x/fortran/bool_chain.f90
@@ -1,8 +1,8 @@
 program main
   implicit none
-  print *, merge('true','false', ((((1 < 2)) .and. ((2 < 3))) .and. ((3 < 4))))
-  print *, merge('true','false', ((((1 < 2)) .and. ((2 > 3))) .and. boom()))
-  print *, merge('true','false', (((((1 < 2)) .and. ((2 < 3))) .and. ((3 > 4))) .and. boom()))
+  print *, merge('true ','false', (1 < 2) .and. (2 < 3) .and. (3 < 4))
+  print *, merge('true ','false', (1 < 2) .and. (2 > 3) .and. boom())
+  print *, merge('true ','false', (1 < 2) .and. (2 < 3) .and. (3 > 4) .and. boom())
 contains
   function boom() result(res)
     logical :: res

--- a/tests/transpiler/x/fortran/for_list_collection.error
+++ b/tests/transpiler/x/fortran/for_list_collection.error
@@ -1,31 +1,6 @@
 exit status 1
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:3:29:
+/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:6:5:
 
-    3 |   integer, dimension(3) :: __arr = (/ 1, 2, 3 /)
-      |                             1
-Error: Invalid character in name at (1)
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:4:15:
-
-    4 |   integer :: __i
-      |               1
-Error: Invalid character in name at (1)
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:5:7:
-
-    5 |   do __i = 1, size(__arr)
-      |       1
-Error: Invalid character in name at (1)
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:6:10:
-
-    6 |     n = __arr(__i)
-      |          1
-Error: Invalid character in name at (1)
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:8:5:
-
-    8 |   end do
+    6 |     n = n_arr(i_n)
       |     1
-Error: Expecting END PROGRAM statement at (1)
-/workspace/mochi/tests/transpiler/x/fortran/for_list_collection.f90:7:14:
-
-    7 |     print *, n
-      |              1
 Error: Symbol ‘n’ at (1) has no IMPLICIT type

--- a/tests/transpiler/x/fortran/if_else.f90
+++ b/tests/transpiler/x/fortran/if_else.f90
@@ -1,7 +1,8 @@
 program main
   implicit none
   integer :: x = 5
-  if ((x > 3)) then
+
+  if (x > 3) then
     print *, trim("big")
   else
     print *, trim("small")

--- a/tests/transpiler/x/fortran/if_then_else.f90
+++ b/tests/transpiler/x/fortran/if_then_else.f90
@@ -2,7 +2,8 @@ program main
   implicit none
   integer :: x = 12
   character(len=100) :: msg
-  if ((x > 10)) then
+
+  if (x > 10) then
     msg = "yes"
   else
     msg = "no"

--- a/tests/transpiler/x/fortran/if_then_else_nested.f90
+++ b/tests/transpiler/x/fortran/if_then_else_nested.f90
@@ -2,10 +2,11 @@ program main
   implicit none
   integer :: x = 8
   character(len=100) :: msg
-  if ((x > 10)) then
+
+  if (x > 10) then
     msg = "big"
   else
-    if ((x > 5)) then
+    if (x > 5) then
       msg = "medium"
     else
       msg = "small"

--- a/tests/transpiler/x/fortran/len_string.error
+++ b/tests/transpiler/x/fortran/len_string.error
@@ -1,1 +1,0 @@
-unsupported expression

--- a/tests/transpiler/x/fortran/let_and_print.f90
+++ b/tests/transpiler/x/fortran/let_and_print.f90
@@ -2,5 +2,6 @@ program main
   implicit none
   integer :: a = 10
   integer :: b = 20
-  print '(I0)', (a + b)
+
+  print '(I0)', a + b
 end program main

--- a/tests/transpiler/x/fortran/math_ops.f90
+++ b/tests/transpiler/x/fortran/math_ops.f90
@@ -1,6 +1,6 @@
 program main
   implicit none
-  print '(I0)', (6 * 7)
-  print '(I0)', (7 / 2)
+  print '(I0)', 6 * 7
+  print '(I0)', 7 / 2
   print '(I0)', mod(7, 2)
 end program main

--- a/tests/transpiler/x/fortran/pure_fold.error
+++ b/tests/transpiler/x/fortran/pure_fold.error
@@ -1,1 +1,0 @@
-unsupported statement

--- a/tests/transpiler/x/fortran/pure_global_fold.error
+++ b/tests/transpiler/x/fortran/pure_global_fold.error
@@ -1,1 +1,0 @@
-unsupported statement

--- a/tests/transpiler/x/fortran/typed_let.f90
+++ b/tests/transpiler/x/fortran/typed_let.f90
@@ -1,5 +1,6 @@
 program main
   implicit none
   integer :: y = 0
+
   print '(I0)', y
 end program main

--- a/tests/transpiler/x/fortran/typed_var.f90
+++ b/tests/transpiler/x/fortran/typed_var.f90
@@ -1,5 +1,6 @@
 program main
   implicit none
   integer :: x = 0
+
   print '(I0)', x
 end program main

--- a/tests/transpiler/x/fortran/unary_neg.f90
+++ b/tests/transpiler/x/fortran/unary_neg.f90
@@ -1,5 +1,5 @@
 program main
   implicit none
   print '(I0)', -3
-  print '(I0)', (5 + (-2))
+  print '(I0)', 5 + (-2)
 end program main

--- a/tests/transpiler/x/fortran/var_assignment.f90
+++ b/tests/transpiler/x/fortran/var_assignment.f90
@@ -1,6 +1,7 @@
 program main
   implicit none
   integer :: x = 1
+
   x = 2
   print '(I0)', x
 end program main

--- a/tests/transpiler/x/fortran/while_loop.f90
+++ b/tests/transpiler/x/fortran/while_loop.f90
@@ -1,8 +1,9 @@
 program main
   implicit none
   integer :: i = 0
-  do while ((i < 3))
+
+  do while (i < 3)
     print '(I0)', i
-    i = (i + 1)
+    i = i + 1
   end do
 end program main

--- a/transpiler/x/fortran/TASKS.md
+++ b/transpiler/x/fortran/TASKS.md
@@ -1,3 +1,21 @@
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
+## Progress (2025-07-20 11:06 +0700)
+- docs(fortran): update progress checklist
+
 ## Progress (2025-07-20 10:26 +0700)
 - fortran transpiler: improve loop variable names
 

--- a/transpiler/x/fortran/transpiler.go
+++ b/transpiler/x/fortran/transpiler.go
@@ -85,17 +85,20 @@ func (f *Function) emit(w io.Writer) {
 		writeIndent(w, 4)
 		fmt.Fprintf(w, "%s :: %s\n", d.Type, d.Name)
 	}
-	for _, d := range f.Decls {
-		writeIndent(w, 4)
-		fmt.Fprintf(w, "%s :: %s", d.Type, d.Name)
-		if d.Init != "" {
-			fmt.Fprintf(w, " = %s", d.Init)
-		}
-		fmt.Fprintln(w)
-	}
-	for _, s := range f.Stmts {
-		s.emit(w, 4)
-	}
+        for _, d := range f.Decls {
+                writeIndent(w, 4)
+                fmt.Fprintf(w, "%s :: %s", d.Type, d.Name)
+                if d.Init != "" {
+                        fmt.Fprintf(w, " = %s", d.Init)
+                }
+                fmt.Fprintln(w)
+        }
+        if len(f.Decls) > 0 {
+                fmt.Fprintln(w)
+        }
+        for _, s := range f.Stmts {
+                s.emit(w, 4)
+        }
 	writeIndent(w, 2)
 	fmt.Fprintf(w, "end function %s\n", f.Name)
 }
@@ -131,9 +134,9 @@ func (p *PrintStmt) emit(w io.Writer, ind int) {
 	case types.FloatType, types.BigRatType:
 		writeIndent(w, ind)
 		fmt.Fprintf(w, "print '(F0.6)', %s\n", p.Expr)
-	case types.BoolType:
-		writeIndent(w, ind)
-		fmt.Fprintf(w, "print *, merge('true','false', %s)\n", p.Expr)
+        case types.BoolType:
+                writeIndent(w, ind)
+                fmt.Fprintf(w, "print *, merge('true ','false', %s)\n", p.Expr)
 	case types.StringType:
 		writeIndent(w, ind)
 		fmt.Fprintf(w, "print *, trim(%s)\n", p.Expr)
@@ -209,20 +212,23 @@ func (f *ForStmt) emit(w io.Writer, ind int) {
 }
 
 func (p *Program) Emit() []byte {
-	var buf bytes.Buffer
-	buf.WriteString("program main\n")
-	buf.WriteString("  implicit none\n")
-	for _, d := range p.Decls {
-		writeIndent(&buf, 2)
-		fmt.Fprintf(&buf, "%s :: %s", d.Type, d.Name)
-		if d.Init != "" {
-			fmt.Fprintf(&buf, " = %s", d.Init)
-		}
-		buf.WriteByte('\n')
-	}
-	for _, s := range p.Stmts {
-		s.emit(&buf, 2)
-	}
+        var buf bytes.Buffer
+        buf.WriteString("program main\n")
+        buf.WriteString("  implicit none\n")
+        for _, d := range p.Decls {
+                writeIndent(&buf, 2)
+                fmt.Fprintf(&buf, "%s :: %s", d.Type, d.Name)
+                if d.Init != "" {
+                        fmt.Fprintf(&buf, " = %s", d.Init)
+                }
+                buf.WriteByte('\n')
+        }
+        if len(p.Decls) > 0 {
+                buf.WriteByte('\n')
+        }
+        for _, s := range p.Stmts {
+                s.emit(&buf, 2)
+        }
 	if len(p.Funcs) > 0 {
 		buf.WriteString("contains\n")
 		for _, f := range p.Funcs {
@@ -776,12 +782,12 @@ func toBinaryExpr(b *parser.BinaryExpr, env *types.Env) (string, error) {
 		{".or."},
 	}
 
-	apply := func(a, op, b string) string {
-		if op == "mod" {
-			return fmt.Sprintf("mod(%s, %s)", a, b)
-		}
-		return fmt.Sprintf("(%s %s %s)", a, op, b)
-	}
+        apply := func(a, op, b string) string {
+                if op == "mod" {
+                        return fmt.Sprintf("mod(%s, %s)", a, b)
+                }
+                return fmt.Sprintf("%s %s %s", a, op, b)
+        }
 
 	contains := func(list []string, s string) bool {
 		for _, v := range list {


### PR DESCRIPTION
## Summary
- tweak the Fortran emitter to drop unnecessary parens
- pad boolean output for gfortran
- generate blank lines after declarations
- update progress docs for the Fortran backend
- refresh Fortran golden files

## Testing
- `go test ./transpiler/x/fortran -tags=slow -run TestTranspilerGolden -updateftn -count=1`
- `go test ./transpiler/x/fortran -tags=slow -run '^$' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687c6b48c8448320aafb5e712e62c434