### PR TITLE
Update scheme rosetta outputs

### DIFF
--- a/transpiler/x/scheme/README.md
+++ b/transpiler/x/scheme/README.md
@@ -3,7 +3,7 @@
 Generated Scheme code for programs in `tests/vm/valid`. Each program has a `.scm` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## VM Golden Test Checklist (79/103)
-Last updated: 2025-07-22 16:33 UTC
+Last updated: 2025-07-23 03:13 UTC
 
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (4/284)
-Last updated: 2025-07-23 02:37 UTC
+Last updated: 2025-07-23 03:13 UTC
 
 1. [x] 100-doors-2
 2. [x] 100-doors-3

--- a/transpiler/x/scheme/TASKS.md
+++ b/transpiler/x/scheme/TASKS.md
@@ -1,50 +1,50 @@
-## Progress (2025-07-22 23:33 +0700)
-- Commit ad51d90e5: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:32 +0700)
-- Commit c1b37f609: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:32 +0700)
-- Commit 1ae3f6dc7: scheme: update logs
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:32 +0700)
-- Commit 4c7bdc6b7: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:31 +0700)
-- Commit d197fa1ee: scheme: update logs
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:31 +0700)
-- Commit d197fa1ee: scheme: update logs
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:31 +0700)
-- Commit 2e75df459: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:30 +0700)
-- Commit 8e0c94110: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:30 +0700)
-- Commit 4559ff978: scheme: update tasks log
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-22 23:30 +0700)
-- Commit 2a6adc666: scheme: update logs
+## Progress (2025-07-23 10:13 +0700)
+- Commit 15cb4dd502: cpp: fix deterministic now seed
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 


### PR DESCRIPTION
## Summary
- regenerate scheme outputs for the first 10 Rosetta Code programs
- refresh Scheme checklist timestamps

## Testing
- `MOCHI_ROSETTA_INDEX=10 go test ./transpiler/x/scheme -run TestSchemeTranspiler_Rosetta_Golden -update-rosetta-scheme -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688053b6095883209fce78b02322fcfd