### PR TITLE
Improve Java transpiler map casting

### DIFF
--- a/tests/rosetta/transpiler/Java/2048.error
+++ b/tests/rosetta/transpiler/Java/2048.error
@@ -1,127 +1,44 @@
 compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:5: error: incompatible types: Object cannot be converted to Map
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:5: error: incompatible types: Object cannot be converted to Map
     static java.util.Map full = r.get("full");
                                      ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:72: error: incompatible types: int cannot be converted to Map
-                java.util.Map v = b[y][x];
-                                      ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:73: error: bad operand types for binary operator '=='
-                if (v == 0) {
-                      ^
-  first type:  Map
-  second type: int
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:76: error: incompatible types: Map cannot be converted to int
-                    line = line + pad(v) + "|";
-                                      ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:89: error: cannot find symbol
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:89: error: cannot find symbol
         int i = r.size() - 1;
                  ^
   symbol:   method size()
   location: variable r of type int[]
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:91: error: cannot find symbol
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:91: error: cannot find symbol
             out = java.util.stream.IntStream.concat(java.util.Arrays.stream(out), java.util.stream.IntStream.of(r.get(i))).toArray();
                                                                                                                  ^
   symbol:   method get(int)
   location: variable r of type int[]
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:131: error: incompatible types: Object cannot be converted to Map
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:131: error: incompatible types: Object cannot be converted to Map
             java.util.Map new_ = r.get("row");
                                       ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:132: error: bad operand types for binary operator '+'
-            score = score + r.get("gain");
-                          ^
-  first type:  int
-  second type: Object
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:135: error: array required, but Map found
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:135: error: array required, but Map found
                 if (b[y][x] != new_[x]) {
                                    ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:138: error: array required, but Map found
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:138: error: array required, but Map found
 b[y][x] = new_[x];
               ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:152: error: incompatible types: Object cannot be converted to int[]
-            rev = r.get("row");
-                       ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:153: error: bad operand types for binary operator '+'
-            score = score + r.get("gain");
-                          ^
-  first type:  int
-  second type: Object
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:192: error: incompatible types: Object cannot be converted to Map
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:192: error: incompatible types: Object cannot be converted to Map
             java.util.Map new_ = r.get("row");
                                       ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:193: error: bad operand types for binary operator '+'
-            score = score + r.get("gain");
-                          ^
-  first type:  int
-  second type: Object
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:196: error: array required, but Map found
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:196: error: array required, but Map found
                 if (b[y][x] != new_[y]) {
                                    ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:199: error: array required, but Map found
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:199: error: array required, but Map found
 b[y][x] = new_[y];
               ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:213: error: incompatible types: Object cannot be converted to int[]
-            col = r.get("row");
-                       ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:214: error: bad operand types for binary operator '+'
-            score = score + r.get("gain");
-                          ^
-  first type:  int
-  second type: Object
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:265: error: incompatible types: Object cannot be converted to int[][]
-        board = r.get("board");
-                     ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:267: error: incompatible types: Object cannot be converted to int[][]
-        board = r.get("board");
-                     ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:268: error: incompatible types: Object cannot be converted to Map
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:268: error: incompatible types: Object cannot be converted to Map
         full = r.get("full");
                     ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:276: error: incompatible types: Object cannot be converted to int[][]
-                board = m.get("board");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:277: error: incompatible types: Object cannot be converted to int
-                score = m.get("score");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:278: error: incompatible types: Object cannot be converted to boolean
-                moved = m.get("moved");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:282: error: incompatible types: Object cannot be converted to int[][]
-                board = m.get("board");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:283: error: incompatible types: Object cannot be converted to int
-                score = m.get("score");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:284: error: incompatible types: Object cannot be converted to boolean
-                moved = m.get("moved");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:288: error: incompatible types: Object cannot be converted to int[][]
-                board = m.get("board");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:289: error: incompatible types: Object cannot be converted to int
-                score = m.get("score");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:290: error: incompatible types: Object cannot be converted to boolean
-                moved = m.get("moved");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:294: error: incompatible types: Object cannot be converted to int[][]
-                board = m.get("board");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:295: error: incompatible types: Object cannot be converted to int
-                score = m.get("score");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:296: error: incompatible types: Object cannot be converted to boolean
-                moved = m.get("moved");
-                             ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:303: error: incompatible types: Object cannot be converted to int[][]
-                board = r2.get("board");
-                              ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:304: error: incompatible types: Object cannot be converted to Map
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:304: error: incompatible types: Object cannot be converted to Map
                 full = r2.get("full");
                              ^
-/tmp/TestJavaTranspiler_Rosetta_Golden2048365922123/001/Main.java:305: error: bad operand types for binary operator '&&'
+/tmp/TestJavaTranspiler_Rosetta_Golden2048472155227/001/Main.java:305: error: bad operand types for binary operator '&&'
                 if (full && (!(Boolean)hasMoves(board))) {
                          ^
   first type:  Map
   second type: boolean
-Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
-36 errors
+12 errors

--- a/tests/rosetta/transpiler/Java/2048.java
+++ b/tests/rosetta/transpiler/Java/2048.java
@@ -69,7 +69,7 @@ b[cell[1]][cell[0]] = val;
             String line = "|";
             int x = 0;
             while (x < SIZE) {
-                java.util.Map v = b[y][x];
+                int v = b[y][x];
                 if (v == 0) {
                     line = line + "    |";
                 } else {
@@ -129,7 +129,7 @@ b[cell[1]][cell[0]] = val;
         while (y < SIZE) {
             java.util.Map<String,Object> r = slideLeft(b[y]);
             java.util.Map new_ = r.get("row");
-            score = score + r.get("gain");
+            score = score + (int)(r.get("gain"));
             int x = 0;
             while (x < SIZE) {
                 if (b[y][x] != new_[x]) {
@@ -149,8 +149,8 @@ b[y][x] = new_[x];
         while (y < SIZE) {
             int[] rev = reverseRow(b[y]);
             java.util.Map<String,Object> r = slideLeft(rev);
-            rev = r.get("row");
-            score = score + r.get("gain");
+            rev = (int[])(r.get("row"));
+            score = score + (int)(r.get("gain"));
             rev = reverseRow(rev);
             int x = 0;
             while (x < SIZE) {
@@ -190,7 +190,7 @@ b[y][x] = col[y];
             int[] col = getCol(b, x);
             java.util.Map<String,Object> r = slideLeft(col);
             java.util.Map new_ = r.get("row");
-            score = score + r.get("gain");
+            score = score + (int)(r.get("gain"));
             int y = 0;
             while (y < SIZE) {
                 if (b[y][x] != new_[y]) {
@@ -210,8 +210,8 @@ b[y][x] = new_[y];
         while (x < SIZE) {
             int[] col = reverseRow(getCol(b, x));
             java.util.Map<String,Object> r = slideLeft(col);
-            col = r.get("row");
-            score = score + r.get("gain");
+            col = (int[])(r.get("row"));
+            score = score + (int)(r.get("gain"));
             col = reverseRow(col);
             int y = 0;
             while (y < SIZE) {
@@ -262,9 +262,9 @@ b[y][x] = col[y];
         return false;
     }
     public static void main(String[] args) {
-        board = r.get("board");
+        board = (int[][])(r.get("board"));
         r = spawnTile(board);
-        board = r.get("board");
+        board = (int[][])(r.get("board"));
         full = r.get("full");
         draw(board, score);
         while (true) {
@@ -273,34 +273,34 @@ b[y][x] = col[y];
             boolean moved = false;
             if (((cmd.equals("a")) || cmd.equals("A"))) {
                 java.util.Map<String,Object> m = moveLeft(board, score);
-                board = m.get("board");
-                score = m.get("score");
-                moved = m.get("moved");
+                board = (int[][])(m.get("board"));
+                score = (int)(m.get("score"));
+                moved = (boolean)(m.get("moved"));
             }
             if (((cmd.equals("d")) || cmd.equals("D"))) {
                 java.util.Map<String,Object> m = moveRight(board, score);
-                board = m.get("board");
-                score = m.get("score");
-                moved = m.get("moved");
+                board = (int[][])(m.get("board"));
+                score = (int)(m.get("score"));
+                moved = (boolean)(m.get("moved"));
             }
             if (((cmd.equals("w")) || cmd.equals("W"))) {
                 java.util.Map<String,Object> m = moveUp(board, score);
-                board = m.get("board");
-                score = m.get("score");
-                moved = m.get("moved");
+                board = (int[][])(m.get("board"));
+                score = (int)(m.get("score"));
+                moved = (boolean)(m.get("moved"));
             }
             if (((cmd.equals("s")) || cmd.equals("S"))) {
                 java.util.Map<String,Object> m = moveDown(board, score);
-                board = m.get("board");
-                score = m.get("score");
-                moved = m.get("moved");
+                board = (int[][])(m.get("board"));
+                score = (int)(m.get("score"));
+                moved = (boolean)(m.get("moved"));
             }
             if (((cmd.equals("q")) || cmd.equals("Q"))) {
                 break;
             }
             if (moved) {
                 java.util.Map<String,Object> r2 = spawnTile(board);
-                board = r2.get("board");
+                board = (int[][])(r2.get("board"));
                 full = r2.get("full");
                 if (full && (!(Boolean)hasMoves(board))) {
                     draw(board, score);


### PR DESCRIPTION
## Summary
- enhance cast logic in Java transpiler to better handle values read from `Map`
- adjust length handling for array values before map checks
- update generated Java/error output for `2048` sample

## Testing
- `go test ./transpiler/x/java -tags slow -run Rosetta -index=7` *(fails: javac 2048)*

------
https://chatgpt.com/codex/tasks/task_e_68805b4f0b9c832084f7694e3db8fe5b