### PR TITLE
Improve Haskell transpiler type inference

### DIFF
--- a/transpiler/x/hs/TASKS.md
+++ b/transpiler/x/hs/TASKS.md
@@ -1,3 +1,8 @@
+## Progress (2025-07-21 17:26 +0700)
+- Added int and float type inference for variables
+- Track local variable types when compiling blocks
+- README checklist regenerated from golden tests
+
 ## Progress (2025-07-21 16:57 +0700)
 - Removed unsafePerformIO helper and related imports
 - Simplified call expression emission


### PR DESCRIPTION
## Summary
- add basic int/float inference for recorded variables
- track local variable types in blocks
- handle float literals when transpiling
- document new progress for the Haskell backend

## Testing
- `go test ./transpiler/x/hs -run TestTranspile_PrintHello -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e16173aa48320a9af60dba7cf2117