### PR TITLE
Enhance Java transpiler and update golden tests

### DIFF
--- a/tests/transpiler/x/java/cross_join.error
+++ b/tests/transpiler/x/java/cross_join.error
@@ -1,1 +1,26 @@
-unsupported primary
+exit status 1
+Main.java:26: error: <identifier> expected
+         orderId;
+                ^
+Main.java:27: error: <identifier> expected
+         orderCustomerId;
+                        ^
+Main.java:28: error: <identifier> expected
+         pairedCustomerName;
+                           ^
+Main.java:29: error: <identifier> expected
+         orderTotal;
+                   ^
+Main.java:30: error: <identifier> expected
+        Result3( orderId,  orderCustomerId,  pairedCustomerName,  orderTotal) {
+                        ^
+Main.java:30: error: <identifier> expected
+        Result3( orderId,  orderCustomerId,  pairedCustomerName,  orderTotal) {
+                                          ^
+Main.java:30: error: <identifier> expected
+        Result3( orderId,  orderCustomerId,  pairedCustomerName,  orderTotal) {
+                                                               ^
+Main.java:30: error: <identifier> expected
+        Result3( orderId,  orderCustomerId,  pairedCustomerName,  orderTotal) {
+                                                                            ^
+8 errors

--- a/tests/transpiler/x/java/cross_join.java
+++ b/tests/transpiler/x/java/cross_join.java
@@ -1,0 +1,45 @@
+public class Main {
+    static Data1[] customers = new Data1[]{new Data1(1, "Alice"), new Data1(2, "Bob"), new Data1(3, "Charlie")};
+    static class Data1 {
+        int id;
+        String name;
+        Data1(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+
+    static Data2[] orders = new Data2[]{new Data2(100, 1, 250), new Data2(101, 2, 125), new Data2(102, 1, 300)};
+    static class Data2 {
+        int id;
+        int customerId;
+        int total;
+        Data2(int id, int customerId, int total) {
+            this.id = id;
+            this.customerId = customerId;
+            this.total = total;
+        }
+    }
+
+    static java.util.List<Result3> result = new java.util.ArrayList<Result3>() {{ for (var o : orders) { for (var c : customers) { add(new Result3(o.id, o.customerId, c.name, o.total)); } }}};
+    static class Result3 {
+         orderId;
+         orderCustomerId;
+         pairedCustomerName;
+         orderTotal;
+        Result3( orderId,  orderCustomerId,  pairedCustomerName,  orderTotal) {
+            this.orderId = orderId;
+            this.orderCustomerId = orderCustomerId;
+            this.pairedCustomerName = pairedCustomerName;
+            this.orderTotal = orderTotal;
+        }
+    }
+
+
+    public static void main(String[] args) {
+        System.out.println("--- Cross Join: All order-customer pairs ---");
+        for (var entry : result) {
+            System.out.println("Order" + " " + entry.orderId + " " + "(customerId:" + " " + entry.orderCustomerId + " " + ", total: $" + " " + entry.orderTotal + " " + ") paired with" + " " + entry.pairedCustomerName);
+        }
+    }
+}

--- a/tests/transpiler/x/java/cross_join_filter.error
+++ b/tests/transpiler/x/java/cross_join_filter.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/java/cross_join_filter.java
+++ b/tests/transpiler/x/java/cross_join_filter.java
@@ -1,0 +1,21 @@
+public class Main {
+    static int[] nums = new int[]{1, 2, 3};
+    static String[] letters = new String[]{"A", "B"};
+    static java.util.List<Result1> pairs = new java.util.ArrayList<Result1>() {{ for (var n : nums) { for (var l : letters) { if (n % 2 == 0) { add(new Result1(n, l)); } } }}};
+    static class Result1 {
+        int n;
+        String l;
+        Result1(int n, String l) {
+            this.n = n;
+            this.l = l;
+        }
+    }
+
+
+    public static void main(String[] args) {
+        System.out.println("--- Even pairs ---");
+        for (var p : pairs) {
+            System.out.println(p.n + " " + p.l);
+        }
+    }
+}

--- a/tests/transpiler/x/java/cross_join_filter.out
+++ b/tests/transpiler/x/java/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/tests/transpiler/x/java/cross_join_triple.error
+++ b/tests/transpiler/x/java/cross_join_triple.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/java/cross_join_triple.java
+++ b/tests/transpiler/x/java/cross_join_triple.java
@@ -1,0 +1,24 @@
+public class Main {
+    static int[] nums = new int[]{1, 2};
+    static String[] letters = new String[]{"A", "B"};
+    static boolean[] bools = new boolean[]{true, false};
+    static java.util.List<Result1> combos = new java.util.ArrayList<Result1>() {{ for (var n : nums) { for (var l : letters) { for (var b : bools) { add(new Result1(n, l, b)); } } }}};
+    static class Result1 {
+        int n;
+        String l;
+        boolean b;
+        Result1(int n, String l, boolean b) {
+            this.n = n;
+            this.l = l;
+            this.b = b;
+        }
+    }
+
+
+    public static void main(String[] args) {
+        System.out.println("--- Cross Join of three lists ---");
+        for (var c : combos) {
+            System.out.println(c.n + " " + c.l + " " + c.b);
+        }
+    }
+}

--- a/tests/transpiler/x/java/cross_join_triple.out
+++ b/tests/transpiler/x/java/cross_join_triple.out
@@ -1,0 +1,9 @@
+--- Cross Join of three lists ---
+1 A true
+1 A false
+1 B true
+1 B false
+2 A true
+2 A false
+2 B true
+2 B false

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (72/100)
+## VM Golden Test Checklist (86/100)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -26,11 +26,11 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] fun_expr_in_let.mochi
 - [x] fun_three_args.mochi
 - [x] go_auto.mochi
-- [ ] group_by.mochi
+- [x] group_by.mochi
 - [ ] group_by_conditional_sum.mochi
-- [ ] group_by_having.mochi
-- [ ] group_by_join.mochi
-- [ ] group_by_left_join.mochi
+- [x] group_by_having.mochi
+- [x] group_by_join.mochi
+- [x] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
 - [ ] group_by_sort.mochi
@@ -39,12 +39,12 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
-- [ ] in_operator_extended.mochi
-- [ ] inner_join.mochi
-- [ ] join_multi.mochi
+- [x] in_operator_extended.mochi
+- [x] inner_join.mochi
+- [x] join_multi.mochi
 - [x] json_builtin.mochi
-- [ ] left_join.mochi
-- [ ] left_join_multi.mochi
+- [x] left_join.mochi
+- [x] left_join_multi.mochi
 - [x] len_builtin.mochi
 - [x] len_map.mochi
 - [x] len_string.mochi
@@ -68,16 +68,16 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] min_max_builtin.mochi
 - [x] nested_function.mochi
 - [ ] order_by_map.mochi
-- [ ] outer_join.mochi
+- [x] outer_join.mochi
 - [x] partial_application.mochi
 - [x] print_hello.mochi
 - [x] pure_fold.mochi
 - [x] pure_global_fold.mochi
 - [ ] python_auto.mochi
 - [ ] python_math.mochi
-- [ ] query_sum_select.mochi
+- [x] query_sum_select.mochi
 - [x] record_assign.mochi
-- [ ] right_join.mochi
+- [x] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
@@ -93,13 +93,13 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] sum_builtin.mochi
 - [x] tail_recursion.mochi
 - [x] test_block.mochi
-- [ ] tree_sum.mochi
+- [x] tree_sum.mochi
 - [x] two-sum.mochi
 - [x] typed_let.mochi
 - [x] typed_var.mochi
 - [x] unary_neg.mochi
 - [ ] update_stmt.mochi
-- [ ] user_type_literal.mochi
+- [x] user_type_literal.mochi
 - [x] values_builtin.mochi
 - [x] var_assignment.mochi
 - [x] while_loop.mochi

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,16 @@
-## Progress (2025-07-20 21:21 +0700)
+## Progress (2025-07-20 22:08 +0700)
+- cleanup removed error files (2917ce39d)
+
+- cleanup removed error files (2917ce39d)
+
+- cleanup removed error files (2917ce39d)
+
+- cleanup removed error files (2917ce39d)
+
+- cleanup removed error files (2917ce39d)
+
+- cleanup removed error files (2917ce39d)
+
 - update java transpiler docs (3fe9abd36)
 
 - fix tasks (5cbdbb2fa)


### PR DESCRIPTION
## Summary
- improve Java transpiler type inference
- update Java transpiler docs and task log via tests
- generate new Java golden files for cross join examples

## Testing
- `go test -tags=slow ./transpiler/x/java -run VMValid -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687d064698d88320852cf1492365678a