### PR TITLE
Improve Pascal group_by average

### DIFF
--- a/tests/transpiler/x/pas/group_by.pas
+++ b/tests/transpiler/x/pas/group_by.pas
@@ -22,8 +22,8 @@ var
   i3: integer;
   sum4: integer;
   stats: array of Anon3;
-  person: Anon1;
   s: integer;
+  person: Anon1;
 begin
   people := [(name: 'Alice'; age: 30; city: 'Paris'), (name: 'Bob'; age: 15; city: 'Hanoi'), (name: 'Charlie'; age: 65; city: 'Paris'), (name: 'Diana'; age: 45; city: 'Hanoi'), (name: 'Eve'; age: 70; city: 'Paris'), (name: 'Frank'; age: 22; city: 'Hanoi')];
   grp1 := [];
@@ -48,7 +48,7 @@ end;
   for person in g.items do begin
   sum4 := sum4 + person.age;
 end;
-  stats := concat(stats, [(city: g.city; count: g.count; avg_age: sum4 div Length(g.items))]);
+  stats := concat(stats, [(city: g.city; count: g.count; avg_age: sum4 / Length(g.items))]);
 end;
   writeln('--- People grouped by city ---');
   for s in stats do begin

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,3 +1,18 @@
+## Progress (2025-07-21 12:53 +0700)
+- pl transpiler: basic map and query support (progress 50/100)
+
+## Progress (2025-07-21 06:05 UTC)
+- pascal: improve group_by average (progress 50/100)
+
+## Progress (2025-07-21 12:53 +0700)
+- pl transpiler: basic map and query support (progress 50/100)
+
+## Progress (2025-07-21 12:53 +0700)
+- pl transpiler: basic map and query support (progress 50/100)
+
+## Progress (2025-07-21 12:53 +0700)
+- pl transpiler: basic map and query support (progress 50/100)
+
 ## Progress (2025-07-21 12:24 +0700)
 - transpiler/cs: support grouping with left join (progress 50/100)
 


### PR DESCRIPTION
## Summary
- make avg_expr use real division via new flag in Pascal BinaryExpr
- regenerate group_by.pas output
- note progress

## Testing
- `go test -tags slow ./transpiler/x/pas -run TestPascalTranspiler/group_by -count=1` *(fails: compile error)*

------
https://chatgpt.com/codex/tasks/task_e_687dd701215483208e3576595fca11e2