### PR TITLE
Update cpp rosetta tests to use index list

### DIFF
--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,10 +2,10 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (2/284) - Last updated 2025-07-22 22:22 +0700:
+Checklist of programs that currently transpile and run (3/284) - Last updated 2025-07-22 22:49 +0700:
 1. [x] 100-doors-2
 2. [x] 100-doors-3
-3. [ ] 100-doors
+3. [x] 100-doors
 4. [ ] 100-prisoners
 5. [ ] 15-puzzle-game
 6. [ ] 15-puzzle-solver


### PR DESCRIPTION
## Summary
- run C++ Rosetta tests using `index.txt`
- update progress checklist (3 programs pass)

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/cpp -run TestCPPTranspiler_Rosetta_Golden -tags=slow`
- `MOCHI_ROSETTA_INDEX=3 go test ./transpiler/x/cpp -run TestCPPTranspiler_Rosetta_Golden -tags=slow`
- `MOCHI_ROSETTA_INDEX=4 go test ./transpiler/x/cpp -run TestCPPTranspiler_Rosetta_Golden -tags=slow` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_687fb36809988320b0225639276f1bff