### PR TITLE
Improve C transpiler bool inference

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-21 11:02 +0700)
+- VM valid golden test results updated to 58/100
+
 ## Progress (2025-07-21 07:03 +0700)
 - VM valid golden test results updated to 58/100
 - Added Python math extern mapping and new golden file `python_math`.

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -1957,6 +1957,12 @@ func evalBool(e Expr) (bool, bool) {
 	switch v := e.(type) {
 	case *IntLit:
 		return v.Value != 0, true
+	case *VarRef:
+		if val, err := currentEnv.GetValue(v.Name); err == nil {
+			if b, ok := val.(bool); ok {
+				return b, true
+			}
+		}
 	case *UnaryExpr:
 		if v.Op == "!" {
 			if b, ok := evalBool(v.Expr); ok {
@@ -2229,6 +2235,17 @@ func exprIsBool(e Expr) bool {
 		return v.Value == 0 || v.Value == 1
 	case *FloatLit:
 		return v.Value == 0.0 || v.Value == 1.0
+	case *VarRef:
+		if t, err := currentEnv.GetVar(v.Name); err == nil {
+			if _, ok := t.(types.BoolType); ok {
+				return true
+			}
+		}
+		if val, err := currentEnv.GetValue(v.Name); err == nil {
+			if _, ok := val.(bool); ok {
+				return true
+			}
+		}
 	case *UnaryExpr:
 		if v.Op == "!" {
 			return exprIsBool(v.Expr)

--- a/transpiler/x/c/transpiler_test.go
+++ b/transpiler/x/c/transpiler_test.go
@@ -266,7 +266,7 @@ func updateTasks() {
 	ts := ""
 	if err == nil {
 		if t, perr := time.Parse(time.RFC3339, strings.TrimSpace(string(out))); perr == nil {
-			ts = t.Format("2006-01-02 15:04 MST")
+			ts = t.Format("2006-01-02 15:04 -0700")
 		}
 	}
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- enhance boolean type detection in C transpiler
- record latest test progress with nicer timestamp

## Testing
- `go test ./transpiler/x/c -run TestTranspilerGolden -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_687dbc0edc4483209508842fef29bda0