### PR TITLE
Update Prolog transpiler for string slices

### DIFF
--- a/tests/transpiler/x/pl/string_prefix_slice.out
+++ b/tests/transpiler/x/pl/string_prefix_slice.out
@@ -1,0 +1,2 @@
+true
+false

--- a/tests/transpiler/x/pl/string_prefix_slice.pl
+++ b/tests/transpiler/x/pl/string_prefix_slice.pl
@@ -1,8 +1,8 @@
 :- initialization(main).
 
 main :-
-    Prefix = 'fore',
-    S1 = 'forest',
-    L2 is 4 - 0, sub_string(S1, 0, L2, _, T2), (T2 = Prefix) -> writeln(true) ; writeln(false)),
-    S2 = 'desert',
-    L4 is 4 - 0, sub_string(S2, 0, L4, _, T4), (T4 = Prefix) -> writeln(true) ; writeln(false)).
+    Prefix = "fore",
+    S1 = "forest",
+    L2 is 4 - 0, sub_string(S1, 0, L2, _, T2), ((T2 = Prefix) -> writeln(true) ; writeln(false)),
+    S2 = "desert",
+    L4 is 4 - 0, sub_string(S2, 0, L4, _, T4), ((T4 = Prefix) -> writeln(true) ; writeln(false)).

--- a/tests/vm/valid/string_prefix_slice.pl.out
+++ b/tests/vm/valid/string_prefix_slice.pl.out
@@ -1,27 +1,8 @@
-:- style_check(-singleton).
-slice(Str, I, J, Out) :-
-    string(Str), !,
-    Len is J - I,
-    sub_string(Str, I, Len, _, Out).
-slice(List, I, J, Out) :-
-    length(Prefix, I),
-    append(Prefix, Rest, List),
-    Len is J - I,
-    length(Out, Len),
-    append(Out, _, Rest).
+:- initialization(main).
 
-
-    main :-
+main :-
     Prefix = "fore",
     S1 = "forest",
-    length(Prefix, _V0),
-    slice(S1, 0, _V0, _V1),
-    write(_V1 == Prefix),
-    nl,
+    L2 is 4 - 0, sub_string(S1, 0, L2, _, T2), ((T2 = Prefix) -> writeln(true) ; writeln(false)),
     S2 = "desert",
-    length(Prefix, _V2),
-    slice(S2, 0, _V2, _V3),
-    write(_V3 == Prefix),
-    nl
-    .
-:- initialization(main, main).
+    L4 is 4 - 0, sub_string(S2, 0, L4, _, T4), ((T4 = Prefix) -> writeln(true) ; writeln(false)).

--- a/transpiler/x/pl/README.md
+++ b/transpiler/x/pl/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a tiny transpiler that converts a restricted subset of Mochi programs to SWI-Prolog. It is mainly used for experimentation and golden tests.
 
-## VM Golden Test Checklist (34/100)
+## VM Golden Test Checklist (35/100)
 - [x] `append_builtin`
 - [x] `avg_builtin`
 - [x] `basic_compare`
@@ -88,7 +88,7 @@ This directory contains a tiny transpiler that converts a restricted subset of M
 - [x] `string_contains`
 - [x] `string_in_operator`
 - [x] `string_index`
-- [ ] `string_prefix_slice`
+- [x] `string_prefix_slice`
 - [x] `substring_builtin`
 - [x] `sum_builtin`
 - [ ] `tail_recursion`

--- a/transpiler/x/pl/TASKS.md
+++ b/transpiler/x/pl/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-21 07:08 +0700)
+- VM valid golden test results updated to 35/100
+
 ## Progress (2025-07-20 22:11 +0700)
 - docs(pl): tidy tasks list
 - 34/100 VM programs transpiled successfully

--- a/transpiler/x/pl/transpiler.go
+++ b/transpiler/x/pl/transpiler.go
@@ -155,9 +155,9 @@ func (p *PrintStmt) emit(w io.Writer, idx int) {
 				se.Start.emit(w)
 				fmt.Fprintf(w, ", L%d, _, T%d), ", idx, idx)
 				if be.Op == "=" {
-					fmt.Fprintf(w, "(T%d = ", idx)
+					fmt.Fprintf(w, "((T%d = ", idx)
 				} else {
-					fmt.Fprintf(w, "(T%d \\= ", idx)
+					fmt.Fprintf(w, "((T%d \\= ", idx)
 				}
 				be.Right.emit(w)
 				io.WriteString(w, ") -> writeln(true) ; writeln(false))")
@@ -448,7 +448,7 @@ type InExpr struct {
 
 func (i *IntLit) emit(w io.Writer)    { fmt.Fprintf(w, "%d", i.Value) }
 func (b *BoolLit) emit(w io.Writer)   { fmt.Fprintf(w, "%v", b.Value) }
-func (s *StringLit) emit(w io.Writer) { fmt.Fprintf(w, "'%s'", escape(s.Value)) }
+func (s *StringLit) emit(w io.Writer) { fmt.Fprintf(w, "\"%s\"", escape(s.Value)) }
 func (v *Var) emit(w io.Writer)       { io.WriteString(w, v.Name) }
 func (b *BinaryExpr) emit(w io.Writer) {
 	if b.Op == "+" {
@@ -1300,7 +1300,10 @@ func toPrimary(p *parser.Primary, env *compileEnv) (Expr, error) {
 						return &IntLit{Value: len(c.Value)}, nil
 					}
 				}
-				return &LenExpr{Value: arg}, nil
+				if isStringLike(arg, env) {
+					return &CallExpr{Name: "string_length", Args: []Expr{arg}}, nil
+				}
+				return &CallExpr{Name: "length", Args: []Expr{arg}}, nil
 			case "str":
 				return &StrExpr{Value: arg}, nil
 			case "count":


### PR DESCRIPTION
## Summary
- improve Prolog transpiler: emit real strings and call `string_length`
- mark `string_prefix_slice` as working in README and TASKS
- regenerate golden file for `string_prefix_slice`

## Testing
- `go vet -tags slow ./transpiler/x/pl`
- `go build -tags slow ./tools/gen_pl.go`
- `go test -tags slow ./transpiler/x/pl -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687d861772688320b39c14db78023bf8