### PR TITLE
Add release notes for v0.10.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # 📦 CHANGELOG.md
+## [0.10.32] – 2025-07-20T15:13:08+07:00
+
+### Added
+
+* Experimental transpiler framework supporting many languages
+* AST printing helpers and golden tests for transpiled programs
+* Map operations, joins, slicing and membership across languages
+
+### Changed
+
+* Code generation improved with typed variables and header comments
+* Documentation and progress logs reorganized across compilers
+
+### Fixed
+
+* Runtime string membership issues
+* Go and C build/test stability
+
 ## [0.10.31] – 2025-07-19T10:21:06+07:00
 
 ### Added

--- a/releases/v0.10.32.md
+++ b/releases/v0.10.32.md
@@ -1,0 +1,28 @@
+# Jul 2025 (v0.10.32)
+
+Released on Sun Jul 20 15:13:08 2025 +0700.
+
+Mochi v0.10.32 introduces a cross-language transpiler framework and extends builtin operations across languages with improved tests and documentation.
+
+## Examples
+
+- Test outputs generated for new transpilers across languages
+- Progress logs updated for each backend
+
+## Compilers
+
+- Experimental transpilers added for C, C++, C#, Dart, Erlang, F#, Fortran, Go, Haskell, Java, Kotlin, Lua, OCaml, Pascal, PHP, Prolog, Ruby, Rust, Scala, Scheme, Smalltalk, Swift, TypeScript, Zig and more
+- AST printing helpers and header comments for generated code
+- Slicing, membership, match expressions and map operations across languages
+- Improved typed variables and code generation
+
+## Runtime
+
+- String membership handled by the runtime
+- Obsolete PHP runtime helpers removed
+
+## Documentation
+
+- Progress checklists reorganized for new languages
+- Golden tests refreshed with consistent headers
+


### PR DESCRIPTION
## Summary
- document new experimental transpiler framework and updates
- add changelog entry for v0.10.32

## Testing
- `make test` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687ca53fd7d8832084482cbcb6e9cf4a