### PR TITLE
Improve Rust transpiler print handling

### DIFF
--- a/tests/transpiler/x/rs/group_by.error
+++ b/tests/transpiler/x/rs/group_by.error
@@ -1,1 +1,0 @@
-transpile: unsupported primary

--- a/transpiler/x/rs/TASKS.md
+++ b/transpiler/x/rs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 11:50 +0700)
+- Generated Rust for 81/100 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-21 11:30 +0700)
 - Generated Rust for 81/100 programs
 - Updated README checklist and outputs

--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -86,15 +86,6 @@ func (b *BoolLit) emit(w io.Writer) {
 	}
 }
 
-// BoolIntExpr converts a boolean expression to 1 or 0.
-type BoolIntExpr struct{ Expr Expr }
-
-func (b *BoolIntExpr) emit(w io.Writer) {
-	io.WriteString(w, "if ")
-	b.Expr.emit(w)
-	io.WriteString(w, " { 1 } else { 0 }")
-}
-
 // BreakStmt represents a `break` statement.
 type BreakStmt struct{}
 
@@ -1496,15 +1487,12 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 		}
 		name := p.Call.Func
 		if name == "print" {
-			for i, a := range args {
-				if inferType(a) == "bool" {
-					args[i] = &BoolIntExpr{Expr: a}
-				}
-			}
 			if len(args) == 1 {
 				fmtStr := "{}"
 				switch a := args[0].(type) {
-				case *MapLit, *ValuesExpr, *AppendExpr, *ListLit:
+				case *ValuesExpr:
+					args[0] = &JoinExpr{List: a}
+				case *MapLit, *AppendExpr, *ListLit:
 					fmtStr = "{:?}"
 				case *SliceExpr:
 					if inferType(a) != "String" {


### PR DESCRIPTION
## Summary
- simplify print logic in the Rust transpiler
- track progress update
- delete outdated error output for `group_by`

## Testing
- `go test ./transpiler/x/rs -tags slow -run RSTranspiler_VMValid_Golden/exists_builtin$ -count=1`
- `go test ./transpiler/x/rs -tags slow -run RSTranspiler_VMValid_Golden/group_by$ -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687dc72e2eb08320ac434efcff8bb9e2