### PR TITLE
Add v0.10.37 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 # 📦 CHANGELOG.md
+## [0.10.37] – 2025-07-22T17:53:32+07:00
+
+### Added
+
+* Rosetta golden tests for C, Go, Python and Clojure
+* Global variables with save/update statements in the Scala transpiler
+* Union support started for the C++ `tree_sum` example
+* JSONL load/save and update features for Ruby
+* Nested list and map assignments across Prolog and Haskell
+* Basic map support in the C backend with a `load_file` helper for Racket
+* Save and update capabilities added to Swift
+* Special join logic and mix import handling for Python
+
+### Changed
+
+* Partial application and query sorting improved in Scala
+* Map literal inference and boolean `in` operator fixes in TypeScript
+* Golden outputs refreshed with progress logs updated across languages
+
+### Fixed
+
+* Environment variable path bug in the Scala transpiler
+* Formatting cleanup and obsolete error files removed
+
 ## [0.10.36] – 2025-07-22T16:14:06+07:00
 
 ### Added

--- a/releases/v0.10.37.md
+++ b/releases/v0.10.37.md
@@ -1,0 +1,21 @@
+# Jul 2025 (v0.10.37)
+
+Released on Tue Jul 22 17:53:32 2025 +0700.
+
+Mochi v0.10.37 broadens transpiler features and regenerates tests across several languages.
+
+## Compilers
+
+- Rosetta golden tests for C, Go, Python and Clojure
+- Global variables plus save/update statements added to the Scala backend
+- Union support initiated for the C++ `tree_sum` example
+- JSONL load and save operations introduced in the Ruby transpiler
+- Nested list assignment and set operations for Prolog with map assignments in Haskell
+- Basic map handling for C and save/update features for Swift
+- `load_file` helper included in Racket with formatting fixes
+- Special join logic and mix import handling improved for Python
+
+## Documentation
+
+- Progress logs updated and obsolete error files removed
+- Golden outputs refreshed for Zig, TypeScript and others


### PR DESCRIPTION
## Summary
- document v0.10.37 release notes
- update CHANGELOG with entries for v0.10.37

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687f6dd6434c8320b4546a3396308274