### PR TITLE
Add input and abs builtins to Clojure transpiler

### DIFF
--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -1265,6 +1265,20 @@ func transpileCall(c *parser.CallExpr) (Node, error) {
 		elems = append(elems, Symbol("apply"), Symbol("max"))
 	case "substring":
 		elems = append(elems, Symbol("subs"))
+	case "input":
+		if len(c.Args) != 0 {
+			return nil, fmt.Errorf("input expects no args")
+		}
+		return &List{Elems: []Node{Symbol("read-line")}}, nil
+	case "abs":
+		if len(c.Args) != 1 {
+			return nil, fmt.Errorf("abs expects 1 arg")
+		}
+		arg, err := transpileExpr(c.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		return &List{Elems: []Node{Symbol("Math/abs"), arg}}, nil
 	case "append":
 		elems = append(elems, Symbol("conj"))
 	case "sum":


### PR DESCRIPTION
## Summary
- support `input` builtin by emitting `(read-line)`
- support `abs` builtin via `Math/abs`
- run Clojure Rosetta tests (skipped - clojure not installed)

## Testing
- `go test ./transpiler/x/clj -run TestRosetta -tags slow -v`

------
https://chatgpt.com/codex/tasks/task_e_687f7c5688bc8320a0617e2a4be064bc