### PR TITLE
Add clj golden for group_by_multi_sort

### DIFF
--- a/tests/transpiler/x/clj/group_by_multi_sort.clj
+++ b/tests/transpiler/x/clj/group_by_multi_sort.clj
@@ -1,0 +1,14 @@
+(ns main)
+
+(require 'clojure.set)
+
+(defrecord Items [a b val])
+
+(def items [{:a "x" :b 1 :val 2} {:a "x" :b 2 :val 3} {:a "y" :b 1 :val 4} {:a "y" :b 2 :val 1}])
+
+(def grouped (for [g (sort-by (fn [g] (- (reduce + 0 (for [x (:items g)] (:val x))))) (for [[k rows] (group-by :key (for [i items :let [k {:a (:a i) :b (:b i)}]] {:key k :item i})) :let [g {:key k :items (map :item rows)}]] g))] {:a (:a (:key g)) :b (:b (:key g)) :total (reduce + 0 (for [x (:items g)] (:val x)))}))
+
+(defn -main []
+  (println grouped))
+
+(-main)

--- a/tests/transpiler/x/clj/group_by_multi_sort.output
+++ b/tests/transpiler/x/clj/group_by_multi_sort.output
@@ -1,0 +1,1 @@
+({:a y, :b 1, :total 4} {:a x, :b 2, :total 3} {:a x, :b 1, :total 2} {:a y, :b 2, :total 1})

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -2,7 +2,8 @@
 
 This directory contains experimental source translators for generating Clojure code. Each program in `tests/vm/valid` is transpiled and executed with `clojure`.
 
-Compiled programs: 100/100
+Compiled programs: 101/101
+
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
@@ -33,6 +34,7 @@ Compiled programs: 100/100
 - [x] group_by_left_join
 - [x] group_by_multi_join
 - [x] group_by_multi_join_sort
+- [x] group_by_multi_sort
 - [x] group_by_sort
 - [x] group_items_iteration
 - [x] if_else
@@ -103,4 +105,4 @@ Compiled programs: 100/100
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-21 13:48 +0000
+Last updated: 2025-07-22 06:31 +0700

--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-07-22 06:31 +0700)
+- docs(clj): refresh checklist and progress
+- Regenerated golden files - 101/101 vm valid programs passing
+
+## Progress (2025-07-22 06:19 +0700)
+- clj transpiler: add group_by_multi_sort golden test
+- Regenerated golden files - 101/101 vm valid programs passing
+
 ## Progress (2025-07-21 13:48 +0000)
 - clj transpiler: support right joins
 - 100/100 VM programs transpiled successfully
@@ -121,3 +129,4 @@
 ## Progress (2025-07-21 12:07 +0700)
 - remove old error files
 - Regenerated golden files - 88/100 vm valid programs passing
+


### PR DESCRIPTION
## Summary
- refresh the clojure test checklist and progress logs
- support `group_by_multi_sort` and add golden files

## Testing
- `go test ./transpiler/x/clj -tags slow -run TestTranspile_Golden/group_by_multi_sort -v`


------
https://chatgpt.com/codex/tasks/task_e_687ecb786b84832092e33845968a628e