### PR TITLE
Improve Prolog rosetta tests

### DIFF
--- a/transpiler/x/pl/rosetta_test.go
+++ b/transpiler/x/pl/rosetta_test.go
@@ -70,6 +70,9 @@ func runRosettaTask(t *testing.T, name string) {
 	}
 	cmd := exec.Command("swipl", "-q", "-f", plFile)
 	cmd.Env = append(os.Environ(), "MOCHI_ROOT="+root)
+	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+		cmd.Stdin = bytes.NewReader(data)
+	}
 	out, err := cmd.CombinedOutput()
 	got := bytes.TrimSpace(out)
 	if err != nil || bytes.Contains(out, []byte("ERROR:")) {


### PR DESCRIPTION
## Summary
- allow stdin when running Prolog rosetta programs

## Testing
- `ROSETTA_INDEX=5 go test -tags=slow ./transpiler/x/pl -run Rosetta -count=1` *(fails: unsupported while)*

------
https://chatgpt.com/codex/tasks/task_e_68804a79dc508320ad1dfa0a73408d0a