### PR TITLE
Improve Dart rosetta index

### DIFF
--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -290,4 +290,4 @@ Compiled and ran: 2/284
 283. [ ] define-a-primitive-data-type
 284. [ ] md5
 
-_Last updated: 2025-07-22 22:18 +0700_
+_Last updated: 2025-07-22 22:49 +0700_


### PR DESCRIPTION
## Summary
- use index.txt in dart Rosetta tests
- update generated Rosetta checklist

## Testing
- `go test ./transpiler/x/dart -c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_687fb3a62f34832098ed9baa9e7be096