### PR TITLE
Improve F# transpiler docs and printing

### DIFF
--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -107,4 +107,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-07-21 20:06 +0700
+Last updated: 2025-07-21 14:41 +0000

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-21 14:41 +0000)
+- fs: improve print handling and docs update helpers
+- Generated F# for 100/100 programs (93 passing)
+
 ## Progress (2025-07-21 20:06 +0700)
 - Generated F# for 100/100 programs (93 passing)
 - Added join/group query support and removed helper functions for cleaner code


### PR DESCRIPTION
## Summary
- generate nicer timestamped checklist and progress for F# transpiler
- make README and TASKS regeneration utilities smarter
- tweak F# emitter to print strings without extra casts
- ensure header uses git time with timezone

## Testing
- `go test ./transpiler/x/fs -tags slow -run VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e4fd9aa0c8320a18d7ac635dec91e