### PR TITLE
Improve PHP transpiler for left join group queries

### DIFF
--- a/tests/transpiler/x/php/group_by_left_join.error
+++ b/tests/transpiler/x/php/group_by_left_join.error
@@ -1,1 +1,0 @@
-transpile: unsupported join

--- a/tests/transpiler/x/php/group_by_left_join.out
+++ b/tests/transpiler/x/php/group_by_left_join.out
@@ -1,0 +1,4 @@
+--- Group Left Join ---
+Alice orders: 2
+Bob orders: 1
+Charlie orders: 0

--- a/tests/transpiler/x/php/group_by_left_join.php
+++ b/tests/transpiler/x/php/group_by_left_join.php
@@ -1,0 +1,44 @@
+<?php
+$customers = [["id" => 1, "name" => "Alice"], ["id" => 2, "name" => "Bob"], ["id" => 3, "name" => "Charlie"]];
+$orders = [["id" => 100, "customerId" => 1], ["id" => 101, "customerId" => 1], ["id" => 102, "customerId" => 2]];
+$stats = (function() use ($customers, $orders) {
+  $groups = [];
+  foreach ($customers as $c) {
+    $matched = false;
+    foreach ($orders as $o) {
+      if (!($o["customerId"] == $c["id"])) continue;
+      $matched = true;
+      $key = $c["name"];
+      if (!array_key_exists($key, $groups)) {
+        $groups[$key] = ['key' => $key, 'items' => []];
+      }
+      $groups[$key]['items'][] = ['c' => $c, 'o' => $o];
+    }
+    if (!$matched) {
+      $o = null;
+      $key = $c["name"];
+      if (!array_key_exists($key, $groups)) {
+        $groups[$key] = ['key' => $key, 'items' => []];
+      }
+      $groups[$key]['items'][] = ['c' => $c, 'o' => $o];
+    }
+  }
+  $result = [];
+  foreach ($groups as $g) {
+      $result[] = ["name" => $g["key"], "count" => count((function() use ($c, $o, $g) {
+  $result = [];
+  foreach ($g["items"] as $r) {
+    if ($r["o"]) {
+      $result[] = $r;
+    }
+  }
+  return $result;
+})())];
+  }
+  return $result;
+})();
+echo rtrim("--- Group Left Join ---"), PHP_EOL;
+foreach ($stats as $s) {
+  echo rtrim((is_float($s["name"]) ? sprintf("%.15f", $s["name"]) : $s["name"]) . " " . "orders:" . " " . (is_float($s["count"]) ? sprintf("%.15f", $s["count"]) : $s["count"])), PHP_EOL;
+}
+?>

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-## VM Golden Test Checklist (88/100)
+## VM Golden Test Checklist (89/100)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -30,7 +30,7 @@ Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/
 - [x] group_by_conditional_sum
 - [x] group_by_having
 - [x] group_by_join
-- [ ] group_by_left_join
+- [x] group_by_left_join
 - [ ] group_by_multi_join
 - [ ] group_by_multi_join_sort
 - [x] group_by_sort

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-07-21 16:22 +0700)
+- Generated PHP for 89/100 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-21 16:22 +0700)
+- Generated PHP for 89/100 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-21 16:07 +0700)
 - Generated PHP for 88/100 programs
 - Updated README checklist and outputs


### PR DESCRIPTION
## Summary
- add `LeftJoinLoop` for group queries
- support left join inside grouped queries
- update generated golden outputs for PHP
- update README and TASKS progress

## Testing
- `go test ./transpiler/x/php -run TestPHPTranspiler_VMValid_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687e06f68fdc832086df844b595b245c