### PR TITLE
Enhance Kotlin transpiler with join & group

### DIFF
--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,7 @@
+## VM Golden Progress (2025-07-20 21:23 +0700)
+- Added join and group-by query support with automatic data class generation.
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-20 17:52 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- generate new progress entry for kotlin tasks
- support join clauses and simple group by queries
- emit data classes for query grouping

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./transpiler/x/kt -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687cfbf91070832091f9d2125ed55dce