### PR TITLE
Update scheme rosetta tests to use index file

### DIFF
--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (3/284)
-Last updated: 2025-07-22 14:48 UTC
+Last updated: 2025-07-22 15:54 UTC
 
 1. [x] 100-doors-2
 2. [x] 100-doors-3

--- a/transpiler/x/scheme/rosetta_test.go
+++ b/transpiler/x/scheme/rosetta_test.go
@@ -3,6 +3,7 @@
 package scheme_test
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"mochi/parser"
@@ -11,12 +12,31 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+func readIndex(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var names []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		parts := strings.Fields(scanner.Text())
+		if len(parts) == 2 {
+			names = append(names, parts[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return names, nil
+}
 
 func TestSchemeTranspiler_Rosetta_Golden(t *testing.T) {
 	if _, err := exec.LookPath("chibi-scheme"); err != nil {
@@ -28,27 +48,27 @@ func TestSchemeTranspiler_Rosetta_Golden(t *testing.T) {
 	os.MkdirAll(outDir, 0o755)
 	t.Cleanup(updateRosettaChecklist)
 
-	files, err := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
+	names, err := readIndex(filepath.Join(srcDir, "index.txt"))
 	if err != nil {
-		t.Fatalf("glob: %v", err)
+		t.Fatalf("read index: %v", err)
 	}
-	sort.Strings(files)
-	if len(files) == 0 {
+	if len(names) == 0 {
 		t.Fatalf("no Mochi files found: %s", srcDir)
 	}
 	if idxStr := os.Getenv("MOCHI_ROSETTA_INDEX"); idxStr != "" {
 		idx, err := strconv.Atoi(idxStr)
-		if err != nil || idx < 1 || idx > len(files) {
+		if err != nil || idx < 1 || idx > len(names) {
 			t.Fatalf("invalid MOCHI_ROSETTA_INDEX: %s", idxStr)
 		}
-		files = files[idx-1 : idx]
+		names = names[idx-1 : idx]
 	} else if only := os.Getenv("MOCHI_ROSETTA_ONLY"); only != "" {
-		files = []string{filepath.Join(srcDir, only+".mochi")}
+		names = []string{only + ".mochi"}
 	}
 
 	var firstFail string
-	for _, src := range files {
-		base := strings.TrimSuffix(filepath.Base(src), ".mochi")
+	for _, nameFile := range names {
+		src := filepath.Join(srcDir, nameFile)
+		base := strings.TrimSuffix(nameFile, ".mochi")
 		ok := t.Run(base, func(t *testing.T) {
 			codePath := filepath.Join(outDir, base+".scm")
 			outPath := filepath.Join(outDir, base+".out")
@@ -109,13 +129,12 @@ func updateRosettaChecklist() {
 	outDir := filepath.Join(root, "tests", "rosetta", "transpiler", "scheme")
 	readmePath := filepath.Join(root, "transpiler", "x", "scheme", "ROSETTA.md")
 
-	files, _ := filepath.Glob(filepath.Join(srcDir, "*.mochi"))
-	sort.Strings(files)
-	total := len(files)
+	names, _ := readIndex(filepath.Join(srcDir, "index.txt"))
+	total := len(names)
 	completed := 0
 	var lines []string
-	for i, f := range files {
-		name := strings.TrimSuffix(filepath.Base(f), ".mochi")
+	for i, nameFile := range names {
+		name := strings.TrimSuffix(nameFile, ".mochi")
 		mark := "[ ]"
 		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
 			if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {


### PR DESCRIPTION
## Summary
- add readIndex helper in Scheme rosetta tests
- read `index.txt` and use MOCHI_ROSETTA_INDEX
- update scheme ROSETTA.md progress timestamp

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test -tags slow ./transpiler/x/scheme -run TestSchemeTranspiler_Rosetta_Golden -v`

------
https://chatgpt.com/codex/tasks/task_e_687fb2e50a508320846b1b5062d2d1b0