### PR TITLE
Fix go build/test without slow tag

### DIFF
--- a/tools/genpas.go
+++ b/tools/genpas.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/transpiler/x/pas/stub.go
+++ b/transpiler/x/pas/stub.go
@@ -1,6 +1,6 @@
 //go:build !slow
 
-package ctrans
+package pas
 
 import (
 	"mochi/parser"

--- a/transpiler/x/php/stub.go
+++ b/transpiler/x/php/stub.go
@@ -1,8 +1,10 @@
 //go:build !slow
 
-package ctrans
+package php
 
 import (
+	"io"
+
 	"mochi/parser"
 	"mochi/types"
 )
@@ -11,9 +13,9 @@ import (
 type Program struct{}
 
 // Transpile returns a placeholder program so dependent packages compile without the slow implementation.
-func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
+func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 	return &Program{}, nil
 }
 
-// Emit returns an empty byte slice. It is a no-op replacement for the real function.
-func (p *Program) Emit() []byte { return nil }
+// Emit is a no-op replacement for the real function.
+func Emit(w io.Writer, p *Program) error { return nil }

--- a/transpiler/x/php/vm_valid_golden_test.go
+++ b/transpiler/x/php/vm_valid_golden_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php_test
 
 import (


### PR DESCRIPTION
## Summary
- add build tag to genpas tool
- provide stub versions of C, Pascal, and PHP transpilers when `slow` tag isn't used
- skip PHP golden tests unless `slow` tag is specified

## Testing
- `go build ./...`
- `go test ./... | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687c82941c34832098ea1974d8c225c2