### PR TITLE
Add index-based Rosetta test control for Rust

### DIFF
--- a/transpiler/x/rs/ROSETTA.md
+++ b/transpiler/x/rs/ROSETTA.md
@@ -1,289 +1,289 @@
 # Rosetta Rust Transpiler Output (2/284)
-Last updated: 2025-07-22 20:48 +0700
+Last updated: 2025-07-22 21:48 +0700
 
 ## Program checklist
 
-- [x] 100-doors-2.mochi
-- [x] 100-doors-3.mochi
-- [ ] 100-doors.mochi
-- [ ] 100-prisoners.mochi
-- [ ] 15-puzzle-game.mochi
-- [ ] 15-puzzle-solver.mochi
-- [ ] 2048.mochi
-- [ ] 21-game.mochi
-- [ ] 24-game-solve.mochi
-- [ ] 24-game.mochi
-- [ ] 4-rings-or-4-squares-puzzle.mochi
-- [ ] 9-billion-names-of-god-the-integer.mochi
-- [ ] 99-bottles-of-beer-2.mochi
-- [ ] 99-bottles-of-beer.mochi
-- [ ] DNS-query.mochi
-- [ ] a+b.mochi
-- [ ] abbreviations-automatic.mochi
-- [ ] abbreviations-easy.mochi
-- [ ] abbreviations-simple.mochi
-- [ ] abc-problem.mochi
-- [ ] abelian-sandpile-model-identity.mochi
-- [ ] abelian-sandpile-model.mochi
-- [ ] abstract-type.mochi
-- [ ] abundant-deficient-and-perfect-number-classifications.mochi
-- [ ] abundant-odd-numbers.mochi
-- [ ] accumulator-factory.mochi
-- [ ] achilles-numbers.mochi
-- [ ] ackermann-function-2.mochi
-- [ ] ackermann-function-3.mochi
-- [ ] ackermann-function.mochi
-- [ ] active-directory-connect.mochi
-- [ ] active-directory-search-for-a-user.mochi
-- [ ] active-object.mochi
-- [ ] add-a-variable-to-a-class-instance-at-runtime.mochi
-- [ ] additive-primes.mochi
-- [ ] address-of-a-variable.mochi
-- [ ] adfgvx-cipher.mochi
-- [ ] aks-test-for-primes.mochi
-- [ ] algebraic-data-types.mochi
-- [ ] align-columns.mochi
-- [ ] aliquot-sequence-classifications.mochi
-- [ ] almkvist-giullera-formula-for-pi.mochi
-- [ ] almost-prime.mochi
-- [ ] amb.mochi
-- [ ] amicable-pairs.mochi
-- [ ] anagrams-deranged-anagrams.mochi
-- [ ] anagrams.mochi
-- [ ] angle-difference-between-two-bearings-1.mochi
-- [ ] angle-difference-between-two-bearings-2.mochi
-- [ ] angles-geometric-normalization-and-conversion.mochi
-- [ ] animate-a-pendulum.mochi
-- [ ] animation.mochi
-- [ ] anonymous-recursion-1.mochi
-- [ ] anonymous-recursion-2.mochi
-- [ ] anonymous-recursion.mochi
-- [ ] anti-primes.mochi
-- [ ] append-a-record-to-the-end-of-a-text-file.mochi
-- [ ] apply-a-callback-to-an-array-1.mochi
-- [ ] apply-a-callback-to-an-array-2.mochi
-- [ ] apply-a-digital-filter-direct-form-ii-transposed-.mochi
-- [ ] approximate-equality.mochi
-- [ ] arbitrary-precision-integers-included-.mochi
-- [ ] archimedean-spiral.mochi
-- [ ] arena-storage-pool.mochi
-- [ ] arithmetic-complex.mochi
-- [ ] arithmetic-derivative.mochi
-- [ ] arithmetic-evaluation.mochi
-- [ ] arithmetic-geometric-mean-calculate-pi.mochi
-- [ ] arithmetic-geometric-mean.mochi
-- [ ] arithmetic-integer-1.mochi
-- [ ] arithmetic-integer-2.mochi
-- [ ] arithmetic-numbers.mochi
-- [ ] arithmetic-rational.mochi
-- [ ] array-concatenation.mochi
-- [ ] array-length.mochi
-- [ ] arrays.mochi
-- [ ] ascending-primes.mochi
-- [ ] ascii-art-diagram-converter.mochi
-- [ ] assertions.mochi
-- [ ] associative-array-creation.mochi
-- [ ] associative-array-iteration.mochi
-- [ ] associative-array-merging.mochi
-- [ ] atomic-updates.mochi
-- [ ] attractive-numbers.mochi
-- [ ] average-loop-length.mochi
-- [ ] averages-arithmetic-mean.mochi
-- [ ] averages-mean-time-of-day.mochi
-- [ ] averages-median-1.mochi
-- [ ] averages-median-2.mochi
-- [ ] averages-median-3.mochi
-- [ ] averages-mode.mochi
-- [ ] averages-pythagorean-means.mochi
-- [ ] averages-root-mean-square.mochi
-- [ ] averages-simple-moving-average.mochi
-- [ ] avl-tree.mochi
-- [ ] b-zier-curves-intersections.mochi
-- [ ] babbage-problem.mochi
-- [ ] babylonian-spiral.mochi
-- [ ] balanced-brackets.mochi
-- [ ] balanced-ternary.mochi
-- [ ] barnsley-fern.mochi
-- [ ] base64-decode-data.mochi
-- [ ] bell-numbers.mochi
-- [ ] benfords-law.mochi
-- [ ] bernoulli-numbers.mochi
-- [ ] best-shuffle.mochi
-- [ ] bifid-cipher.mochi
-- [ ] bin-given-limits.mochi
-- [ ] binary-digits.mochi
-- [ ] binary-search.mochi
-- [ ] binary-strings.mochi
-- [ ] bioinformatics-base-count.mochi
-- [ ] bioinformatics-global-alignment.mochi
-- [ ] bioinformatics-sequence-mutation.mochi
-- [ ] biorhythms.mochi
-- [ ] bitcoin-address-validation.mochi
-- [ ] bitmap-b-zier-curves-cubic.mochi
-- [ ] bitmap-b-zier-curves-quadratic.mochi
-- [ ] bitmap-bresenhams-line-algorithm.mochi
-- [ ] bitmap-flood-fill.mochi
-- [ ] bitmap-histogram.mochi
-- [ ] bitmap-midpoint-circle-algorithm.mochi
-- [ ] bitmap-ppm-conversion-through-a-pipe.mochi
-- [ ] bitmap-read-a-ppm-file.mochi
-- [ ] bitmap-read-an-image-through-a-pipe.mochi
-- [ ] bitmap-write-a-ppm-file.mochi
-- [ ] bitmap.mochi
-- [ ] bitwise-io-1.mochi
-- [ ] bitwise-io-2.mochi
-- [ ] bitwise-operations.mochi
-- [ ] blum-integer.mochi
-- [ ] boolean-values.mochi
-- [ ] box-the-compass.mochi
-- [ ] boyer-moore-string-search.mochi
-- [ ] brazilian-numbers.mochi
-- [ ] break-oo-privacy.mochi
-- [ ] brilliant-numbers.mochi
-- [ ] brownian-tree.mochi
-- [ ] bulls-and-cows-player.mochi
-- [ ] bulls-and-cows.mochi
-- [ ] burrows-wheeler-transform.mochi
-- [ ] caesar-cipher-1.mochi
-- [ ] caesar-cipher-2.mochi
-- [ ] calculating-the-value-of-e.mochi
-- [ ] calendar---for-real-programmers-1.mochi
-- [ ] calendar---for-real-programmers-2.mochi
-- [ ] calendar.mochi
-- [ ] calkin-wilf-sequence.mochi
-- [ ] call-a-foreign-language-function.mochi
-- [ ] call-a-function-1.mochi
-- [ ] call-a-function-10.mochi
-- [ ] call-a-function-11.mochi
-- [ ] call-a-function-12.mochi
-- [ ] call-a-function-2.mochi
-- [ ] call-a-function-3.mochi
-- [ ] call-a-function-4.mochi
-- [ ] call-a-function-5.mochi
-- [ ] call-a-function-6.mochi
-- [ ] call-a-function-7.mochi
-- [ ] call-a-function-8.mochi
-- [ ] call-a-function-9.mochi
-- [ ] call-an-object-method-1.mochi
-- [ ] call-an-object-method-2.mochi
-- [ ] call-an-object-method-3.mochi
-- [ ] call-an-object-method.mochi
-- [ ] camel-case-and-snake-case.mochi
-- [ ] canny-edge-detector.mochi
-- [ ] canonicalize-cidr.mochi
-- [ ] cantor-set.mochi
-- [ ] carmichael-3-strong-pseudoprimes.mochi
-- [ ] cartesian-product-of-two-or-more-lists-1.mochi
-- [ ] cartesian-product-of-two-or-more-lists-2.mochi
-- [ ] cartesian-product-of-two-or-more-lists-3.mochi
-- [ ] cartesian-product-of-two-or-more-lists-4.mochi
-- [ ] case-sensitivity-of-identifiers.mochi
-- [ ] casting-out-nines.mochi
-- [ ] catalan-numbers-1.mochi
-- [ ] catalan-numbers-2.mochi
-- [ ] catalan-numbers-pascals-triangle.mochi
-- [ ] catamorphism.mochi
-- [ ] catmull-clark-subdivision-surface.mochi
-- [ ] chaocipher.mochi
-- [ ] chaos-game.mochi
-- [ ] character-codes-1.mochi
-- [ ] character-codes-2.mochi
-- [ ] character-codes-3.mochi
-- [ ] character-codes-4.mochi
-- [ ] character-codes-5.mochi
-- [ ] chat-server.mochi
-- [ ] check-machin-like-formulas.mochi
-- [ ] check-that-file-exists.mochi
-- [ ] checkpoint-synchronization-1.mochi
-- [ ] checkpoint-synchronization-2.mochi
-- [ ] checkpoint-synchronization-3.mochi
-- [ ] checkpoint-synchronization-4.mochi
-- [ ] chernicks-carmichael-numbers.mochi
-- [ ] cheryls-birthday.mochi
-- [ ] chinese-remainder-theorem.mochi
-- [ ] chinese-zodiac.mochi
-- [ ] cholesky-decomposition-1.mochi
-- [ ] cholesky-decomposition.mochi
-- [ ] chowla-numbers.mochi
-- [ ] church-numerals-1.mochi
-- [ ] church-numerals-2.mochi
-- [ ] circles-of-given-radius-through-two-points.mochi
-- [ ] circular-primes.mochi
-- [ ] cistercian-numerals.mochi
-- [ ] comma-quibbling.mochi
-- [ ] compiler-virtual-machine-interpreter.mochi
-- [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
-- [ ] compound-data-type.mochi
-- [ ] concurrent-computing-1.mochi
-- [ ] concurrent-computing-2.mochi
-- [ ] concurrent-computing-3.mochi
-- [ ] conditional-structures-1.mochi
-- [ ] conditional-structures-10.mochi
-- [ ] conditional-structures-2.mochi
-- [ ] conditional-structures-3.mochi
-- [ ] conditional-structures-4.mochi
-- [ ] conditional-structures-5.mochi
-- [ ] conditional-structures-6.mochi
-- [ ] conditional-structures-7.mochi
-- [ ] conditional-structures-8.mochi
-- [ ] conditional-structures-9.mochi
-- [ ] consecutive-primes-with-ascending-or-descending-differences.mochi
-- [ ] constrained-genericity-1.mochi
-- [ ] constrained-genericity-2.mochi
-- [ ] constrained-genericity-3.mochi
-- [ ] constrained-genericity-4.mochi
-- [ ] constrained-random-points-on-a-circle-1.mochi
-- [ ] constrained-random-points-on-a-circle-2.mochi
-- [ ] continued-fraction.mochi
-- [ ] convert-decimal-number-to-rational.mochi
-- [ ] convert-seconds-to-compound-duration.mochi
-- [ ] convex-hull.mochi
-- [ ] conways-game-of-life.mochi
-- [ ] copy-a-string-1.mochi
-- [ ] copy-a-string-2.mochi
-- [ ] copy-stdin-to-stdout-1.mochi
-- [ ] copy-stdin-to-stdout-2.mochi
-- [ ] count-in-factors.mochi
-- [ ] count-in-octal-1.mochi
-- [ ] count-in-octal-2.mochi
-- [ ] count-in-octal-3.mochi
-- [ ] count-in-octal-4.mochi
-- [ ] count-occurrences-of-a-substring.mochi
-- [ ] count-the-coins-1.mochi
-- [ ] count-the-coins-2.mochi
-- [ ] cramers-rule.mochi
-- [ ] crc-32-1.mochi
-- [ ] crc-32-2.mochi
-- [ ] create-a-file-on-magnetic-tape.mochi
-- [ ] create-a-file.mochi
-- [ ] create-a-two-dimensional-array-at-runtime-1.mochi
-- [ ] create-an-html-table.mochi
-- [ ] create-an-object-at-a-given-address.mochi
-- [ ] csv-data-manipulation.mochi
-- [ ] csv-to-html-translation-1.mochi
-- [ ] csv-to-html-translation-2.mochi
-- [ ] csv-to-html-translation-3.mochi
-- [ ] csv-to-html-translation-4.mochi
-- [ ] csv-to-html-translation-5.mochi
-- [ ] cuban-primes.mochi
-- [ ] cullen-and-woodall-numbers.mochi
-- [ ] cumulative-standard-deviation.mochi
-- [ ] currency.mochi
-- [ ] currying.mochi
-- [ ] curzon-numbers.mochi
-- [ ] cusip.mochi
-- [ ] cyclops-numbers.mochi
-- [ ] damm-algorithm.mochi
-- [ ] date-format.mochi
-- [ ] date-manipulation.mochi
-- [ ] day-of-the-week.mochi
-- [ ] de-bruijn-sequences.mochi
-- [ ] deal-cards-for-freecell.mochi
-- [ ] death-star.mochi
-- [ ] deceptive-numbers.mochi
-- [ ] deconvolution-1d-2.mochi
-- [ ] deconvolution-1d-3.mochi
-- [ ] deconvolution-1d.mochi
-- [ ] deepcopy-1.mochi
-- [ ] define-a-primitive-data-type.mochi
-- [ ] md5.mochi
+  1. [x] 100-doors-2.mochi
+  2. [x] 100-doors-3.mochi
+  3. [ ] 100-doors.mochi
+  4. [ ] 100-prisoners.mochi
+  5. [ ] 15-puzzle-game.mochi
+  6. [ ] 15-puzzle-solver.mochi
+  7. [ ] 2048.mochi
+  8. [ ] 21-game.mochi
+  9. [ ] 24-game-solve.mochi
+ 10. [ ] 24-game.mochi
+ 11. [ ] 4-rings-or-4-squares-puzzle.mochi
+ 12. [ ] 9-billion-names-of-god-the-integer.mochi
+ 13. [ ] 99-bottles-of-beer-2.mochi
+ 14. [ ] 99-bottles-of-beer.mochi
+ 15. [ ] DNS-query.mochi
+ 16. [ ] a+b.mochi
+ 17. [ ] abbreviations-automatic.mochi
+ 18. [ ] abbreviations-easy.mochi
+ 19. [ ] abbreviations-simple.mochi
+ 20. [ ] abc-problem.mochi
+ 21. [ ] abelian-sandpile-model-identity.mochi
+ 22. [ ] abelian-sandpile-model.mochi
+ 23. [ ] abstract-type.mochi
+ 24. [ ] abundant-deficient-and-perfect-number-classifications.mochi
+ 25. [ ] abundant-odd-numbers.mochi
+ 26. [ ] accumulator-factory.mochi
+ 27. [ ] achilles-numbers.mochi
+ 28. [ ] ackermann-function-2.mochi
+ 29. [ ] ackermann-function-3.mochi
+ 30. [ ] ackermann-function.mochi
+ 31. [ ] active-directory-connect.mochi
+ 32. [ ] active-directory-search-for-a-user.mochi
+ 33. [ ] active-object.mochi
+ 34. [ ] add-a-variable-to-a-class-instance-at-runtime.mochi
+ 35. [ ] additive-primes.mochi
+ 36. [ ] address-of-a-variable.mochi
+ 37. [ ] adfgvx-cipher.mochi
+ 38. [ ] aks-test-for-primes.mochi
+ 39. [ ] algebraic-data-types.mochi
+ 40. [ ] align-columns.mochi
+ 41. [ ] aliquot-sequence-classifications.mochi
+ 42. [ ] almkvist-giullera-formula-for-pi.mochi
+ 43. [ ] almost-prime.mochi
+ 44. [ ] amb.mochi
+ 45. [ ] amicable-pairs.mochi
+ 46. [ ] anagrams-deranged-anagrams.mochi
+ 47. [ ] anagrams.mochi
+ 48. [ ] angle-difference-between-two-bearings-1.mochi
+ 49. [ ] angle-difference-between-two-bearings-2.mochi
+ 50. [ ] angles-geometric-normalization-and-conversion.mochi
+ 51. [ ] animate-a-pendulum.mochi
+ 52. [ ] animation.mochi
+ 53. [ ] anonymous-recursion-1.mochi
+ 54. [ ] anonymous-recursion-2.mochi
+ 55. [ ] anonymous-recursion.mochi
+ 56. [ ] anti-primes.mochi
+ 57. [ ] append-a-record-to-the-end-of-a-text-file.mochi
+ 58. [ ] apply-a-callback-to-an-array-1.mochi
+ 59. [ ] apply-a-callback-to-an-array-2.mochi
+ 60. [ ] apply-a-digital-filter-direct-form-ii-transposed-.mochi
+ 61. [ ] approximate-equality.mochi
+ 62. [ ] arbitrary-precision-integers-included-.mochi
+ 63. [ ] archimedean-spiral.mochi
+ 64. [ ] arena-storage-pool.mochi
+ 65. [ ] arithmetic-complex.mochi
+ 66. [ ] arithmetic-derivative.mochi
+ 67. [ ] arithmetic-evaluation.mochi
+ 68. [ ] arithmetic-geometric-mean-calculate-pi.mochi
+ 69. [ ] arithmetic-geometric-mean.mochi
+ 70. [ ] arithmetic-integer-1.mochi
+ 71. [ ] arithmetic-integer-2.mochi
+ 72. [ ] arithmetic-numbers.mochi
+ 73. [ ] arithmetic-rational.mochi
+ 74. [ ] array-concatenation.mochi
+ 75. [ ] array-length.mochi
+ 76. [ ] arrays.mochi
+ 77. [ ] ascending-primes.mochi
+ 78. [ ] ascii-art-diagram-converter.mochi
+ 79. [ ] assertions.mochi
+ 80. [ ] associative-array-creation.mochi
+ 81. [ ] associative-array-iteration.mochi
+ 82. [ ] associative-array-merging.mochi
+ 83. [ ] atomic-updates.mochi
+ 84. [ ] attractive-numbers.mochi
+ 85. [ ] average-loop-length.mochi
+ 86. [ ] averages-arithmetic-mean.mochi
+ 87. [ ] averages-mean-time-of-day.mochi
+ 88. [ ] averages-median-1.mochi
+ 89. [ ] averages-median-2.mochi
+ 90. [ ] averages-median-3.mochi
+ 91. [ ] averages-mode.mochi
+ 92. [ ] averages-pythagorean-means.mochi
+ 93. [ ] averages-root-mean-square.mochi
+ 94. [ ] averages-simple-moving-average.mochi
+ 95. [ ] avl-tree.mochi
+ 96. [ ] b-zier-curves-intersections.mochi
+ 97. [ ] babbage-problem.mochi
+ 98. [ ] babylonian-spiral.mochi
+ 99. [ ] balanced-brackets.mochi
+100. [ ] balanced-ternary.mochi
+101. [ ] barnsley-fern.mochi
+102. [ ] base64-decode-data.mochi
+103. [ ] bell-numbers.mochi
+104. [ ] benfords-law.mochi
+105. [ ] bernoulli-numbers.mochi
+106. [ ] best-shuffle.mochi
+107. [ ] bifid-cipher.mochi
+108. [ ] bin-given-limits.mochi
+109. [ ] binary-digits.mochi
+110. [ ] binary-search.mochi
+111. [ ] binary-strings.mochi
+112. [ ] bioinformatics-base-count.mochi
+113. [ ] bioinformatics-global-alignment.mochi
+114. [ ] bioinformatics-sequence-mutation.mochi
+115. [ ] biorhythms.mochi
+116. [ ] bitcoin-address-validation.mochi
+117. [ ] bitmap-b-zier-curves-cubic.mochi
+118. [ ] bitmap-b-zier-curves-quadratic.mochi
+119. [ ] bitmap-bresenhams-line-algorithm.mochi
+120. [ ] bitmap-flood-fill.mochi
+121. [ ] bitmap-histogram.mochi
+122. [ ] bitmap-midpoint-circle-algorithm.mochi
+123. [ ] bitmap-ppm-conversion-through-a-pipe.mochi
+124. [ ] bitmap-read-a-ppm-file.mochi
+125. [ ] bitmap-read-an-image-through-a-pipe.mochi
+126. [ ] bitmap-write-a-ppm-file.mochi
+127. [ ] bitmap.mochi
+128. [ ] bitwise-io-1.mochi
+129. [ ] bitwise-io-2.mochi
+130. [ ] bitwise-operations.mochi
+131. [ ] blum-integer.mochi
+132. [ ] boolean-values.mochi
+133. [ ] box-the-compass.mochi
+134. [ ] boyer-moore-string-search.mochi
+135. [ ] brazilian-numbers.mochi
+136. [ ] break-oo-privacy.mochi
+137. [ ] brilliant-numbers.mochi
+138. [ ] brownian-tree.mochi
+139. [ ] bulls-and-cows-player.mochi
+140. [ ] bulls-and-cows.mochi
+141. [ ] burrows-wheeler-transform.mochi
+142. [ ] caesar-cipher-1.mochi
+143. [ ] caesar-cipher-2.mochi
+144. [ ] calculating-the-value-of-e.mochi
+145. [ ] calendar---for-real-programmers-1.mochi
+146. [ ] calendar---for-real-programmers-2.mochi
+147. [ ] calendar.mochi
+148. [ ] calkin-wilf-sequence.mochi
+149. [ ] call-a-foreign-language-function.mochi
+150. [ ] call-a-function-1.mochi
+151. [ ] call-a-function-10.mochi
+152. [ ] call-a-function-11.mochi
+153. [ ] call-a-function-12.mochi
+154. [ ] call-a-function-2.mochi
+155. [ ] call-a-function-3.mochi
+156. [ ] call-a-function-4.mochi
+157. [ ] call-a-function-5.mochi
+158. [ ] call-a-function-6.mochi
+159. [ ] call-a-function-7.mochi
+160. [ ] call-a-function-8.mochi
+161. [ ] call-a-function-9.mochi
+162. [ ] call-an-object-method-1.mochi
+163. [ ] call-an-object-method-2.mochi
+164. [ ] call-an-object-method-3.mochi
+165. [ ] call-an-object-method.mochi
+166. [ ] camel-case-and-snake-case.mochi
+167. [ ] canny-edge-detector.mochi
+168. [ ] canonicalize-cidr.mochi
+169. [ ] cantor-set.mochi
+170. [ ] carmichael-3-strong-pseudoprimes.mochi
+171. [ ] cartesian-product-of-two-or-more-lists-1.mochi
+172. [ ] cartesian-product-of-two-or-more-lists-2.mochi
+173. [ ] cartesian-product-of-two-or-more-lists-3.mochi
+174. [ ] cartesian-product-of-two-or-more-lists-4.mochi
+175. [ ] case-sensitivity-of-identifiers.mochi
+176. [ ] casting-out-nines.mochi
+177. [ ] catalan-numbers-1.mochi
+178. [ ] catalan-numbers-2.mochi
+179. [ ] catalan-numbers-pascals-triangle.mochi
+180. [ ] catamorphism.mochi
+181. [ ] catmull-clark-subdivision-surface.mochi
+182. [ ] chaocipher.mochi
+183. [ ] chaos-game.mochi
+184. [ ] character-codes-1.mochi
+185. [ ] character-codes-2.mochi
+186. [ ] character-codes-3.mochi
+187. [ ] character-codes-4.mochi
+188. [ ] character-codes-5.mochi
+189. [ ] chat-server.mochi
+190. [ ] check-machin-like-formulas.mochi
+191. [ ] check-that-file-exists.mochi
+192. [ ] checkpoint-synchronization-1.mochi
+193. [ ] checkpoint-synchronization-2.mochi
+194. [ ] checkpoint-synchronization-3.mochi
+195. [ ] checkpoint-synchronization-4.mochi
+196. [ ] chernicks-carmichael-numbers.mochi
+197. [ ] cheryls-birthday.mochi
+198. [ ] chinese-remainder-theorem.mochi
+199. [ ] chinese-zodiac.mochi
+200. [ ] cholesky-decomposition-1.mochi
+201. [ ] cholesky-decomposition.mochi
+202. [ ] chowla-numbers.mochi
+203. [ ] church-numerals-1.mochi
+204. [ ] church-numerals-2.mochi
+205. [ ] circles-of-given-radius-through-two-points.mochi
+206. [ ] circular-primes.mochi
+207. [ ] cistercian-numerals.mochi
+208. [ ] comma-quibbling.mochi
+209. [ ] compiler-virtual-machine-interpreter.mochi
+210. [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
+211. [ ] compound-data-type.mochi
+212. [ ] concurrent-computing-1.mochi
+213. [ ] concurrent-computing-2.mochi
+214. [ ] concurrent-computing-3.mochi
+215. [ ] conditional-structures-1.mochi
+216. [ ] conditional-structures-10.mochi
+217. [ ] conditional-structures-2.mochi
+218. [ ] conditional-structures-3.mochi
+219. [ ] conditional-structures-4.mochi
+220. [ ] conditional-structures-5.mochi
+221. [ ] conditional-structures-6.mochi
+222. [ ] conditional-structures-7.mochi
+223. [ ] conditional-structures-8.mochi
+224. [ ] conditional-structures-9.mochi
+225. [ ] consecutive-primes-with-ascending-or-descending-differences.mochi
+226. [ ] constrained-genericity-1.mochi
+227. [ ] constrained-genericity-2.mochi
+228. [ ] constrained-genericity-3.mochi
+229. [ ] constrained-genericity-4.mochi
+230. [ ] constrained-random-points-on-a-circle-1.mochi
+231. [ ] constrained-random-points-on-a-circle-2.mochi
+232. [ ] continued-fraction.mochi
+233. [ ] convert-decimal-number-to-rational.mochi
+234. [ ] convert-seconds-to-compound-duration.mochi
+235. [ ] convex-hull.mochi
+236. [ ] conways-game-of-life.mochi
+237. [ ] copy-a-string-1.mochi
+238. [ ] copy-a-string-2.mochi
+239. [ ] copy-stdin-to-stdout-1.mochi
+240. [ ] copy-stdin-to-stdout-2.mochi
+241. [ ] count-in-factors.mochi
+242. [ ] count-in-octal-1.mochi
+243. [ ] count-in-octal-2.mochi
+244. [ ] count-in-octal-3.mochi
+245. [ ] count-in-octal-4.mochi
+246. [ ] count-occurrences-of-a-substring.mochi
+247. [ ] count-the-coins-1.mochi
+248. [ ] count-the-coins-2.mochi
+249. [ ] cramers-rule.mochi
+250. [ ] crc-32-1.mochi
+251. [ ] crc-32-2.mochi
+252. [ ] create-a-file-on-magnetic-tape.mochi
+253. [ ] create-a-file.mochi
+254. [ ] create-a-two-dimensional-array-at-runtime-1.mochi
+255. [ ] create-an-html-table.mochi
+256. [ ] create-an-object-at-a-given-address.mochi
+257. [ ] csv-data-manipulation.mochi
+258. [ ] csv-to-html-translation-1.mochi
+259. [ ] csv-to-html-translation-2.mochi
+260. [ ] csv-to-html-translation-3.mochi
+261. [ ] csv-to-html-translation-4.mochi
+262. [ ] csv-to-html-translation-5.mochi
+263. [ ] cuban-primes.mochi
+264. [ ] cullen-and-woodall-numbers.mochi
+265. [ ] cumulative-standard-deviation.mochi
+266. [ ] currency.mochi
+267. [ ] currying.mochi
+268. [ ] curzon-numbers.mochi
+269. [ ] cusip.mochi
+270. [ ] cyclops-numbers.mochi
+271. [ ] damm-algorithm.mochi
+272. [ ] date-format.mochi
+273. [ ] date-manipulation.mochi
+274. [ ] day-of-the-week.mochi
+275. [ ] de-bruijn-sequences.mochi
+276. [ ] deal-cards-for-freecell.mochi
+277. [ ] death-star.mochi
+278. [ ] deceptive-numbers.mochi
+279. [ ] deconvolution-1d-2.mochi
+280. [ ] deconvolution-1d-3.mochi
+281. [ ] deconvolution-1d.mochi
+282. [ ] deepcopy-1.mochi
+283. [ ] define-a-primitive-data-type.mochi
+284. [ ] md5.mochi


### PR DESCRIPTION
## Summary
- allow selecting Rosetta cases for the Rust transpiler via `MOCHI_ROSETTA_INDEX`
- update `ROSETTA.md` to enumerate programs with numeric indices

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/rs -run TestTranspiler_Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687fa7b6cdd08320816e2e71a17298b4