### PR TITLE
Update Dart transpiler

### DIFF
--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -2,13 +2,13 @@
 
 This directory contains Dart code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each program has a `.dart` file and `.out` output. Compilation or runtime failures are captured in a `.error` file.
 
-Compiled and ran: 0/284
+Compiled and ran: 5/284
 
 ## Checklist
-- [ ] 100-doors-2
-- [ ] 100-doors-3
-- [ ] 100-doors
-- [ ] 100-prisoners
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
+- [x] 100-prisoners
 - [ ] 15-puzzle-game
 - [ ] 15-puzzle-solver
 - [ ] 2048
@@ -290,4 +290,4 @@ Compiled and ran: 0/284
 - [ ] define-a-primitive-data-type
 - [ ] md5
 
-_Last updated: 2025-07-22 20:32 +0700_
+_Last updated: 2025-07-22 20:55 +0700_

--- a/transpiler/x/dart/rosetta_test.go
+++ b/transpiler/x/dart/rosetta_test.go
@@ -26,7 +26,8 @@ func TestDartTranspiler_Rosetta_Golden(t *testing.T) {
 	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "Dart")
 	os.MkdirAll(outDir, 0o755)
 
-	files, _ := filepath.Glob(filepath.Join("tests", "rosetta", "x", "Mochi", "*.mochi"))
+	srcDir := filepath.Join(root, "tests", "rosetta", "x", "Mochi")
+	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
 	sort.Strings(files)
 	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".mochi")


### PR DESCRIPTION
## Summary
- fix path to Rosetta samples in Dart transpiler tests
- escape newlines and keywords when emitting Dart strings
- introduce reserved-word sanitization and stdin input support
- generate `_start` wrapper if program already defines `main`
- update Dart Rosetta checklist

## Testing
- `go test ./transpiler/x/dart -run Rosetta -tags=slow -count=1 -v` *(fails: first failing program: 15-puzzle-game)*

------
https://chatgpt.com/codex/tasks/task_e_687f98686b0083209a04f66d7c82da7b