### PR TITLE
Improve Rust rosetta test indexing

### DIFF
--- a/transpiler/x/rs/ROSETTA.md
+++ b/transpiler/x/rs/ROSETTA.md
@@ -1,5 +1,5 @@
 # Rosetta Rust Transpiler Output (2/284)
-Last updated: 2025-07-22 21:48 +0700
+Last updated: 2025-07-22 22:36 +0700
 
 ## Program checklist
 


### PR DESCRIPTION
## Summary
- use `index.txt` for ordering Rosetta test programs
- update rosetta Rust progress list

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test -tags slow ./transpiler/x/rs -run TestTranspiler_Rosetta -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_687faffde4608320ace552b6b903290b