### PR TITLE
Improve C transpiler constants

### DIFF
--- a/transpiler/x/c/TASKS.md
+++ b/transpiler/x/c/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-21 14:47 +0700)
+## Progress (2025-07-21 15:31 +0700)
 - VM valid golden test results updated to 66/100
 
 ## Progress (2025-07-21 14:47 +0700)

--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -430,6 +430,10 @@ func (f *FloatLit) emitExpr(w io.Writer) {
 	fmt.Fprintf(w, "%g", f.Value)
 }
 
+type NullLit struct{}
+
+func (n *NullLit) emitExpr(w io.Writer) { io.WriteString(w, "NULL") }
+
 type UnaryExpr struct {
 	Op   string
 	Expr Expr
@@ -2627,6 +2631,13 @@ func inferCType(env *types.Env, name string, e Expr) string {
 
 func anyToExpr(v any) Expr {
 	switch t := v.(type) {
+	case bool:
+		if t {
+			return &IntLit{Value: 1}
+		}
+		return &IntLit{Value: 0}
+	case nil:
+		return &NullLit{}
 	case int:
 		return &IntLit{Value: t}
 	case int64:


### PR DESCRIPTION
## Summary
- support `nil` and boolean values when converting constants
- document current progress for the C transpiler

## Testing
- `go test ./transpiler/x/c -tags slow -run 'TestTranspilerGolden/print_hello$' -update`

------
https://chatgpt.com/codex/tasks/task_e_687dfb1b9a488320ac4adbe4ea7763ed