### PR TITLE
Fix Rosetta program 4 for C++ transpiler

### DIFF
--- a/transpiler/x/cpp/README.md
+++ b/transpiler/x/cpp/README.md
@@ -3,7 +3,7 @@
 This checklist is auto-generated.
 Generated C++ code for programs in `tests/vm/valid`. Each program has a `.cpp` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
-Last updated: 2025-07-22 22:22 +0700
+Last updated: 2025-07-22 23:06 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,11 +2,11 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (2/284) - Last updated 2025-07-22 22:22 +0700:
+Checklist of programs that currently transpile and run (4/284) - Last updated 2025-07-22 23:06 +0700:
 1. [x] 100-doors-2
 2. [x] 100-doors-3
-3. [ ] 100-doors
-4. [ ] 100-prisoners
+3. [x] 100-doors
+4. [x] 100-prisoners
 5. [ ] 15-puzzle-game
 6. [ ] 15-puzzle-solver
 7. [ ] 2048

--- a/transpiler/x/cpp/TASKS.md
+++ b/transpiler/x/cpp/TASKS.md
@@ -1,3 +1,38 @@
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:06 +0700)
+- c transpiler: use rosetta index
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-22 22:22 +0700)
 - cpp transpiler: add index-based rosetta run
 - Generated C++ for 102/103 programs


### PR DESCRIPTION
## Summary
- handle reserved names like `this` in the C++ transpiler
- infer types for list indexing expressions
- rename user defined `main` to `user_main`
- generate 64-bit timestamps for `_now`
- update auto-generated docs after running Rosetta test

## Testing
- `MOCHI_ROSETTA_INDEX=4 go test ./transpiler/x/cpp -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_687fb6f657e48320baf9fb64ce002e41