### PR TITLE
Improve C# transpiler type inference

### DIFF
--- a/transpiler/x/cs/README.md
+++ b/transpiler/x/cs/README.md
@@ -2,7 +2,7 @@
 
 Generated C# code for programs in `tests/vm/valid`. Each program has a `.cs` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
-Compiled programs: 84/100
+Compiled programs: 91/100
 
 ## Checklist
 - [x] append_builtin
@@ -32,9 +32,9 @@ Compiled programs: 84/100
 - [x] group_by_conditional_sum
 - [ ] group_by_having
 - [x] group_by_join
-- [ ] group_by_left_join
-- [ ] group_by_multi_join
-- [ ] group_by_multi_join_sort
+- [x] group_by_left_join
+- [x] group_by_multi_join
+- [x] group_by_multi_join_sort
 - [x] group_by_sort
 - [x] group_items_iteration
 - [x] if_else
@@ -45,8 +45,8 @@ Compiled programs: 84/100
 - [x] inner_join
 - [x] join_multi
 - [x] json_builtin
-- [ ] left_join
-- [ ] left_join_multi
+- [x] left_join
+- [x] left_join_multi
 - [x] len_builtin
 - [x] len_map
 - [x] len_string
@@ -70,7 +70,7 @@ Compiled programs: 84/100
 - [x] min_max_builtin
 - [x] nested_function
 - [x] order_by_map
-- [ ] outer_join
+ - [x] outer_join
 - [x] partial_application
 - [x] print_hello
 - [x] pure_fold
@@ -79,7 +79,7 @@ Compiled programs: 84/100
 - [ ] python_math
 - [x] query_sum_select
 - [x] record_assign
-- [ ] right_join
+ - [x] right_join
 - [ ] save_jsonl_stdout
 - [x] short_circuit
 - [x] slice

--- a/transpiler/x/cs/TASKS.md
+++ b/transpiler/x/cs/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-20T21:09:48+07:00)
+- cs transpiler: typed join and group by results with structs (progress 91/100)
+
 ## Progress (2025-07-20 20:47 +0700)
 - cs transpiler: typed groups and right join support (progress 84/100)
 
@@ -90,6 +93,8 @@
 ## Remaining Work
 - [x] Implement loops and conditionals
 - [ ] Support map and list mutation operations
+
+
 
 
 


### PR DESCRIPTION
## Summary
- improve C# transpiler to track variables across joins and generate struct
types for grouped results
- output any newly created struct declarations
- update README checklist for C# transpiler (91/100 tests)
- document latest progress in TASKS

## Testing
- `go test -tags slow ./transpiler/x/cs -run TestCSTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687cf8b51fac8320935347b82f435822