### PR TITLE
Improve C++ transpiler type inference

### DIFF
--- a/transpiler/x/cpp/TASKS.md
+++ b/transpiler/x/cpp/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-07-21 11:17 +07:00)
+- update dart tasks progress
+- Generated C++ for 83/100 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-21 11:04 +0700)
 - cpp transpiler: improve print handling
 - Generated C++ for 83/100 programs

--- a/transpiler/x/cpp/transpiler.go
+++ b/transpiler/x/cpp/transpiler.go
@@ -2408,14 +2408,45 @@ func exprType(e Expr) string {
 		return "int"
 	case *AvgExpr:
 		return "double"
+	case *SumExpr:
+		elem := elementTypeFromListType(exprType(v.Arg))
+		if elem == "double" {
+			return "double"
+		}
+		if elem == "int" {
+			return "int"
+		}
+		return "auto"
+	case *AppendExpr:
+		return exprType(v.List)
+	case *ContainsExpr, *InExpr, *ExistsExpr:
+		return "bool"
+	case *SubstringExpr:
+		return "std::string"
+	case *SliceExpr:
+		return exprType(v.Target)
+	case *StrExpr:
+		return "std::string"
+	case *ValuesExpr:
+		mt := exprType(v.Map)
+		vt := "auto"
+		if strings.HasPrefix(mt, "std::map<") && strings.HasSuffix(mt, ">") {
+			parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(mt, "std::map<"), ">"), ",")
+			if len(parts) == 2 {
+				vt = strings.TrimSpace(parts[1])
+			}
+		}
+		return fmt.Sprintf("std::vector<%s>", vt)
+	case *MinExpr:
+		return elementTypeFromListType(exprType(v.List))
+	case *MaxExpr:
+		return elementTypeFromListType(exprType(v.List))
 	case *MultiListComp:
 		return fmt.Sprintf("std::vector<%s>", v.ElemType)
 	case *GroupComp:
 		return fmt.Sprintf("std::vector<%s>", v.ElemType)
 	case *SortComp:
 		return fmt.Sprintf("std::vector<%s>", v.ElemType)
-	case *ExistsExpr:
-		return "bool"
 	}
 	return "auto"
 }


### PR DESCRIPTION
## Summary
- enhance C++ transpiler `exprType` to infer more builtin types
- record progress with nicer timestamp and avoid duplicates
- regenerate progress log

## Testing
- `go test -tags slow ./transpiler/x/cpp -run TestMain -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687dbf9d67f48320a700235e9a7ca739