### PR TITLE
Enhance Pascal transpiler and docs

### DIFF
--- a/tests/transpiler/x/pas/group_by_multi_join.pas
+++ b/tests/transpiler/x/pas/group_by_multi_join.pas
@@ -1,0 +1,69 @@
+{$mode objfpc}
+program Main;
+type Anon1 = record
+  id: integer;
+  name: string;
+end;
+type Anon2 = record
+  id: integer;
+  nation: integer;
+end;
+type Anon3 = record
+  part: integer;
+  supplier: integer;
+  cost: real;
+  qty: integer;
+end;
+type Anon4 = record
+  part: integer;
+  value: real;
+end;
+type Anon5 = record
+  part: integer;
+  total: real;
+end;
+var
+  nations: array of Anon1;
+  suppliers: array of Anon2;
+  partsupp: array of Anon3;
+  filtered: array of Anon4;
+  grp4: array of Anon5;
+  idx5: integer;
+  i6: integer;
+  grouped: array of Anon5;
+  ps: Anon3;
+  s: Anon2;
+  n: Anon1;
+  x: Anon4;
+begin
+  nations := [(id: 1; name: 'A'), (id: 2; name: 'B')];
+  suppliers := [(id: 1; nation: 1), (id: 2; nation: 2)];
+  partsupp := [(part: 100; supplier: 1; cost: 10; qty: 2), (part: 100; supplier: 2; cost: 20; qty: 1), (part: 200; supplier: 1; cost: 5; qty: 3)];
+  filtered := [];
+  for ps in partsupp do begin
+  for s in suppliers do begin
+  for n in nations do begin
+  if ((s.id = ps.supplier) and (n.id = s.nation)) and (n.name = 'A') then begin
+  filtered := concat(filtered, [(part: ps.part; value: ps.cost * ps.qty)]);
+end;
+end;
+end;
+end;
+  grp4 := [];
+  for x in filtered do begin
+  idx5 := -1;
+  for i6 := 0 to (Length(grp4) - 1) do begin
+  if grp4[i6].part = x.part then begin
+  idx5 := i6;
+  break;
+end;
+end;
+  if idx5 = -1 then begin
+  grp4 := concat(grp4, [(part: x.part; total: x.value)]);
+end else begin
+  grp4[idx5].total := grp4[idx5].total + x.value;
+end;
+end;
+  grouped := grp4;
+  writeln(grouped);
+end.

--- a/transpiler/x/pas/README.md
+++ b/transpiler/x/pas/README.md
@@ -3,7 +3,7 @@
 This folder contains the experimental Pascal transpiler.
 Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 
-## VM Golden Test Checklist (77/100)
+## VM Golden Test Checklist (78/100)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -32,7 +32,7 @@ Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 - [ ] group_by_having
 - [x] group_by_join
 - [x] group_by_left_join
-- [ ] group_by_multi_join
+- [x] group_by_multi_join
 - [ ] group_by_multi_join_sort
 - [ ] group_by_sort
 - [ ] group_items_iteration
@@ -104,4 +104,4 @@ Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-21 11:59 UTC
+Last updated: 2025-07-21 19:10 +0700

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,3 +1,9 @@
+## Progress (2025-07-21 19:10 +0700)
+- docs: refresh generated pas files (progress 78/100)
+
+## Progress (2025-07-21 19:10 +0700)
+- docs: refresh generated pas files (progress 77/100)
+
 ## Progress (2025-07-21 11:59 UTC)
 - docs: update pascal transpiler progress (progress 77/100)
 


### PR DESCRIPTION
## Summary
- support floating point literals and inference in the Pascal transpiler
- add detection and generation for `group_by_multi_join` queries
- regenerate Pascal README and TASKS progress
- add generated source for `group_by_multi_join` test

## Testing
- `go run /tmp/update.go`

------
https://chatgpt.com/codex/tasks/task_e_687e301553008320aa26ea8a2b62ccda