### PR TITLE
Improve Kotlin transpiler coverage

### DIFF
--- a/tests/transpiler/x/kt/in_operator_extended.kt
+++ b/tests/transpiler/x/kt/in_operator_extended.kt
@@ -1,0 +1,20 @@
+fun main() {
+    val xs: MutableList<Int> = mutableListOf(1, 2, 3)
+    val ys: MutableList<Int> = run {
+    val _res = mutableListOf<Any>()
+    for (x in xs) {
+        if ((x % 2) == 1) {
+            _res.add(x)
+        }
+    }
+    _res
+}
+    println(1 in ys)
+    println(2 in ys)
+    val m: MutableMap<String, Int> = mutableMapOf("a" to 1)
+    println("a" in m)
+    println("b" in m)
+    val s: String = "hello"
+    println("ell" in s)
+    println("foo" in s)
+}

--- a/tests/transpiler/x/kt/in_operator_extended.out
+++ b/tests/transpiler/x/kt/in_operator_extended.out
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+true
+false

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **61/100** (auto-generated)
+Completed golden tests: **62/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -43,7 +43,7 @@ Completed golden tests: **61/100** (auto-generated)
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
-- [ ] in_operator_extended.mochi
+- [x] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
 - [ ] json_builtin.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,18 @@
+## VM Golden Progress (2025-07-20 22:08 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-20 22:08 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-20 22:08 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-20 22:08 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-20 22:08 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-20 21:23 +0700)
 - Added join and group-by query support with automatic data class generation.
 - Regenerated Kotlin golden files and README

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1845,9 +1845,15 @@ func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
 	case p.Map != nil:
 		items := make([]MapItem, len(p.Map.Items))
 		for i, it := range p.Map.Items {
-			k, err := convertExpr(env, it.Key)
-			if err != nil {
-				return nil, err
+			var k Expr
+			if s, ok := types.SimpleStringKey(it.Key); ok {
+				k = &StringLit{Value: s}
+			} else {
+				var err error
+				k, err = convertExpr(env, it.Key)
+				if err != nil {
+					return nil, err
+				}
 			}
 			v, err := convertExpr(env, it.Value)
 			if err != nil {


### PR DESCRIPTION
## Summary
- generate Kotlin for `in_operator_extended` golden test
- auto-update progress checklist and tasks
- infer simple map keys as string literals in the Kotlin transpiler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687d068f5010832085a18e9bf53f3f66