### PR TITLE
Improve F# transpiler record handling

### DIFF
--- a/tests/transpiler/x/fs/cross_join.error
+++ b/tests/transpiler/x/fs/cross_join.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/fs/cross_join.fs
+++ b/tests/transpiler/x/fs/cross_join.fs
@@ -1,0 +1,24 @@
+// Generated 2025-07-20 17:52 +0700
+open System
+
+type Anon1 = {
+    id: int
+    name: string
+}
+type Anon2 = {
+    id: int
+    customerId: int
+    total: int
+}
+type Anon3 = {
+    orderId: obj
+    orderCustomerId: obj
+    pairedCustomerName: obj
+    orderTotal: obj
+}
+let customers: Anon1 list = [{ id = 1; name = "Alice" }; { id = 2; name = "Bob" }; { id = 3; name = "Charlie" }]
+let orders: Anon2 list = [{ id = 100; customerId = 1; total = 250 }; { id = 101; customerId = 2; total = 125 }; { id = 102; customerId = 1; total = 300 }]
+let result: Anon3 list = [ for o in orders do for c in customers do yield { orderId = o.id; orderCustomerId = o.customerId; pairedCustomerName = c.name; orderTotal = o.total } ]
+printfn "%s" (string "--- Cross Join: All order-customer pairs ---")
+for entry in result do
+printfn "%s" (String.concat " " [string "Order"; string (entry.orderId); string "(customerId:"; string (entry.orderCustomerId); string ", total: $"; string (entry.orderTotal); string ") paired with"; string (entry.pairedCustomerName)])

--- a/tests/transpiler/x/fs/cross_join.out
+++ b/tests/transpiler/x/fs/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (56/100)
+## Golden Test Checklist (57/100)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
@@ -16,7 +16,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [ ] cast_struct.mochi
 - [x] closure.mochi
 - [x] count_builtin.mochi
-- [ ] cross_join.mochi
+- [x] cross_join.mochi
 - [ ] cross_join_filter.mochi
 - [ ] cross_join_triple.mochi
 - [ ] dataset_sort_take_limit.mochi

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,15 @@
+## Progress (2025-07-20 17:52 +0700)
+- VM valid golden test results updated
+
+## Progress (2025-07-20 17:52 +0700)
+- VM valid golden test results updated
+
+## Progress (2025-07-20 17:52 +0700)
+- VM valid golden test results updated
+
+## Progress (2025-07-20 17:52 +0700)
+- VM valid golden test results updated
+
 ## Progress (2025-07-20 09:58 UTC)
 - VM valid golden test results updated
 


### PR DESCRIPTION
## Summary
- generate struct definitions for list literals
- support map literals with simple keys as records
- implement simple query expression support
- regenerate golden output for `cross_join.mochi`
- update progress docs

## Testing
- `go test -tags slow ./transpiler/x/fs -run TestFSTranspiler_VMValid_Golden/cross_join$ -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687cc8bbc9e883208c6e8634dd0f63f8