### PR TITLE
Improve Java transpiler membership handling

### DIFF
--- a/tests/transpiler/x/java/in_operator.java
+++ b/tests/transpiler/x/java/in_operator.java
@@ -2,7 +2,7 @@ public class Main {
     static int[] xs = new int[]{1, 2, 3};
 
     public static void main(String[] args) {
-        System.out.println(java.util.Arrays.asList(xs).contains(2));
-        System.out.println(!(java.util.Arrays.asList(xs).contains(5)));
+        System.out.println(java.util.Arrays.stream(xs).anyMatch((int x) -> x == 2));
+        System.out.println(!(java.util.Arrays.stream(xs).anyMatch((int x) -> x == 5)));
     }
 }

--- a/tests/transpiler/x/java/in_operator.out
+++ b/tests/transpiler/x/java/in_operator.out
@@ -1,2 +1,2 @@
-false
+true
 true

--- a/tests/transpiler/x/java/membership.java
+++ b/tests/transpiler/x/java/membership.java
@@ -2,7 +2,7 @@ public class Main {
     static int[] nums = new int[]{1, 2, 3};
 
     public static void main(String[] args) {
-        System.out.println(java.util.Arrays.asList(nums).contains(2));
-        System.out.println(java.util.Arrays.asList(nums).contains(4));
+        System.out.println(java.util.Arrays.stream(nums).anyMatch((int x) -> x == 2));
+        System.out.println(java.util.Arrays.stream(nums).anyMatch((int x) -> x == 4));
     }
 }

--- a/tests/transpiler/x/java/membership.out
+++ b/tests/transpiler/x/java/membership.out
@@ -1,2 +1,2 @@
-false
+true
 false

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,21 +1,9 @@
-## Progress (2025-07-21 13:50 +0700)
-- ctrans: add map iteration support (b88d08eca)
+## Progress (2025-07-21 15:12 +0700)
+- java transpiler: add sum and values builtins (68173845e)
 
-- ctrans: add map iteration support (b88d08eca)
+- java transpiler: add sum and values builtins (68173845e)
 
+Recent tasks:
 - ctrans: add map iteration support (b88d08eca)
-
-- ctrans: add map iteration support (b88d08eca)
-
-- ctrans: add map iteration support (b88d08eca)
-
-- ctrans: add map iteration support (b88d08eca)
-
-- ctrans: add map iteration support (b88d08eca)
-
 - java transpiler: improve avg output (d7e50da39)
-
 - java transpiler: improve group_by handling (f5e1460a5)
-- pl transpiler: basic map and query support (acbf323ef)
-- rs transpiler: simplify print bool and join (e600b5d77)
-- Added basic avg and count handling for group_by (HEAD)


### PR DESCRIPTION
## Summary
- improve membership operator for arrays in the Java transpiler
- regenerate golden outputs for `membership` and `in_operator`
- trim and update Java TASKS progress file

## Testing
- `go test ./transpiler/x/java -tags slow -count=1 > /tmp/go_test.log && tail -n 20 /tmp/go_test.log`
- `go test ./transpiler/x/java -tags slow -run '^$' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687df679caac8320b2cef6c82fa094e8