### PR TITLE
Improve TypeScript transpiler join typing

### DIFF
--- a/tests/transpiler/x/ts/group_by.error
+++ b/tests/transpiler/x/ts/group_by.error
@@ -1,4 +1,4 @@
 run: exit status 1
 [0m[1m[31merror[0m: Uncaught (in promise) ReferenceError: g is not defined
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by.ts[0m:[0m[33m8[0m:[0m[33m24[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by.ts[0m:[0m[33m19[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by.ts[0m:[0m[33m9[0m:[0m[33m24[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by.ts[0m:[0m[33m20[0m:[0m[33m2[0m

--- a/tests/transpiler/x/ts/group_by_conditional_sum.error
+++ b/tests/transpiler/x/ts/group_by_conditional_sum.error
@@ -2,5 +2,5 @@ run: exit status 1
 [0m[1m[31merror[0m: Uncaught (in promise) ReferenceError: g is not defined
     result.push({k: g["key"], v: {cat: g["key"], share: ((() => {
 [0m[31m                    ^[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_conditional_sum.ts[0m:[0m[33m8[0m:[0m[33m21[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_conditional_sum.ts[0m:[0m[33m27[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_conditional_sum.ts[0m:[0m[33m9[0m:[0m[33m21[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_conditional_sum.ts[0m:[0m[33m28[0m:[0m[33m2[0m

--- a/tests/transpiler/x/ts/group_by_having.error
+++ b/tests/transpiler/x/ts/group_by_having.error
@@ -2,5 +2,5 @@ run: exit status 1
 [0m[1m[31merror[0m: Uncaught (in promise) ReferenceError: g is not defined
     result.push({city: g["key"], num: (Array.isArray(g) || typeof g === 'string' ? g.length : Object.keys(g ?? {}).length)})
 [0m[31m                       ^[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_having.ts[0m:[0m[33m8[0m:[0m[33m24[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_having.ts[0m:[0m[33m12[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_having.ts[0m:[0m[33m9[0m:[0m[33m24[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_having.ts[0m:[0m[33m13[0m:[0m[33m2[0m

--- a/tests/transpiler/x/ts/group_by_join.error
+++ b/tests/transpiler/x/ts/group_by_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_join.ts:20:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_join.ts:21:3
 
     let _rows = _items
     ~~~

--- a/tests/transpiler/x/ts/group_by_left_join.error
+++ b/tests/transpiler/x/ts/group_by_left_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_left_join.ts:21:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_left_join.ts:22:3
 
     let _rows = _items
     ~~~

--- a/tests/transpiler/x/ts/group_by_multi_join.error
+++ b/tests/transpiler/x/ts/group_by_multi_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_multi_join.ts:22:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_multi_join.ts:23:3
 
     { const _joined = []
     ~

--- a/tests/transpiler/x/ts/group_by_multi_join_sort.error
+++ b/tests/transpiler/x/ts/group_by_multi_join_sort.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_multi_join_sort.ts:26:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/group_by_multi_join_sort.ts:27:3
 
     { const _joined = []
     ~

--- a/tests/transpiler/x/ts/group_by_sort.error
+++ b/tests/transpiler/x/ts/group_by_sort.error
@@ -2,6 +2,6 @@ run: exit status 1
 [0m[1m[31merror[0m: Uncaught (in promise) ReferenceError: g is not defined
   for (const x of g) {
 [0m[31m                  ^[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m10[0m:[0m[33m19[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m15[0m:[0m[33m2[0m
-    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m27[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m11[0m:[0m[33m19[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m16[0m:[0m[33m2[0m
+    at [0m[36mfile:///workspace/mochi/tests/transpiler/x/ts/group_by_sort.ts[0m:[0m[33m28[0m:[0m[33m2[0m

--- a/tests/transpiler/x/ts/inner_join.error
+++ b/tests/transpiler/x/ts/inner_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/inner_join.ts:20:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/inner_join.ts:21:3
 
     let _rows = _items
     ~~~

--- a/tests/transpiler/x/ts/join_multi.error
+++ b/tests/transpiler/x/ts/join_multi.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/join_multi.ts:22:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/join_multi.ts:23:3
 
     { const _joined = []
     ~

--- a/tests/transpiler/x/ts/left_join.error
+++ b/tests/transpiler/x/ts/left_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/left_join.ts:21:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/left_join.ts:22:3
 
     let _rows = _items
     ~~~

--- a/tests/transpiler/x/ts/left_join_multi.error
+++ b/tests/transpiler/x/ts/left_join_multi.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/left_join_multi.ts:22:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got '{' at file:///workspace/mochi/tests/transpiler/x/ts/left_join_multi.ts:23:3
 
     { const _joined = []
     ~

--- a/tests/transpiler/x/ts/outer_join.error
+++ b/tests/transpiler/x/ts/outer_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/outer_join.ts:25:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/outer_join.ts:26:3
 
     let _rows = _items
     ~~~

--- a/tests/transpiler/x/ts/right_join.error
+++ b/tests/transpiler/x/ts/right_join.error
@@ -1,5 +1,5 @@
 run: exit status 1
-[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/right_join.ts:24:3
+[0m[1m[31merror[0m: The module's source code could not be parsed: Expected ',', got 'let' at file:///workspace/mochi/tests/transpiler/x/ts/right_join.ts:25:3
 
     let _rows = _items
     ~~~

--- a/transpiler/x/ts/TASKS.md
+++ b/transpiler/x/ts/TASKS.md
@@ -1,9 +1,19 @@
-## Progress (2025-07-20 20:36 +0700)
+## Progress (2025-07-20 20:46 +0700)
 - Generated TypeScript for 100/100 programs (75 passing)
 - Updated README checklist and outputs
 - Enhanced readability and type inference
 - Removed runtime helper functions
 
+## Progress (2025-07-20 20:46 +0700)
+- Generated TypeScript for 100/100 programs (75 passing)
+- Updated README checklist and outputs
+- Enhanced readability and type inference
+- Removed runtime helper functions
+## Progress (2025-07-20 20:36 +0700)
+- Generated TypeScript for 100/100 programs (75 passing)
+- Updated README checklist and outputs
+- Enhanced readability and type inference
+- Removed runtime helper functions
 ## Progress (2025-07-20 20:25 +0700)
 - Generated TypeScript for 100/100 programs (75 passing)
 - Updated README checklist and outputs
@@ -16,11 +26,6 @@
 - Removed runtime helper functions
 ## Progress (2025-07-20 17:52 +0700)
 - Generated TypeScript for 100/100 programs (80 passing)
-- Updated README checklist and outputs
-- Enhanced readability and type inference
-- Removed runtime helper functions
-## Progress (2025-07-20 17:34 +0700)
-- Generated TypeScript for 100/100 programs (76 passing)
 - Updated README checklist and outputs
 - Enhanced readability and type inference
 - Removed runtime helper functions


### PR DESCRIPTION
## Summary
- improve query result inference in TypeScript transpiler
- generate interfaces for map literals in queries
- annotate generated query results with the inferred type
- update TASKS progress
- update failing *.error files with new line numbers

## Testing
- `go test -tags slow ./transpiler/x/ts -run TestTSTranspiler_VMValid_Golden -count=1` *(fails: 75 passed, 25 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687cf2fbd5c48320a5269b0174ae0c3b