### PR TITLE
Add C++ rosetta golden tests

### DIFF
--- a/transpiler/x/cpp/rosetta_test.go
+++ b/transpiler/x/cpp/rosetta_test.go
@@ -1,0 +1,115 @@
+//go:build slow
+
+package cpp_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"mochi/golden"
+	"mochi/parser"
+	cpp "mochi/transpiler/x/cpp"
+	"mochi/types"
+)
+
+func TestCPPTranspiler_Rosetta_Golden(t *testing.T) {
+	if _, err := exec.LookPath("g++"); err != nil {
+		t.Skip("g++ not installed")
+	}
+	root := repoRoot(t)
+	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "CPP")
+	os.MkdirAll(outDir, 0o755)
+
+	golden.RunWithSummary(t, "tests/rosetta/x/Mochi", ".mochi", ".out", func(src string) ([]byte, error) {
+		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+		codePath := filepath.Join(outDir, base+".cpp")
+		outPath := filepath.Join(outDir, base+".out")
+		errPath := filepath.Join(outDir, base+".error")
+
+		prog, err := parser.Parse(src)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("parse: "+err.Error()), 0o644)
+			return nil, err
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			_ = os.WriteFile(errPath, []byte("type: "+errs[0].Error()), 0o644)
+			return nil, errs[0]
+		}
+		ast, err := cpp.Transpile(prog, env)
+		if err != nil {
+			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
+			return nil, err
+		}
+		code := ast.Emit()
+		if err := os.WriteFile(codePath, code, 0o644); err != nil {
+			return nil, err
+		}
+		bin := filepath.Join(outDir, base)
+		if out, err := exec.Command("g++", codePath, "-std=c++20", "-o", bin).CombinedOutput(); err != nil {
+			_ = os.WriteFile(errPath, append([]byte("compile: "+err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		defer os.Remove(bin)
+		cmd := exec.Command(bin)
+		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+			cmd.Stdin = bytes.NewReader(data)
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			_ = os.WriteFile(errPath, append([]byte("run: "+err.Error()+"\n"), out...), 0o644)
+			return nil, err
+		}
+		_ = os.Remove(errPath)
+		outBytes := bytes.TrimSpace(out)
+		_ = os.WriteFile(outPath, outBytes, 0o644)
+		return outBytes, nil
+	})
+}
+
+func updateRosettaReadme() {
+	root := repoRoot(&testing.T{})
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "CPP")
+	readmePath := filepath.Join(root, "transpiler", "x", "cpp", "ROSETTA.md")
+
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	sort.Strings(files)
+	total := len(files)
+	compiled := 0
+	var lines []string
+	for _, f := range files {
+		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+		mark := "[ ]"
+		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
+			if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {
+				compiled++
+				mark = "[x]"
+			}
+		}
+		lines = append(lines, fmt.Sprintf("- %s %s", mark, name))
+	}
+	tsRaw, _ := exec.Command("git", "log", "-1", "--format=%cI").Output()
+	ts := strings.TrimSpace(string(tsRaw))
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
+			ts = t.In(loc).Format("2006-01-02 15:04 -0700")
+		} else {
+			ts = t.Format("2006-01-02 15:04 MST")
+		}
+	}
+	var buf bytes.Buffer
+	buf.WriteString("# C++ Transpiler Rosetta Output\n\n")
+	buf.WriteString("This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.\n\n")
+	fmt.Fprintf(&buf, "Checklist of programs that currently transpile and run (%d/%d) - Last updated %s:\n", compiled, total, ts)
+	buf.WriteString(strings.Join(lines, "\n"))
+	buf.WriteString("\n")
+	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
+}

--- a/transpiler/x/cpp/vm_valid_golden_test.go
+++ b/transpiler/x/cpp/vm_valid_golden_test.go
@@ -77,6 +77,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	updateReadme()
 	updateTasks()
+	updateRosettaReadme()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
## Summary
- add Rosetta tests for the C++ transpiler
- update C++ TestMain to regenerate the Rosetta checklist

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687f6e0b2b648320828b60c249524af4