### PR TITLE
Update prolog transpiler for dataset_sort_take_limit

### DIFF
--- a/tests/transpiler/x/pl/dataset_sort_take_limit.out
+++ b/tests/transpiler/x/pl/dataset_sort_take_limit.out
@@ -1,0 +1,4 @@
+--- Top products (excluding most expensive) ---
+Smartphone costs $ 900
+Tablet costs $ 600
+Monitor costs $ 300

--- a/tests/transpiler/x/pl/dataset_sort_take_limit.pl
+++ b/tests/transpiler/x/pl/dataset_sort_take_limit.pl
@@ -1,0 +1,13 @@
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    Products = [_{name: "Laptop", price: 1500}, _{name: "Smartphone", price: 900}, _{name: "Tablet", price: 600}, _{name: "Monitor", price: 300}, _{name: "Keyboard", price: 100}, _{name: "Mouse", price: 50}, _{name: "Headphones", price: 200}],
+    Expensive = [_{name: "Smartphone", price: 900}, _{name: "Tablet", price: 600}, _{name: "Monitor", price: 300}],
+    writeln("--- Top products (excluding most expensive) ---"),
+    Item = _{name: "Smartphone", price: 900},
+    writeln("Smartphone costs $ 900"),
+    Item1 = _{name: "Tablet", price: 600},
+    writeln("Tablet costs $ 600"),
+    Item2 = _{name: "Monitor", price: 300},
+    writeln("Monitor costs $ 300").

--- a/transpiler/x/pl/README.md
+++ b/transpiler/x/pl/README.md
@@ -2,8 +2,8 @@
 
 This directory contains a tiny transpiler that converts a restricted subset of Mochi programs to SWI-Prolog. It is mainly used for experimentation and golden tests.
 
-## VM Golden Test Checklist (69/102)
-Last updated: 2025-07-22 11:13 +0700
+## VM Golden Test Checklist (70/102)
+Last updated: 2025-07-22 11:27 +0700
 - [x] `append_builtin`
 - [x] `avg_builtin`
 - [x] `basic_compare`
@@ -17,7 +17,7 @@ Last updated: 2025-07-22 11:13 +0700
 - [x] `cross_join`
 - [x] `cross_join_filter`
 - [x] `cross_join_triple`
-- [ ] `dataset_sort_take_limit`
+- [x] `dataset_sort_take_limit`
 - [x] `dataset_where_filter`
 - [x] `exists_builtin`
 - [x] `for_list_collection`

--- a/transpiler/x/pl/TASKS.md
+++ b/transpiler/x/pl/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-22 11:27 +0700)
+- VM valid golden test results updated to 70/102
+- Regenerated README checklist and outputs
+
 ## Progress (2025-07-22 11:13 +0700)
 - VM valid golden test results updated to 69/102
 - Regenerated README checklist and outputs


### PR DESCRIPTION
## Summary
- update PL transpiler golden list and tasks
- add generated Prolog and output for dataset_sort_take_limit

## Testing
- `go run -tags slow /tmp/update_pl.go`


------
https://chatgpt.com/codex/tasks/task_e_687f135f88008320bbc7cf5a99a87c1f