### PR TITLE
Update ocaml transpiler docs

### DIFF
--- a/transpiler/x/ocaml/README.md
+++ b/transpiler/x/ocaml/README.md
@@ -2,14 +2,14 @@
 
 The following Mochi programs under `tests/vm/valid` are used as golden inputs for transpiler implementations.  Tick a box once the OCaml transpiler can successfully generate code that matches the VM output.
 
-Completed: 51/100
+Completed: 56/100
 
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
 - [x] binary_precedence
 - [x] bool_chain
-- [ ] break_continue
+ - [x] break_continue
 - [x] cast_string_to_int
 - [ ] cast_struct
 - [ ] closure
@@ -80,8 +80,8 @@ Completed: 51/100
 - [ ] record_assign
 - [ ] right_join
 - [ ] save_jsonl_stdout
-- [ ] short_circuit
-- [ ] slice
+ - [x] short_circuit
+ - [x] slice
 - [ ] sort_stable
 - [x] str_builtin
 - [x] string_compare
@@ -92,10 +92,10 @@ Completed: 51/100
 - [x] string_prefix_slice
 - [x] substring_builtin
 - [x] sum_builtin
-- [ ] tail_recursion
+ - [x] tail_recursion
 - [ ] test_block
 - [ ] tree_sum
-- [ ] two-sum
+ - [x] two-sum
 - [x] typed_let
 - [x] typed_var
 - [x] unary_neg

--- a/transpiler/x/ocaml/TASKS.md
+++ b/transpiler/x/ocaml/TASKS.md
@@ -1,3 +1,13 @@
+## Progress (2025-07-20 08:24 UTC)
+- Checklist updated: 56/100 tests compiled
+- Added support for `break` and `continue` statements using recursive loops.
+- Implemented list slicing for lists.
+- Enabled golden tests for `break_continue`, `short_circuit`, `slice`, `tail_recursion` and `two-sum`.
+
+## Progress (2025-07-20 15:14 +0700)
+- Checklist updated: 51/100 tests compiled
+- Added support for `list_nested_assign` and improved list assignment handling.
+
 ## Progress (2025-07-20 08:02 UTC)
 - Checklist updated: 51/100 tests compiled
 - Added map type inference with support for integer keys and nested updates.


### PR DESCRIPTION
## Summary
- update README checklist for ocaml transpiler progress
- document new progress entry in TASKS

## Testing
- `go test ./... -tags slow` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687ca57da970832085fbd582c06d91e6