### PR TITLE
Improve Kotlin transpiler tests

### DIFF
--- a/tests/transpiler/x/kt/append_builtin.kt
+++ b/tests/transpiler/x/kt/append_builtin.kt
@@ -1,4 +1,4 @@
 fun main() {
     val a: MutableList<Int> = mutableListOf(1, 2)
-    println(a + 3)
+    println((a + 3).toMutableList())
 }

--- a/tests/transpiler/x/kt/basic_compare.kt
+++ b/tests/transpiler/x/kt/basic_compare.kt
@@ -2,6 +2,6 @@ fun main() {
     val a = 10 - 3
     val b = 2 + 2
     println(a)
-    println(a == 7)
-    println(b < 5)
+    println(if (a == 7) 1 else 0)
+    println(if ((b as Number).toDouble() < 5) 1 else 0)
 }

--- a/tests/transpiler/x/kt/bool_chain.kt
+++ b/tests/transpiler/x/kt/bool_chain.kt
@@ -4,7 +4,7 @@ fun boom(): Boolean {
 }
 
 fun main() {
-    println(((1 < 2) && (2 < 3)) && (3 < 4))
-    println(((1 < 2) && (2 > 3)) && boom())
-    println((((1 < 2) && (2 < 3)) && (3 > 4)) && boom())
+    println(if (((1 < 2) && (2 < 3)) && (3 < 4)) 1 else 0)
+    println(if (((1 < 2) && (2 > 3)) && boom()) 1 else 0)
+    println(if ((((1 < 2) && (2 < 3)) && (3 > 4)) && boom()) 1 else 0)
 }

--- a/tests/transpiler/x/kt/cross_join.kt
+++ b/tests/transpiler/x/kt/cross_join.kt
@@ -1,17 +1,17 @@
 fun main() {
-    val customers: MutableList<MutableMap<String, Any>> = mutableListOf(mutableMapOf("id" to 1, "name" to "Alice"), mutableMapOf("id" to 2, "name" to "Bob"), mutableMapOf("id" to 3, "name" to "Charlie"))
-    val orders: MutableList<MutableMap<String, Int>> = mutableListOf(mutableMapOf("id" to 100, "customerId" to 1, "total" to 250), mutableMapOf("id" to 101, "customerId" to 2, "total" to 125), mutableMapOf("id" to 102, "customerId" to 1, "total" to 300))
+    val customers: MutableList<MutableMap<String, Any>> = mutableListOf(mutableMapOf<String, Any>("id" to 1, "name" to "Alice"), mutableMapOf<String, Any>("id" to 2, "name" to "Bob"), mutableMapOf<String, Any>("id" to 3, "name" to "Charlie"))
+    val orders: MutableList<MutableMap<String, Int>> = mutableListOf(mutableMapOf<String, Int>("id" to 100, "customerId" to 1, "total" to 250), mutableMapOf<String, Int>("id" to 101, "customerId" to 2, "total" to 125), mutableMapOf<String, Int>("id" to 102, "customerId" to 1, "total" to 300))
     val result: MutableList<MutableMap<String, Int>> = run {
     val _res = mutableListOf<MutableMap<String, Any>>()
     for (o in orders) {
         for (c in customers) {
-            _res.add(mutableMapOf("orderId" to o["id"], "orderCustomerId" to o["customerId"], "pairedCustomerName" to c["name"], "orderTotal" to o["total"]))
+            _res.add(mutableMapOf<String, Any>("orderId" to (o["id"]!!), "orderCustomerId" to (o["customerId"]!!), "pairedCustomerName" to (c["name"]!!), "orderTotal" to (o["total"]!!)))
         }
     }
     _res
 }
     println("--- Cross Join: All order-customer pairs ---")
     for (entry in result) {
-        println(listOf("Order", entry["orderId"], "(customerId:", entry["orderCustomerId"], ", total: $", entry["orderTotal"], ") paired with", entry["pairedCustomerName"]).joinToString(" "))
+        println(listOf("Order", (entry["orderId"]!!), "(customerId:", (entry["orderCustomerId"]!!), ", total: $", (entry["orderTotal"]!!), ") paired with", (entry["pairedCustomerName"]!!)).joinToString(" "))
     }
 }

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,11 +2,11 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-22 11:13 +0700
+Last updated: 2025-07-22 20:38 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **102/102** (auto-generated)
+Completed golden tests: **102/103** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
@@ -74,6 +74,7 @@ Completed golden tests: **102/102** (auto-generated)
 - [x] math_ops.mochi
 - [x] membership.mochi
 - [x] min_max_builtin.mochi
+- [ ] mix_go_python.mochi
 - [x] nested_function.mochi
 - [x] order_by_map.mochi
 - [x] outer_join.mochi

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,14 +2,14 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-22 17:27 +0700
+Last updated: 2025-07-22 21:06 +0700
 
-Completed tasks: **0/284**
+Completed tasks: **3/284**
 
 ### Checklist
-- [ ] `100-doors-2`
-- [ ] `100-doors-3`
-- [ ] `100-doors`
+- [x] `100-doors-2`
+- [x] `100-doors-3`
+- [x] `100-doors`
 - [ ] `100-prisoners`
 - [ ] `15-puzzle-game`
 - [ ] `15-puzzle-solver`

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,6 @@
+## VM Golden Progress (2025-07-22 20:38 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-22 11:13 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/rosetta_test.go
+++ b/transpiler/x/kt/rosetta_test.go
@@ -53,59 +53,58 @@ func TestRosettaKotlin(t *testing.T) {
 		name := strings.TrimSuffix(filepath.Base(outPath), ".out")
 		srcPath := filepath.Join(srcDir, name+".mochi")
 		ktPath := filepath.Join(outDir, name+".kt")
-		t.Run(name, func(t *testing.T) {
-			prog, err := parser.Parse(srcPath)
+
+		prog, err := parser.Parse(srcPath)
+		if err != nil {
+			writeKTError(outDir, name, fmt.Errorf("parse error: %w", err))
+			t.Fatalf("%s: parse: %v", name, err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			writeKTError(outDir, name, fmt.Errorf("type error: %v", errs[0]))
+			t.Fatalf("%s: type: %v", name, errs[0])
+		}
+		ast, err := kt.Transpile(env, prog)
+		if err != nil {
+			writeKTError(outDir, name, fmt.Errorf("transpile error: %w", err))
+			t.Fatalf("%s: transpile: %v", name, err)
+		}
+		code := kt.Emit(ast)
+		if err := os.WriteFile(ktPath, code, 0o644); err != nil {
+			t.Fatalf("%s: write: %v", name, err)
+		}
+		jar := filepath.Join(outDir, name+".jar")
+		if out, err := exec.Command("kotlinc", ktPath, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
+			_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
+			t.Fatalf("%s: kotlinc: %v", name, err)
+		}
+		cmd := exec.Command("java", "-jar", jar)
+		cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
+		if inData, err := os.ReadFile(filepath.Join(srcDir, name+".in")); err == nil {
+			cmd.Stdin = bytes.NewReader(inData)
+		}
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+		if err := cmd.Run(); err != nil {
+			_ = os.WriteFile(filepath.Join(outDir, name+".error"), buf.Bytes(), 0o644)
+			t.Fatalf("%s: run: %v", name, err)
+		}
+		got := bytes.TrimSpace(buf.Bytes())
+		wantData, err := os.ReadFile(filepath.Join(outDir, name+".out"))
+		if err != nil {
+			// fall back to source out if not found
+			wantData, err = os.ReadFile(outPath)
 			if err != nil {
-				writeKTError(outDir, name, fmt.Errorf("parse error: %w", err))
-				t.Fatalf("parse: %v", err)
+				t.Fatalf("%s: read want: %v", name, err)
 			}
-			env := types.NewEnv(nil)
-			if errs := types.Check(prog, env); len(errs) > 0 {
-				writeKTError(outDir, name, fmt.Errorf("type error: %v", errs[0]))
-				t.Fatalf("type: %v", errs[0])
-			}
-			ast, err := kt.Transpile(env, prog)
-			if err != nil {
-				writeKTError(outDir, name, fmt.Errorf("transpile error: %w", err))
-				t.Fatalf("transpile: %v", err)
-			}
-			code := kt.Emit(ast)
-			if err := os.WriteFile(ktPath, code, 0o644); err != nil {
-				t.Fatalf("write: %v", err)
-			}
-			jar := filepath.Join(outDir, name+".jar")
-			if out, err := exec.Command("kotlinc", ktPath, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
-				_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
-				t.Fatalf("kotlinc: %v", err)
-			}
-			cmd := exec.Command("java", "-jar", jar)
-			cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
-			if inData, err := os.ReadFile(filepath.Join(srcDir, name+".in")); err == nil {
-				cmd.Stdin = bytes.NewReader(inData)
-			}
-			var buf bytes.Buffer
-			cmd.Stdout = &buf
-			cmd.Stderr = &buf
-			if err := cmd.Run(); err != nil {
-				_ = os.WriteFile(filepath.Join(outDir, name+".error"), buf.Bytes(), 0o644)
-				t.Fatalf("run: %v", err)
-			}
-			got := bytes.TrimSpace(buf.Bytes())
-			wantData, err := os.ReadFile(filepath.Join(outDir, name+".out"))
-			if err != nil {
-				// fall back to source out if not found
-				wantData, err = os.ReadFile(outPath)
-				if err != nil {
-					t.Fatalf("read want: %v", err)
-				}
-			}
-			want := bytes.TrimSpace(wantData)
-			if !bytes.Equal(got, want) {
-				writeKTError(outDir, name, fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, want))
-				t.Fatalf("output mismatch")
-			}
-			_ = os.Remove(filepath.Join(outDir, name+".error"))
-			_ = os.Remove(jar)
-		})
+		}
+		want := bytes.TrimSpace(wantData)
+		if !bytes.Equal(got, want) {
+			writeKTError(outDir, name, fmt.Errorf("output mismatch\n-- got --\n%s\n-- want --\n%s", got, want))
+			t.Fatalf("%s: output mismatch", name)
+		}
+		_ = os.Remove(filepath.Join(outDir, name+".error"))
+		_ = os.Remove(jar)
 	}
 }

--- a/transpiler/x/kt/transpiler_test.go
+++ b/transpiler/x/kt/transpiler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -41,120 +42,118 @@ func TestTranspilePrograms(t *testing.T) {
 		t.Skip("kotlinc not installed")
 	}
 	cases := []string{
-		"print_hello",
-		"count_builtin",
+		"append_builtin",
 		"avg_builtin",
-		"sum_builtin",
-		"len_builtin",
-		"len_string",
-		"str_builtin",
-		"let_and_print",
 		"basic_compare",
 		"binary_precedence",
-		"math_ops",
-		"unary_neg",
-		"string_compare",
-		"string_concat",
-		"append_builtin",
-		"min_max_builtin",
-		"substring_builtin",
-		"typed_let",
-		"typed_var",
-		"var_assignment",
-		"len_map",
-		"list_index",
-		"string_contains",
-		"string_in_operator",
-		"string_index",
 		"bool_chain",
+		"break_continue",
+		"cast_string_to_int",
+		"closure",
+		"count_builtin",
+		"cross_join",
+		"for_list_collection",
+		"for_loop",
+		"for_map_collection",
+		"fun_call",
+		"fun_expr_in_let",
+		"fun_three_args",
+		"group_by_multi_join",
 		"if_else",
 		"if_then_else",
 		"if_then_else_nested",
-		"break_continue",
-		"for_list_collection",
-		"for_loop",
-		"while_loop",
-		"fun_call",
-		"fun_three_args",
-		"fun_expr_in_let",
+		"len_builtin",
+		"len_map",
+		"len_string",
 		"list_assign",
+		"list_index",
+		"list_nested_assign",
+		"load_jsonl",
+		"load_yaml",
 		"map_assign",
 		"map_in_operator",
-		"slice",
-		"string_prefix_slice",
-		"cast_string_to_int",
-		"for_map_collection",
-		"list_nested_assign",
-		"map_nested_assign",
-		"tail_recursion",
-		"two-sum",
-		"membership",
-		"map_membership",
-		"closure",
-		"nested_function",
 		"map_literal_dynamic",
-		"cross_join",
-		"pure_fold",
-		"pure_global_fold",
-		"short_circuit",
+		"map_membership",
+		"map_nested_assign",
 		"match_expr",
 		"match_full",
-		"group_by_multi_join",
-		"user_type_literal",
+		"math_ops",
+		"membership",
+		"min_max_builtin",
+		"nested_function",
 		"order_by_map",
-		"sort_stable",
-		"load_yaml",
-		"load_jsonl",
+		"print_hello",
+		"pure_fold",
+		"pure_global_fold",
 		"save_jsonl_stdout",
+		"short_circuit",
+		"slice",
+		"sort_stable",
+		"str_builtin",
+		"string_compare",
+		"string_concat",
+		"string_contains",
+		"string_in_operator",
+		"string_index",
+		"string_prefix_slice",
+		"substring_builtin",
+		"sum_builtin",
+		"tail_recursion",
+		"two-sum",
+		"typed_let",
+		"typed_var",
 		"update_stmt",
+		"unary_neg",
+		"user_type_literal",
+		"var_assignment",
+		"while_loop",
 	}
+	sort.Strings(cases)
 	root := repoRoot(t)
 	outDir := filepath.Join(root, "tests", "transpiler", "x", "kt")
 	os.MkdirAll(outDir, 0o755)
 	for _, name := range cases {
-		t.Run(name, func(t *testing.T) {
-			src := filepath.Join(root, "tests", "vm", "valid", name+".mochi")
-			prog, err := parser.Parse(src)
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
-			env := types.NewEnv(nil)
-			if errs := types.Check(prog, env); len(errs) > 0 {
-				t.Fatalf("type: %v", errs[0])
-			}
-			ast, err := kt.Transpile(env, prog)
-			if err != nil {
-				t.Fatalf("transpile: %v", err)
-			}
-			code := kt.Emit(ast)
-			ktFile := filepath.Join(outDir, name+".kt")
-			if err := os.WriteFile(ktFile, code, 0o644); err != nil {
-				t.Fatalf("write: %v", err)
-			}
-			jar := filepath.Join(outDir, name+".jar")
-			if out, err := exec.Command("kotlinc", ktFile, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
-				_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
-				t.Fatalf("kotlinc: %v", err)
-			}
-			cmd := exec.Command("java", "-jar", jar)
-			cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
-			out, err := cmd.CombinedOutput()
-			got := bytes.TrimSpace(out)
-			if err != nil {
-				_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
-				t.Fatalf("run: %v", err)
-			}
-			_ = os.Remove(filepath.Join(outDir, name+".error"))
-			want, err := os.ReadFile(filepath.Join(outDir, name+".out"))
-			if err != nil {
-				t.Fatalf("read want: %v", err)
-			}
-			want = bytes.TrimSpace(want)
-			if !bytes.Equal(got, want) {
-				t.Errorf("output mismatch:\nGot: %s\nWant: %s", got, want)
-			}
-			_ = os.Remove(jar)
-		})
+		src := filepath.Join(root, "tests", "vm", "valid", name+".mochi")
+		prog, err := parser.Parse(src)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", name, err)
+		}
+		env := types.NewEnv(nil)
+		if errs := types.Check(prog, env); len(errs) > 0 {
+			t.Fatalf("%s: type: %v", name, errs[0])
+		}
+		ast, err := kt.Transpile(env, prog)
+		if err != nil {
+			t.Fatalf("%s: transpile: %v", name, err)
+		}
+		code := kt.Emit(ast)
+		ktFile := filepath.Join(outDir, name+".kt")
+		if err := os.WriteFile(ktFile, code, 0o644); err != nil {
+			t.Fatalf("%s: write: %v", name, err)
+		}
+		jar := filepath.Join(outDir, name+".jar")
+		if out, err := exec.Command("kotlinc", ktFile, "-include-runtime", "-d", jar).CombinedOutput(); err != nil {
+			_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
+			t.Fatalf("%s: kotlinc: %v", name, err)
+		}
+		cmd := exec.Command("java", "-jar", jar)
+		cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
+		out, err := cmd.CombinedOutput()
+		got := bytes.TrimSpace(out)
+		if err != nil {
+			_ = os.WriteFile(filepath.Join(outDir, name+".error"), out, 0o644)
+			t.Fatalf("%s: run: %v", name, err)
+		}
+		_ = os.Remove(filepath.Join(outDir, name+".error"))
+		want, err := os.ReadFile(filepath.Join(outDir, name+".out"))
+		if err != nil {
+			t.Fatalf("%s: read want: %v", name, err)
+		}
+		want = bytes.TrimSpace(want)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s: output mismatch\nGot: %s\nWant: %s", name, got, want)
+		}
+		_ = os.Remove(jar)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop Kotlin transpiler tests after the first failure
- ensure rosetta tests stop at first failing program
- convert boolean expressions to `1`/`0` when printing
- regenerate Rosetta checklist showing first successes

## Testing
- `go test ./transpiler/x/kt -run TestTranspilePrograms -tags slow -count=1` *(fails: cross_join: kotlinc: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_687f945fc90083209d78ea14deeb070c