### PR TITLE
Update Kotlin transpiler

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/15-puzzle-game.error
+++ b/tests/rosetta/transpiler/Kotlin/15-puzzle-game.error
@@ -1,82 +1,10 @@
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:25:14: error: unresolved reference: board
-        if ((board[i] as Int) != (solved[i] as Int)) {
-             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:25:35: error: unresolved reference: solved
-        if ((board[i] as Int) != (solved[i] as Int)) {
-                                  ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:33:45: error: unresolved reference: any
-fun isValidMove(m: Int): MutableMap<String, any> {
-                                            ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:35:51: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty - 4, "ok" to (empty / 4) > 0)
-                                                  ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:35:71: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty - 4, "ok" to (empty / 4) > 0)
-                                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:38:51: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty + 4, "ok" to (empty / 4) < 3)
-                                                  ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:38:71: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty + 4, "ok" to (empty / 4) < 3)
-                                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:41:51: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty + 1, "ok" to (empty % 4) < 3)
-                                                  ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:41:71: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty + 1, "ok" to (empty % 4) < 3)
-                                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:44:51: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty - 1, "ok" to (empty % 4) > 0)
-                                                  ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:44:71: error: unresolved reference: empty
-        return mutableMapOf<String, Any>("idx" to empty - 1, "ok" to (empty % 4) > 0)
-                                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:54:18: error: unresolved reference: empty
-    val i: Int = empty
-                 ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:55:13: error: unresolved reference: int
-    val j = int((r["idx"]!!))
-            ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:56:21: error: unresolved reference: board
-    val tmp: Int = (board[i] as Int)
-                    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:57:5: error: unresolved reference: board
-    board[i] = (board[j] as Int)
-    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:57:17: error: unresolved reference: board
-    board[i] = (board[j] as Int)
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:58:5: error: unresolved reference: board
-    board[j] = tmp
-    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:59:5: error: unresolved reference: empty
-    empty = j
-    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:60:5: error: unresolved reference: moves
-    moves = moves + 1
-    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:60:13: error: unresolved reference: moves
-    moves = moves + 1
-            ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:77:26: error: unresolved reference: board
-        val _val: Int = (board[i] as Int)
-                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:98:36: error: unresolved reference: moves
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:105:42: error: none of the following functions can be called with the arguments supplied: 
+public final operator fun plus(other: Byte): Int defined in kotlin.Int
+public final operator fun plus(other: Double): Double defined in kotlin.Int
+public final operator fun plus(other: Float): Float defined in kotlin.Int
+public final operator fun plus(other: Int): Int defined in kotlin.Int
+public final operator fun plus(other: Long): Long defined in kotlin.Int
+public final operator fun plus(other: Short): Int defined in kotlin.Int
         println(("Enter move #" + (moves + 1.toString()).toString()) + " (U, D, L, R, or Q): ")
-                                   ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:99:17: error: unresolved reference: input
-        val s = input()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:118:58: error: unresolved reference: moves
-                            println(("Quiting after " + (moves.toString()).toString()) + " moves.")
-                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:119:29: error: unresolved reference: quit
-                            quit = true
-                            ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:139:13: error: unresolved reference: quit
-    while (!quit && (isSolved() == false)) {
-            ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt:145:49: error: unresolved reference: moves
-        println(("You solved the puzzle in " + (moves.toString()).toString()) + " moves.")
-                                                ^
+                                         ^

--- a/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt
+++ b/tests/rosetta/transpiler/Kotlin/15-puzzle-game.kt
@@ -15,6 +15,13 @@ fun _now(): Int {
     }
 }
 
+fun input(): String = readLine() ?: ""
+
+var board: MutableList<Int> = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0)
+val solved: MutableList<Int> = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0)
+var empty: Int = 15
+var moves: Int = 0
+var quit: Boolean = false
 fun randMove(): Int {
     return _now() % 4
 }
@@ -30,20 +37,20 @@ fun isSolved(): Boolean {
     return true
 }
 
-fun isValidMove(m: Int): MutableMap<String, any> {
+fun isValidMove(m: Int): MutableMap<String, Any> {
     if (m == 0) {
-        return mutableMapOf<String, Any>("idx" to empty - 4, "ok" to (empty / 4) > 0)
+        return mutableMapOf<String, Any>("idx" to (empty - 4), "ok" to ((empty / 4) > 0))
     }
     if (m == 1) {
-        return mutableMapOf<String, Any>("idx" to empty + 4, "ok" to (empty / 4) < 3)
+        return mutableMapOf<String, Any>("idx" to (empty + 4), "ok" to ((empty / 4) < 3))
     }
     if (m == 2) {
-        return mutableMapOf<String, Any>("idx" to empty + 1, "ok" to (empty % 4) < 3)
+        return mutableMapOf<String, Any>("idx" to (empty + 1), "ok" to ((empty % 4) < 3))
     }
     if (m == 3) {
-        return mutableMapOf<String, Any>("idx" to empty - 1, "ok" to (empty % 4) > 0)
+        return mutableMapOf<String, Any>("idx" to (empty - 1), "ok" to ((empty % 4) > 0))
     }
-    return mutableMapOf<String, Any>("idx" to 0, "ok" to false)
+    return mutableMapOf<String, Any>("idx" to (0), "ok" to (false))
 }
 
 fun doMove(m: Int): Boolean {
@@ -52,7 +59,7 @@ fun doMove(m: Int): Boolean {
         return false
     }
     val i: Int = empty
-    val j = int((r["idx"]!!))
+    val j = (r["idx"]!!) as Int
     val tmp: Int = (board[i] as Int)
     board[i] = (board[j] as Int)
     board[j] = tmp
@@ -95,12 +102,12 @@ fun printBoard(): Unit {
 
 fun playOneMove(): Unit {
     while (true) {
-        println(("Enter move #" + (moves + 1.toString()).toString()) + " (U, D, L, R, or Q): ")
-        val s = input()
+        println(("Enter move #" + ((moves + 1).toString()).toString()) + " (U, D, L, R, or Q): ")
+        val s: String = input()
         if (s == "") {
             continue
         }
-        val c = s.subList(0, 1)
+        val c = s.substring(0, 1)
         var m: Int = 0
         if ((c == "U") || (c == "u")) {
             m = 0
@@ -152,10 +159,5 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    var board: MutableList<Int> = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0)
-    val solved: MutableList<Int> = mutableListOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0)
-    var empty: Int = 15
-    var moves: Int = 0
-    var quit: Boolean = false
     user_main()
 }

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-22 22:58 +0700
+Last updated: 2025-07-22 23:19 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-22 22:58 +0700
+Last updated: 2025-07-22 23:19 +0700
 
 Completed tasks: **4/284**
 

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,57 @@
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:19 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-22 23:15 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-22 22:58 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- add global variable support for Kotlin transpiler
- implement `input()` built‑in and integer casts
- fix string conversion for expressions
- regenerate Kotlin Rosetta docs

## Testing
- `ROSETTA_INDEX=1 go test -tags slow -run TestRosettaKotlin -v -count=1`
- `ROSETTA_INDEX=2 go test -tags slow -run TestRosettaKotlin -v -count=1`
- `ROSETTA_INDEX=3 go test -tags slow -run TestRosettaKotlin -v -count=1`
- `ROSETTA_INDEX=4 go test -tags slow -run TestRosettaKotlin -v -count=1`
- `ROSETTA_INDEX=5 go test -tags slow -run TestRosettaKotlin -v -count=1` *(fails: read want: open /workspace/mochi/tests/rosetta/x/Mochi/15-puzzle-game.out: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687fb93eac7c83208c9c05d3a6f06fa3