### PR TITLE
Fix Go Rosetta test determinism and list typing

### DIFF
--- a/transpiler/x/go/rosetta_test.go
+++ b/transpiler/x/go/rosetta_test.go
@@ -66,6 +66,7 @@ func TestGoTranspiler_Rosetta_Golden(t *testing.T) {
 				t.Fatalf("write code: %v", err)
 			}
 			cmd := exec.Command("go", "run", codePath)
+			cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 			if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 				cmd.Stdin = bytes.NewReader(data)
 			}


### PR DESCRIPTION
## Summary
- ensure Go Rosetta tests set `MOCHI_NOW_SEED` for deterministic runs
- infer list element types from variable declarations
- keep variable types in the environment so boolean logic is emitted correctly
- handle `[]any` typing in `toGoTypeFromType`

## Testing
- `go test -run TestGoTranspiler_Rosetta_Golden/100-prisoners -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687f9765f6148320bb57ae38cbdfe292