### PR TITLE
Improve C# formatting

### DIFF
--- a/transpiler/x/cs/README.md
+++ b/transpiler/x/cs/README.md
@@ -3,7 +3,7 @@
 Generated C# code for programs in `tests/vm/valid`. Each program has a `.cs` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
 Compiled programs: 102/103
-Last updated: 2025-07-22 21:48 +0700
+Last updated: 2025-07-23 09:12 +0700
 
 ## Checklist
 - [x] append_builtin

--- a/transpiler/x/cs/ROSETTA.md
+++ b/transpiler/x/cs/ROSETTA.md
@@ -1,7 +1,7 @@
 # Rosetta C# Transpiler Output
 
 Completed programs: 4/284
-Last updated: 2025-07-23 00:38 +0700
+Last updated: 2025-07-23 09:12 +0700
 
 ## Checklist
 1. [x] 100-doors-2

--- a/transpiler/x/cs/TASKS.md
+++ b/transpiler/x/cs/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-23 09:12 +0700)
+- cs rosetta: add index handling and compile 100-doors (progress 102/103)
+
 ## Progress (2025-07-22 21:48 +0700)
 - ex: start handling mutable for loops and clean rosetta test (progress 102/103)
 
@@ -16,6 +19,7 @@
 
 ## Progress (2025-07-22 03:14 +0000)
 - cs transpiler: 100/102 tests compiled
+
 
 
 

--- a/transpiler/x/cs/transpiler.go
+++ b/transpiler/x/cs/transpiler.go
@@ -3003,8 +3003,22 @@ func Emit(prog *Program) []byte {
 func formatCS(src []byte) []byte {
 	s := strings.ReplaceAll(string(src), "\t", "    ")
 	lines := strings.Split(s, "\n")
+	indent := 0
 	for i, ln := range lines {
-		lines[i] = strings.TrimRight(ln, " ")
+		trimmed := strings.TrimSpace(ln)
+		if strings.HasPrefix(trimmed, "}") {
+			if indent > 0 {
+				indent--
+			}
+		}
+		if trimmed != "" {
+			lines[i] = strings.Repeat("    ", indent) + strings.TrimRight(trimmed, " ")
+		} else {
+			lines[i] = ""
+		}
+		if strings.HasSuffix(trimmed, "{") {
+			indent++
+		}
 	}
 	out := strings.Join(lines, "\n")
 	if !strings.HasSuffix(out, "\n") {


### PR DESCRIPTION
## Summary
- generate formatted C# code with basic brace-based indentation
- update C# transpiler rosetta docs

## Testing
- `go test ./transpiler/x/cs -c -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6880454f21d483209cba1dc01992d312