### PR TITLE
Update Lua rosetta harness

### DIFF
--- a/transpiler/x/lua/ROSETTA.md
+++ b/transpiler/x/lua/ROSETTA.md
@@ -4,7 +4,7 @@ Generated Lua code for programs in `tests/rosetta/x/Mochi`. Each program has a `
 
 Transpiled programs: 4/284
 
-Last updated: 2025-07-22 21:48 GMT+7
+Last updated: 2025-07-22 22:32 GMT+7
 
 Checklist:
 

--- a/transpiler/x/lua/rosetta_test.go
+++ b/transpiler/x/lua/rosetta_test.go
@@ -94,9 +94,10 @@ func TestLuaTranspiler_Rosetta(t *testing.T) {
 	}
 
 	var passed int
-	for _, src := range files {
+	for i, src := range files {
 		name := strings.TrimSuffix(filepath.Base(src), ".mochi")
-		ok := t.Run(name, func(t *testing.T) {
+		testName := fmt.Sprintf("%03d_%s", i+1, name)
+		ok := t.Run(testName, func(t *testing.T) {
 			got, err := runCase(src, outDir)
 			if err != nil {
 				t.Fatalf("run error: %v", err)
@@ -129,7 +130,7 @@ func TestLuaTranspiler_Rosetta(t *testing.T) {
 			}
 		})
 		if !ok {
-			t.Fatalf("first failing program: %s", name)
+			t.Fatalf("first failing program: %s", testName)
 		}
 		passed++
 	}


### PR DESCRIPTION
## Summary
- run Lua Rosetta programs with an index prefix so tests can be selected numerically
- refresh Rosetta checklist with latest timestamp

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/lua -tags=slow -run TestLuaTranspiler_Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687faf0e7d2c8320874d75ed61c6366c