### PR TITLE
Add Rosetta golden suite for F# transpiler

### DIFF
--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -1,0 +1,7 @@
+# F# Rosetta Transpiler
+
+This file is auto-generated from rosetta tests.
+
+## Checklist (0/0)
+
+_Last updated automatically._

--- a/transpiler/x/fs/rosetta_test.go
+++ b/transpiler/x/fs/rosetta_test.go
@@ -1,0 +1,145 @@
+//go:build slow
+
+package fstrans_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/golden"
+	"mochi/parser"
+	fstrans "mochi/transpiler/x/fs"
+	"mochi/types"
+)
+
+func ensureFSharp(t *testing.T) {
+	if _, err := exec.LookPath("fsharpc"); err != nil {
+		t.Skip("fsharpc not installed")
+	}
+	if _, err := exec.LookPath("mono"); err != nil {
+		t.Skip("mono not installed")
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestFSTranspiler_Rosetta_Golden(t *testing.T) {
+	ensureFSharp(t)
+	root := repoRoot(t)
+	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "FS")
+	os.MkdirAll(outDir, 0o755)
+
+	golden.RunWithSummary(t, "tests/rosetta/x/Mochi", ".mochi", ".out", func(src string) ([]byte, error) {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		codePath := filepath.Join(outDir, base+".fs")
+		outPath := filepath.Join(outDir, base+".out")
+		errPath := filepath.Join(outDir, base+".error")
+		exePath := filepath.Join(outDir, base+".exe")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("parse: "+err.Error()), 0o644)
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			_ = os.WriteFile(errPath, []byte("type: "+errs[0].Error()), 0o644)
+			return nil, errs[0]
+		}
+		ast, err := fstrans.Transpile(prog, env)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
+			return nil, err
+		}
+		code := fstrans.Emit(ast)
+		if err := os.WriteFile(codePath, code, 0o644); err != nil {
+			return nil, err
+		}
+		cmd := exec.Command("fsharpc", "--target:exe", "--out:"+exePath, codePath)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			_ = os.WriteFile(errPath, append([]byte("compile: "+err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		run := exec.Command("mono", exePath)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			run.Stdin = bytes.NewReader(data)
+		}
+		out, err := run.CombinedOutput()
+		got := bytes.TrimSpace(out)
+		if err != nil {
+			_ = os.WriteFile(errPath, append([]byte("run: "+err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		_ = os.Remove(errPath)
+		_ = os.WriteFile(outPath, got, 0o644)
+		return got, nil
+	})
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateRosetta()
+	os.Exit(code)
+}
+
+func updateRosetta() {
+	root := repoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "FS")
+	readmePath := filepath.Join(root, "transpiler", "x", "fs", "ROSETTA.md")
+
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	sort.Strings(files)
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {
+				mark = "[x]"
+				compiled++
+			}
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+	}
+	tsRaw, _ := exec.Command("git", "log", "-1", "--format=%cI").Output()
+	ts := strings.TrimSpace(string(tsRaw))
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		ts = t.Format("2006-01-02 15:04 -0700")
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("# F# Rosetta Transpiler\n\n")
+	buf.WriteString("This file is auto-generated from rosetta tests.\n\n")
+	fmt.Fprintf(&buf, "## Checklist (%d/%d)\n", compiled, total)
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n\n")
+	fmt.Fprintf(&buf, "Last updated: %s\n", ts)
+	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
+}


### PR DESCRIPTION
## Summary
- add Rosetta golden test harness for F# transpiler
- generate checklist under `transpiler/x/fs/ROSETTA.md`
- include directory for transpiler output

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f69f924f883208deff0115b8e158d