### PR TITLE
Add release notes for v0.10.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 # 📦 CHANGELOG.md
+## [0.10.38] – 2025-07-23T10:17:23+07:00
+
+### Added
+
+* Global variable support for Rust and struct pattern matching in Ruby
+* Additional Rosetta examples across C#, Lua, Racket and Swift
+* Map key handling for TypeScript with selector calls for Zig
+* Local variable tracking and typed call arguments in multiple backends
+
+### Changed
+
+* Improved type inference for Kotlin and container metadata in Scala
+* Enhanced C++ variable management and indentation fixes in C#
+* Rosetta outputs regenerated and stored with source code
+
+### Fixed
+
+* Deterministic `now` seeding for C++
+* Global variable rename issues in Rust
+* Miscellaneous compilation bugs across languages
+
+
 ## [0.10.37] – 2025-07-22T17:53:32+07:00
 
 ### Added

--- a/releases/v0.10.38.md
+++ b/releases/v0.10.38.md
@@ -1,0 +1,21 @@
+# Jul 2025 (v0.10.38)
+
+Released on Wed Jul 23 10:17:23 2025 +0700.
+
+Mochi v0.10.38 expands Rosetta examples and improves type handling across numerous transpilers.
+
+## Compilers
+
+- Initial global variable support for the Rust backend with struct literal patterns
+- Indentation and index handling updates for the C# transpiler
+- Enhanced C++ variable management with deterministic `now` seeding
+- Input helpers and integer builtins added to Swift with array support started in F#
+- Lua local variables and additional programs plus wider Ruby coverage using the input builtin
+- Map key support and parameter scoping fixes for TypeScript with selector calls in Zig
+- Improved type inference for Kotlin and container type metadata for Scala
+- Typed call arguments handled in Go and various OCaml and Racket test additions
+
+## Documentation
+
+- Rosetta progress logs updated for many languages
+- Golden outputs regenerated and stored with source code


### PR DESCRIPTION
## Summary
- document new release v0.10.38
- list recent features in CHANGELOG

## Testing
- `make test` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688054d4807883209b8e5dd59c102ee3