### PR TITLE
Enhance Kotlin transpiler for group joins

### DIFF
--- a/tests/transpiler/x/kt/append_builtin.kt
+++ b/tests/transpiler/x/kt/append_builtin.kt
@@ -1,4 +1,4 @@
 fun main() {
-    val a = mutableListOf(1, 2)
+    val a: MutableList<Int> = mutableListOf(1, 2)
     println(a + 3)
 }

--- a/tests/transpiler/x/kt/break_continue.kt
+++ b/tests/transpiler/x/kt/break_continue.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val numbers = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val numbers: MutableList<Int> = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9)
     for (n in numbers) {
         if ((n % 2) == 0) {
             continue

--- a/tests/transpiler/x/kt/closure.kt
+++ b/tests/transpiler/x/kt/closure.kt
@@ -3,6 +3,6 @@ fun makeAdder(n: Int): (Int) -> Int {
 }
 
 fun main() {
-    val add10 = makeAdder(10)
+    val add10: (Int) -> Int = makeAdder(10)
     println(add10(7))
 }

--- a/tests/transpiler/x/kt/cross_join.kt
+++ b/tests/transpiler/x/kt/cross_join.kt
@@ -1,7 +1,7 @@
 fun main() {
-    val customers = mutableListOf(mutableMapOf("id" to 1, "name" to "Alice"), mutableMapOf("id" to 2, "name" to "Bob"), mutableMapOf("id" to 3, "name" to "Charlie"))
-    val orders = mutableListOf(mutableMapOf("id" to 100, "customerId" to 1, "total" to 250), mutableMapOf("id" to 101, "customerId" to 2, "total" to 125), mutableMapOf("id" to 102, "customerId" to 1, "total" to 300))
-    val result = run {
+    val customers: MutableList<MutableMap<String, Any>> = mutableListOf(mutableMapOf("id" to 1, "name" to "Alice"), mutableMapOf("id" to 2, "name" to "Bob"), mutableMapOf("id" to 3, "name" to "Charlie"))
+    val orders: MutableList<MutableMap<String, Int>> = mutableListOf(mutableMapOf("id" to 100, "customerId" to 1, "total" to 250), mutableMapOf("id" to 101, "customerId" to 2, "total" to 125), mutableMapOf("id" to 102, "customerId" to 1, "total" to 300))
+    val result: MutableList<MutableMap<String, Int>> = run {
     val _res = mutableListOf<MutableMap<String, Any>>()
     for (o in orders) {
         for (c in customers) {

--- a/tests/transpiler/x/kt/for_map_collection.kt
+++ b/tests/transpiler/x/kt/for_map_collection.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var m = mutableMapOf("a" to 1, "b" to 2)
+    var m: MutableMap<String, Int> = mutableMapOf("a" to 1, "b" to 2)
     for (k in m.keys) {
         println(k)
     }

--- a/tests/transpiler/x/kt/fun_expr_in_let.kt
+++ b/tests/transpiler/x/kt/fun_expr_in_let.kt
@@ -1,4 +1,4 @@
 fun main() {
-    val square = { x: Int -> x * x }
+    val square: (Int) -> Int = { x: Int -> x * x }
     println(square(6))
 }

--- a/tests/transpiler/x/kt/group_by_multi_join.kt
+++ b/tests/transpiler/x/kt/group_by_multi_join.kt
@@ -1,0 +1,39 @@
+data class GGroup(val key: Any, val items: MutableList<MutableMap<String, Any>>)
+fun main() {
+    val nations: MutableList<MutableMap<String, Any>> = mutableListOf(mutableMapOf<String, Any>("id" to 1, "name" to "A"), mutableMapOf<String, Any>("id" to 2, "name" to "B"))
+    val suppliers: MutableList<MutableMap<String, Int>> = mutableListOf(mutableMapOf<String, Int>("id" to 1, "nation" to 1), mutableMapOf<String, Int>("id" to 2, "nation" to 2))
+    val partsupp: MutableList<MutableMap<String, Any>> = mutableListOf(mutableMapOf<String, Any>("part" to 100, "supplier" to 1, "cost" to 10.0, "qty" to 2), mutableMapOf<String, Any>("part" to 100, "supplier" to 2, "cost" to 20.0, "qty" to 1), mutableMapOf<String, Any>("part" to 200, "supplier" to 1, "cost" to 5.0, "qty" to 3))
+    val filtered: MutableList<MutableMap<String, Any>> = run {
+    val _res = mutableListOf<MutableMap<String, Any>>()
+    for (ps in partsupp) {
+        for (s in suppliers) {
+            for (n in nations) {
+                if (((s["id"]!! == ps["supplier"]!!) && (n["id"]!! == s["nation"]!!)) && (n["name"]!! == "A")) {
+                    _res.add(mutableMapOf<String, Any>("part" to ps["part"]!!, "value" to (ps["cost"]!! as Number).toDouble() * (ps["qty"]!! as Number).toDouble()))
+                }
+            }
+        }
+    }
+    _res
+}
+    val grouped: MutableList<MutableMap<String, Any>> = run {
+    val _groups = mutableMapOf<Any, MutableList<MutableMap<String, Any>>>()
+    for (x in filtered) {
+        val _list = _groups.getOrPut(x["part"]!! as Any) { mutableListOf<MutableMap<String, Any>>() }
+        _list.add(x)
+    }
+    val _res = mutableListOf<MutableMap<String, Any>>()
+    for ((key, items) in _groups) {
+        val g = GGroup(key, items)
+        _res.add(mutableMapOf<String, Any>("part" to g.key, "total" to (run {
+    val _res = mutableListOf<Any>()
+    for (r in g.items) {
+        _res.add(r["value"]!!)
+    }
+    _res
+}.map{(it as Number).toDouble()}).sum()))
+    }
+    _res
+}
+    println(grouped)
+}

--- a/tests/transpiler/x/kt/group_by_multi_join.out
+++ b/tests/transpiler/x/kt/group_by_multi_join.out
@@ -1,0 +1,1 @@
+[{part=100, total=20.0}, {part=200, total=15.0}]

--- a/tests/transpiler/x/kt/if_else.kt
+++ b/tests/transpiler/x/kt/if_else.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val x = 5
+    val x: Int = 5
     if (x > 3) {
         println("big")
     } else {

--- a/tests/transpiler/x/kt/if_then_else.kt
+++ b/tests/transpiler/x/kt/if_then_else.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val x = 12
-    val msg = if (x > 10) "yes" else "no"
+    val x: Int = 12
+    val msg: String = if (x > 10) "yes" else "no"
     println(msg)
 }

--- a/tests/transpiler/x/kt/if_then_else_nested.kt
+++ b/tests/transpiler/x/kt/if_then_else_nested.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val x = 8
-    val msg = if (x > 10) "big" else if (x > 5) "medium" else "small"
+    val x: Int = 8
+    val msg: String = if (x > 10) "big" else if (x > 5) "medium" else "small"
     println(msg)
 }

--- a/tests/transpiler/x/kt/let_and_print.kt
+++ b/tests/transpiler/x/kt/let_and_print.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val a = 10
+    val a: Int = 10
     val b: Int = 20
     println(a + b)
 }

--- a/tests/transpiler/x/kt/list_assign.kt
+++ b/tests/transpiler/x/kt/list_assign.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var nums = mutableListOf(1, 2)
+    var nums: MutableList<Int> = mutableListOf(1, 2)
     nums[1] = 3
     println(nums[1])
 }

--- a/tests/transpiler/x/kt/list_index.kt
+++ b/tests/transpiler/x/kt/list_index.kt
@@ -1,4 +1,4 @@
 fun main() {
-    val xs = mutableListOf(10, 20, 30)
+    val xs: MutableList<Int> = mutableListOf(10, 20, 30)
     println(xs[1])
 }

--- a/tests/transpiler/x/kt/list_nested_assign.kt
+++ b/tests/transpiler/x/kt/list_nested_assign.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var matrix = mutableListOf(mutableListOf(1, 2), mutableListOf(3, 4))
+    var matrix: MutableList<MutableList<Int>> = mutableListOf(mutableListOf(1, 2), mutableListOf(3, 4))
     matrix[1][0] = 5
     println(matrix[1][0])
 }

--- a/tests/transpiler/x/kt/map_assign.kt
+++ b/tests/transpiler/x/kt/map_assign.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var scores = mutableMapOf("alice" to 1)
+    var scores: MutableMap<String, Int> = mutableMapOf("alice" to 1)
     scores["bob"] = 2
     println(scores["bob"])
 }

--- a/tests/transpiler/x/kt/map_in_operator.kt
+++ b/tests/transpiler/x/kt/map_in_operator.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val m = mutableMapOf(1 to "a", 2 to "b")
+    val m: MutableMap<Int, String> = mutableMapOf(1 to "a", 2 to "b")
     println(1 in m)
     println(3 in m)
 }

--- a/tests/transpiler/x/kt/map_literal_dynamic.kt
+++ b/tests/transpiler/x/kt/map_literal_dynamic.kt
@@ -1,6 +1,6 @@
 fun main() {
-    var x = 3
-    var y = 4
-    var m = mutableMapOf("a" to x, "b" to y)
+    var x: Int = 3
+    var y: Int = 4
+    var m: MutableMap<String, Int> = mutableMapOf("a" to x, "b" to y)
     println(listOf(m["a"], m["b"]).joinToString(" "))
 }

--- a/tests/transpiler/x/kt/map_membership.kt
+++ b/tests/transpiler/x/kt/map_membership.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val m = mutableMapOf("a" to 1, "b" to 2)
+    val m: MutableMap<String, Int> = mutableMapOf("a" to 1, "b" to 2)
     println("a" in m)
     println("c" in m)
 }

--- a/tests/transpiler/x/kt/map_nested_assign.kt
+++ b/tests/transpiler/x/kt/map_nested_assign.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var data = mutableMapOf("outer" to mutableMapOf("inner" to 1))
+    var data: MutableMap<String, MutableMap<String, Int>> = mutableMapOf("outer" to mutableMapOf("inner" to 1))
     data["outer"]["inner"] = 2
     println(data["outer"]["inner"])
 }

--- a/tests/transpiler/x/kt/match_expr.kt
+++ b/tests/transpiler/x/kt/match_expr.kt
@@ -1,6 +1,6 @@
 fun main() {
-    val x = 2
-    val label = when (x) {
+    val x: Int = 2
+    val label: String = when (x) {
     1 -> "one"
     2 -> "two"
     3 -> "three"

--- a/tests/transpiler/x/kt/match_full.kt
+++ b/tests/transpiler/x/kt/match_full.kt
@@ -7,24 +7,24 @@ fun classify(n: Int): String {
 }
 
 fun main() {
-    val x = 2
-    val label = when (x) {
+    val x: Int = 2
+    val label: String = when (x) {
     1 -> "one"
     2 -> "two"
     3 -> "three"
     else -> "unknown"
 }
     println(label)
-    val day = "sun"
-    val mood = when (day) {
+    val day: String = "sun"
+    val mood: String = when (day) {
     "mon" -> "tired"
     "fri" -> "excited"
     "sun" -> "relaxed"
     else -> "normal"
 }
     println(mood)
-    val ok = true
-    val status = when (ok) {
+    val ok: Boolean = true
+    val status: String = when (ok) {
     true -> "confirmed"
     false -> "denied"
 }

--- a/tests/transpiler/x/kt/membership.kt
+++ b/tests/transpiler/x/kt/membership.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val nums = mutableListOf(1, 2, 3)
+    val nums: MutableList<Int> = mutableListOf(1, 2, 3)
     println(2 in nums)
     println(4 in nums)
 }

--- a/tests/transpiler/x/kt/min_max_builtin.kt
+++ b/tests/transpiler/x/kt/min_max_builtin.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val nums = mutableListOf(3, 1, 4)
+    val nums: MutableList<Int> = mutableListOf(3, 1, 4)
     println(nums.min())
     println(nums.max())
 }

--- a/tests/transpiler/x/kt/pure_global_fold.kt
+++ b/tests/transpiler/x/kt/pure_global_fold.kt
@@ -3,6 +3,6 @@ fun inc(x: Int): Int {
 }
 
 fun main() {
-    val k = 2
+    val k: Int = 2
     println(inc(3))
 }

--- a/tests/transpiler/x/kt/string_contains.kt
+++ b/tests/transpiler/x/kt/string_contains.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val s = "catch"
+    val s: String = "catch"
     println(s.contains("cat"))
     println(s.contains("dog"))
 }

--- a/tests/transpiler/x/kt/string_in_operator.kt
+++ b/tests/transpiler/x/kt/string_in_operator.kt
@@ -1,5 +1,5 @@
 fun main() {
-    val s = "catch"
+    val s: String = "catch"
     println("cat" in s)
     println("dog" in s)
 }

--- a/tests/transpiler/x/kt/string_index.kt
+++ b/tests/transpiler/x/kt/string_index.kt
@@ -1,4 +1,4 @@
 fun main() {
-    val s = "mochi"
+    val s: String = "mochi"
     println(s[1])
 }

--- a/tests/transpiler/x/kt/string_prefix_slice.kt
+++ b/tests/transpiler/x/kt/string_prefix_slice.kt
@@ -1,7 +1,7 @@
 fun main() {
-    val prefix = "fore"
-    val s1 = "forest"
+    val prefix: String = "fore"
+    val s1: String = "forest"
     println(s1.substring(0, prefix.length) == prefix)
-    val s2 = "desert"
+    val s2: String = "desert"
     println(s2.substring(0, prefix.length) == prefix)
 }

--- a/tests/transpiler/x/kt/two-sum.kt
+++ b/tests/transpiler/x/kt/two-sum.kt
@@ -11,7 +11,7 @@ fun twoSum(nums: MutableList<Int>, target: Int): MutableList<Int> {
 }
 
 fun main() {
-    val result = twoSum(mutableListOf(2, 7, 11, 15), 9)
+    val result: MutableList<Int> = twoSum(mutableListOf(2, 7, 11, 15), 9)
     println(result[0])
     println(result[1])
 }

--- a/tests/transpiler/x/kt/var_assignment.kt
+++ b/tests/transpiler/x/kt/var_assignment.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var x = 1
+    var x: Int = 1
     x = 2
     println(x)
 }

--- a/tests/transpiler/x/kt/while_loop.kt
+++ b/tests/transpiler/x/kt/while_loop.kt
@@ -1,5 +1,5 @@
 fun main() {
-    var i = 0
+    var i: Int = 0
     while (i < 3) {
         println(i)
         i = i + 1

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,11 +2,11 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-21 19:10 +0700
+Last updated: 2025-07-21 19:43 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **82/100** (auto-generated)
+Completed golden tests: **83/100** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -37,7 +37,7 @@ Completed golden tests: **82/100** (auto-generated)
 - [x] group_by_having.mochi
 - [x] group_by_join.mochi
 - [x] group_by_left_join.mochi
-- [ ] group_by_multi_join.mochi
+- [x] group_by_multi_join.mochi
 - [ ] group_by_multi_join_sort.mochi
 - [x] group_by_sort.mochi
 - [ ] group_items_iteration.mochi

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,9 +1,5 @@
-## VM Golden Progress (2025-07-21 19:10 +0700)
+## VM Golden Progress (2025-07-21 19:43 +0700)
 - Regenerated Kotlin golden files and README
-
-## VM Golden Progress (2025-07-21 19:10 +0700)
-- Regenerated Kotlin golden files and README
-
 ## VM Golden Progress (2025-07-21 19:10 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- support `group_by_multi_join` query in Kotlin transpiler
- improve numeric operations and map literal emission
- regenerate Kotlin golden outputs and docs

## Testing
- `go test ./transpiler/x/kt -tags slow -run TestTranspilePrograms/group_by_multi_join`
- `go test ./transpiler/x/kt -tags slow -run TestTranspilePrograms/print_hello`


------
https://chatgpt.com/codex/tasks/task_e_687e35ff84ac8320bce638b0616b05d0