### PR TITLE
Improve F# transpiler

### DIFF
--- a/tests/transpiler/x/fs/dataset_sort_take_limit.fs
+++ b/tests/transpiler/x/fs/dataset_sort_take_limit.fs
@@ -1,0 +1,16 @@
+// Generated 2025-07-21 13:05 +0700
+open System
+
+type Anon1 = {
+    name: string
+    price: int
+}
+type Anon2 = {
+    name: string
+    price: int
+}
+let products: Anon2 list = [{ name = "Laptop"; price = 1500 }; { name = "Smartphone"; price = 900 }; { name = "Tablet"; price = 600 }; { name = "Monitor"; price = 300 }; { name = "Keyboard"; price = 100 }; { name = "Mouse"; price = 50 }; { name = "Headphones"; price = 200 }]
+let expensive = [ for p in List.take 3 (List.skip 1 (List.sortBy (fun p -> (-(p.price))) products)) do yield p ]
+printfn "%s" (string "--- Top products (excluding most expensive) ---")
+for item in expensive do
+printfn "%s" (String.concat " " [string (item.name); string "costs $"; string (item.price)])

--- a/tests/transpiler/x/fs/dataset_sort_take_limit.out
+++ b/tests/transpiler/x/fs/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (64/100)
+## Golden Test Checklist (71/100)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
@@ -13,14 +13,14 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] bool_chain.mochi
 - [x] break_continue.mochi
 - [x] cast_string_to_int.mochi
-- [ ] cast_struct.mochi
+- [x] cast_struct.mochi
 - [x] closure.mochi
 - [x] count_builtin.mochi
 - [x] cross_join.mochi
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
-- [ ] dataset_sort_take_limit.mochi
-- [ ] dataset_where_filter.mochi
+- [x] dataset_sort_take_limit.mochi
+- [x] dataset_where_filter.mochi
 - [x] exists_builtin.mochi
 - [x] for_list_collection.mochi
 - [x] for_loop.mochi
@@ -37,12 +37,12 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
 - [ ] group_by_sort.mochi
-- [ ] group_items_iteration.mochi
+- [x] group_items_iteration.mochi
 - [x] if_else.mochi
 - [x] if_then_else.mochi
 - [x] if_then_else_nested.mochi
 - [x] in_operator.mochi
-- [ ] in_operator_extended.mochi
+- [x] in_operator_extended.mochi
 - [ ] inner_join.mochi
 - [ ] join_multi.mochi
 - [ ] json_builtin.mochi
@@ -64,7 +64,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] map_literal_dynamic.mochi
 - [x] map_membership.mochi
 - [x] map_nested_assign.mochi
-- [ ] match_expr.mochi
+- [x] match_expr.mochi
 - [ ] match_full.mochi
 - [x] math_ops.mochi
 - [x] membership.mochi
@@ -79,7 +79,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [ ] python_auto.mochi
 - [ ] python_math.mochi
 - [ ] query_sum_select.mochi
-- [ ] record_assign.mochi
+- [x] record_assign.mochi
 - [x] right_join.mochi
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,15 @@
+## Progress (2025-07-21 13:05 +0700)
+- Generated F# for 100/100 programs (71 passing)
+
+## Progress (2025-07-21 13:05 +0700)
+- Generated F# for 100/100 programs (64 passing)
+
+## Progress (2025-07-21 13:05 +0700)
+- Generated F# for 100/100 programs (64 passing)
+
+## Progress (2025-07-21 13:05 +0700)
+- Generated F# for 100/100 programs (64 passing)
+
 ## Progress (2025-07-21 12:53 +0700)
 - Generated F# for 100/100 programs (64 passing)
 


### PR DESCRIPTION
## Summary
- extend F# transpiler with sort/skip/take for query expressions
- infer struct literals in list constants
- update generated README and progress
- add dataset_sort_take_limit outputs

## Testing
- `go test -tags=slow ./transpiler/x/fs -run TestMain`
- `go run -tags=slow /tmp/compile_single.go tests/vm/valid/dataset_sort_take_limit.mochi`

------
https://chatgpt.com/codex/tasks/task_e_687dd8ce74b48320a5af23cbe44ab57c