### PR TITLE
Implement indexed rosetta run for C++ transpiler

### DIFF
--- a/transpiler/x/cpp/README.md
+++ b/transpiler/x/cpp/README.md
@@ -3,7 +3,7 @@
 This checklist is auto-generated.
 Generated C++ code for programs in `tests/vm/valid`. Each program has a `.cpp` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
-Last updated: 2025-07-22 20:30 +0700
+Last updated: 2025-07-22 22:22 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (1/284) - Last updated 2025-07-22 21:48 +0700:
+Checklist of programs that currently transpile and run (2/284) - Last updated 2025-07-22 22:22 +0700:
 1. [x] 100-doors-2
-2. [ ] 100-doors-3
+2. [x] 100-doors-3
 3. [ ] 100-doors
 4. [ ] 100-prisoners
 5. [ ] 15-puzzle-game

--- a/transpiler/x/cpp/TASKS.md
+++ b/transpiler/x/cpp/TASKS.md
@@ -1,3 +1,33 @@
+## Progress (2025-07-22 22:22 +0700)
+- cpp transpiler: add index-based rosetta run
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 22:15 +0700)
+- cpp transpiler: run rosetta tasks by index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 22:15 +0700)
+- cpp transpiler: run rosetta tasks by index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 22:15 +0700)
+- cpp transpiler: run rosetta tasks by index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 22:15 +0700)
+- cpp transpiler: run rosetta tasks by index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 22:15 +0700)
+- cpp transpiler: run rosetta tasks by index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-22 20:30 +0700)
 - cpp transpiler: support update statements
 - Generated C++ for 102/103 programs

--- a/transpiler/x/cpp/rosetta_test.go
+++ b/transpiler/x/cpp/rosetta_test.go
@@ -29,13 +29,24 @@ func TestCPPTranspiler_Rosetta_Golden(t *testing.T) {
 
 	files, _ := filepath.Glob(filepath.Join(root, "tests", "rosetta", "x", "Mochi", "*.mochi"))
 	sort.Strings(files)
+
+	startIdx := 1
 	if v := os.Getenv("ROSETTA_INDEX"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= len(files) {
+			startIdx = n
 			files = files[n-1 : n]
 		} else {
 			t.Fatalf("invalid ROSETTA_INDEX %s", v)
 		}
+	} else if v := os.Getenv("MOCHI_ROSETTA_INDEX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= len(files) {
+			startIdx = n
+			files = files[n-1 : n]
+		} else {
+			t.Fatalf("invalid MOCHI_ROSETTA_INDEX %s", v)
+		}
 	}
+	t.Cleanup(updateRosettaReadme)
 	var firstErr string
 	runOne := func(src string) error {
 		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
@@ -83,9 +94,11 @@ func TestCPPTranspiler_Rosetta_Golden(t *testing.T) {
 		return nil
 	}
 
-	for _, src := range files {
+	for i, src := range files {
+		idx := startIdx + i
 		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
-		ok := t.Run(name, func(t *testing.T) {
+		tname := fmt.Sprintf("%03d_%s", idx, name)
+		ok := t.Run(tname, func(t *testing.T) {
 			if err := runOne(src); err != nil {
 				firstErr = name
 				t.Fail()


### PR DESCRIPTION
## Summary
- allow running single rosetta example by index via `ROSETTA_INDEX` or `MOCHI_ROSETTA_INDEX`
- name rosetta subtests with numeric prefix and update the progress file automatically
- update progress checklist in `ROSETTA.md`
- record worklog entry

## Testing
- `ROSETTA_INDEX=2 go test ./transpiler/x/cpp -run TestCPPTranspiler_Rosetta_Golden -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687fab1befb483209171fb2ceba8f1fc