### PR TITLE
Improve Dart transpiler join handling

### DIFF
--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -104,3 +104,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [ ] var_assignment.mochi
 - [ ] while_loop.mochi
 
+_Last updated: 2025-07-21 18:44 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,8 +1,10 @@
-## Recent Enhancements (2025-07-21 18:06 +0700)
-- Improved readability of generated code and removed helper functions.
-- Enhanced type inference for records and loops.
+## Recent Enhancements (2025-07-21 18:44 +0700)
+- Added query cross join support using collection `for` loops.
+- Removed `where`/`map` helpers for cleaner output.
+- Simplified join result collection for readability.
+- Enhanced type inference for query results.
 
-## Progress (2025-07-21 18:06 +0700)
+## Progress (2025-07-21 18:44 +0700)
 - VM valid 7/100
 
 # Dart Transpiler Tasks

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -1139,7 +1139,7 @@ func (l *LeftJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var _res = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+l.LeftVar+" in "); err != nil {
@@ -1160,19 +1160,19 @@ func (l *LeftJoinExpr) emit(w io.Writer) error {
 	if err := l.Cond.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      results.add("); err != nil {
 		return err
 	}
 	if err := l.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+l.RightVar+" = null;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+l.RightVar+" = null;\n      results.add("); err != nil {
 		return err
 	}
 	if err := l.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n  }\n  return _res;\n})()"); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n  }\n  return results;\n})()"); err != nil {
 		return err
 	}
 	return nil
@@ -1192,7 +1192,7 @@ func (r *RightJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var _res = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+r.RightVar+" in "); err != nil {
@@ -1213,19 +1213,19 @@ func (r *RightJoinExpr) emit(w io.Writer) error {
 	if err := r.Cond.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      results.add("); err != nil {
 		return err
 	}
 	if err := r.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+r.LeftVar+" = null;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+r.LeftVar+" = null;\n      results.add("); err != nil {
 		return err
 	}
 	if err := r.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n  }\n  return _res;\n})()"); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n  }\n  return results;\n})()"); err != nil {
 		return err
 	}
 	return nil
@@ -1245,7 +1245,7 @@ func (o *OuterJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var _res = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+o.LeftVar+" in "); err != nil {
@@ -1266,13 +1266,13 @@ func (o *OuterJoinExpr) emit(w io.Writer) error {
 	if err := o.Cond.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ")) continue;\n      matched = true;\n      results.add("); err != nil {
 		return err
 	}
 	if err := o.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+o.RightVar+" = null;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n    if (!matched) {\n      var "+o.RightVar+" = null;\n      results.add("); err != nil {
 		return err
 	}
 	if err := o.Select.emit(w); err != nil {
@@ -1296,13 +1296,13 @@ func (o *OuterJoinExpr) emit(w io.Writer) error {
 	if err := o.Cond.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ") { exists = true; break; }\n    }\n    if (!exists) {\n      var "+o.LeftVar+" = null;\n      _res.add("); err != nil {
+	if _, err := io.WriteString(w, ") { exists = true; break; }\n    }\n    if (!exists) {\n      var "+o.LeftVar+" = null;\n      results.add("); err != nil {
 		return err
 	}
 	if err := o.Select.emit(w); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, ");\n    }\n  }\n  return _res;\n})()"); err != nil {
+	if _, err := io.WriteString(w, ");\n    }\n  }\n  return results;\n})()"); err != nil {
 		return err
 	}
 	return nil

--- a/transpiler/x/dart/vm_valid_golden_test.go
+++ b/transpiler/x/dart/vm_valid_golden_test.go
@@ -106,6 +106,17 @@ func updateReadme() {
 	srcDir := filepath.Join(root, "tests", "vm", "valid")
 	outDir := filepath.Join(root, "tests", "transpiler", "x", "dart")
 	readmePath := filepath.Join(root, "transpiler", "x", "dart", "README.md")
+	out, err := exec.Command("git", "log", "-1", "--format=%cI").Output()
+	ts := ""
+	if err == nil {
+		if t, perr := time.Parse(time.RFC3339, strings.TrimSpace(string(out))); perr == nil {
+			if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
+				ts = t.In(loc).Format("2006-01-02 15:04 -0700")
+			} else {
+				ts = t.Format("2006-01-02 15:04 MST")
+			}
+		}
+	}
 	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
 	total := len(files)
 	compiled := 0
@@ -125,6 +136,9 @@ func updateReadme() {
 	fmt.Fprintf(&buf, "## VM Golden Test Checklist (%d/%d)\n", compiled, total)
 	buf.WriteString(strings.Join(lines, "\n"))
 	buf.WriteString("\n")
+	if ts != "" {
+		buf.WriteString(fmt.Sprintf("\n_Last updated: %s_\n", ts))
+	}
 	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
 }
 
@@ -175,6 +189,7 @@ func updateTasks() {
 	buf.WriteString(fmt.Sprintf("## Recent Enhancements (%s)\n", ts))
 	buf.WriteString("- Added query cross join support using collection `for` loops.\n")
 	buf.WriteString("- Removed `where`/`map` helpers for cleaner output.\n")
+	buf.WriteString("- Simplified join result collection for readability.\n")
 	buf.WriteString("- Enhanced type inference for query results.\n\n")
 	buf.WriteString(fmt.Sprintf("## Progress (%s)\n", ts))
 	buf.WriteString(fmt.Sprintf("- VM valid %d/%d\n\n", compiled, total))


### PR DESCRIPTION
## Summary
- tweak join queries in Dart transpiler to collect results in a `results` list
- show last updated timestamp in README
- log simplified join collection improvement in TASKS

## Testing
- `go test -tags slow ./transpiler/x/dart -run TestDartTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e2605741c8320babb4c23ae2e20d0