### PR TITLE
Fix Java print output quoting

### DIFF
--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -2,10 +2,10 @@
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Rosetta Checklist (2/284) - updated 2025-07-22 15:58 UTC
+## Rosetta Checklist (3/284) - updated 2025-07-22 16:20 UTC
 1. [x] 100-doors-2
 2. [x] 100-doors-3
-3. [ ] 100-doors
+3. [x] 100-doors
 4. [ ] 100-prisoners
 5. [ ] 15-puzzle-game
 6. [ ] 15-puzzle-solver

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -2395,7 +2395,7 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 				} else if isBoolExpr(a) {
 					args[i] = &TernaryExpr{Cond: a, Then: &StringLit{Value: "True"}, Else: &StringLit{Value: "False"}}
 				} else if isStringExpr(a) {
-					args[i] = &BinaryExpr{Left: &BinaryExpr{Left: &StringLit{Value: "'"}, Op: "+", Right: a}, Op: "+", Right: &StringLit{Value: "'"}}
+					args[i] = a
 				}
 			}
 			if len(args) > 1 {


### PR DESCRIPTION
## Summary
- remove extra quotes around printed strings in Java transpiler
- regenerate the Rosetta progress for first three programs

## Testing
- `UPDATE=1 go test -tags=slow ./transpiler/x/java -run Rosetta -index=1`
- `UPDATE=1 go test -tags=slow ./transpiler/x/java -run Rosetta -index=2`
- `UPDATE=1 go test -tags=slow ./transpiler/x/java -run Rosetta -index=3`

------
https://chatgpt.com/codex/tasks/task_e_687fb90bebc0832098390241c697beb4