### PR TITLE
Improve Go transpiler type inference

### DIFF
--- a/transpiler/x/go/TASKS.md
+++ b/transpiler/x/go/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 18:22 +0700)
+- go transpiler: improve type inference
+- Regenerated golden files - 85/100 vm valid programs passing
+
 ## Progress (2025-07-21 17:38 +0700)
 - go transpiler: support group join left
 - Regenerated golden files - 85/100 vm valid programs passing


### PR DESCRIPTION
## Summary
- improve Go transpiler's type inference
- support `option` generics and pointer zero values
- document progress

## Testing
- `go test -tags slow ./transpiler/x/go -run TestMain -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e213d9964832096fe62a19475994d