### PR TITLE
Add deterministic now() in interpreter

### DIFF
--- a/interpreter/builtins.go
+++ b/interpreter/builtins.go
@@ -1,13 +1,14 @@
 package interpreter
 
 import (
-	"bufio"
-	"encoding/json"
-	"fmt"
-	"io"
-	"strconv"
-	"strings"
-	"time"
+        "bufio"
+        "encoding/json"
+        "fmt"
+        "io"
+        "os"
+        "strconv"
+        "strings"
+        "time"
 
 	"mochi/parser"
 	"mochi/runtime/data"
@@ -88,11 +89,29 @@ func builtinAppend(i *Interpreter, c *parser.CallExpr) (any, error) {
 	}
 }
 
+var (
+        seededNow bool
+        nowSeed   int64
+)
+
+func init() {
+        if s := os.Getenv("MOCHI_NOW_SEED"); s != "" {
+                if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+                        nowSeed = v
+                        seededNow = true
+                }
+        }
+}
+
 func builtinNow(i *Interpreter, c *parser.CallExpr) (any, error) {
-	if len(c.Args) != 0 {
-		return nil, fmt.Errorf("now() takes no arguments")
-	}
-	return time.Now().UnixNano(), nil
+        if len(c.Args) != 0 {
+                return nil, fmt.Errorf("now() takes no arguments")
+        }
+        if seededNow {
+                nowSeed = (nowSeed*1664525 + 1013904223) % 2147483647
+                return nowSeed, nil
+        }
+        return time.Now().UnixNano(), nil
 }
 
 func builtinJSON(i *Interpreter, c *parser.CallExpr) (any, error) {


### PR DESCRIPTION
## Summary
- seed `now()` in the interpreter with `MOCHI_NOW_SEED`

## Testing
- `ROSETTA_INDEX=4 go test -tags=slow -run TestPrologTranspiler_Rosetta -count=1 -v` *(fails: unsupported while)*

------
https://chatgpt.com/codex/tasks/task_e_687fc53a34e88320804ef56ca44feff7