### PR TITLE
Add v0.10.35 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 # 📦 CHANGELOG.md
+## [0.10.35] – 2025-07-22T10:43:45+07:00
+
+### Added
+
+* Int-keyed maps in the C transpiler
+* Sum query support in PHP and JSONL load improvements for Elixir
+* Group query sorting with HAVING in Python
+* Save statements and stable sort in Lua with left joins in Erlang
+* `group_by_multi_sort` across Kotlin, Pascal and Swift plus new loop helpers
+
+### Changed
+
+* TypeScript compiler cleaned up with regenerated outputs
+* Progress logs and tasks refreshed across languages
+
+### Fixed
+
+* Query and dataset bugs across multiple backends
+* Miscellaneous documentation issues
+
 ## [0.10.34] – 2025-07-21T19:10:17+07:00
 
 ### Added

--- a/releases/v0.10.35.md
+++ b/releases/v0.10.35.md
@@ -1,0 +1,20 @@
+# Jul 2025 (v0.10.35)
+
+Released on Tue Jul 22 10:43:45 2025 +0700.
+
+Mochi v0.10.35 extends dataset and query features across language backends with updated documentation and tests.
+
+## Compilers
+
+- Int-keyed map support for the C transpiler
+- Sum queries enabled in the PHP backend
+- Group query sorting and HAVING clauses for Python
+- Save statements and stable sort in Lua with left join chaining for Erlang
+- `group_by_multi_sort` implemented across Kotlin, Pascal and Swift
+- JSONL loading and inference improved for Elixir
+- Basic loop helpers added to Scheme with continue/break in Haskell
+
+## Documentation
+
+- Progress logs and tasks refreshed across many languages
+- Golden outputs regenerated with TypeScript cleanup


### PR DESCRIPTION
## Summary
- document v0.10.35 in CHANGELOG
- add release notes file

## Testing
- `go test ./... --vet=off`

------
https://chatgpt.com/codex/tasks/task_e_687f0925b5a48320afe29488d8e52469