### PR TITLE
Fix Dart float literals

### DIFF
--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -730,9 +730,6 @@ type FloatLit struct{ Value float64 }
 
 func (f *FloatLit) emit(w io.Writer) error {
 	s := strconv.FormatFloat(f.Value, 'f', -1, 64)
-	if !strings.ContainsAny(s, ".eE") {
-		s += ".0"
-	}
 	_, err := io.WriteString(w, s)
 	return err
 }


### PR DESCRIPTION
## Summary
- adjust FloatLit emitter to avoid printing trailing `.0`

## Testing
- `go test ./transpiler/x/dart -run Rosetta_Golden/angle-difference-between-two-bearings-1 -tags slow -v -count=1`
- `go test ./transpiler/x/dart -run VMValid_Golden/print_hello -tags slow -v -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687f73000184832099532777c54048cd