### PR TITLE
Improve Java transpiler and docs

### DIFF
--- a/tests/transpiler/x/java/string_contains.error
+++ b/tests/transpiler/x/java/string_contains.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/java/string_contains.java
+++ b/tests/transpiler/x/java/string_contains.java
@@ -1,0 +1,8 @@
+public class Main {
+    static String s = "catch";
+
+    public static void main(String[] args) {
+        System.out.println(s.contains("cat"));
+        System.out.println(s.contains("dog"));
+    }
+}

--- a/tests/transpiler/x/java/string_contains.out
+++ b/tests/transpiler/x/java/string_contains.out
@@ -1,0 +1,2 @@
+true
+false

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (53/100)
+## VM Golden Test Checklist (54/100)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -85,7 +85,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi
-- [ ] string_contains.mochi
+- [x] string_contains.mochi
 - [ ] string_in_operator.mochi
 - [x] string_index.mochi
 - [x] string_prefix_slice.mochi

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,6 @@
-## Progress (2025-07-20 12:01 +0700)
+## Progress (2025-07-20 12:37 +0700)
+- java transpiler: support method calls (a5791d107)
+
 - java transpiler: improve formatting and inference (5540777bf)
 
 - java transpiler: add foreach loops and list/map literals (93aba1531)


### PR DESCRIPTION
## Summary
- update Java transpiler to support method calls
- generate Java code for `string_contains.mochi`
- update README checklist and TASKS progress
- format code

## Testing
- `go run -tags=slow /tmp/build_string_contains.go`


------
https://chatgpt.com/codex/tasks/task_e_687c7e6d0bc483209cfdcf7dafa03583