### PR TITLE
Enhance Scala transpiler

### DIFF
--- a/transpiler/x/scala/TASKS.md
+++ b/transpiler/x/scala/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 18:32 +0700)
+- scala transpiler: improve formatting and inference
+- Regenerated golden files - 90/100 vm valid programs passing
+
 ## Progress (2025-07-21 17:26 +0700)
 - scala: support multi-join queries
 - Regenerated golden files - 90/100 vm valid programs passing

--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -763,7 +763,7 @@ func Emit(p *Program) []byte {
 	}
 	buf.WriteString("  }\n")
 	buf.WriteString("}\n")
-	return buf.Bytes()
+	return formatScala(buf.Bytes())
 }
 
 // Transpile converts a Mochi AST into our simple Scala AST.
@@ -2087,6 +2087,8 @@ func inferType(e Expr) string {
 			}
 		}
 		return "Any"
+	case *SubstringExpr:
+		return "String"
 	case *BinaryExpr:
 		switch ex.Op {
 		case "+", "-", "*", "/", "%":
@@ -2318,4 +2320,23 @@ func exprNode(e Expr) *ast.Node {
 	default:
 		return &ast.Node{Kind: "unknown"}
 	}
+}
+
+func formatScala(src []byte) []byte {
+	lines := strings.Split(string(src), "\n")
+	var out []string
+	indent := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "}") {
+			if indent > 0 {
+				indent--
+			}
+		}
+		out = append(out, strings.Repeat("  ", indent)+trimmed)
+		if strings.HasSuffix(trimmed, "{") {
+			indent++
+		}
+	}
+	return []byte(strings.Join(out, "\n"))
 }


### PR DESCRIPTION
## Summary
- improve readability with a basic Scala formatter
- refine type inference for substring expressions
- record latest progress for Scala backend

## Testing
- `go test ./transpiler/x/scala -run PrintHello -run BasicCompare -run StringConcat -run StringCompare -tags slow`
- `go test -count=1 ./transpiler/x/scala -run=NONE -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687e218f8af8832095b821d2d91ba487