### PR TITLE
Improve Rosetta Haskell tests

### DIFF
--- a/transpiler/x/hs/ROSETTA.md
+++ b/transpiler/x/hs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Haskell code for Rosetta Mochi programs. Each `.hs` file is in `tests/rosetta/transpiler/Haskell` with matching `.out` output. Failures produce a `.error` file.
 
-Last updated: 2025-07-22 18:14 GMT+7
+Last updated: 2025-07-22 20:35 GMT+7
 
 ## Checklist
 - [ ] 100-doors-2

--- a/transpiler/x/hs/rosetta_test.go
+++ b/transpiler/x/hs/rosetta_test.go
@@ -110,9 +110,18 @@ func TestHSTranspiler_Rosetta_Golden(t *testing.T) {
 	if len(files) < max {
 		max = len(files)
 	}
+	firstErr := ""
 	for _, f := range files[:max] {
 		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
 		t.Run(name, func(t *testing.T) { runRosettaTask(t, root, name) })
+		if firstErr == "" {
+			if _, err := os.Stat(filepath.Join(root, "tests", "rosetta", "transpiler", "Haskell", name+".error")); err == nil {
+				firstErr = name
+			}
+		}
+	}
+	if firstErr != "" {
+		t.Fatalf("first failing program: %s", firstErr)
 	}
 }
 

--- a/transpiler/x/hs/transpiler.go
+++ b/transpiler/x/hs/transpiler.go
@@ -705,9 +705,9 @@ func (f *ForStmt) emit(w io.Writer) {
 			pushIndent()
 			ps.emit(w)
 			io.WriteString(w, "\n")
-			popIndent()
 			writeIndent(w)
 			io.WriteString(w, ") ")
+			popIndent()
 			if f.To != nil {
 				io.WriteString(w, "[")
 				f.From.emit(w)
@@ -733,9 +733,9 @@ func (f *ForStmt) emit(w io.Writer) {
 		st.emit(w)
 		io.WriteString(w, "\n")
 	}
-	popIndent()
 	writeIndent(w)
 	io.WriteString(w, ") ")
+	popIndent()
 	if f.To != nil {
 		io.WriteString(w, "[")
 		f.From.emit(w)
@@ -1000,8 +1000,9 @@ func (n *NameRef) emit(w io.Writer) {
 	name := safeName(n.Name)
 	if mutated[n.Name] {
 		needIORef = true
-		io.WriteString(w, "readIORef ")
+		io.WriteString(w, "(unsafePerformIO (readIORef ")
 		io.WriteString(w, name)
+		io.WriteString(w, "))")
 	} else {
 		io.WriteString(w, name)
 	}
@@ -1662,6 +1663,7 @@ func header(withList, withMap, withJSON, withTrace, withIORef bool) string {
 	}
 	if withIORef {
 		h += "import Data.IORef\n"
+		h += "import System.IO.Unsafe (unsafePerformIO)\n"
 	}
 	return h
 }


### PR DESCRIPTION
## Summary
- stop Rosetta golden test after the first failing case
- allow mutated variables to be read via `unsafePerformIO`
- adjust loop code generation to indent closing parens correctly

## Testing
- `go test -run Rosetta_Golden -tags slow -count=1 -v` *(fails: first failing program: 100-doors-2)*

------
https://chatgpt.com/codex/tasks/task_e_687f93b80a14832085011939f5e2aff4