### PR TITLE
Refactor Scala rosetta tests to use index

### DIFF
--- a/transpiler/x/scala/ROSETTA.md
+++ b/transpiler/x/scala/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scala code for Rosetta tasks in `tests/rosetta/x/Mochi`. Each program has a `.scala` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## Golden Test Checklist (5/284)
-_Last updated: 2025-07-22 22:46 +0700_
+_Last updated: 2025-07-22 23:06 +0700_
 
 1. [x] 100-doors-2
 2. [x] 100-doors-3


### PR DESCRIPTION
## Summary
- load Rosetta program list from `index.txt`
- allow selecting a case by `MOCHI_ROSETTA_INDEX`
- regenerate Scala Rosetta checklist

## Testing
- `go test ./transpiler/x/scala -run Rosetta_Golden -tags slow -count=1 -v -timeout=0`
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/scala -run Rosetta_Golden -tags slow -count=1 -v -timeout=0`


------
https://chatgpt.com/codex/tasks/task_e_687fb600c2a883209e57b6238559d5d5