### PR TITLE
Improve TypeScript transpiler sorting

### DIFF
--- a/tests/transpiler/x/ts/dataset_sort_take_limit.out
+++ b/tests/transpiler/x/ts/dataset_sort_take_limit.out
@@ -1,4 +1,4 @@
 --- Top products (excluding most expensive) ---
-Laptop costs $ 1500
-Headphones costs $ 200
+Smartphone costs $ 900
+Tablet costs $ 600
 Monitor costs $ 300

--- a/tests/transpiler/x/ts/dataset_sort_take_limit.ts
+++ b/tests/transpiler/x/ts/dataset_sort_take_limit.ts
@@ -7,7 +7,12 @@ const expensive: Record<string, any>[] = (() => {
   for (const p of products) {
     result.push({k: -p["price"], v: p})
   }
-  result.sort((a, b) => {const ak = JSON.stringify(a.k); const bk = JSON.stringify(b.k); return ak < bk ? -1 : ak > bk ? 1 : 0})
+  result.sort((a, b) => {
+    const ak = a.k; const bk = b.k;
+    if (ak < bk) return -1; if (ak > bk) return 1;
+    const sak = JSON.stringify(ak); const sbk = JSON.stringify(bk);
+    return sak < sbk ? -1 : sak > sbk ? 1 : 0
+  })
   const out = result.map(r => r.v)
   return out.slice(1, (1 + 3))
 })();

--- a/transpiler/x/ts/README.md
+++ b/transpiler/x/ts/README.md
@@ -3,7 +3,7 @@
 This directory contains the experimental TypeScript transpiler.
 Generated sources for the golden tests live under `tests/transpiler/x/ts`.
 
-## VM Golden Test Checklist (79/100)
+## VM Golden Test Checklist (80/100)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -17,7 +17,7 @@ Generated sources for the golden tests live under `tests/transpiler/x/ts`.
 - [x] cross_join.mochi
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
+- [x] dataset_sort_take_limit.mochi
 - [ ] dataset_where_filter.mochi
 - [x] exists_builtin.mochi
 - [x] for_list_collection.mochi

--- a/transpiler/x/ts/TASKS.md
+++ b/transpiler/x/ts/TASKS.md
@@ -1,31 +1,11 @@
-## Progress (2025-07-20 21:58 +0700)
-- Generated TypeScript for 100/100 programs (79 passing)
+## Progress (2025-07-20 22:22 +0700)
+- Generated TypeScript for 100/100 programs (80 passing)
 - Updated README checklist and outputs
 - Enhanced readability and type inference
 - Removed runtime helper functions
 
 ## Progress (2025-07-20 21:58 +0700)
 - Generated TypeScript for 100/100 programs (79 passing)
-- Updated README checklist and outputs
-- Enhanced readability and type inference
-- Removed runtime helper functions
-## Progress (2025-07-20 21:58 +0700)
-- Generated TypeScript for 100/100 programs (76 passing)
-- Updated README checklist and outputs
-- Enhanced readability and type inference
-- Removed runtime helper functions
-## Progress (2025-07-20 21:58 +0700)
-- Generated TypeScript for 100/100 programs (76 passing)
-- Updated README checklist and outputs
-- Enhanced readability and type inference
-- Removed runtime helper functions
-## Progress (2025-07-20 21:58 +0700)
-- Generated TypeScript for 100/100 programs (76 passing)
-- Updated README checklist and outputs
-- Enhanced readability and type inference
-- Removed runtime helper functions
-## Progress (2025-07-20 21:28 +0700)
-- Generated TypeScript for 100/100 programs (76 passing)
 - Updated README checklist and outputs
 - Enhanced readability and type inference
 - Removed runtime helper functions

--- a/transpiler/x/ts/transpiler.go
+++ b/transpiler/x/ts/transpiler.go
@@ -755,8 +755,10 @@ func (q *QueryExprJS) emit(w io.Writer) {
 		emitLoops(0, 1)
 		if q.Sort != nil {
 			io.WriteString(iw, "  result.sort((a, b) => {")
-			io.WriteString(iw, "const ak = JSON.stringify(a.k); const bk = JSON.stringify(b.k);")
-			io.WriteString(iw, " return ak < bk ? -1 : ak > bk ? 1 : 0})\n")
+			io.WriteString(iw, "const ak = a.k; const bk = b.k;")
+			io.WriteString(iw, " if (ak < bk) return -1; if (ak > bk) return 1;")
+			io.WriteString(iw, " const sak = JSON.stringify(ak); const sbk = JSON.stringify(bk);")
+			io.WriteString(iw, " return sak < sbk ? -1 : sak > sbk ? 1 : 0})\n")
 			io.WriteString(iw, "  const out = result.map(r => r.v)\n")
 		} else {
 			io.WriteString(iw, "  const out = result\n")
@@ -883,7 +885,7 @@ func (q *QueryExprJS) emit(w io.Writer) {
 		io.WriteString(iw, "] = r; return {item: r, key: ")
 		q.Sort.emit(iw)
 		io.WriteString(iw, "} });\n")
-		io.WriteString(iw, "    _pairs.sort((a,b)=>{const ak=JSON.stringify(a.key);const bk=JSON.stringify(b.key);return ak<bk?-1:ak>bk?1:0});\n")
+		io.WriteString(iw, "    _pairs.sort((a,b)=>{const ak=a.key;const bk=b.key;if(ak<bk)return -1;if(ak>bk)return 1;const sak=JSON.stringify(ak);const sbk=JSON.stringify(bk);return sak<sbk?-1:sak>sbk?1:0});\n")
 		io.WriteString(iw, "    _rows = _pairs.map(p=>p.item); }\n")
 	}
 


### PR DESCRIPTION
## Summary
- improve sort comparator logic in TypeScript transpiler
- regenerate dataset_sort_take_limit output
- update TypeScript checklist and task progress

## Testing
- `go test -tags=slow ./transpiler/x/ts -run TestTSTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687d09e018d483209de1938e583ea9fb