### PR TITLE
Improve clj transpiler

### DIFF
--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,31 @@
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
+## Progress (2025-07-21 17:37 +0700)
+- feat(clj): simplify json output and group-by
+- Regenerated golden files - 96/100 vm valid programs passing
+
 ## Progress (2025-07-21 16:30 +0700)
 - add update statement support
 - Regenerated golden files - 96/100 vm valid programs passing

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -1400,13 +1400,27 @@ func transpileQueryExpr(q *parser.QueryExpr) (Node, error) {
 		return forForm, nil
 	}
 
-	if len(q.Group.Exprs) == 0 {
-		return nil, fmt.Errorf("missing group key")
-	}
-	keyExpr, err := transpileExpr(q.Group.Exprs[0])
-	if err != nil {
-		return nil, err
-	}
+       if len(q.Group.Exprs) == 0 {
+               return nil, fmt.Errorf("missing group key")
+       }
+       var keyExpr Node
+       if len(q.Group.Exprs) == 1 {
+               var err error
+               keyExpr, err = transpileExpr(q.Group.Exprs[0])
+               if err != nil {
+                       return nil, err
+               }
+       } else {
+               keys := []Node{}
+               for _, ke := range q.Group.Exprs {
+                       kn, err := transpileExpr(ke)
+                       if err != nil {
+                               return nil, err
+                       }
+                       keys = append(keys, kn)
+               }
+               keyExpr = &Vector{Elems: keys}
+       }
 
 	names := []string{q.Var}
 	for _, f := range q.Froms {


### PR DESCRIPTION
## Summary
- enable multi-key group by queries in the Clojure transpiler
- update transpiler tasks progress

## Testing
- `go test -tags slow ./transpiler/x/clj -run TestTranspile_Golden -update`
- `go test -tags slow ./transpiler/x/clj -run TestTranspile_Golden/json_builtin -update`
- `go test -tags slow ./transpiler/x/clj -run TestTranspile_Golden/save_jsonl_stdout -update`

------
https://chatgpt.com/codex/tasks/task_e_687e15521734832097c0182516a449f5