### PR TITLE
Update Racket transpiler tasks

### DIFF
--- a/transpiler/x/rkt/TASKS.md
+++ b/transpiler/x/rkt/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-07-20 11:38 +0700)
+- Removed BoolToInt helper; booleans print as #t/#f
+- Updated README checklist (92/100)
+- Regenerated golden outputs
+
 ## Progress (2025-07-20 10:18 +0700)
 - Generated Racket for 92/100 programs
 - Updated README checklist


### PR DESCRIPTION
## Summary
- improve Racket transpiler by printing booleans directly
- log new progress entry in TASKS

## Testing
- `go test ./transpiler/x/rkt -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_687c732d291483209ee49c04b04845e5