### PR TITLE
Enhance PHP transpiler

### DIFF
--- a/tests/transpiler/x/php/break_continue.out
+++ b/tests/transpiler/x/php/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7

--- a/tests/transpiler/x/php/break_continue.php
+++ b/tests/transpiler/x/php/break_continue.php
@@ -1,0 +1,12 @@
+<?php
+$numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+foreach ($numbers as $n) {
+  if ($n % 2 == 0) {
+  continue;
+}
+  if ($n > 7) {
+  break;
+}
+  echo "odd number:" . " " . $n, PHP_EOL;
+}
+?>

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,13 +2,13 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-## VM Golden Test Checklist (35/100)
+## VM Golden Test Checklist (36/100)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
 - [x] binary_precedence
 - [x] bool_chain
-- [ ] break_continue
+- [x] break_continue
 - [x] cast_string_to_int
 - [ ] cast_struct
 - [ ] closure

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-07-20 12:19 +0700)
+- Generated PHP for 36/100 programs
+- Added break and continue statement support enabling break_continue test
+- Updated README checklist and outputs
+
 ## Progress (2025-07-20 11:56 +0700)
 - Generated PHP for 35/100 programs
 - Added map literal support and len() for maps enabling len_map test


### PR DESCRIPTION
## Summary
- support `break` and `continue` statements in the PHP transpiler
- update README checklist (36/100 done)
- log new progress entry
- add generated PHP and output for `break_continue`

## Testing
- `go test -tags slow ./transpiler/x/php -run TestPHPTranspiler_VMValid_Golden/break_continue -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687c7e72ebe08320914deb75df96ea16