### PR TITLE
Improve field type inference for Haskell transpiler

### DIFF
--- a/transpiler/x/hs/README.md
+++ b/transpiler/x/hs/README.md
@@ -2,8 +2,8 @@
 
 This package contains experimental transpilers that convert Mochi bytecode to other programming languages. The Haskell backend currently supports a tiny subset of the language.
 
-Compiled programs: 82/103
-Last updated: 2025-07-22 18:00 GMT+7
+Compiled programs: 86/103
+Last updated: 2025-07-22 18:14 GMT+7
 
 ## Golden test checklist
 - [x] append_builtin
@@ -86,15 +86,15 @@ Last updated: 2025-07-22 18:00 GMT+7
 - [ ] right_join
 - [ ] save_jsonl_stdout
 - [x] short_circuit
-- [ ] slice
-- [ ] sort_stable
+- [x] slice
+- [x] sort_stable
 - [ ] str_builtin
 - [x] string_compare
 - [x] string_concat
 - [x] string_contains
 - [x] string_in_operator
 - [x] string_index
-- [ ] string_prefix_slice
+- [x] string_prefix_slice
 - [x] substring_builtin
 - [x] sum_builtin
 - [ ] tail_recursion
@@ -105,7 +105,7 @@ Last updated: 2025-07-22 18:00 GMT+7
 - [x] typed_var
 - [x] unary_neg
 - [ ] update_stmt
-- [ ] user_type_literal
+- [x] user_type_literal
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop

--- a/transpiler/x/hs/ROSETTA.md
+++ b/transpiler/x/hs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Haskell code for Rosetta Mochi programs. Each `.hs` file is in `tests/rosetta/transpiler/Haskell` with matching `.out` output. Failures produce a `.error` file.
 
-Last updated: 2025-07-22 17:27 GMT+7
+Last updated: 2025-07-22 18:14 GMT+7
 
 ## Checklist
 - [ ] 100-doors-2

--- a/transpiler/x/hs/TASKS.md
+++ b/transpiler/x/hs/TASKS.md
@@ -1,3 +1,43 @@
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
+## Progress (2025-07-22 18:14 +0700)
+- VM valid golden test results updated
+- Added escaping for Haskell reserved keywords
+- Regenerated README checklist from golden tests
+
 ## Progress (2025-07-22 18:00 +0700)
 - VM valid golden test results updated
 - Added escaping for Haskell reserved keywords


### PR DESCRIPTION
## Summary
- enhance Haskell transpiler type detection for nested record fields
- regenerate README, ROSETTA and TASKS docs

## Testing
- `go test ./transpiler/x/hs -tags slow -run Rosetta_Golden -count=1`
- `go test ./transpiler/x/hs -tags slow -run TestHSTranspiler_VMValid_Golden/user_type_literal -count=1`
- `go test ./transpiler/x/hs -tags slow -run VMValid_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687f730c4f548320bdf5e1de95380813