### PR TITLE
Update C transpiler loop handling

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 06:48 +0700)
+- Added fallback loop handling for constant lists stored in variables.
+- VM valid golden test results updated to 57/100
+
 ## Progress (2025-07-20 22:54 +0700)
 - Added constant map indexing and new golden file `map_index`.
 - VM valid golden test results updated to 57/100

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -1037,6 +1037,23 @@ func compileStmt(env *types.Env, s *parser.Statement) (Stmt, error) {
 			return &ForStmt{Var: s.For.Name, Start: start, End: end, Body: body}, nil
 		}
 		list, ok := convertListExpr(s.For.Source)
+		if !ok {
+			ex := convertExpr(s.For.Source)
+			if val, ok2 := valueFromExpr(ex); ok2 {
+				if arr, ok3 := val.([]any); ok3 {
+					var elems []Expr
+					for _, it := range arr {
+						e := anyToExpr(it)
+						if e == nil {
+							return nil, fmt.Errorf("unsupported for-loop")
+						}
+						elems = append(elems, e)
+					}
+					list = elems
+					ok = true
+				}
+			}
+		}
 		if ok {
 			elemType := "int"
 			if len(list) > 0 {


### PR DESCRIPTION
## Summary
- enhance C transpiler for-loops to support iterating over constant lists stored in variables
- log new progress for the C backend

## Testing
- `go test ./transpiler/x/c -tags slow -run TestTranspilerGolden`


------
https://chatgpt.com/codex/tasks/task_e_687d8064f85c83208752af1c206e2070