### PR TITLE
Improve Go transpiler field access

### DIFF
--- a/transpiler/x/go/transpiler.go
+++ b/transpiler/x/go/transpiler.go
@@ -2279,24 +2279,26 @@ func compilePostfix(pf *parser.PostfixExpr, env *types.Env, base string) (Expr, 
 				return nil, fmt.Errorf("unsupported postfix")
 			}
 		} else if op.Field != nil {
-			switch tt := t.(type) {
-			case types.MapType:
-				expr = &IndexExpr{X: expr, Index: &StringLit{Value: op.Field.Name}}
-				t = tt.Value
-			case types.StructType:
-				expr = &FieldExpr{X: expr, Name: op.Field.Name}
-				if ft, ok := tt.Fields[op.Field.Name]; ok {
-					t = ft
-				} else {
-					t = types.AnyType{}
-				}
-			default:
-				expr = &FieldExpr{X: expr, Name: op.Field.Name}
-				t = types.AnyType{}
-			}
-		}
-	}
-	return expr, nil
+               switch tt := t.(type) {
+               case types.MapType:
+                       expr = &IndexExpr{X: expr, Index: &StringLit{Value: op.Field.Name}}
+                       t = tt.Value
+               case types.StructType:
+                       expr = &FieldExpr{X: expr, Name: op.Field.Name}
+                       if ft, ok := tt.Fields[op.Field.Name]; ok {
+                               t = ft
+                       } else {
+                               t = types.AnyType{}
+                       }
+               default:
+                       // when type information is unknown, assume map access to
+                       // avoid generating invalid struct field references
+                       expr = &IndexExpr{X: expr, Index: &StringLit{Value: op.Field.Name}}
+                       t = types.AnyType{}
+               }
+               }
+       }
+       return expr, nil
 }
 
 func compilePrimary(p *parser.Primary, env *types.Env, base string) (Expr, error) {


### PR DESCRIPTION
## Summary
- adjust field access logic for unknown types to default to map index

## Testing
- `go test ./transpiler/x/go -tags slow -run TestGoTranspiler_VMValid_Golden/group_by_left_join -count=1` (fails: 1 failed)


------
https://chatgpt.com/codex/tasks/task_e_687e119e4e6c832087a7498399cf4d24