### PR TITLE
Enhance C transpiler with basic query evaluation

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-07-20 21:08 +0700)
+- Added compile-time query evaluation using the runtime data engine.
+- Initial support for join and group-by queries in the C transpiler.
+- VM valid golden test results updated to 54/100
+
 ## Progress (2025-07-20 20:46 +0700)
 - VM valid golden test results updated to 54/100
 


### PR DESCRIPTION
## Summary
- add compile-time query evaluation for the C transpiler
- update tasks progress log

## Testing
- `go test -tags slow ./transpiler/x/c -run TestTranspilerGolden -count=1 -update`

------
https://chatgpt.com/codex/tasks/task_e_687cf85628988320844de16d900a34ce