### PR TITLE
Improve Go transpiler features

### DIFF
--- a/transpiler/x/go/rosetta_test.go
+++ b/transpiler/x/go/rosetta_test.go
@@ -94,11 +94,9 @@ func TestGoTranspiler_Rosetta_Golden(t *testing.T) {
 	t.Logf("Summary: %d passed, %d failed", passed, failed)
 }
 
-func TestMain(m *testing.M) {
-	code := m.Run()
-	updateRosettaChecklist()
-	os.Exit(code)
-}
+// TestMain is defined in vm_valid_golden_test.go. That TestMain updates
+// README and TASKS files after the test run. We hook the rosetta checklist
+// update there as well, so we don't need a separate TestMain in this file.
 
 func updateRosettaChecklist() {
 	root := findRepoRoot(&testing.T{})
@@ -137,24 +135,7 @@ func updateRosettaChecklist() {
 	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
 }
 
-func findRepoRoot(t *testing.T) string {
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatal("cannot determine working directory")
-	}
-	for i := 0; i < 10; i++ {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	t.Fatal("go.mod not found")
-	return ""
-}
+// findRepoRoot is declared in vm_valid_golden_test.go and shared across tests.
 
 func updating() bool {
 	f := flag.Lookup("update")

--- a/transpiler/x/go/vm_valid_golden_test.go
+++ b/transpiler/x/go/vm_valid_golden_test.go
@@ -90,6 +90,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	updateReadme()
 	updateTasks()
+	updateRosettaChecklist()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
## Summary
- support `now()` builtin
- allow casting to `float`
- rename user `main` function to avoid collisions
- share rosetta checklist logic via existing TestMain

## Testing
- `go test ./transpiler/x/go -run ^TestGoTranspiler_Rosetta_Golden/100-prisoners$ -tags slow -count=1 -v` *(fails: exit status 1)*


------
https://chatgpt.com/codex/tasks/task_e_687f72f5fea88320811f2692a7d4250a