### PR TITLE
Update F# transpiler for method calls

### DIFF
--- a/tests/transpiler/x/fs/string_contains.error
+++ b/tests/transpiler/x/fs/string_contains.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/fs/string_contains.fs
+++ b/tests/transpiler/x/fs/string_contains.fs
@@ -1,0 +1,6 @@
+// Generated 2025-07-20 11:38 +0700
+open System
+
+let s: string = "catch"
+printfn "%b" (s.Contains("cat"))
+printfn "%b" (s.Contains("dog"))

--- a/tests/transpiler/x/fs/string_contains.out
+++ b/tests/transpiler/x/fs/string_contains.out
@@ -1,0 +1,2 @@
+true
+false

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (41/100)
+## Golden Test Checklist (42/100)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
@@ -88,7 +88,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
-- [ ] string_contains.mochi
+- [x] string_contains.mochi
 - [x] string_in_operator.mochi
 - [x] string_index.mochi
 - [x] string_prefix_slice.mochi

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-20 11:38 +0700)
+- VM valid golden test results updated
+
 ## Progress (2025-07-20 11:05 +0700)
 - VM valid golden test results updated
 


### PR DESCRIPTION
## Summary
- support dotted selectors in F# transpiler and improve inference for `Contains`
- regenerate F# golden output for `string_contains`
- update F# transpiler progress docs

## Testing
- `go test ./transpiler/x/fs -run TestFSTranspiler_VMValid_Golden/string_contains -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c7318c29c8320a1f72bb70365fb11