### PR TITLE
Update rosetta Ruby tests

### DIFF
--- a/transpiler/x/rb/ROSETTA.md
+++ b/transpiler/x/rb/ROSETTA.md
@@ -1,9 +1,9 @@
-# Ruby Rosetta Transpiler Output (1/284)
-Last updated: 2025-07-22 15:41 UTC
+# Ruby Rosetta Transpiler Output (3/284)
+Last updated: 2025-07-22 16:04 UTC
 
   1. [x] 100-doors-2
-  2. [ ] 100-doors-3
-  3. [ ] 100-doors
+  2. [x] 100-doors-3
+  3. [x] 100-doors
   4. [ ] 100-prisoners
   5. [ ] 15-puzzle-game
   6. [ ] 15-puzzle-solver


### PR DESCRIPTION
## Summary
- rework Ruby rosetta tests to read an `index.txt`
- update generated progress checklist

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/rb -tags slow -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=3 go test ./transpiler/x/rb -tags slow -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=4 go test ./transpiler/x/rb -tags slow -run Rosetta -count=1 -timeout=60s` *(fails: test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687fb43b30448320a61f7120ec8bd5aa