### PR TITLE
Improve Java transpiler with query sorting

### DIFF
--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,10 @@
-## Progress (2025-07-21 15:12 +0700)
+## Progress (2025-07-21 15:41 +0700)
+- lua transpiler: add json builtin and group-by having (d9518dd5c)
+
+- lua transpiler: add json builtin and group-by having (d9518dd5c)
+
+- lua transpiler: add json builtin and group-by having (d9518dd5c)
+
 - java transpiler: add sum and values builtins (68173845e)
 
 - java transpiler: add sum and values builtins (68173845e)


### PR DESCRIPTION
## Summary
- support `sort`, `skip` and `take` in Java query transpiler
- add renameVar helper and update TASKS progress

## Testing
- `go test -tags=slow ./transpiler/x/java -run TestTranspilePrintHello -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687dfd2ce83c83208b502ec96027ad61