### PR TITLE
Improve scheme transpiler expression statements

### DIFF
--- a/transpiler/x/scheme/transpiler.go
+++ b/transpiler/x/scheme/transpiler.go
@@ -131,7 +131,9 @@ func Format(src []byte) []byte {
 			buf.WriteByte('(')
 			indent++
 		case ')':
-			indent--
+			if indent > 0 {
+				indent--
+			}
 			buf.WriteByte(')')
 			if i+1 < len(src) && src[i+1] != '\n' {
 				buf.WriteByte('\n')
@@ -363,9 +365,19 @@ func convertStmt(st *parser.Statement) (Node, error) {
 					&List{Elems: []Node{Symbol("newline")}},
 				}
 				return &List{Elems: forms}, nil
+			default:
+				expr, err := convertCall(Symbol(call.Func), &parser.CallOp{Args: call.Args})
+				if err != nil {
+					return nil, err
+				}
+				return expr, nil
 			}
 		}
-		return nil, fmt.Errorf("unsupported expression statement")
+		expr, err := convertParserExpr(st.Expr.Expr)
+		if err != nil {
+			return nil, err
+		}
+		return expr, nil
 	case st.Let != nil:
 		name := st.Let.Name
 		var val Node


### PR DESCRIPTION
## Summary
- allow scheme transpiler to emit generic expression statements
- guard scheme formatter against negative indentation

## Testing
- `go test ./transpiler/x/scheme -tags slow -run Rosetta/100-prisoners -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687f732278208320a55b0e3ef0ede3d1