### PR TITLE
Fix Zig list literal init

### DIFF
--- a/transpiler/x/zig/ROSETTA.md
+++ b/transpiler/x/zig/ROSETTA.md
@@ -2,12 +2,12 @@
 
 Generated Zig code for Rosetta tasks lives under `tests/rosetta/out/Zig`.
 
-Last updated: 2025-07-22 23:11 +0700
+Last updated: 2025-07-22 23:35 +0700
 
-## Program Checklist (13/284)
+## Program Checklist (14/284)
 1. [x] 100-doors-2
 2. [x] 100-doors-3
-3. [ ] 100-doors
+3. [x] 100-doors
 4. [ ] 100-prisoners
 5. [ ] 15-puzzle-game
 6. [ ] 15-puzzle-solver

--- a/transpiler/x/zig/transpiler.go
+++ b/transpiler/x/zig/transpiler.go
@@ -1182,6 +1182,10 @@ func (b *BinaryExpr) emit(w io.Writer) {
 
 func (l *ListLit) emit(w io.Writer) {
 	if l.ElemType != "" {
+		if len(l.Elems) == 0 {
+			fmt.Fprintf(w, "&[_]%s{}", l.ElemType)
+			return
+		}
 		fmt.Fprintf(w, "[%d]%s{", len(l.Elems), l.ElemType)
 	} else if len(l.Elems) > 0 {
 		if _, ok := l.Elems[0].(*ListLit); ok {
@@ -1192,7 +1196,8 @@ func (l *ListLit) emit(w io.Writer) {
 			fmt.Fprintf(w, "[%d]i64{", len(l.Elems))
 		}
 	} else {
-		io.WriteString(w, "[_]i64{")
+		io.WriteString(w, "&[_]i64{}")
+		return
 	}
 	for i, e := range l.Elems {
 		if i > 0 {


### PR DESCRIPTION
## Summary
- ensure Zig transpiler emits valid empty list literals
- update Rosetta progress for Zig

## Testing
- `go build -tags slow ./transpiler/x/zig`
- `go test ./transpiler/x/zig -tags slow -c`

------
https://chatgpt.com/codex/tasks/task_e_687fbbb000cc8320a51997ea8325a7a6