### PR TITLE
Improve pascal rosetta runner

### DIFF
--- a/transpiler/x/pas/README.md
+++ b/transpiler/x/pas/README.md
@@ -107,4 +107,4 @@ Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-22 21:48 +0700
+Last updated: 2025-07-22 15:38 UTC

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (3/284) - updated 2025-07-22 21:48 +0700
+## Rosetta Checklist (3/284) - updated 2025-07-22 15:38 UTC
 - [x] 100-doors-2
 - [x] 100-doors-3
 - [x] 100-doors

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,3 +1,9 @@
+## Progress (2025-07-22 15:38 UTC)
+- pascal rosetta tests use index (progress 87/103)
+
+## Progress (2025-07-22 22:32 +0700)
+- pascal rosetta: run program by index (progress 87/103)
+
 ## Progress (2025-07-22 21:48 +0700)
 - ex: start handling mutable for loops and clean rosetta test (progress 87/103)
 


### PR DESCRIPTION
## Summary
- rework Pascal Rosetta test to use `index.txt`
- run Rosetta programs by numeric index
- update Pascal transpiler progress notes

## Testing
- `go test -tags=slow ./transpiler/x/pas -run TestPascalTranspiler_Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687faf19fab08320b114530b1b8e3156