### PR TITLE
Improve C transpiler test harness

### DIFF
--- a/transpiler/x/c/transpiler_test.go
+++ b/transpiler/x/c/transpiler_test.go
@@ -19,7 +19,7 @@ import (
 	"mochi/types"
 )
 
-var update = flag.Bool("update", false, "update golden files")
+var updateFlag = flag.Bool("ctrans_update", false, "update golden files")
 
 func repoRoot(t *testing.T) string {
 	t.Helper()
@@ -83,7 +83,7 @@ func transpileAndRun(src string) ([]byte, error) {
 }
 
 func updateEnabled() bool {
-	return *update
+	return *updateFlag
 }
 
 func normalize(root string, b []byte) []byte {


### PR DESCRIPTION
## Summary
- streamline `rosetta_test.go` by using `golden.RunFirstFailure`
- rename `update` flag in C transpiler tests to avoid collision

## Testing
- `MOCHI_ROSETTA_ONLY=100-doors go test -run TestRosettaTranspilerGolden -tags slow`
- `MOCHI_ROSETTA_ONLY=24-game-solve go test -run TestRosettaTranspilerGolden -tags slow` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_687f9e5e471c8320a8ac78e2be9ab9e7