### PR TITLE
Update Java transpiler

### DIFF
--- a/tests/transpiler/x/java/string_in_operator.error
+++ b/tests/transpiler/x/java/string_in_operator.error
@@ -1,1 +1,0 @@
-unsupported binary op: in

--- a/tests/transpiler/x/java/string_in_operator.java
+++ b/tests/transpiler/x/java/string_in_operator.java
@@ -1,0 +1,8 @@
+public class Main {
+    static String s = "catch";
+
+    public static void main(String[] args) {
+        System.out.println(s.contains("cat"));
+        System.out.println(s.contains("dog"));
+    }
+}

--- a/tests/transpiler/x/java/string_in_operator.out
+++ b/tests/transpiler/x/java/string_in_operator.out
@@ -1,0 +1,2 @@
+true
+false

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (54/100)
+## VM Golden Test Checklist (57/100)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -10,7 +10,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] bool_chain.mochi
 - [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
-- [ ] cast_struct.mochi
+- [x] cast_struct.mochi
 - [ ] closure.mochi
 - [x] count_builtin.mochi
 - [ ] cross_join.mochi
@@ -25,7 +25,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] fun_call.mochi
 - [ ] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
-- [ ] go_auto.mochi
+- [x] go_auto.mochi
 - [ ] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
 - [ ] group_by_having.mochi
@@ -86,7 +86,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] string_compare.mochi
 - [x] string_concat.mochi
 - [x] string_contains.mochi
-- [ ] string_in_operator.mochi
+- [x] string_in_operator.mochi
 - [x] string_index.mochi
 - [x] string_prefix_slice.mochi
 - [x] substring_builtin.mochi

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,6 @@
-## Progress (2025-07-20 12:37 +0700)
+## Progress (2025-07-20 12:53 +0700)
+- java: support 'in' operator for strings (565a22891)
+
 - java transpiler: support method calls (a5791d107)
 
 - java transpiler: improve formatting and inference (5540777bf)

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -83,6 +83,8 @@ func inferType(e Expr) string {
 			return "int"
 		case "==", "!=", "<", "<=", ">", ">=", "&&", "||":
 			return "boolean"
+		case "in":
+			return "boolean"
 		}
 	case *TernaryExpr:
 		t := inferType(ex.Then)
@@ -859,6 +861,12 @@ func compileExpr(e *parser.Expr) (Expr, error) {
 		switch op.Op {
 		case "+", "-", "*", "/", "%", "==", "!=", "<", "<=", ">", ">=", "&&", "||":
 			expr = &BinaryExpr{Left: expr, Op: op.Op, Right: r}
+		case "in":
+			if isStringExpr(r) {
+				expr = &MethodCallExpr{Target: r, Name: "contains", Args: []Expr{expr}}
+			} else {
+				return nil, fmt.Errorf("unsupported binary op: %s", op.Op)
+			}
 		default:
 			return nil, fmt.Errorf("unsupported binary op: %s", op.Op)
 		}


### PR DESCRIPTION
## Summary
- support `in` operator for strings in Java transpiler
- add generated Java and output for `string_in_operator`
- update Java transpiler checklist and progress

## Testing
- `go test ./transpiler/x/java -tags=slow -run VMValid_Golden -count=1` *(fails: 69 of 100 tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c82e41d588320b9465d6d5879f0af