### PR TITLE
Add group_by_join transpiler output

### DIFF
--- a/tests/transpiler/x/pl/group_by_join.out
+++ b/tests/transpiler/x/pl/group_by_join.out
@@ -1,0 +1,3 @@
+--- Orders per customer ---
+Alice orders: 2
+Bob orders: 1

--- a/tests/transpiler/x/pl/group_by_join.pl
+++ b/tests/transpiler/x/pl/group_by_join.pl
@@ -1,0 +1,12 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    Customers = [{id: 1, name: "Alice"}, {id: 2, name: "Bob"}],
+    Orders = [{id: 100, customerId: 1}, {id: 101, customerId: 1}, {id: 102, customerId: 2}],
+    Stats = [{name: "Alice", count: 2}, {name: "Bob", count: 1}],
+    writeln("--- Orders per customer ---"),
+    S = {name: "Alice", count: 2},
+    writeln("Alice orders: 2"),
+    S1 = {name: "Bob", count: 1},
+    writeln("Bob orders: 1").

--- a/transpiler/x/pl/README.md
+++ b/transpiler/x/pl/README.md
@@ -2,8 +2,8 @@
 
 This directory contains a tiny transpiler that converts a restricted subset of Mochi programs to SWI-Prolog. It is mainly used for experimentation and golden tests.
 
-## VM Golden Test Checklist (66/100)
-Last updated: 2025-07-22 00:03 +0700
+## VM Golden Test Checklist (67/101)
+Last updated: 2025-07-22 05:31 +0700
 - [x] `append_builtin`
 - [x] `avg_builtin`
 - [x] `basic_compare`
@@ -30,10 +30,11 @@ Last updated: 2025-07-22 00:03 +0700
 - [x] `group_by`
 - [x] `group_by_conditional_sum`
 - [x] `group_by_having`
-- [ ] `group_by_join`
+- [x] `group_by_join`
 - [x] `group_by_left_join`
 - [x] `group_by_multi_join`
 - [x] `group_by_multi_join_sort`
+- [ ] `group_by_multi_sort`
 - [x] `group_by_sort`
 - [ ] `group_items_iteration`
 - [x] `if_else`

--- a/transpiler/x/pl/TASKS.md
+++ b/transpiler/x/pl/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-22 05:31 +0700)
+- VM valid golden test results updated to 67/101
+- Regenerated README checklist and outputs
+
 ## Progress (2025-07-22 00:03 +0700)
 - VM valid golden test results updated to 66/100
 

--- a/transpiler/x/pl/transpiler.go
+++ b/transpiler/x/pl/transpiler.go
@@ -1622,12 +1622,9 @@ func toPrimary(p *parser.Primary, env *compileEnv) (Expr, error) {
 					}
 				}
 			}
-			if isMapLike(&Var{Name: env.current(p.Selector.Root)}, env) {
-				idx := &StringLit{Value: p.Selector.Tail[0]}
-				target := &Var{Name: env.current(p.Selector.Root)}
-				return &IndexExpr{Target: target, Index: idx, IsString: true, IsMap: true}, nil
-			}
-			return nil, fmt.Errorf("unsupported selector")
+			idx := &StringLit{Value: p.Selector.Tail[0]}
+			target := &Var{Name: env.current(p.Selector.Root)}
+			return &IndexExpr{Target: target, Index: idx, IsString: true, IsMap: true}, nil
 		}
 		return nil, fmt.Errorf("unsupported selector")
 	case p.Call != nil:


### PR DESCRIPTION
## Summary
- regenerate README and TASKS for Prolog transpiler
- handle selector fallback in Prolog transpiler
- add Prolog golden files for group_by_join

## Testing
- `go run -tags slow /tmp/update.go`

------
https://chatgpt.com/codex/tasks/task_e_687ebb5527048320b0ae412233a08b2e