### PR TITLE
Enable YAML load and JSONL save in Java transpiler

### DIFF
--- a/tests/transpiler/x/java/load_yaml.error
+++ b/tests/transpiler/x/java/load_yaml.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/java/load_yaml.java
+++ b/tests/transpiler/x/java/load_yaml.java
@@ -1,0 +1,36 @@
+public class Main {
+    static class Person {
+        String name;
+        int age;
+        String email;
+        Person(String name, int age, String email) {
+            this.name = name;
+            this.age = age;
+            this.email = email;
+        }
+        @Override public String toString() {
+            return String.format("{'name': %s, 'age': %s, 'email': %s}", name, age, email);
+        }
+    }
+
+    static Person[] people = new Person[]{new Person("Alice", 30, "alice@example.com"), new Person("Bob", 15, "bob@example.com"), new Person("Charlie", 20, "charlie@example.com")};
+    static java.util.List<Result2> adults = new java.util.ArrayList<Result2>() {{ java.util.ArrayList<Result2> _tmp = new java.util.ArrayList<>(); for (var p : people) { if (p.age >= 18) { _tmp.add(new Result2(p.name, p.email)); } } java.util.ArrayList<Result2> list = _tmp; java.util.ArrayList<Result2> _res = new java.util.ArrayList<>(); int skip = 0; int take = -1; for (int i = 0; i < list.size(); i++) { if (i < skip) continue; if (take >= 0 && i >= skip + take) break; _res.add((Result2)list.get(i)); } addAll(_res);}};
+    static class Result2 {
+        String name;
+        String email;
+        Result2(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+        @Override public String toString() {
+            return String.format("{'name': %s, 'email': %s}", name, email);
+        }
+    }
+
+
+    public static void main(String[] args) {
+        for (var a : adults) {
+            System.out.println(a.name + " " + a.email);
+        }
+    }
+}

--- a/tests/transpiler/x/java/load_yaml.out
+++ b/tests/transpiler/x/java/load_yaml.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/tests/transpiler/x/java/save_jsonl_stdout.error
+++ b/tests/transpiler/x/java/save_jsonl_stdout.error
@@ -1,1 +1,0 @@
-unsupported primary

--- a/tests/transpiler/x/java/save_jsonl_stdout.java
+++ b/tests/transpiler/x/java/save_jsonl_stdout.java
@@ -1,0 +1,46 @@
+public class Main {
+    static Data1[] people = new Data1[]{new Data1("Alice", 30), new Data1("Bob", 25)};
+    static class Data1 {
+        String name;
+        int age;
+        Data1(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+        @Override public String toString() {
+            return String.format("{'name': %s, 'age': %s}", name, age);
+        }
+    }
+
+
+    static java.util.Map<String,Object> asMap(Object o) {
+        if (o instanceof java.util.Map<?,?> mm) {
+            java.util.LinkedHashMap<String,Object> m = new java.util.LinkedHashMap<>();
+            for (java.util.Map.Entry<?,?> e : mm.entrySet()) m.put(String.valueOf(e.getKey()), e.getValue());
+            return m;
+        }
+        java.util.LinkedHashMap<String,Object> m = new java.util.LinkedHashMap<>();
+        for (var f : o.getClass().getDeclaredFields()) { try { f.setAccessible(true); m.put(f.getName(), f.get(o)); } catch (Exception e) { throw new RuntimeException(e); } }
+        return m;
+    }
+
+    static void saveJsonl(java.util.List<?> list) {
+        for (Object obj : list) {
+            java.util.Map<String,Object> m = asMap(obj);
+            java.util.List<String> parts = new java.util.ArrayList<>();
+            for (java.util.Map.Entry<?,?> e : m.entrySet()) {
+                Object v = e.getValue();
+                if (v instanceof String) {
+                    parts.add("\"" + e.getKey() + "\": " + "\"" + v + "\"");
+                } else {
+                    parts.add("\"" + e.getKey() + "\": " + v);
+                }
+            }
+            System.out.println("{" + String.join(", ", parts) + "}");
+        }
+    }
+
+    public static void main(String[] args) {
+        saveJsonl(java.util.Arrays.asList(people));
+    }
+}

--- a/tests/transpiler/x/java/save_jsonl_stdout.out
+++ b/tests/transpiler/x/java/save_jsonl_stdout.out
@@ -1,0 +1,2 @@
+{"name": "Alice", "age": 30}
+{"name": "Bob", "age": 25}

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (96/100) - updated 2025-07-21 16:18 UTC
+## VM Golden Test Checklist (98/100) - updated 2025-07-21 17:14 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -53,7 +53,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
-- [ ] load_yaml.mochi
+- [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi
 - [x] map_index.mochi
@@ -78,7 +78,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] query_sum_select.mochi
 - [x] record_assign.mochi
 - [x] right_join.mochi
-- [ ] save_jsonl_stdout.mochi
+- [x] save_jsonl_stdout.mochi
 - [x] short_circuit.mochi
 - [x] slice.mochi
 - [x] sort_stable.mochi

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,24 @@
-## Progress (2025-07-21 23:17 +0700)
+## Progress (2025-07-21 23:57 +0700)
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
+- py transpiler: support dataclass for top-level vars (d34a22daa)
+
 - java transpiler: fix update stmt (31e246ed7)
 
 - java transpiler: fix list printing and grouping (a164b1578)


### PR DESCRIPTION
## Summary
- enhance Java transpiler to support `load` and `save` expressions
- generate helper functions for YAML loading and JSONL saving
- update README and TASKS
- add golden outputs for `load_yaml.mochi` and `save_jsonl_stdout.mochi`

## Testing
- `go test ./transpiler/x/java -tags slow -run TestJavaTranspiler_VMValid_Golden/load_yaml -count=1`
- `go test ./transpiler/x/java -tags slow -run TestJavaTranspiler_VMValid_Golden/save_jsonl_stdout -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687e6e0a595c83208b657b1ce2850d08