### PR TITLE
Improve Kotlin transpiler and update golden tests

### DIFF
--- a/tests/transpiler/x/kt/cross_join_filter.kt
+++ b/tests/transpiler/x/kt/cross_join_filter.kt
@@ -1,0 +1,19 @@
+fun main() {
+    val nums = mutableListOf(1, 2, 3)
+    val letters = mutableListOf("A", "B")
+    val pairs = run {
+    val _res = mutableListOf<MutableMap<String, Any>>()
+    for (n in nums) {
+        for (l in letters) {
+            if ((n % 2) == 0) {
+                _res.add(mutableMapOf("n" to n, "l" to l) as MutableMap<String, Any>)
+            }
+        }
+    }
+    _res
+}
+    println("--- Even pairs ---")
+    for (p in pairs) {
+        println(listOf(p["n"]!!, p["l"]!!).joinToString(" "))
+    }
+}

--- a/tests/transpiler/x/kt/cross_join_filter.out
+++ b/tests/transpiler/x/kt/cross_join_filter.out
@@ -1,0 +1,3 @@
+--- Even pairs ---
+2 A
+2 B

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **68/100** (auto-generated)
+Completed golden tests: **69/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -18,7 +18,7 @@ Completed golden tests: **68/100** (auto-generated)
 - [x] closure.mochi
 - [x] count_builtin.mochi
 - [x] cross_join.mochi
-- [ ] cross_join_filter.mochi
+- [x] cross_join_filter.mochi
 - [ ] cross_join_triple.mochi
 - [ ] dataset_sort_take_limit.mochi
 - [x] dataset_where_filter.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,7 @@
+## VM Golden Progress (2025-07-21 13:50 +0700)
+- Added support for cross join queries with where clause.
+- Regenerated Kotlin golden files and README.
+
 ## VM Golden Progress (2025-07-21 13:19 +0700)
 - Added Kotlin lambda generation for partial application.
 - Group-by output no longer depends on runtime helpers.

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1108,6 +1108,19 @@ func guessType(e Expr) string {
 			if val == "" {
 				val = "Any"
 			}
+			for _, it := range v.Items[1:] {
+				vk := guessType(it.Key)
+				vv := guessType(it.Value)
+				if vk != k {
+					k = "Any"
+				}
+				if vv != val {
+					val = "Any"
+				}
+				if k == "Any" && val == "Any" {
+					break
+				}
+			}
 			return "MutableMap<" + k + ", " + val + ">"
 		}
 		return "MutableMap<Any, Any>"


### PR DESCRIPTION
## Summary
- enhance map type inference for mixed value types
- generate Kotlin sources for `cross_join_filter` test
- update Kotlin transpiler progress docs

## Testing
- `go test ./transpiler/x/kt -tags slow -count=1`
- `go test ./... -run TestDummy -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687de5e4de24832083c732251a714389