### PR TITLE
Enhance php transpiler

### DIFF
--- a/tests/transpiler/x/php/exists_builtin.out
+++ b/tests/transpiler/x/php/exists_builtin.out
@@ -1,1 +1,1 @@
-True
+true

--- a/tests/transpiler/x/php/exists_builtin.php
+++ b/tests/transpiler/x/php/exists_builtin.php
@@ -9,4 +9,4 @@ $flag = count((function() use ($data) {
   }
   return $result;
 })()) > 0;
-echo ($flag ? "True" : "False"), PHP_EOL;
+echo ($flag ? "true" : "false"), PHP_EOL;

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-22 09:26 +0700
+Last updated: 2025-07-22 10:10 +0700
 
 ## VM Golden Test Checklist (102/102)
 - [x] append_builtin

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-22 09:26 +0700)
+## Progress (2025-07-22 10:10 +0700)
 - Generated PHP for 102/102 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -1736,6 +1736,8 @@ func convertStmt(st *parser.Statement) (Stmt, error) {
 			switch *st.Let.Type.Simple {
 			case "int":
 				val = &IntLit{Value: 0}
+			case "bigint":
+				val = &IntLit{Value: 0}
 			case "bool":
 				val = &BoolLit{Value: false}
 			case "string":
@@ -1775,6 +1777,8 @@ func convertStmt(st *parser.Statement) (Stmt, error) {
 		} else if st.Var.Type != nil && st.Var.Type.Simple != nil {
 			switch *st.Var.Type.Simple {
 			case "int":
+				val = &IntLit{Value: 0}
+			case "bigint":
 				val = &IntLit{Value: 0}
 			case "bool":
 				val = &BoolLit{Value: false}
@@ -2440,6 +2444,8 @@ func simpleResolveType(t *parser.TypeRef, env *types.Env) types.Type {
 		switch *t.Simple {
 		case "int":
 			return types.IntType{}
+		case "bigint":
+			return types.BigIntType{}
 		case "int64":
 			return types.Int64Type{}
 		case "float":
@@ -2624,20 +2630,13 @@ func convertUpdate(u *parser.UpdateStmt) (*UpdateStmt, error) {
 
 func maybeBoolString(e Expr) Expr {
 	if isBoolExpr(e) {
-		if c, ok := e.(*CallExpr); ok && c.Func == "str_contains" {
-			return &CondExpr{Cond: e, Then: &StringLit{Value: "True"}, Else: &StringLit{Value: "False"}}
-		}
-		return &CondExpr{Cond: e, Then: &IntLit{Value: 1}, Else: &IntLit{Value: 0}}
+		return &CondExpr{Cond: e, Then: &StringLit{Value: "true"}, Else: &StringLit{Value: "false"}}
 	}
 	return e
 }
 
 func maybeFloatString(e Expr) Expr {
-	return &CondExpr{
-		Cond: &CallExpr{Func: "is_float", Args: []Expr{e}},
-		Then: &CallExpr{Func: "json_encode", Args: []Expr{e, &IntLit{Value: 1344}}},
-		Else: e,
-	}
+	return &CallExpr{Func: "json_encode", Args: []Expr{e, &IntLit{Value: 1344}}}
 }
 
 func convertImport(im *parser.ImportStmt) (Stmt, error) {


### PR DESCRIPTION
## Summary
- improve type inference with bigint handling
- emit simpler code for booleans and floats
- regenerate php output for `exists_builtin`
- update PHP README checklist and tasks progress

## Testing
- `go test -tags=slow ./transpiler/x/php -run TestPHPTranspiler_VMValid_Golden/exists_builtin -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687efec6af0883208bc52c0ddd9c040c