### PR TITLE
Fix global rename for assignments

### DIFF
--- a/transpiler/x/rs/transpiler.go
+++ b/transpiler/x/rs/transpiler.go
@@ -913,7 +913,11 @@ type AssignStmt struct {
 }
 
 func (a *AssignStmt) emit(w io.Writer) {
-	io.WriteString(w, a.Name)
+	if newName, ok := globalRenames[a.Name]; ok && !isLocal(a.Name) {
+		io.WriteString(w, newName)
+	} else {
+		io.WriteString(w, a.Name)
+	}
 	io.WriteString(w, " = ")
 	a.Expr.emit(w)
 }


### PR DESCRIPTION
## Summary
- apply global rename logic when emitting assignment statements

## Testing
- `go fmt ./...`

------
https://chatgpt.com/codex/tasks/task_e_68804fa48a34832092e8f40d236db647