### PR TITLE
Add release notes for v0.10.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # 📦 CHANGELOG.md
+## [0.10.34] – 2025-07-21T19:10:17+07:00
+
+### Added
+
+* Struct casts for the Java transpiler
+* More join operations across language backends
+
+### Changed
+
+* Golden outputs regenerated for multiple transpilers
+* Boolean, float and map handling improved
+* Progress logs refreshed across languages
+
+### Fixed
+
+* Assorted formatting and build issues
+
 ## [0.10.33] – 2025-07-21T15:42:34+07:00
 
 ### Added

--- a/releases/v0.10.34.md
+++ b/releases/v0.10.34.md
@@ -1,0 +1,16 @@
+# Jul 2025 (v0.10.34)
+
+Released on Mon Jul 21 19:10:17 2025 +0700.
+
+Mochi v0.10.34 broadens query capabilities across transpilers and refreshes generated tests and documentation.
+
+## Compilers
+
+- Struct casts added to the Java transpiler
+- Join and query operations expanded in many language backends
+- Boolean, float and map handling improved across targets
+
+## Documentation
+
+- Progress logs updated for numerous languages
+- Golden outputs regenerated for F#, Pascal and others


### PR DESCRIPTION
## Summary
- document v0.10.34 release
- update CHANGELOG

## Testing
- `make test STAGE=parser`

------
https://chatgpt.com/codex/tasks/task_e_687e30572c1c83209cbe557b31ad865e