### PR TITLE
Enhance dart transpiler

### DIFF
--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -2,7 +2,7 @@
 
 Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart` file and `.out` output. Compilation or runtime failures are captured in a `.error` file.
 
-## VM Golden Test Checklist (100/100)
+## VM Golden Test Checklist (100/101)
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -33,6 +33,7 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] group_by_left_join.mochi
 - [x] group_by_multi_join.mochi
 - [x] group_by_multi_join_sort.mochi
+- [ ] group_by_multi_sort.mochi
 - [x] group_by_sort.mochi
 - [x] group_items_iteration.mochi
 - [x] if_else.mochi
@@ -104,4 +105,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-07-21 23:44 +0700_
+_Last updated: 2025-07-22 04:52 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,12 +1,11 @@
-## Recent Enhancements (2025-07-21 23:44 +0700)
+## Recent Enhancements (2025-07-22 04:52 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
-- Added YAML load support with compile-time data.
 
-## Progress (2025-07-21 23:44 +0700)
-- VM valid 100/100
+## Progress (2025-07-22 04:52 +0700)
+- VM valid 100/101
 
 # Dart Transpiler Tasks
 - Added boolean literals and logical operators.


### PR DESCRIPTION
## Summary
- regenerate README/TASKS for dart
- remove runtime prelude code from dart transpiler
- improve list append type inference in dart transpiler

## Testing
- `go test ./transpiler/x/dart -tags=slow -run TestDartTranspiler_VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687eb86995c08320834d419a88e80394