### PR TITLE
Update scheme rosetta tests

### DIFF
--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (3/284)
-Last updated: 2025-07-22 14:48 UTC
+Last updated: 2025-07-22 15:49 UTC
 
 1. [x] 100-doors-2
 2. [x] 100-doors-3


### PR DESCRIPTION
## Summary
- update Scheme rosetta tests to use explicit index file
- update generated checklist

## Testing
- `MOCHI_ROSETTA_INDEX=2 go test ./transpiler/x/scheme -run Rosetta -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687fb60b6d048320b029201d8c18e6f0