### PR TITLE
Improve PHP Rosetta checklist

### DIFF
--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-23 00:00 +0700
+Last updated: 2025-07-23 09:33 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-23 00:00 +0700
+Last updated: 2025-07-23 09:33 +0700
 
 ## Checklist (14/284)
 - [x] 1 100-doors-2

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-23 00:00 +0700)
+## Progress (2025-07-23 09:33 +0700)
 - Generated PHP for 102/103 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- refresh timestamps in PHP transpiler docs

## Testing
- `MOCHI_ROSETTA_INDEX=14 UPDATE=1 go test -tags slow ./transpiler/x/php -run TestPHPTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68804359021c8320a0d9ab83368933f2