### PR TITLE
Improve Racket transpiler task tracking

### DIFF
--- a/transpiler/x/rkt/TASKS.md
+++ b/transpiler/x/rkt/TASKS.md
@@ -1,3 +1,21 @@
+## Progress (2025-07-21 16:57 +0700)
+- Commit 1dad0b0fb: fortran: support inner join and bool folding
+- Generated Racket for 1/100 programs
+- Updated README checklist
+
+## Progress (2025-07-21 16:57 +0700)
+- Commit 1dad0b0fb: fortran: support inner join and bool folding
+- Generated Racket for 1/100 programs
+- Updated README checklist
+
+## Progress (2025-07-21 16:57 +0700)
+- Generated Racket for 1/100 programs
+- Updated README checklist
+
+## Progress (2025-07-21 16:57 +0700)
+- Generated Racket for 1/100 programs
+- Updated README checklist
+
 ## Progress (2025-07-21 16:07 +0700)
 - Generated Racket for 1/100 programs
 - Updated README checklist


### PR DESCRIPTION
## Summary
- capture git commit details when updating transpiler progress
- record commit info in TASKS.md progress entries
- keep README checklist generation stable with sorted test files

## Testing
- `go test ./transpiler/x/rkt -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e11ce96ac83209e1a0d6a92caa54b