### PR TITLE
Use rosetta index for F# transpiler tests

### DIFF
--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -288,4 +288,4 @@ This file is auto-generated from rosetta tests.
 283. [ ] define-a-primitive-data-type
 284. [ ] md5
 
-Last updated: 2025-07-22 22:23 +0700
+Last updated: 2025-07-22 22:49 +0700


### PR DESCRIPTION
## Summary
- update `fs` transpiler test to read `index.txt`
- regenerate `ROSETTA.md` to refresh timestamp

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/fs -run Rosetta -count=1 -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_687fb3c3fca88320ad211839c596db87