### PR TITLE
Fix tests

### DIFF
--- a/runtime/infer/infer_noslow_test.go
+++ b/runtime/infer/infer_noslow_test.go
@@ -1,0 +1,9 @@
+//go:build !slow
+
+package infer_test
+
+import "testing"
+
+func TestInferSkipped(t *testing.T) {
+	t.Skip("slow tests disabled; build with -tags=slow to enable")
+}


### PR DESCRIPTION
## Summary
- add `infer_noslow_test.go` to let `runtime/infer` compile when `slow` tag is not set

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687c8a1ad9288320b4ba09c049657d74