### PR TITLE
Improve Python transpiler type inference

### DIFF
--- a/transpiler/x/py/README.md
+++ b/transpiler/x/py/README.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated Python code from programs in `tests/vm/valid` lives in `tests/transpiler/x/py`.
-Last updated: 2025-07-21 18:17 UTC
+Last updated: 2025-07-21 22:04 UTC
 
 ## VM Golden Test Checklist (101/101)
 - [x] append_builtin

--- a/transpiler/x/py/TASKS.md
+++ b/transpiler/x/py/TASKS.md
@@ -1,5 +1,5 @@
-## Progress (2025-07-22 00:56 +0700)
-- Commit 4596d7902: ts transpiler: add struct names
+## Progress (2025-07-22 05:04 +0700)
+- Commit bb3001896: py transpiler: improve numeric and boolean inference
 - Generated Python for 101/101 programs
 - Updated README checklist and outputs
 - Refactored join handling and improved type inference from loaded data

--- a/transpiler/x/py/transpiler.go
+++ b/transpiler/x/py/transpiler.go
@@ -1346,7 +1346,7 @@ func inferPyType(e Expr, env *types.Env) types.Type {
 		lt := inferPyType(ex.Left, env)
 		rt := inferPyType(ex.Right, env)
 		switch ex.Op {
-		case "+", "-", "*":
+		case "+", "-", "*", "%":
 			if isNumeric(lt) && isNumeric(rt) {
 				if lt.String() == (types.FloatType{}).String() || rt.String() == (types.FloatType{}).String() {
 					return types.FloatType{}
@@ -1359,6 +1359,8 @@ func inferPyType(e Expr, env *types.Env) types.Type {
 				return types.FloatType{}
 			}
 			return types.AnyType{}
+		case "==", "!=", "<", "<=", ">", ">=", "&&", "||":
+			return types.BoolType{}
 		default:
 			return types.AnyType{}
 		}
@@ -1574,7 +1576,7 @@ func inferTypeFromExpr(e *parser.Expr) types.Type {
 			rt := inferTypeFromExpr(exprFromPostfix(r.Right))
 			switch r.Op {
 			case "&&", "||", "==", "!=", "<", "<=", ">", ">=":
-				lt = types.IntType{}
+				lt = types.BoolType{}
 			case "+", "-", "*", "/", "%":
 				if lt.String() == (types.FloatType{}).String() || rt.String() == (types.FloatType{}).String() {
 					lt = types.FloatType{}


### PR DESCRIPTION
## Summary
- improve boolean and numeric type inference for Python transpiler
- regenerate README and TASKS for Python transpiler

## Testing
- `go test ./transpiler/x/py -tags slow -run TestPyTranspiler_VMValid_Golden -update` *(fails: 79 passed, 22 failed)*

------
https://chatgpt.com/codex/tasks/task_e_687eb7ace3f48320944a865973c00a38