### PR TITLE
Enhance PHP query emission

### DIFF
--- a/tests/transpiler/x/php/cross_join.out
+++ b/tests/transpiler/x/php/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/tests/transpiler/x/php/cross_join.php
+++ b/tests/transpiler/x/php/cross_join.php
@@ -1,0 +1,15 @@
+<?php
+$customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"]];
+$orders = [["id" => 100, "customerId" => 1, "total" => 250], ["id" => 101, "customerId" => 2, "total" => 125], ["id" => 102, "customerId" => 1, "total" => 300]];
+$result = [];
+foreach ($orders as $o) {
+  foreach ($customers as $c) {
+    $result[] = ["orderId" => $o["id"], "orderCustomerId" => $o["customerId"], "pairedCustomerName" => $c["name"], "orderTotal" => $o["total"]];
+  }
+}
+
+echo "--- Cross Join: All order-customer pairs ---", PHP_EOL;
+foreach ($result as $entry) {
+  echo "Order" . " " . $entry["orderId"] . " " . "(customerId:" . " " . $entry["orderCustomerId"] . " " . ", total: $" . " " . $entry["orderTotal"] . " " . ") paired with" . " " . $entry["pairedCustomerName"], PHP_EOL;
+}
+?>

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-## VM Golden Test Checklist (66/100)
+## VM Golden Test Checklist (67/100)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -13,7 +13,7 @@ Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/
 - [x] cast_struct
 - [x] closure
 - [x] count_builtin
-- [ ] cross_join
+- [x] cross_join
 - [ ] cross_join_filter
 - [ ] cross_join_triple
 - [ ] dataset_sort_take_limit

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-07-20 18:07 +0700)
+- Generated PHP for 67/100 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-20 17:38 +0700)
+- Generated PHP for 67/100 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-20 16:47 +0700)
 - Generated PHP for 66/100 programs
 - Updated README checklist and outputs


### PR DESCRIPTION
## Summary
- refactor PHP transpiler to emit query results without closures
- add QueryLetStmt and emitInto helper for building nested loops
- update progress log
- regenerate `cross_join.php` with idiomatic loops

## Testing
- `go vet -tags slow ./transpiler/x/php`
- `go build -tags slow ./transpiler/x/php`
- `go test -tags slow ./transpiler/x/php -run '^$'`
- `php tests/transpiler/x/php/cross_join.php > tests/transpiler/x/php/cross_join.out`

------
https://chatgpt.com/codex/tasks/task_e_687cc8d5bc1c8320958bb4fff881c8d7