### PR TITLE
docs(fortran): refresh progress

### DIFF
--- a/transpiler/x/fortran/README.md
+++ b/transpiler/x/fortran/README.md
@@ -105,4 +105,4 @@ Checklist of programs that currently transpile and run (74/100):
 - [x] var_assignment
 - [x] while_loop
 
-_Last updated: 2025-07-21 19:10:17 +0700_
+_Last updated: 2025-07-21 19:34:17 +0700_

--- a/transpiler/x/fortran/TASKS.md
+++ b/transpiler/x/fortran/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-21 19:34:17 +0700)
+- fortran: support multi join grouping
+
 ## Progress (2025-07-21 19:10:17 +0700)
 - docs: refresh generated pas files
 

--- a/transpiler/x/fortran/transpiler.go
+++ b/transpiler/x/fortran/transpiler.go
@@ -279,6 +279,12 @@ func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 	return fp, nil
 }
 
+// constTranspile is a temporary fallback used when the main compiler
+// encounters unsupported language features. It attempts a series of
+// specialised constant evaluators and ultimately falls back to running
+// the interpreter at compile time. The generated program simply prints
+// the interpreted result. In the future this should be replaced with a
+// real code generator for the missing features.
 func constTranspile(prog *parser.Program, env *types.Env) (*Program, error) {
 	if p, ok := constCrossJoinFilter(prog); ok {
 		return p, nil


### PR DESCRIPTION
## Summary
- regenerate progress checklist for the Fortran backend
- note latest change in TASKS
- clarify fallback `constTranspile` behaviour

## Testing
- `go build ./transpiler/x/fortran`

------
https://chatgpt.com/codex/tasks/task_e_687e33f0ac908320af6fefc427582fce