### PR TITLE
Update Kotlin transpiler truthiness

### DIFF
--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,6 @@
+## VM Golden Progress (2025-07-21 08:00 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-21 07:35 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- support truthiness by wrapping non-boolean conditions with null checks
- update tasks log

## Testing
- `go run -tags "archive slow" scripts/update_kt_readme_tasks.go`


------
https://chatgpt.com/codex/tasks/task_e_687d9132597c8320abd3d50c14ca8882