### PR TITLE
Improve Kotlin index emitter

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/2048.error
+++ b/tests/rosetta/transpiler/Kotlin/2048.error
@@ -1,110 +1,67 @@
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:91:37: error: type mismatch: inferred type is Any but Int was expected
-                line = (line + (pad(v)).toString()) + "|"
-                                    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:147:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:147:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:150:55: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Any?>.get(key: Int): Any? defined in kotlin.collections
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
-                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:150:58: error: no get method providing array access
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
-                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:153:46: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Int?>.get(key: Int): Int? defined in kotlin.collections
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:154:46: error: type mismatch: inferred type is Any but Int? was expected
+            (b[y] as MutableList<Int>)[x] = ((new as MutableList<Any>)[x]!!)
                                              ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:153:49: error: no get method providing array access
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
-                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:167:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:169:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
         rev = (r["row"]!!)
                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:168:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:168:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:208:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:208:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:211:55: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Any?>.get(key: Int): Any? defined in kotlin.collections
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
-                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:211:58: error: no get method providing array access
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
-                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:214:46: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Int?>.get(key: Int): Int? defined in kotlin.collections
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:177:46: error: type mismatch: inferred type is Any but Int? was expected
+            (b[y] as MutableList<Int>)[x] = ((rev as MutableList<Any>)[x]!!)
                                              ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:214:49: error: no get method providing array access
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
-                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:228:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:217:46: error: type mismatch: inferred type is Any but Int? was expected
+            (b[y] as MutableList<Int>)[x] = ((new as MutableList<Any>)[y]!!)
+                                             ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:232:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
         col = (r["row"]!!)
                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:229:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:229:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:281:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:240:46: error: type mismatch: inferred type is Any but Int? was expected
+            (b[y] as MutableList<Int>)[x] = ((col as MutableList<Any>)[y]!!)
+                                             ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:285:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
     board = (r["board"]!!)
              ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:283:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:287:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
     board = (r["board"]!!)
              ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:292:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:296:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = ((m as MutableMap<String, Any>)["board"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:293:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:297:22: error: type mismatch: inferred type is Any? but Int? was expected
+            score = ((m as MutableMap<String, Any>)["score"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:294:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:298:22: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:298:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:302:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = ((m as MutableMap<String, Any>)["board"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:299:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:303:22: error: type mismatch: inferred type is Any? but Int? was expected
+            score = ((m as MutableMap<String, Any>)["score"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:300:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:304:22: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:304:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:308:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = ((m as MutableMap<String, Any>)["board"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:305:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:309:22: error: type mismatch: inferred type is Any? but Int? was expected
+            score = ((m as MutableMap<String, Any>)["score"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:306:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:310:22: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:310:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:314:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = ((m as MutableMap<String, Any>)["board"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:311:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:315:22: error: type mismatch: inferred type is Any? but Int? was expected
+            score = ((m as MutableMap<String, Any>)["score"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:312:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:316:22: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:319:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (r2["board"]!!)
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:323:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = ((r2 as MutableMap<String, Any>)["board"]!!)
                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:321:17: error: type mismatch: inferred type is Any but Boolean was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:325:17: error: type mismatch: inferred type is Any but Boolean was expected
             if (full && !(hasMoves(board) as Boolean)) {
                 ^

--- a/tests/rosetta/transpiler/Kotlin/2048.kt
+++ b/tests/rosetta/transpiler/Kotlin/2048.kt
@@ -18,7 +18,7 @@ fun _now(): Int {
 fun input(): String = readLine() ?: ""
 
 val SIZE: Int = 4
-var board = newBoard()
+var board: MutableList<MutableList<Int>> = newBoard()
 var r: MutableMap<String, Any> = spawnTile(board)
 var full = (r["full"]!!)
 var score: Int = 0
@@ -44,7 +44,7 @@ fun spawnTile(b: MutableList<MutableList<Int>>): MutableMap<String, Any> {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) == 0) {
+            if (((b[y] as MutableList<Int>)[x] as Int) == 0) {
                 empty = run { val _tmp = empty.toMutableList(); _tmp.add(mutableListOf(x, y)); _tmp }
             }
             x = x + 1
@@ -84,7 +84,7 @@ fun draw(b: MutableList<MutableList<Int>>, score: Int): Unit {
         var line: String = "|"
         var x: Int = 0
         while (x < SIZE) {
-            var v: Any = ((b[y] as MutableList<Int>)[x]!!)
+            var v: Int = ((b[y] as MutableList<Int>)[x] as Int)
             if (v == 0) {
                 line = line + "    |"
             } else {
@@ -139,18 +139,19 @@ fun slideLeft(row: MutableList<Int>): MutableMap<String, Any> {
 }
 
 fun moveLeft(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
         val r: MutableMap<String, Any> = slideLeft((b[y] as MutableList<Int>))
-        val new: Any = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        val new = (r["row"]!!)
+        score = score + ((r["gain"]!!) as Int)
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
+            if (((b[y] as MutableList<Int>)[x] as Int) != ((new as MutableList<Any>)[x]!!)) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
+            (b[y] as MutableList<Int>)[x] = ((new as MutableList<Any>)[x]!!)
             x = x + 1
         }
         y = y + 1
@@ -159,20 +160,21 @@ fun moveLeft(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, A
 }
 
 fun moveRight(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
         var rev = reverseRow((b[y] as MutableList<Int>))
         val r: MutableMap<String, Any> = slideLeft(rev)
         rev = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        score = score + ((r["gain"]!!) as Int)
         rev = reverseRow(rev)
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (rev[x]!!)) {
+            if (((b[y] as MutableList<Int>)[x] as Int) != ((rev as MutableList<Any>)[x]!!)) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (rev[x]!!)
+            (b[y] as MutableList<Int>)[x] = ((rev as MutableList<Any>)[x]!!)
             x = x + 1
         }
         y = y + 1
@@ -184,7 +186,7 @@ fun getCol(b: MutableList<MutableList<Int>>, x: Int): MutableList<Int> {
     var col: MutableList<Int> = mutableListOf()
     var y: Int = 0
     while (y < SIZE) {
-        col = run { val _tmp = col.toMutableList(); _tmp.add(((b[y] as MutableList<Int>)[x]!!)); _tmp }
+        col = run { val _tmp = col.toMutableList(); _tmp.add(((b[y] as MutableList<Int>)[x] as Int)); _tmp }
         y = y + 1
     }
     return col
@@ -199,19 +201,20 @@ fun setCol(b: MutableList<MutableList<Int>>, x: Int, col: MutableList<Int>): Uni
 }
 
 fun moveUp(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var x: Int = 0
     while (x < SIZE) {
         var col = getCol(b, x)
         val r: MutableMap<String, Any> = slideLeft(col)
-        val new: Any = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        val new = (r["row"]!!)
+        score = score + ((r["gain"]!!) as Int)
         var y: Int = 0
         while (y < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
+            if (((b[y] as MutableList<Int>)[x] as Int) != ((new as MutableList<Any>)[y]!!)) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
+            (b[y] as MutableList<Int>)[x] = ((new as MutableList<Any>)[y]!!)
             y = y + 1
         }
         x = x + 1
@@ -220,20 +223,21 @@ fun moveUp(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any
 }
 
 fun moveDown(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var x: Int = 0
     while (x < SIZE) {
         var col = reverseRow(getCol(b, x))
         val r: MutableMap<String, Any> = slideLeft(col)
         col = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        score = score + ((r["gain"]!!) as Int)
         col = reverseRow(col)
         var y: Int = 0
         while (y < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (col[y]!!)) {
+            if (((b[y] as MutableList<Int>)[x] as Int) != ((col as MutableList<Any>)[y]!!)) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (col[y]!!)
+            (b[y] as MutableList<Int>)[x] = ((col as MutableList<Any>)[y]!!)
             y = y + 1
         }
         x = x + 1
@@ -246,13 +250,13 @@ fun hasMoves(b: MutableList<MutableList<Int>>): Boolean {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) == 0) {
+            if (((b[y] as MutableList<Int>)[x] as Int) == 0) {
                 return true
             }
-            if (((x + 1) < SIZE) && (((b[y] as MutableList<Int>)[x]!!) == ((b[y] as MutableList<Int>)[x + 1]!!))) {
+            if (((x + 1) < SIZE) && (((b[y] as MutableList<Int>)[x] as Int) == ((b[y] as MutableList<Int>)[x + 1] as Int))) {
                 return true
             }
-            if (((y + 1) < SIZE) && (((b[y] as MutableList<Int>)[x]!!) == ((b[y + 1] as MutableList<Int>)[x]!!))) {
+            if (((y + 1) < SIZE) && (((b[y] as MutableList<Int>)[x] as Int) == ((b[y + 1] as MutableList<Int>)[x] as Int))) {
                 return true
             }
             x = x + 1
@@ -267,7 +271,7 @@ fun has2048(b: MutableList<MutableList<Int>>): Boolean {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if ((((b[y] as MutableList<Int>)[x]!!) as Number).toDouble() >= 2048) {
+            if (((b[y] as MutableList<Int>)[x] as Int) >= 2048) {
                 return true
             }
             x = x + 1
@@ -289,35 +293,35 @@ fun main() {
         var moved: Boolean = false
         if ((cmd == "a") || (cmd == "A")) {
             val m = moveLeft(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = ((m as MutableMap<String, Any>)["board"]!!)
+            score = ((m as MutableMap<String, Any>)["score"]!!)
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
         }
         if ((cmd == "d") || (cmd == "D")) {
             val m = moveRight(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = ((m as MutableMap<String, Any>)["board"]!!)
+            score = ((m as MutableMap<String, Any>)["score"]!!)
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
         }
         if ((cmd == "w") || (cmd == "W")) {
             val m = moveUp(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = ((m as MutableMap<String, Any>)["board"]!!)
+            score = ((m as MutableMap<String, Any>)["score"]!!)
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
         }
         if ((cmd == "s") || (cmd == "S")) {
             val m = moveDown(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = ((m as MutableMap<String, Any>)["board"]!!)
+            score = ((m as MutableMap<String, Any>)["score"]!!)
+            moved = ((m as MutableMap<String, Any>)["moved"]!!)
         }
         if ((cmd == "q") || (cmd == "Q")) {
             break
         }
         if (moved as Boolean) {
             val r2 = spawnTile(board)
-            board = (r2["board"]!!)
-            full = (r2["full"]!!)
+            board = ((r2 as MutableMap<String, Any>)["board"]!!)
+            full = ((r2 as MutableMap<String, Any>)["full"]!!)
             if (full && !(hasMoves(board) as Boolean)) {
                 draw(board, score)
                 println("Game Over")

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-23 00:26 +0700
+Last updated: 2025-07-23 11:36 +0700
 
 Completed tasks: **6/284**
 


### PR DESCRIPTION
## Summary
- adjust Kotlin transpiler index generation for unknown containers
- regenerate Kotlin rosetta outputs for index 7

## Testing
- `ROSETTA_INDEX=7 go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1` *(fails: program failed)*

------
https://chatgpt.com/codex/tasks/task_e_688067c1b2e483208ffd6104c04a73ed