### PR TITLE
Enhance F# transpiler

### DIFF
--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -2402,6 +2402,12 @@ func convertImport(im *parser.ImportStmt) (Stmt, error) {
 				&LetStmt{Name: "Answer", Expr: &IntLit{Value: 42}},
 			}}, nil
 		}
+		if path == "strings" {
+			return &ModuleDef{Open: true, Name: alias, Stmts: []Stmt{
+				&FunDef{Name: "ToUpper", Params: []string{"s"}, Body: []Stmt{&ReturnStmt{Expr: &MethodCallExpr{Target: &IdentExpr{Name: "s"}, Name: "ToUpper"}}}},
+				&FunDef{Name: "TrimSpace", Params: []string{"s"}, Body: []Stmt{&ReturnStmt{Expr: &MethodCallExpr{Target: &IdentExpr{Name: "s"}, Name: "Trim"}}}},
+			}}, nil
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
- add support for importing Go's `strings` package

## Testing
- `go vet ./...`
- `go test ./transpiler/x/fs -tags=slow -run Rosetta -v`

------
https://chatgpt.com/codex/tasks/task_e_687f80294d2c8320a9be50f654c3a4b6