### PR TITLE
Update Fortran transpiler

### DIFF
--- a/tests/transpiler/x/fortran/string_contains.error
+++ b/tests/transpiler/x/fortran/string_contains.error
@@ -1,1 +1,0 @@
-postfix operations unsupported

--- a/tests/transpiler/x/fortran/string_contains.f90
+++ b/tests/transpiler/x/fortran/string_contains.f90
@@ -1,0 +1,7 @@
+program main
+  implicit none
+  character(len=100) :: s = "catch"
+
+  print '(A)', trim(merge('true  ','false ',index(s, "cat") > 0))
+  print '(A)', trim(merge('true  ','false ',index(s, "dog") > 0))
+end program main

--- a/tests/transpiler/x/fortran/string_contains.out
+++ b/tests/transpiler/x/fortran/string_contains.out
@@ -1,0 +1,2 @@
+true
+false

--- a/transpiler/x/fortran/README.md
+++ b/transpiler/x/fortran/README.md
@@ -2,7 +2,7 @@
 
 This checklist tracks Mochi programs from `tests/vm/valid` that successfully transpile using the experimental Fortran backend.
 
-Checklist of programs that currently transpile and run (32/100):
+Checklist of programs that currently transpile and run (33/100):
 
 - [ ] append_builtin
 - [x] avg_builtin
@@ -86,7 +86,7 @@ Checklist of programs that currently transpile and run (32/100):
 - [ ] str_builtin
 - [x] string_compare
 - [x] string_concat
-- [ ] string_contains
+- [x] string_contains
 - [ ] string_in_operator
 - [x] string_index
 - [ ] string_prefix_slice

--- a/transpiler/x/fortran/TASKS.md
+++ b/transpiler/x/fortran/TASKS.md
@@ -1,3 +1,33 @@
+## Progress (2025-07-20 22:51 +0700)
+- fortran: add string.contains support
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
+## Progress (2025-07-20 22:30 +0700)
+- ftn: support multiple print args and update progress
+
 ## Progress (2025-07-20 22:06 +0700)
 - docs(fortran): update progress
 


### PR DESCRIPTION
## Summary
- improve boolean printing in Fortran code generation
- implement `string.contains` for the Fortran backend
- regenerate README progress checklist
- log latest progress entry
- add generated Fortran test files for `string_contains`

## Testing
- `go test ./transpiler/x/fortran -tags slow -run TestFortranTranspiler_VMValid_Golden/string_contains -count=1`
- `go test ./transpiler/x/fortran -tags slow -run ^$ -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687d0ba6e4108320b431b5f81c762b53