### PR TITLE
Fix Lua transpiler rosetta flow

### DIFF
--- a/tests/rosetta/transpiler/Lua/100-prisoners.out
+++ b/tests/rosetta/transpiler/Lua/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 0 relative frequency = 0%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 0 relative frequency = 0%
+  strategy = random  pardoned = 0 relative frequency = 0.0%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%

--- a/transpiler/x/lua/ROSETTA.md
+++ b/transpiler/x/lua/ROSETTA.md
@@ -2,16 +2,16 @@
 
 Generated Lua code for programs in `tests/rosetta/x/Mochi`. Each program has a `.lua` file produced by the transpiler and a `.out` file with its runtime output. Compilation or runtime errors are captured in `.error` files.
 
-Transpiled programs: 0/284
+Transpiled programs: 4/284
 
-Last updated: 2025-07-22 17:27 GMT+7
+Last updated: 2025-07-22 21:04 GMT+7
 
 Checklist:
 
-- [ ] 100-doors-2
-- [ ] 100-doors-3
-- [ ] 100-doors
-- [ ] 100-prisoners
+- [x] 100-doors-2
+- [x] 100-doors-3
+- [x] 100-doors
+- [x] 100-prisoners
 - [ ] 15-puzzle-game
 - [ ] 15-puzzle-solver
 - [ ] 2048

--- a/transpiler/x/lua/rosetta_test.go
+++ b/transpiler/x/lua/rosetta_test.go
@@ -87,6 +87,7 @@ func TestLuaTranspiler_Rosetta(t *testing.T) {
 	sort.Strings(files)
 
 	var passed, failed int
+	var firstFail string
 	for _, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
 		ok := t.Run(name, func(t *testing.T) {
@@ -125,9 +126,16 @@ func TestLuaTranspiler_Rosetta(t *testing.T) {
 			passed++
 		} else {
 			failed++
+			if firstFail == "" {
+				firstFail = name
+				break
+			}
 		}
 	}
 	t.Logf("Summary: %d passed, %d failed", passed, failed)
+	if firstFail != "" {
+		t.Fatalf("first failing program: %s", firstFail)
+	}
 }
 
 func updateRosettaReadme() {


### PR DESCRIPTION
## Summary
- stop Lua rosetta tests after the first failure and report the program
- correctly transpile boolean negation
- handle `as float` casts so division uses floating point
- update Lua rosetta checklist
- refresh golden output for `100-prisoners`

## Testing
- `MOCHI_ROSETTA_ONLY=100-prisoners go test ./transpiler/x/lua -tags slow -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687f9a899fc48320818c157e80e32691