### PR TITLE
Add MOCHI_ROSETTA_ONLY filter for ST Rosetta tests

### DIFF
--- a/transpiler/x/st/rosetta_test.go
+++ b/transpiler/x/st/rosetta_test.go
@@ -23,19 +23,23 @@ func TestSmalltalkRosetta(t *testing.T) {
 	if _, err := exec.LookPath("gst"); err != nil {
 		t.Skip("gst not installed")
 	}
-	root := repoRootDir(t)
-	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
-	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "st")
-	os.MkdirAll(outDir, 0o755)
+       root := repoRootDir(t)
+       srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+       outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "st")
+       os.MkdirAll(outDir, 0o755)
 
-	files, err := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-	sort.Strings(files)
-	if len(files) == 0 {
-		t.Fatal("no Mochi Rosetta tests found")
-	}
+       pattern := filepath.Join(srcDir, "*.mochi")
+       if only := os.Getenv("MOCHI_ROSETTA_ONLY"); only != "" {
+               pattern = filepath.Join(srcDir, only+".mochi")
+       }
+       files, err := filepath.Glob(pattern)
+       if err != nil {
+               t.Fatalf("glob: %v", err)
+       }
+       sort.Strings(files)
+       if len(files) == 0 {
+               t.Fatalf("no Mochi Rosetta tests found: %s", pattern)
+       }
 
 	for _, srcPath := range files {
 		name := strings.TrimSuffix(filepath.Base(srcPath), ".mochi")


### PR DESCRIPTION
## Summary
- allow `transpiler/x/st/rosetta_test.go` to filter Rosetta cases using the `MOCHI_ROSETTA_ONLY` environment variable

## Testing
- `go test -tags slow ./transpiler/x/st -run TestSmalltalkRosetta -count=1 -v` *(fails: gst not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f9016df408320ae5b68922ac7696b