### PR TITLE
Fix C# transpiler rosetta case

### DIFF
--- a/transpiler/x/cs/ROSETTA.md
+++ b/transpiler/x/cs/ROSETTA.md
@@ -1,13 +1,13 @@
 # Rosetta C# Transpiler Output
 
-Completed programs: 0/284
-Last updated: 2025-07-22 17:27 +0700
+Completed programs: 4/284
+Last updated: 2025-07-22 20:31 +0700
 
 ## Checklist
-- [ ] 100-doors-2
-- [ ] 100-doors-3
-- [ ] 100-doors
-- [ ] 100-prisoners
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
+- [x] 100-prisoners
 - [ ] 15-puzzle-game
 - [ ] 15-puzzle-solver
 - [ ] 2048


### PR DESCRIPTION
## Summary
- allow skipping after first Rosetta failure with `MOCHI_FIRST_ERROR`
- escape C# reserved keywords in emitted identifiers
- add `_now()` helper and support `now()` builtin
- propagate element type for empty list literals
- update C# Rosetta checklist

## Testing
- `MOCHI_FIRST_ERROR=1 go test ./transpiler/x/cs -run Rosetta -tags slow -count=1 -v` *(fails: exit status 134)*
- `MOCHI_ROSETTA_ONLY=100-prisoners go test ./transpiler/x/cs -run Rosetta -tags slow -count=1 -v` *(passes)*
- `go test ./transpiler/x/cs -run Rosetta -tags slow -count=1 -v` *(timeout: 1m0s)*

------
https://chatgpt.com/codex/tasks/task_e_687f92bb06d08320b7bfc8870c91c08e