### PR TITLE
Add JSONL load support to Java transpiler

### DIFF
--- a/tests/transpiler/x/java/load_jsonl.java
+++ b/tests/transpiler/x/java/load_jsonl.java
@@ -1,0 +1,41 @@
+public class Main {
+    static class Person {
+        String name;
+        int age;
+        String email;
+        Person(String name, int age, String email) {
+            this.name = name;
+            this.age = age;
+            this.email = email;
+        }
+        @Override public String toString() {
+            return String.format("{'name': '%s', 'age': %s, 'email': '%s'}", q(name), q(age), q(email));
+        }
+    }
+
+    static Person[] people = new Person[]{new Person("Alice", 30, "alice@example.com"), new Person("Bob", 15, "bob@example.com"), new Person("Charlie", 20, "charlie@example.com")};
+    static java.util.List<Result2> adults = new java.util.ArrayList<Result2>() {{ java.util.ArrayList<Result2> _tmp = new java.util.ArrayList<>(); for (var p : people) { if (p.age >= 18) { _tmp.add(new Result2(p.name, p.email)); } } java.util.ArrayList<Result2> list = _tmp; java.util.ArrayList<Result2> _res = new java.util.ArrayList<>(); int skip = 0; int take = -1; for (int i = 0; i < list.size(); i++) { if (i < skip) continue; if (take >= 0 && i >= skip + take) break; _res.add((Result2)list.get(i)); } addAll(_res);}};
+    static class Result2 {
+        String name;
+        String email;
+        Result2(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+        @Override public String toString() {
+            return String.format("{'name': '%s', 'email': '%s'}", q(name), q(email));
+        }
+    }
+
+
+    static String q(Object v) {
+        if (v instanceof String) return "'" + v.toString() + "'";
+        return String.valueOf(v);
+    }
+
+    public static void main(String[] args) {
+        for (var a : adults) {
+            System.out.println(a.name + " " + a.email);
+        }
+    }
+}

--- a/tests/transpiler/x/java/load_jsonl.out
+++ b/tests/transpiler/x/java/load_jsonl.out
@@ -1,0 +1,2 @@
+Alice alice@example.com
+Charlie charlie@example.com

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (101/101) - updated 2025-07-21 23:51 UTC
+## VM Golden Test Checklist (102/102) - updated 2025-07-22 02:06 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
@@ -54,6 +54,7 @@ Generated Java code for programs in `tests/vm/valid`. Each program has a `.java`
 - [x] list_index.mochi
 - [x] list_nested_assign.mochi
 - [x] list_set_ops.mochi
+- [x] load_jsonl.mochi
 - [x] load_yaml.mochi
 - [x] map_assign.mochi
 - [x] map_in_operator.mochi

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,8 @@
-## Progress (2025-07-21 23:51 UTC)
+## Progress (2025-07-22 02:06 UTC)
+- java: support jsonl load (e71ba2347)
+
+- docs(java): update golden outputs (83b8c2544)
+
 - java transpiler: simplify avg handling (6a6d5558c)
 
 - docs: update java transpiler progress (52a94e25e)


### PR DESCRIPTION
## Summary
- support `jsonl` format in Java transpiler
- generate new golden files for `load_jsonl.mochi`
- update progress logs and checklist

## Testing
- `go test ./transpiler/x/java -run "TestJavaTranspiler_VMValid_Golden/load_jsonl$" -tags slow -count=1`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687eef924c708320b9b1e80a1f150bf4