### PR TITLE
Enable indexing for Java Rosetta tests

### DIFF
--- a/transpiler/x/java/rosetta_test.go
+++ b/transpiler/x/java/rosetta_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -99,6 +100,19 @@ func TestJavaTranspiler_Rosetta_Golden(t *testing.T) {
 		t.Fatalf("glob: %v", err)
 	}
 	sort.Strings(files)
+
+	if v := os.Getenv("ROSETTA_INDEX"); v != "" {
+		idx, err := strconv.Atoi(v)
+		if err != nil || idx < 1 || idx > len(files) {
+			t.Fatalf("invalid ROSETTA_INDEX %s", v)
+		}
+		files = files[idx-1 : idx]
+	} else if v := os.Getenv("ROSETTA_MAX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n < len(files) {
+			files = files[:n]
+		}
+	}
+
 	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "Java")
 	os.MkdirAll(outDir, 0o755)
 	var firstFail string


### PR DESCRIPTION
## Summary
- allow running Java Rosetta transpiler tests by index using `ROSETTA_INDEX`

## Testing
- `ROSETTA_INDEX=1 go test ./transpiler/x/java -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687fa71791c483209531fda96f9c9c48