### PR TITLE
Refactor PHP rosetta runner

### DIFF
--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-22 22:32 +0700
+Last updated: 2025-07-22 23:00 +0700
 
 ## Checklist (3/284)
 - [x] 100-doors-2

--- a/transpiler/x/php/rosetta_test.go
+++ b/transpiler/x/php/rosetta_test.go
@@ -51,10 +51,10 @@ func TestPHPTranspiler_Rosetta_Golden(t *testing.T) {
 		t.Fatal("no rosetta programs found")
 	}
 
-	if s := os.Getenv("ROSETTA_INDEX"); s != "" {
+	if s := os.Getenv("MOCHI_ROSETTA_INDEX"); s != "" {
 		idx, err := strconv.Atoi(s)
 		if err != nil || idx <= 0 || idx > len(files) {
-			t.Fatalf("invalid ROSETTA_INDEX: %s", s)
+			t.Fatalf("invalid MOCHI_ROSETTA_INDEX: %s", s)
 		}
 		files = files[idx-1 : idx]
 	} else if s := os.Getenv("ROSETTA_LIMIT"); s != "" {


### PR DESCRIPTION
## Summary
- let PHP rosetta tests accept `MOCHI_ROSETTA_INDEX`
- refresh PHP transpiler Rosetta checklist timestamp

## Testing
- `ROSETTA_LIMIT=1 MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/php -tags slow -run Rosetta -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_687fb40e6764832096974a071cd706de