### PR TITLE
Scala transpiler improvements

### DIFF
--- a/transpiler/x/scala/README.md
+++ b/transpiler/x/scala/README.md
@@ -2,8 +2,8 @@
 
 Generated Scala code for programs in `tests/vm/valid`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Golden Test Checklist (69/101)
-_Last updated: 2025-07-22 06:36 +0700_
+## Golden Test Checklist (69/102)
+_Last updated: 2025-07-22 09:31 +0700_
 
 - [x] append_builtin
 - [x] avg_builtin
@@ -56,6 +56,7 @@ _Last updated: 2025-07-22 06:36 +0700_
 - [x] list_index
 - [x] list_nested_assign
 - [ ] list_set_ops
+- [ ] load_jsonl
 - [ ] load_yaml
 - [x] map_assign
 - [x] map_in_operator

--- a/transpiler/x/scala/TASKS.md
+++ b/transpiler/x/scala/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-22 09:22 +0700)
+- docs: refresh rkt checklist
+- Regenerated golden files - 69/102 vm valid programs passing
+
 ## Progress (2025-07-22 06:37 +0700)
 - scala transpiler: support union types
 - Regenerated golden files - 69/101 vm valid programs passing


### PR DESCRIPTION
## Summary
- escape Scala reserved words when emitting identifiers
- infer user-defined struct names properly
- convert map literals cast to structs
- fix size on binary expressions
- regenerate docs for Scala backend

## Testing
- `go test ./transpiler/x/scala -tags slow -run TestScalaTranspiler_VMValid_Golden -count=1 -v` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687ef0dde5d48320a12ea8b8f2c1af2f