### PR TITLE
Fix Zig rosetta failure handling

### DIFF
--- a/transpiler/x/zig/ROSETTA.md
+++ b/transpiler/x/zig/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Zig code for Rosetta tasks lives under `tests/rosetta/out/Zig`.
 
 ## Rosetta Test Checklist (13/284)
-_Last updated: 2025-07-22 20:44 +0700_
+_Last updated: 2025-07-22 21:14 +0700_
 - [x] 100-doors-2
 - [x] 100-doors-3
 - [ ] 100-doors


### PR DESCRIPTION
## Summary
- update Zig rosetta test to use `golden.RunFirstFailure`
- support dynamic `append` in Zig transpiler
- refresh rosetta checklist timestamp

## Testing
- `ROSETTA_MAX=1 go test ./transpiler/x/zig -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687f9d07d0688320a885f553c3ae05b3