### PR TITLE
Improve OCaml transpiler

### DIFF
--- a/tests/transpiler/x/ocaml/cross_join.out
+++ b/tests/transpiler/x/ocaml/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/transpiler/x/ocaml/README.md
+++ b/transpiler/x/ocaml/README.md
@@ -2,7 +2,7 @@
 
 The following Mochi programs under `tests/vm/valid` are used as golden inputs for transpiler implementations.  Tick a box once the OCaml transpiler can successfully generate code that matches the VM output.
 
-Completed: 52/100
+Completed: 53/100
 
 - [x] append_builtin
 - [x] avg_builtin
@@ -14,7 +14,7 @@ Completed: 52/100
 - [ ] cast_struct
 - [x] closure
 - [x] count_builtin
-- [ ] cross_join
+- [x] cross_join
 - [ ] cross_join_filter
 - [ ] cross_join_triple
 - [ ] dataset_sort_take_limit

--- a/transpiler/x/ocaml/TASKS.md
+++ b/transpiler/x/ocaml/TASKS.md
@@ -1,3 +1,15 @@
+## Progress (2025-07-21 07:08 +0700)
+- Checklist updated: 53/100 tests compiled
+- Added cross join query support.
+
+## Progress (2025-07-21 07:08 +0700)
+- Checklist updated: 53/100 tests compiled
+- Added cross join query support.
+
+## Progress (2025-07-21 07:08 +0700)
+- Checklist updated: 53/100 tests compiled
+- Added support for `list_nested_assign` and improved list assignment handling.
+
 ## Progress (2025-07-20 16:45 +0700)
 - Checklist updated: 52/100 tests compiled
 - Added support for function return types so `closure` now compiles.

--- a/transpiler/x/ocaml/transpiler_test.go
+++ b/transpiler/x/ocaml/transpiler_test.go
@@ -2061,6 +2061,52 @@ func TestTranspileTailRecursion(t *testing.T) {
 	}
 }
 
+func TestTranspileCrossJoin(t *testing.T) {
+	if _, err := exec.LookPath("ocamlc"); err != nil {
+		t.Skip("ocamlc not installed")
+	}
+	root := repoRoot(t)
+	outDir := filepath.Join(root, "tests", "transpiler", "x", "ocaml")
+	os.MkdirAll(outDir, 0o755)
+
+	src := filepath.Join(root, "tests", "vm", "valid", "cross_join.mochi")
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		t.Fatalf("type: %v", errs[0])
+	}
+	ast, err := ocaml.Transpile(prog, env)
+	if err != nil {
+		t.Fatalf("transpile: %v", err)
+	}
+	code := ast.Emit()
+	mlFile := filepath.Join(outDir, "cross_join.ml")
+	if err := os.WriteFile(mlFile, code, 0o644); err != nil {
+		t.Fatalf("write ml: %v", err)
+	}
+	exe := filepath.Join(outDir, "cross_join")
+	if out, err := exec.Command("ocamlc", mlFile, "-o", exe).CombinedOutput(); err != nil {
+		os.WriteFile(filepath.Join(outDir, "cross_join.error"), out, 0o644)
+		t.Fatalf("ocamlc: %v", err)
+	}
+	out, err := exec.Command(exe).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := bytes.TrimSpace(out)
+	want, err := os.ReadFile(filepath.Join(outDir, "cross_join.out"))
+	if err != nil {
+		t.Fatalf("read want: %v", err)
+	}
+	want = bytes.TrimSpace(want)
+	if !bytes.Equal(got, want) {
+		t.Errorf("output mismatch\nGot: %s\nWant: %s", got, want)
+	}
+}
+
 func TestMain(m *testing.M) {
 	code := m.Run()
 	updateReadme()
@@ -2115,7 +2161,7 @@ func updateTasks() {
 	compiled := len(compiledFiles)
 	fmt.Fprintf(&buf, "## Progress (%s)\n", ts)
 	fmt.Fprintf(&buf, "- Checklist updated: %d/%d tests compiled\n", compiled, total)
-	buf.WriteString("- Added support for `list_nested_assign` and improved list assignment handling.\n\n")
+	buf.WriteString("- Added cross join query support.\n\n")
 	if data, err := os.ReadFile(taskFile); err == nil {
 		buf.Write(data)
 	}


### PR DESCRIPTION
## Summary
- implement simple query expression support in OCaml transpiler
- add golden output for new `cross_join` case
- mark `cross_join` as completed and record progress

## Testing
- `go test -tags slow ./transpiler/x/ocaml -run TestTranspileCrossJoin -count=1`
- `go test -tags slow ./transpiler/x/ocaml`

------
https://chatgpt.com/codex/tasks/task_e_687d85bc18a08320ac2551f5b9942c2b