### PR TITLE
Improve Kotlin transpiler type inference

### DIFF
--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,7 @@
+## VM Golden Progress (2025-07-20 11:38 +0700)
+- Improved expression-based type inference for variable declarations.
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-20 10:30 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- enhance kotlin transpiler to guess types from expressions
- document progress with timestamp

## Testing
- `go test -run TestMain -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687c731d8de08320a593db4b5121c042