### PR TITLE
Improve Elixir transpiler group_by

### DIFF
--- a/transpiler/x/ex/TASKS.md
+++ b/transpiler/x/ex/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 12:53 +0700)
+- Added basic group-by translation using Enum.group_by
+- VM valid golden test results updated
+
 ## Progress (2025-07-21 12:27 +0700)
 - VM valid golden test results updated
 


### PR DESCRIPTION
## Summary
- support group by queries in the Elixir transpiler
- wrap expressions in parentheses when necessary
- track progress for new feature

## Testing
- `go test ./transpiler/x/ex -tags slow -run TestElixirTranspiler_VMValid_Golden/group_by$ -v -count=1`
- `go test ./transpiler/x/ex -tags slow -run TestElixirTranspiler_VMValid_Golden/print_hello$ -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687dd68b20c48320b5db372067caf13c