### PR TITLE
Improve Kotlin transpiler type inference

### DIFF
--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,6 +2,8 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
+Last updated: 2025-07-21 18:38 +0700
+
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
 Completed golden tests: **82/100** (auto-generated)

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,6 @@
+## VM Golden Progress (2025-07-21 18:38 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-21 18:06 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1196,6 +1196,16 @@ func newVarRef(env *types.Env, name string) *VarRef {
 	return &VarRef{Name: name, Type: typ}
 }
 
+func envTypeName(env *types.Env, name string) string {
+	if env == nil {
+		return ""
+	}
+	if t, err := env.GetVar(name); err == nil {
+		return kotlinTypeFromType(t)
+	}
+	return ""
+}
+
 // Transpile converts a Mochi program to a simple Kotlin AST.
 func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 	extraDecls = nil
@@ -1221,7 +1231,7 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 			}
 			typ := kotlinType(st.Let.Type)
 			if st.Let.Type == nil {
-				typ = ""
+				typ = envTypeName(env, st.Let.Name)
 			}
 			p.Stmts = append(p.Stmts, &LetStmt{Name: st.Let.Name, Type: typ, Value: val})
 		case st.Var != nil:
@@ -1237,7 +1247,7 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 			}
 			typ := kotlinType(st.Var.Type)
 			if st.Var.Type == nil {
-				typ = ""
+				typ = envTypeName(env, st.Var.Name)
 			}
 			p.Stmts = append(p.Stmts, &VarStmt{Name: st.Var.Name, Type: typ, Value: val})
 		case st.Assign != nil && len(st.Assign.Index) == 0 && len(st.Assign.Field) == 0:
@@ -1335,7 +1345,7 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 			}
 			typ := kotlinType(s.Let.Type)
 			if s.Let.Type == nil {
-				typ = ""
+				typ = envTypeName(env, s.Let.Name)
 			}
 			out = append(out, &LetStmt{Name: s.Let.Name, Type: typ, Value: v})
 		case s.Var != nil:
@@ -1345,7 +1355,7 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 			}
 			typ := kotlinType(s.Var.Type)
 			if s.Var.Type == nil {
-				typ = ""
+				typ = envTypeName(env, s.Var.Name)
 			}
 			out = append(out, &VarStmt{Name: s.Var.Name, Type: typ, Value: v})
 		case s.Assign != nil && len(s.Assign.Index) == 0 && len(s.Assign.Field) == 0:

--- a/transpiler/x/kt/transpiler_test.go
+++ b/transpiler/x/kt/transpiler_test.go
@@ -174,9 +174,23 @@ func updateReadme() {
 		}
 		lines = append(lines, fmt.Sprintf("- %s %s.mochi", mark, name))
 	}
+	outTs, err := exec.Command("git", "log", "-1", "--date=iso-strict", "--format=%cd").Output()
+	ts := ""
+	if err == nil {
+		if t, perr := time.Parse(time.RFC3339, strings.TrimSpace(string(outTs))); perr == nil {
+			if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
+				ts = t.In(loc).Format("2006-01-02 15:04 -0700")
+			} else {
+				ts = t.Format("2006-01-02 15:04 MST")
+			}
+		}
+	}
 	var buf bytes.Buffer
 	buf.WriteString("# Kotlin Transpiler\n\n")
 	buf.WriteString("Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.\n\n")
+	if ts != "" {
+		buf.WriteString("Last updated: " + ts + "\n\n")
+	}
 	buf.WriteString("The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.\n\n")
 	fmt.Fprintf(&buf, "Completed golden tests: **%d/%d** (auto-generated)\n\n", compiled, total)
 	buf.WriteString("### Golden test checklist\n")

--- a/transpiler/x/kt/updatehelpers.go
+++ b/transpiler/x/kt/updatehelpers.go
@@ -30,9 +30,23 @@ func UpdateReadmeForTests() {
 		}
 		lines = append(lines, fmt.Sprintf("- %s %s.mochi", mark, name))
 	}
+	out, err := exec.Command("git", "log", "-1", "--date=iso-strict", "--format=%cd").Output()
+	ts := ""
+	if err == nil {
+		if t, perr := time.Parse(time.RFC3339, strings.TrimSpace(string(out))); perr == nil {
+			if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
+				ts = t.In(loc).Format("2006-01-02 15:04 -0700")
+			} else {
+				ts = t.Format("2006-01-02 15:04 MST")
+			}
+		}
+	}
 	var buf bytes.Buffer
 	buf.WriteString("# Kotlin Transpiler\n\n")
 	buf.WriteString("Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.\n\n")
+	if ts != "" {
+		buf.WriteString("Last updated: " + ts + "\n\n")
+	}
 	buf.WriteString("The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.\n\n")
 	fmt.Fprintf(&buf, "Completed golden tests: **%d/%d** (auto-generated)\n\n", compiled, total)
 	buf.WriteString("### Golden test checklist\n")


### PR DESCRIPTION
## Summary
- refine Kotlin transpiler type lookup with `envTypeName`
- regenerate Kotlin README and TASKS with git timestamp

## Testing
- `go test -count=1 ./transpiler/x/kt -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687e26cdfff88320b8218dd8b3e8b2f6