### PR TITLE
Verify rosetta index 2

### DIFF
--- a/transpiler/x/cpp/README.md
+++ b/transpiler/x/cpp/README.md
@@ -3,7 +3,7 @@
 This checklist is auto-generated.
 Generated C++ code for programs in `tests/vm/valid`. Each program has a `.cpp` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
-Last updated: 2025-07-22 22:22 +0700
+Last updated: 2025-07-22 23:07 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (3/284) - Last updated 2025-07-22 22:49 +0700:
+Checklist of programs that currently transpile and run (3/284) - Last updated 2025-07-22 23:07 +0700:
 1. [x] 100-doors-2
 2. [x] 100-doors-3
 3. [x] 100-doors

--- a/transpiler/x/cpp/TASKS.md
+++ b/transpiler/x/cpp/TASKS.md
@@ -1,3 +1,18 @@
+## Progress (2025-07-22 23:07 +0700)
+- dart transpiler: index rosetta cases
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:07 +0700)
+- dart transpiler: index rosetta cases
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
+## Progress (2025-07-22 23:07 +0700)
+- dart transpiler: index rosetta cases
+- Generated C++ for 102/103 programs
+- Updated README checklist and outputs
+
 ## Progress (2025-07-22 22:22 +0700)
 - cpp transpiler: add index-based rosetta run
 - Generated C++ for 102/103 programs


### PR DESCRIPTION
## Summary
- run rosetta test for index 2 (100-doors-3)
- regenerate progress docs

## Testing
- `ROSETTA_INDEX=2 go test ./transpiler/x/cpp -run Rosetta -tags slow -count=1`
- `ROSETTA_INDEX=1 go test ./transpiler/x/cpp -run Rosetta -tags slow -count=1`
- `ROSETTA_INDEX=3 go test ./transpiler/x/cpp -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687fb77720148320958cb9d406b9293a