### PR TITLE
Add v0.10.36 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # 📦 CHANGELOG.md
+## [0.10.36] – 2025-07-22T16:14:06+07:00
+
+### Added
+
+* Advanced group query typing for Scala with JSONL and YAML support
+* Update statements in Go and enhanced dataset joins in C and C++
+* Dynamic maps, JSON builtins and struct features across OCaml and Pascal
+* FFI integration for Zig with dataset loading and right join support in Erlang
+
+### Changed
+
+* Join inference and optional handling refined across Python, TypeScript and C++
+* Documentation checklists and progress logs refreshed across languages
+
+### Fixed
+
+* Nested loop closure bug in the C transpiler
+* Various join and query issues with regenerated golden outputs
+
 ## [0.10.35] – 2025-07-22T10:43:45+07:00
 
 ### Added

--- a/releases/v0.10.36.md
+++ b/releases/v0.10.36.md
@@ -1,0 +1,19 @@
+# Jul 2025 (v0.10.36)
+
+Released on Tue Jul 22 16:14:06 2025 +0700.
+
+Mochi v0.10.36 enhances dataset operations and query features across many transpilers with refreshed documentation and tests.
+
+## Compilers
+
+- Advanced group query typing in the Scala backend with JSONL and YAML support
+- Update statement support in Go and a mixed Go/Python example
+- Improved grouping, joins and optional handling across C, C++ and Pascal
+- Dynamic maps and JSON builtins for OCaml with group-by HAVING clauses
+- Dataset loading and right join features for Erlang
+- FFI support introduced in the Zig transpiler
+
+## Documentation
+
+- Progress logs and checklists updated for multiple languages
+- Golden outputs and tests regenerated across backends


### PR DESCRIPTION
## Summary
- document v0.10.36 release
- update changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f599c8b5483209ff963e4597d20e9