### PR TITLE
Improve F# transpiler

### DIFF
--- a/tests/transpiler/x/fs/dataset_where_filter.error
+++ b/tests/transpiler/x/fs/dataset_where_filter.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/fs/dataset_where_filter.fs
+++ b/tests/transpiler/x/fs/dataset_where_filter.fs
@@ -1,0 +1,26 @@
+// Generated 2025-07-21 15:07 +0700
+open System
+
+type Anon1 = {
+    mutable name: string
+    mutable age: int
+}
+type Anon2 = {
+    mutable name: string
+    mutable age: int
+}
+type Anon3 = {
+    mutable name: obj
+    mutable age: obj
+    mutable is_senior: bool
+}
+type Anon4 = {
+    mutable name: obj
+    mutable age: obj
+    mutable is_senior: bool
+}
+let people: Anon2 list = [{ name = "Alice"; age = 30 }; { name = "Bob"; age = 15 }; { name = "Charlie"; age = 65 }; { name = "Diana"; age = 45 }]
+let adults: Anon4 list = [ for person in people do if (person.age) >= 18 then yield { name = person.name; age = person.age; is_senior = (person.age) >= 60 } ]
+printfn "%s" (string "--- Adults ---")
+for person in adults do
+printfn "%s" (String.concat " " [string (person.name); string "is"; string (person.age); string (if person.is_senior then " (senior)" else "")])

--- a/tests/transpiler/x/fs/dataset_where_filter.out
+++ b/tests/transpiler/x/fs/dataset_where_filter.out
@@ -1,0 +1,4 @@
+--- Adults ---
+Alice is 30 
+Charlie is 65  (senior)
+Diana is 45 

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,7 +2,7 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (66/100)
+## Golden Test Checklist (68/100)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
@@ -20,7 +20,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] cross_join_filter.mochi
 - [x] cross_join_triple.mochi
 - [x] dataset_sort_take_limit.mochi
-- [ ] dataset_where_filter.mochi
+- [x] dataset_where_filter.mochi
 - [x] exists_builtin.mochi
 - [x] for_list_collection.mochi
 - [x] for_loop.mochi
@@ -84,7 +84,7 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [ ] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
-- [ ] sort_stable.mochi
+- [x] sort_stable.mochi
 - [x] str_builtin.mochi
 - [x] string_compare.mochi
 - [x] string_concat.mochi

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,15 @@
+## Progress (2025-07-21 15:07 +0700)
+- Generated F# for 100/100 programs (68 passing)
+
+## Progress (2025-07-21 15:07 +0700)
+- Generated F# for 100/100 programs (67 passing)
+
+## Progress (2025-07-21 15:07 +0700)
+- Generated F# for 100/100 programs (66 passing)
+
+## Progress (2025-07-21 15:07 +0700)
+- Generated F# for 100/100 programs (66 passing)
+
 ## Progress (2025-07-21 13:50 +0700)
 - Generated F# for 100/100 programs (66 passing)
 

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -1571,6 +1571,21 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 		}
 		return &StructLit{Name: p.Struct.Name, Fields: fields}, nil
 	case p.Map != nil:
+		if st, ok := types.InferStructFromMapEnv(p.Map, transpileEnv); ok {
+			structCount++
+			name := fmt.Sprintf("Anon%d", structCount)
+			addStructDef(name, st)
+			fields := make([]StructFieldExpr, len(p.Map.Items))
+			for i, it := range p.Map.Items {
+				val, err := convertExpr(it.Value)
+				if err != nil {
+					return nil, err
+				}
+				key, _ := types.SimpleStringKey(it.Key)
+				fields[i] = StructFieldExpr{Name: key, Value: val}
+			}
+			return &StructLit{Name: name, Fields: fields}, nil
+		}
 		items := make([][2]Expr, len(p.Map.Items))
 		for i, it := range p.Map.Items {
 			k, err := convertExpr(it.Key)


### PR DESCRIPTION
## Summary
- infer record structs from map literals in F# backend
- update README and TASKS progress for F# transpiler
- add generated output for `dataset_where_filter`

## Testing
- `go run -tags slow /tmp/dataset.go && mono /tmp/dataset.exe > /tmp/dataset.out && cat /tmp/dataset.out`
- `go test -tags slow ./transpiler/x/fs -run PrintHello -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687df55456b8832084bd18cb84904e06