### PR TITLE
Fix Prolog rosetta first error

### DIFF
--- a/transpiler/x/pl/ROSETTA.md
+++ b/transpiler/x/pl/ROSETTA.md
@@ -1,8 +1,8 @@
 # Rosetta Prolog Transpiler
 
-## Rosetta Golden Test Checklist (0/284)
+## Rosetta Golden Test Checklist (1/284)
 Last updated: 2025-07-22 17:27 +0700
-- [ ] `100-doors-2`
+- [x] `100-doors-2`
 - [ ] `100-doors-3`
 - [ ] `100-doors`
 - [ ] `100-prisoners`


### PR DESCRIPTION
## Summary
- stop Prolog rosetta tests at the first failure and show which program failed
- handle constant string concatenation and constant branch compilation in the Prolog transpiler
- mark `100-doors-2` as working in the Prolog Rosetta checklist

## Testing
- `go test -tags slow ./transpiler/x/pl -run PrologTranspiler_Rosetta -count=1` *(fails at `100-prisoners`)*

------
https://chatgpt.com/codex/tasks/task_e_687f95391b8883208ba12c1467ec682f