### PR TITLE
Fix dart transpiler loop variable types

### DIFF
--- a/transpiler/x/dart/transpiler.go
+++ b/transpiler/x/dart/transpiler.go
@@ -127,7 +127,7 @@ type ForRangeStmt struct {
 }
 
 func (f *ForRangeStmt) emit(out io.Writer) error {
-	if _, err := io.WriteString(out, "for (var "+f.Name+" = "); err != nil {
+	if _, err := io.WriteString(out, "for (int "+f.Name+" = "); err != nil {
 		return err
 	}
 	if f.Start != nil {
@@ -2340,6 +2340,8 @@ func walkTypes(s Stmt) {
 		if st.End != nil {
 			inferType(st.End)
 		}
+		// range loops use integer counters
+		localVarTypes[st.Name] = "int"
 		for _, b := range st.Body {
 			walkTypes(b)
 		}


### PR DESCRIPTION
## Summary
- keep for-range counters as ints when emitting Dart
- record for-range loop variable types during type gathering

## Testing
- `go test ./transpiler/x/dart -tags slow -run TestDartTranspiler_Rosetta_Golden/100-doors -v`

------
https://chatgpt.com/codex/tasks/task_e_687f7f87beac8320b14b20fb6beec03a