### PR TITLE
Improve Kotlin transpiler

### DIFF
--- a/tests/transpiler/x/kt/in_operator.kt
+++ b/tests/transpiler/x/kt/in_operator.kt
@@ -1,0 +1,5 @@
+fun main() {
+    val xs: MutableList<Int> = mutableListOf(1, 2, 3)
+    println(2 in xs)
+    println(!(5 in xs))
+}

--- a/tests/transpiler/x/kt/in_operator.out
+++ b/tests/transpiler/x/kt/in_operator.out
@@ -1,0 +1,2 @@
+true
+true

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **49/100** (auto-generated)
+Completed golden tests: **50/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -42,7 +42,7 @@ Completed golden tests: **49/100** (auto-generated)
 - [x] if_else.mochi
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
-- [ ] in_operator.mochi
+- [x] in_operator.mochi
 - [ ] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,8 @@
+## VM Golden Progress (2025-07-20 12:33 +0700)
+- Fixed precedence for logical not expressions.
+- Added golden test `in_operator` raising progress to 50/100.
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-20 11:55 +0700)
 - Added map membership support using `in` operator for maps
 - Regenerated Kotlin golden files and README

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -499,7 +499,14 @@ type NotExpr struct{ Value Expr }
 
 func (n *NotExpr) emit(w io.Writer) {
 	io.WriteString(w, "!")
-	n.Value.emit(w)
+	switch n.Value.(type) {
+	case *BoolLit, *VarRef, *CallExpr, *IndexExpr, *FieldExpr:
+		n.Value.emit(w)
+	default:
+		io.WriteString(w, "(")
+		n.Value.emit(w)
+		io.WriteString(w, ")")
+	}
 }
 
 type AppendExpr struct {


### PR DESCRIPTION
## Summary
- emit parentheses for `!` expressions in Kotlin output
- add golden test for `in_operator` case
- update Kotlin transpiler README checklist (50/100)
- document progress in Kotlin TASKS

## Testing
- `go run -tags=slow /tmp/update.go`

------
https://chatgpt.com/codex/tasks/task_e_687c7e6e714c8320808a024f319206ae