### PR TITLE
Improve Kotlin transpiler index handling

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/2048.error
+++ b/tests/rosetta/transpiler/Kotlin/2048.error
@@ -1,110 +1,67 @@
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:91:37: error: type mismatch: inferred type is Any but Int was expected
-                line = (line + (pad(v)).toString()) + "|"
-                                    ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:147:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:147:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:150:55: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Any?>.get(key: Int): Any? defined in kotlin.collections
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
-                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:150:58: error: no get method providing array access
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
-                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:153:46: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Int?>.get(key: Int): Int? defined in kotlin.collections
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
-                                             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:153:49: error: no get method providing array access
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
-                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:167:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
-        rev = (r["row"]!!)
-               ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:168:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:168:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:208:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:208:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:211:55: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Any?>.get(key: Int): Any? defined in kotlin.collections
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
-                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:211:58: error: no get method providing array access
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
-                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:214:46: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
-@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, Int?>.get(key: Int): Int? defined in kotlin.collections
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
-                                             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:214:49: error: no get method providing array access
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
-                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:228:16: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
-        col = (r["row"]!!)
-               ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:229:9: error: val cannot be reassigned
-        score = score + ((r["gain"]!!) as Number).toDouble()
-        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:229:17: error: type mismatch: inferred type is Double but Int was expected
-        score = score + ((r["gain"]!!) as Number).toDouble()
-                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:281:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-    board = (r["board"]!!)
-             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:283:14: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-    board = (r["board"]!!)
-             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:292:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:293:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:294:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:298:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:299:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:300:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:304:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:305:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:306:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:310:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (m["board"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:311:22: error: type mismatch: inferred type is Any? but Int? was expected
-            score = (m["score"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:312:22: error: type mismatch: inferred type is Any? but Boolean? was expected
-            moved = (m["moved"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:319:22: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
-            board = (r2["board"]!!)
-                     ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:321:17: error: type mismatch: inferred type is Any but Boolean was expected
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:154:23: error: type mismatch: inferred type is Any? but Int? was expected
+            b[y][x] = (new as MutableList<Any?>)[x]!!
+                      ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:169:15: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
+        rev = (r)["row"]!!
+              ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:177:23: error: type mismatch: inferred type is Any? but Int? was expected
+            b[y][x] = (rev as MutableList<Any?>)[x]!!
+                      ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:217:23: error: type mismatch: inferred type is Any? but Int? was expected
+            b[y][x] = (new as MutableList<Any?>)[y]!!
+                      ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:232:15: error: type mismatch: inferred type is Any? but MutableList<Int>? was expected
+        col = (r)["row"]!!
+              ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:240:23: error: type mismatch: inferred type is Any? but Int? was expected
+            b[y][x] = (col as MutableList<Any?>)[y]!!
+                      ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:285:13: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+    board = (r)["board"]!!
+            ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:287:13: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+    board = (r)["board"]!!
+            ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:296:21: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = (m)["board"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:297:21: error: type mismatch: inferred type is Any? but Int? was expected
+            score = (m)["score"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:298:21: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = (m)["moved"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:302:21: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = (m)["board"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:303:21: error: type mismatch: inferred type is Any? but Int? was expected
+            score = (m)["score"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:304:21: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = (m)["moved"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:308:21: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = (m)["board"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:309:21: error: type mismatch: inferred type is Any? but Int? was expected
+            score = (m)["score"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:310:21: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = (m)["moved"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:314:21: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = (m)["board"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:315:21: error: type mismatch: inferred type is Any? but Int? was expected
+            score = (m)["score"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:316:21: error: type mismatch: inferred type is Any? but Boolean? was expected
+            moved = (m)["moved"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:323:21: error: type mismatch: inferred type is Any? but MutableList<MutableList<Int>>? was expected
+            board = (r2)["board"]!!
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/2048.kt:325:17: error: type mismatch: inferred type is Any but Boolean was expected
             if (full && !(hasMoves(board) as Boolean)) {
                 ^

--- a/tests/rosetta/transpiler/Kotlin/2048.kt
+++ b/tests/rosetta/transpiler/Kotlin/2048.kt
@@ -18,9 +18,9 @@ fun _now(): Int {
 fun input(): String = readLine() ?: ""
 
 val SIZE: Int = 4
-var board = newBoard()
+var board: MutableList<MutableList<Int>> = newBoard()
 var r: MutableMap<String, Any> = spawnTile(board)
-var full = (r["full"]!!)
+var full = (r)["full"]!!
 var score: Int = 0
 fun newBoard(): MutableList<MutableList<Int>> {
     var b: MutableList<MutableList<Int>> = mutableListOf()
@@ -44,7 +44,7 @@ fun spawnTile(b: MutableList<MutableList<Int>>): MutableMap<String, Any> {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) == 0) {
+            if (b[y][x] == 0) {
                 empty = run { val _tmp = empty.toMutableList(); _tmp.add(mutableListOf(x, y)); _tmp }
             }
             x = x + 1
@@ -55,12 +55,12 @@ fun spawnTile(b: MutableList<MutableList<Int>>): MutableMap<String, Any> {
         return mutableMapOf<String, Any>("board" to (b), "full" to (true))
     }
     var idx: Int = _now() % empty.size
-    val cell: MutableList<Int> = (empty[idx] as MutableList<Int>)
+    val cell: MutableList<Int> = empty[idx]
     var _val: Int = 4
     if ((_now() % 10) < 9) {
         _val = 2
     }
-    (b[(cell[1] as Int)] as MutableList<Int>)[(cell[0] as Int)] = _val
+    b[cell[1]][cell[0]] = _val
     return mutableMapOf<String, Any>("board" to (b), "full" to (empty.size == 1))
 }
 
@@ -84,7 +84,7 @@ fun draw(b: MutableList<MutableList<Int>>, score: Int): Unit {
         var line: String = "|"
         var x: Int = 0
         while (x < SIZE) {
-            var v: Any = ((b[y] as MutableList<Int>)[x]!!)
+            var v: Int = b[y][x]
             if (v == 0) {
                 line = line + "    |"
             } else {
@@ -103,7 +103,7 @@ fun reverseRow(r: MutableList<Int>): MutableList<Int> {
     var out: MutableList<Int> = mutableListOf()
     var i: Int = r.size - 1
     while (i >= 0) {
-        out = run { val _tmp = out.toMutableList(); _tmp.add((r[i] as Int)); _tmp }
+        out = run { val _tmp = out.toMutableList(); _tmp.add(r[i]); _tmp }
         i = i - 1
     }
     return out
@@ -113,8 +113,8 @@ fun slideLeft(row: MutableList<Int>): MutableMap<String, Any> {
     var xs: MutableList<Int> = mutableListOf()
     var i: Int = 0
     while (i < row.size) {
-        if ((row[i] as Int) != 0) {
-            xs = run { val _tmp = xs.toMutableList(); _tmp.add((row[i] as Int)); _tmp }
+        if (row[i] != 0) {
+            xs = run { val _tmp = xs.toMutableList(); _tmp.add(row[i]); _tmp }
         }
         i = i + 1
     }
@@ -122,13 +122,13 @@ fun slideLeft(row: MutableList<Int>): MutableMap<String, Any> {
     var gain: Int = 0
     i = 0
     while (i < xs.size) {
-        if (((i + 1) < xs.size) && ((xs[i] as Int) == (xs[i + 1] as Int))) {
-            val v: Int = (xs[i] as Int) * 2
+        if (((i + 1) < xs.size) && (xs[i] == xs[i + 1])) {
+            val v: Int = xs[i] * 2
             gain = gain + v
             res = run { val _tmp = res.toMutableList(); _tmp.add(v); _tmp }
             i = i + 2
         } else {
-            res = run { val _tmp = res.toMutableList(); _tmp.add((xs[i] as Int)); _tmp }
+            res = run { val _tmp = res.toMutableList(); _tmp.add(xs[i]); _tmp }
             i = i + 1
         }
     }
@@ -139,18 +139,19 @@ fun slideLeft(row: MutableList<Int>): MutableMap<String, Any> {
 }
 
 fun moveLeft(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
-        val r: MutableMap<String, Any> = slideLeft((b[y] as MutableList<Int>))
-        val new: Any = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        val r: MutableMap<String, Any> = slideLeft(b[y])
+        val new = (r)["row"]!!
+        score = score + ((r)["gain"]!! as Int)
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[x]!!)) {
+            if (b[y][x] != (new as MutableList<Any?>)[x]!!) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (new[x]!!)
+            b[y][x] = (new as MutableList<Any?>)[x]!!
             x = x + 1
         }
         y = y + 1
@@ -159,20 +160,21 @@ fun moveLeft(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, A
 }
 
 fun moveRight(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
-        var rev = reverseRow((b[y] as MutableList<Int>))
+        var rev = reverseRow(b[y])
         val r: MutableMap<String, Any> = slideLeft(rev)
-        rev = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        rev = (r)["row"]!!
+        score = score + ((r)["gain"]!! as Int)
         rev = reverseRow(rev)
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (rev[x]!!)) {
+            if (b[y][x] != (rev as MutableList<Any?>)[x]!!) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (rev[x]!!)
+            b[y][x] = (rev as MutableList<Any?>)[x]!!
             x = x + 1
         }
         y = y + 1
@@ -184,7 +186,7 @@ fun getCol(b: MutableList<MutableList<Int>>, x: Int): MutableList<Int> {
     var col: MutableList<Int> = mutableListOf()
     var y: Int = 0
     while (y < SIZE) {
-        col = run { val _tmp = col.toMutableList(); _tmp.add(((b[y] as MutableList<Int>)[x]!!)); _tmp }
+        col = run { val _tmp = col.toMutableList(); _tmp.add(b[y][x]); _tmp }
         y = y + 1
     }
     return col
@@ -193,25 +195,26 @@ fun getCol(b: MutableList<MutableList<Int>>, x: Int): MutableList<Int> {
 fun setCol(b: MutableList<MutableList<Int>>, x: Int, col: MutableList<Int>): Unit {
     var y: Int = 0
     while (y < SIZE) {
-        (b[y] as MutableList<Int>)[x] = (col[y] as Int)
+        b[y][x] = col[y]
         y = y + 1
     }
 }
 
 fun moveUp(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var x: Int = 0
     while (x < SIZE) {
         var col = getCol(b, x)
         val r: MutableMap<String, Any> = slideLeft(col)
-        val new: Any = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        val new = (r)["row"]!!
+        score = score + ((r)["gain"]!! as Int)
         var y: Int = 0
         while (y < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (new[y]!!)) {
+            if (b[y][x] != (new as MutableList<Any?>)[y]!!) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (new[y]!!)
+            b[y][x] = (new as MutableList<Any?>)[y]!!
             y = y + 1
         }
         x = x + 1
@@ -220,20 +223,21 @@ fun moveUp(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any
 }
 
 fun moveDown(b: MutableList<MutableList<Int>>, score: Int): MutableMap<String, Any> {
+    var score: Int = score
     var moved: Boolean = false
     var x: Int = 0
     while (x < SIZE) {
         var col = reverseRow(getCol(b, x))
         val r: MutableMap<String, Any> = slideLeft(col)
-        col = (r["row"]!!)
-        score = score + ((r["gain"]!!) as Number).toDouble()
+        col = (r)["row"]!!
+        score = score + ((r)["gain"]!! as Int)
         col = reverseRow(col)
         var y: Int = 0
         while (y < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) != (col[y]!!)) {
+            if (b[y][x] != (col as MutableList<Any?>)[y]!!) {
                 moved = true
             }
-            (b[y] as MutableList<Int>)[x] = (col[y]!!)
+            b[y][x] = (col as MutableList<Any?>)[y]!!
             y = y + 1
         }
         x = x + 1
@@ -246,13 +250,13 @@ fun hasMoves(b: MutableList<MutableList<Int>>): Boolean {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if (((b[y] as MutableList<Int>)[x]!!) == 0) {
+            if (b[y][x] == 0) {
                 return true
             }
-            if (((x + 1) < SIZE) && (((b[y] as MutableList<Int>)[x]!!) == ((b[y] as MutableList<Int>)[x + 1]!!))) {
+            if (((x + 1) < SIZE) && (b[y][x] == b[y][x + 1])) {
                 return true
             }
-            if (((y + 1) < SIZE) && (((b[y] as MutableList<Int>)[x]!!) == ((b[y + 1] as MutableList<Int>)[x]!!))) {
+            if (((y + 1) < SIZE) && (b[y][x] == b[y + 1][x])) {
                 return true
             }
             x = x + 1
@@ -267,7 +271,7 @@ fun has2048(b: MutableList<MutableList<Int>>): Boolean {
     while (y < SIZE) {
         var x: Int = 0
         while (x < SIZE) {
-            if ((((b[y] as MutableList<Int>)[x]!!) as Number).toDouble() >= 2048) {
+            if (b[y][x] >= 2048) {
                 return true
             }
             x = x + 1
@@ -278,10 +282,10 @@ fun has2048(b: MutableList<MutableList<Int>>): Boolean {
 }
 
 fun main() {
-    board = (r["board"]!!)
+    board = (r)["board"]!!
     r = spawnTile(board)
-    board = (r["board"]!!)
-    full = (r["full"]!!)
+    board = (r)["board"]!!
+    full = (r)["full"]!!
     draw(board, score)
     while (true) {
         println("Move: ")
@@ -289,35 +293,35 @@ fun main() {
         var moved: Boolean = false
         if ((cmd == "a") || (cmd == "A")) {
             val m = moveLeft(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = (m)["board"]!!
+            score = (m)["score"]!!
+            moved = (m)["moved"]!!
         }
         if ((cmd == "d") || (cmd == "D")) {
             val m = moveRight(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = (m)["board"]!!
+            score = (m)["score"]!!
+            moved = (m)["moved"]!!
         }
         if ((cmd == "w") || (cmd == "W")) {
             val m = moveUp(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = (m)["board"]!!
+            score = (m)["score"]!!
+            moved = (m)["moved"]!!
         }
         if ((cmd == "s") || (cmd == "S")) {
             val m = moveDown(board, score)
-            board = (m["board"]!!)
-            score = (m["score"]!!)
-            moved = (m["moved"]!!)
+            board = (m)["board"]!!
+            score = (m)["score"]!!
+            moved = (m)["moved"]!!
         }
         if ((cmd == "q") || (cmd == "Q")) {
             break
         }
         if (moved as Boolean) {
             val r2 = spawnTile(board)
-            board = (r2["board"]!!)
-            full = (r2["full"]!!)
+            board = (r2)["board"]!!
+            full = (r2)["full"]!!
             if (full && !(hasMoves(board) as Boolean)) {
                 draw(board, score)
                 println("Game Over")

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-23 00:26 +0700
+Last updated: 2025-07-23 11:36 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-23 00:26 +0700
+Last updated: 2025-07-23 11:36 +0700
 
 Completed tasks: **6/284**
 

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,27 @@
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 11:36 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-23 00:26 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- improve dynamic index handling when the base type is unknown
- update generated Kotlin files and docs due to test run

## Testing
- `ROSETTA_INDEX=7 go test ./transpiler/x/kt -tags=slow -run RosettaKotlin -count=1` *(fails: kotlinc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68805c017c7883209da303951504d620