### PR TITLE
Kotlin transpiler group-by sorting

### DIFF
--- a/tests/transpiler/x/kt/group_by_sort.kt
+++ b/tests/transpiler/x/kt/group_by_sort.kt
@@ -1,0 +1,32 @@
+data class GGroup(val key: Any, val items: MutableList<MutableMap<String, Any>>)
+fun main() {
+    val items = mutableListOf(mutableMapOf("cat" to "a", "val" to 3) as MutableMap<String, Any>, mutableMapOf("cat" to "a", "val" to 1) as MutableMap<String, Any>, mutableMapOf("cat" to "b", "val" to 5) as MutableMap<String, Any>, mutableMapOf("cat" to "b", "val" to 2) as MutableMap<String, Any>)
+    val grouped = run {
+    val _groups = mutableMapOf<Any, MutableList<MutableMap<String, Any>>>()
+    for (i in items) {
+        val _list = _groups.getOrPut(i["cat"]!! as Any) { mutableListOf<MutableMap<String, Any>>() }
+        _list.add(i)
+    }
+    val _res = mutableListOf<MutableMap<String, Any>>()
+val _tmp = mutableListOf<Pair<Any, MutableMap<String, Any>>>()
+    for ((key, items) in _groups) {
+        val g = GGroup(key, items)
+        _tmp.add(Pair(0 - (run {
+    val _res = mutableListOf<Any>()
+    for (x in g.items) {
+        _res.add(x["val"]!!)
+    }
+    _res
+}.map{(it as Number).toDouble()}).sum(), mutableMapOf("cat" to g.key, "total" to (run {
+    val _res = mutableListOf<Any>()
+    for (x in g.items) {
+        _res.add(x["val"]!!)
+    }
+    _res
+}.map{(it as Number).toDouble()}).sum()) as MutableMap<String, Any>))
+    }
+    _tmp.sortBy { it.first }.map { it.second }.toMutableList().also { _res.addAll(it) }
+    _res
+}
+    println(grouped)
+}

--- a/tests/transpiler/x/kt/group_by_sort.out
+++ b/tests/transpiler/x/kt/group_by_sort.out
@@ -1,0 +1,2 @@
+{"cat": "b", "total": 7} {"cat": "a", "total": 4}
+

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -4,7 +4,7 @@ Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **69/100** (auto-generated)
+Completed golden tests: **70/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -37,7 +37,7 @@ Completed golden tests: **69/100** (auto-generated)
 - [ ] group_by_left_join.mochi
 - [ ] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
-- [ ] group_by_sort.mochi
+- [x] group_by_sort.mochi
 - [ ] group_items_iteration.mochi
 - [x] if_else.mochi
 - [x] if_then_else.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,7 @@
+## VM Golden Progress (2025-07-21 15:13 +0700)
+- Added `sort by` support for group-by queries.
+- Regenerated Kotlin golden files and README.
+
 ## VM Golden Progress (2025-07-21 13:50 +0700)
 - Added support for cross join queries with where clause.
 - Regenerated Kotlin golden files and README.


### PR DESCRIPTION
## Summary
- support `sort by` in Kotlin group-by queries
- regenerate README checklist to 70/100
- document progress with git timestamp
- add Kotlin golden for `group_by_sort`

## Testing
- `go run -tags "archive slow" scripts/gen_kt_golden.go group_by_sort`
- `go run -tags "archive slow" scripts/update_kt_readme_tasks.go`

------
https://chatgpt.com/codex/tasks/task_e_687df6ae829083209f733040dc1a9351