### PR TITLE
Update Go rosetta test index handling

### DIFF
--- a/transpiler/x/go/ROSETTA.md
+++ b/transpiler/x/go/ROSETTA.md
@@ -1,7 +1,7 @@
 # Go Rosetta Transpiler Output
 
 Completed programs: 2/284
-Last updated: 2025-07-22 22:04 +0700
+Last updated: 2025-07-22 22:49 +0700
 
 Checklist:
 


### PR DESCRIPTION
## Summary
- enhance Go rosetta tests to read `index.txt`
- generate checklist using the index

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/go -tags slow -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687fb344ebd48320afbb820b3c24dcba