### PR TITLE
Add index filter for Java Rosetta tests

### DIFF
--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Rosetta Checklist (1/284) - updated 2025-07-22 15:37 UTC
+## Rosetta Checklist (2/284) - updated 2025-07-22 15:58 UTC
 1. [x] 100-doors-2
-2. [ ] 100-doors-3
+2. [x] 100-doors-3
 3. [ ] 100-doors
 4. [ ] 100-prisoners
 5. [ ] 15-puzzle-game


### PR DESCRIPTION
## Summary
- allow running a specific Rosetta program by index or name in Java transpiler tests
- auto-update the Java Rosetta checklist
- update checklist marking program 2 as passing

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test -tags slow ./transpiler/x/java -run Rosetta -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_687fb3ebf5e483209d2f2851aaae6296