### PR TITLE
Enable first Rosetta Fortran case

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -464,6 +464,9 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 			if err != nil {
 				return err
 			}
+			if n, ok := toInt(val); ok {
+				val = n
+			}
 		}
 		i.env.SetValue(s.Let.Name, val, false)
 		return nil
@@ -475,6 +478,9 @@ func (i *Interpreter) evalStmt(s *parser.Statement) error {
 			val, err = i.evalExpr(s.Var.Value)
 			if err != nil {
 				return err
+			}
+			if n, ok := toInt(val); ok {
+				val = n
 			}
 		}
 		i.env.SetValue(s.Var.Name, val, true)
@@ -855,12 +861,12 @@ func (i *Interpreter) evalFor(stmt *parser.ForStmt) error {
 		if err != nil {
 			return err
 		}
-		fromInt, ok1 := fromVal.(int)
-		toInt, ok2 := toVal.(int)
+		fromInt, ok1 := toInt(fromVal)
+		toIntVal, ok2 := toInt(toVal)
 		if !ok1 || !ok2 {
 			return errInvalidRangeBounds(stmt.Pos, fmt.Sprintf("%T", fromVal), fmt.Sprintf("%T", toVal))
 		}
-		for x := fromInt; x < toInt; x++ {
+		for x := fromInt; x < toIntVal; x++ {
 			child.SetValue(stmt.Name, x, true)
 			cont, err := i.execLoopBody(stmt.Body)
 			if err != nil {

--- a/interpreter/value.go
+++ b/interpreter/value.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"mochi/parser"
 )
 
 // ValueTag represents the type of a runtime value.
@@ -84,6 +86,8 @@ func anyToValue(v any) Value {
 	case int:
 		return Value{Tag: TagInt, Int: val}
 	case int64:
+		return Value{Tag: TagInt, Int: int(val)}
+	case parser.IntLit:
 		return Value{Tag: TagInt, Int: int(val)}
 	case float64:
 		return Value{Tag: TagFloat, Float: val}

--- a/transpiler/x/fortran/ROSETTA.md
+++ b/transpiler/x/fortran/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist tracks Mochi programs from `tests/rosetta/x/Mochi` that successfully transpile using the experimental Fortran backend.
 
-Checklist of programs that currently transpile and run (0/284):
+Checklist of programs that currently transpile and run (1/284):
 
-1. [ ] 100-doors-2
+1. [x] 100-doors-2
 2. [ ] 100-doors-3
 3. [ ] 100-doors
 4. [ ] 100-prisoners
@@ -289,4 +289,4 @@ Checklist of programs that currently transpile and run (0/284):
 283. [ ] define-a-primitive-data-type
 284. [ ] md5
 
-_Last updated: 2025-07-22 21:48:55 +0700_
+_Last updated: 2025-07-22 22:27:35 +0700_


### PR DESCRIPTION
## Summary
- fix interpreter to properly handle parser.IntLit values
- update Fortran rosetta test harness
- mark the first Rosetta example as working

## Testing
- `go test ./transpiler/x/fortran -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_687fadffcc24832091419520060c6cab