### PR TITLE
Improve Dart transpiler output

### DIFF
--- a/transpiler/x/dart/README.md
+++ b/transpiler/x/dart/README.md
@@ -105,4 +105,4 @@ Generated Dart code for programs in `tests/vm/valid`. Each program has a `.dart`
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-_Last updated: 2025-07-22 04:52 +0700_
+_Last updated: 2025-07-22 05:26 +0700_

--- a/transpiler/x/dart/TASKS.md
+++ b/transpiler/x/dart/TASKS.md
@@ -1,10 +1,10 @@
-## Recent Enhancements (2025-07-22 04:52 +0700)
+## Recent Enhancements (2025-07-22 05:26 +0700)
 - Added query cross join support using collection `for` loops.
 - Removed `where`/`map` helpers for cleaner output.
 - Simplified join result collection for readability.
 - Enhanced type inference for query results.
 
-## Progress (2025-07-22 04:52 +0700)
+## Progress (2025-07-22 05:26 +0700)
 - VM valid 100/101
 
 # Dart Transpiler Tasks

--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -1259,7 +1259,7 @@ func (l *LeftJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  final results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+l.LeftVar+" in "); err != nil {
@@ -1302,7 +1302,7 @@ func (l *LeftJoinMultiExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  final results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+l.Var1+" in "); err != nil {
@@ -1367,7 +1367,7 @@ func (r *RightJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  final results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+r.RightVar+" in "); err != nil {
@@ -1420,7 +1420,7 @@ func (o *OuterJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var results = [];\n"); err != nil {
+	if _, err := io.WriteString(w, "  final results = [];\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+o.LeftVar+" in "); err != nil {
@@ -1487,7 +1487,7 @@ func (gq *GroupQueryExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var groups = <String, Map<String, dynamic>>{};\n"); err != nil {
+	if _, err := io.WriteString(w, "  final groups = <String, Map<String, dynamic>>{};\n"); err != nil {
 		return err
 	}
 	for i, v := range gq.Vars {
@@ -1538,7 +1538,7 @@ func (gq *GroupQueryExpr) emit(w io.Writer) error {
 			return err
 		}
 	}
-	if _, err := io.WriteString(w, "  var _list = groups.values.toList();\n"); err != nil {
+	if _, err := io.WriteString(w, "  final _list = groups.values.toList();\n"); err != nil {
 		return err
 	}
 	if gq.Sort != nil {
@@ -1552,7 +1552,7 @@ func (gq *GroupQueryExpr) emit(w io.Writer) error {
 			return err
 		}
 	}
-	if _, err := io.WriteString(w, "  var res = <"+gq.ElemType+">[];\n  for (var g in _list) {\n"); err != nil {
+	if _, err := io.WriteString(w, "  final res = <"+gq.ElemType+">[];\n  for (var g in _list) {\n"); err != nil {
 		return err
 	}
 	localVarTypes[gq.GroupVar] = "Map<String, dynamic>"
@@ -1594,7 +1594,7 @@ func (g *GroupLeftJoinExpr) emit(w io.Writer) error {
 	if _, err := io.WriteString(w, "(() {\n"); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "  var groups = <String, Map<String, dynamic>>{};\n"); err != nil {
+	if _, err := io.WriteString(w, "  final groups = <String, Map<String, dynamic>>{};\n"); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(w, "  for (var "+g.LeftVar+" in "); err != nil {
@@ -1627,7 +1627,7 @@ func (g *GroupLeftJoinExpr) emit(w io.Writer) error {
 	if err := emitGroupAdd(w, "      ", g.Key, g.Row); err != nil {
 		return err
 	}
-	if _, err := io.WriteString(w, "    }\n  }\n  var _list = groups.values.toList();\n"); err != nil {
+	if _, err := io.WriteString(w, "    }\n  }\n  final _list = groups.values.toList();\n"); err != nil {
 		return err
 	}
 	if g.Sort != nil {
@@ -1641,7 +1641,7 @@ func (g *GroupLeftJoinExpr) emit(w io.Writer) error {
 			return err
 		}
 	}
-	if _, err := io.WriteString(w, "  var res = <"+g.ElemType+">[];\n  for (var "+g.GroupVar+" in _list) {\n"); err != nil {
+	if _, err := io.WriteString(w, "  final res = <"+g.ElemType+">[];\n  for (var "+g.GroupVar+" in _list) {\n"); err != nil {
 		return err
 	}
 	localVarTypes[g.GroupVar] = "Map<String, dynamic>"


### PR DESCRIPTION
## Summary
- generate progress docs for Dart after running tests
- use `final` for query intermediate collections to produce more idiomatic code

## Testing
- `go test -v ./transpiler/x/dart -run TestDartTranspiler_VMValid_Golden -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687ebe8f8d4083208fbb033d5d2f57de