### PR TITLE
Fix PHP transpiler group-by keys and update docs

### DIFF
--- a/tests/transpiler/x/php/group_by_multi_join_sort.error
+++ b/tests/transpiler/x/php/group_by_multi_join_sort.error
@@ -1,7 +1,0 @@
-run: exit status 255
-
-Fatal error: Uncaught TypeError: Cannot access offset of type array on array in /workspace/mochi/tests/transpiler/x/php/group_by_multi_join_sort.php:16
-Stack trace:
-#0 /workspace/mochi/tests/transpiler/x/php/group_by_multi_join_sort.php(44): {closure:/workspace/mochi/tests/transpiler/x/php/group_by_multi_join_sort.php:8}()
-#1 {main}
-  thrown in /workspace/mochi/tests/transpiler/x/php/group_by_multi_join_sort.php on line 16

--- a/tests/transpiler/x/php/group_by_multi_join_sort.out
+++ b/tests/transpiler/x/php/group_by_multi_join_sort.out
@@ -1,0 +1,1 @@
+[{"c_custkey": 1, "c_name": "Alice", "revenue": 900, "c_acctbal": 100, "n_name": "BRAZIL", "c_address": "123 St", "c_phone": "123-456", "c_comment": "Loyal"}]

--- a/tests/transpiler/x/php/group_by_multi_join_sort.php
+++ b/tests/transpiler/x/php/group_by_multi_join_sort.php
@@ -13,10 +13,11 @@ $result = (function() use ($nation, $customer, $orders, $lineitem, $start_date, 
         foreach ($nation as $n) {
           if ($o["o_custkey"] == $c["c_custkey"] && $l["l_orderkey"] == $o["o_orderkey"] && $n["n_nationkey"] == $c["c_nationkey"] && $o["o_orderdate"] >= $start_date && $o["o_orderdate"] < $end_date && $l["l_returnflag"] == "R") {
             $key = ["c_custkey" => $c["c_custkey"], "c_name" => $c["c_name"], "c_acctbal" => $c["c_acctbal"], "c_address" => $c["c_address"], "c_phone" => $c["c_phone"], "c_comment" => $c["c_comment"], "n_name" => $n["n_name"]];
-            if (!array_key_exists($key, $groups)) {
-              $groups[$key] = ['key' => $key, 'items' => []];
+            $k = json_encode($key);
+            if (!array_key_exists($k, $groups)) {
+              $groups[$k] = ['key' => $key, 'items' => []];
             }
-            $groups[$key]['items'][] = ['c' => $c, 'o' => $o, 'l' => $l, 'n' => $n];
+            $groups[$k]['items'][] = ['c' => $c, 'o' => $o, 'l' => $l, 'n' => $n];
           }
         }
       }

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,6 +2,8 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
+Last updated: 2025-07-21 20:44 +0700
+
 ## VM Golden Test Checklist (93/100)
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,11 +1,12 @@
-## Progress (2025-07-21 20:06 +0700)
-- Generated PHP for 93/100 programs
+## Progress (2025-07-21 20:44 +0700)
+- Fixed group-by key serialization to avoid PHP errors
+- Regenerated output for group_by_multi_join_sort
 - Updated README checklist and outputs
-
 
 ## Progress (2025-07-21 19:29 +0700)
 - Generated PHP for 92/100 programs
 - Updated README checklist and outputs
+
 ## Progress (2025-07-21 16:57 +0700)
 - Generated PHP for 89/100 programs
 - Updated README checklist and outputs

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -656,13 +656,15 @@ func (g *GroupByExpr) emit(w io.Writer) {
 			g.Key.emit(w)
 			io.WriteString(w, ";\n")
 			io.WriteString(w, indent)
-			io.WriteString(w, "if (!array_key_exists($key, $groups)) {\n")
+			io.WriteString(w, "$k = json_encode($key);\n")
 			io.WriteString(w, indent)
-			io.WriteString(w, "  $groups[$key] = ['key' => $key, 'items' => []];\n")
+			io.WriteString(w, "if (!array_key_exists($k, $groups)) {\n")
+			io.WriteString(w, indent)
+			io.WriteString(w, "  $groups[$k] = ['key' => $key, 'items' => []];\n")
 			io.WriteString(w, indent)
 			io.WriteString(w, "}\n")
 			io.WriteString(w, indent)
-			io.WriteString(w, "$groups[$key]['items'][] = ")
+			io.WriteString(w, "$groups[$k]['items'][] = ")
 			if len(g.Loops) == 1 {
 				if ql, ok := g.Loops[0].(QueryLoop); ok {
 					fmt.Fprintf(w, "$%s;\n", ql.Name)


### PR DESCRIPTION
## Summary
- improve `GroupByExpr` code generation in PHP transpiler
- regenerate output for `group_by_multi_join_sort`
- drop failing error file
- record progress and update README

## Testing
- `go test -tags slow ./transpiler/x/php -run TestPHPTranspiler_VMValid_Golden/group_by_multi_join_sort -update -count=1`
- `php tests/transpiler/x/php/group_by_multi_join_sort.php`

------
https://chatgpt.com/codex/tasks/task_e_687e442c1e148320b7a75a1482b432e8