### PR TITLE
Fix Kotlin transpiler cross join

### DIFF
--- a/tests/transpiler/x/kt/cross_join.kt
+++ b/tests/transpiler/x/kt/cross_join.kt
@@ -1,17 +1,17 @@
 fun main() {
-    val customers = mutableListOf(mutableMapOf("id" to 1, "name" to "Alice"), mutableMapOf("id" to 2, "name" to "Bob"), mutableMapOf("id" to 3, "name" to "Charlie"))
-    val orders = mutableListOf(mutableMapOf("id" to 100, "customerId" to 1, "total" to 250), mutableMapOf("id" to 101, "customerId" to 2, "total" to 125), mutableMapOf("id" to 102, "customerId" to 1, "total" to 300))
+    val customers = mutableListOf(mutableMapOf("id" to 1, "name" to "Alice") as MutableMap<String, Any>, mutableMapOf("id" to 2, "name" to "Bob") as MutableMap<String, Any>, mutableMapOf("id" to 3, "name" to "Charlie") as MutableMap<String, Any>)
+    val orders = mutableListOf(mutableMapOf("id" to 100, "customerId" to 1, "total" to 250) as MutableMap<String, Any>, mutableMapOf("id" to 101, "customerId" to 2, "total" to 125) as MutableMap<String, Any>, mutableMapOf("id" to 102, "customerId" to 1, "total" to 300) as MutableMap<String, Any>)
     val result = run {
     val _res = mutableListOf<MutableMap<String, Any>>()
     for (o in orders) {
         for (c in customers) {
-            _res.add(mutableMapOf("orderId" to o.id, "orderCustomerId" to o.customerId, "pairedCustomerName" to c["name"], "orderTotal" to o.total))
+            _res.add(mutableMapOf("orderId" to o["id"], "orderCustomerId" to o["customerId"], "pairedCustomerName" to c["name"], "orderTotal" to o["total"]) as MutableMap<String, Any>)
         }
     }
     _res
 }
     println("--- Cross Join: All order-customer pairs ---")
     for (entry in result) {
-        println(((((((((((((("Order" + " ") + entry.orderId) + " ") + "(customerId:") + " ") + entry.orderCustomerId) + " ") + ", total: $") + " ") + entry.orderTotal) + " ") + ") paired with") + " ") + entry.pairedCustomerName)
+        println(((((((((((((("Order" + " ") + entry["orderId"]) + " ") + "(customerId:") + " ") + entry["orderCustomerId"]) + " ") + ", total: $") + " ") + entry["orderTotal"]) + " ") + ") paired with") + " ") + entry["pairedCustomerName"])
     }
 }

--- a/tests/transpiler/x/kt/cross_join.out
+++ b/tests/transpiler/x/kt/cross_join.out
@@ -1,0 +1,10 @@
+--- Cross Join: All order-customer pairs ---
+Order 100 (customerId: 1 , total: $ 250 ) paired with Alice
+Order 100 (customerId: 1 , total: $ 250 ) paired with Bob
+Order 100 (customerId: 1 , total: $ 250 ) paired with Charlie
+Order 101 (customerId: 2 , total: $ 125 ) paired with Alice
+Order 101 (customerId: 2 , total: $ 125 ) paired with Bob
+Order 101 (customerId: 2 , total: $ 125 ) paired with Charlie
+Order 102 (customerId: 1 , total: $ 300 ) paired with Alice
+Order 102 (customerId: 1 , total: $ 300 ) paired with Bob
+Order 102 (customerId: 1 , total: $ 300 ) paired with Charlie

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **63/100** (auto-generated)
+Completed golden tests: **64/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -17,7 +17,7 @@ Completed golden tests: **63/100** (auto-generated)
 - [ ] cast_struct.mochi
 - [x] closure.mochi
 - [x] count_builtin.mochi
-- [ ] cross_join.mochi
+- [x] cross_join.mochi
 - [ ] cross_join_filter.mochi
 - [ ] cross_join_triple.mochi
 - [ ] dataset_sort_take_limit.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,18 @@
+## VM Golden Progress (2025-07-21 11:21 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-21 11:21 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-21 11:21 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-21 11:21 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-21 11:21 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-21 08:00 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- enhance Kotlin transpiler type inference for query vars and `for` loops
- cast map literals for cross join example
- regenerate Kotlin golden data for new checklist

## Testing
- `go test -tags slow ./transpiler/x/kt -run TestTranspilePrograms/cross_join -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687dc0450a0083209361b6c3ffc31f88