### PR TITLE
Improve Prolog transpiler tests

### DIFF
--- a/transpiler/x/pl/ROSETTA.md
+++ b/transpiler/x/pl/ROSETTA.md
@@ -1,11 +1,11 @@
 # Rosetta Prolog Transpiler
 
-## Rosetta Golden Test Checklist (1/284)
+## Rosetta Golden Test Checklist (2/284)
 Last updated: 2025-07-22 17:27 +0700
 - [x] `100-doors-2`
 - [ ] `100-doors-3`
 - [ ] `100-doors`
-- [ ] `100-prisoners`
+- [x] `100-prisoners`
 - [ ] `15-puzzle-game`
 - [ ] `15-puzzle-solver`
 - [ ] `2048`


### PR DESCRIPTION
## Summary
- enhance Prolog rosetta test to stop on first failure
- support `now()` builtin in Prolog transpiler
- generate runtime helper when `now()` is used
- update Prolog rosetta checklist

## Testing
- `go test ./transpiler/x/pl -run TestPrologTranspiler_Rosetta -tags=slow -v`

------
https://chatgpt.com/codex/tasks/task_e_687f9ba2b6688320b567ca68322dc5cb