### PR TITLE
Update Pascal transpiler for foreach vars

### DIFF
--- a/tests/rosetta/transpiler/Pascal/100-prisoners.pas
+++ b/tests/rosetta/transpiler/Pascal/100-prisoners.pas
@@ -1,0 +1,136 @@
+{$mode objfpc}
+program Main;
+uses SysUtils;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64());
+  end;
+end;
+type IntArray = array of integer;
+var
+  arr: IntArray;
+  i: integer;
+  j: integer;
+  tmp: integer;
+  pardoned: integer;
+  t: integer;
+  drawers: array of integer;
+  p: integer;
+  success: boolean;
+  found: boolean;
+  prev: integer;
+  d: integer;
+  this: integer;
+  opened: array of boolean;
+  k: integer;
+  n: integer;
+  rf: integer;
+  trials: integer;
+  strat: string;
+  np: integer;
+function shuffle(xs: IntArray): IntArray;
+begin
+  arr := xs;
+  i := 99;
+  while i > 0 do begin
+  j := _now() mod (i + 1);
+  tmp := arr[i];
+  arr[i] := arr[j];
+  arr[j] := tmp;
+  i := i - 1;
+end;
+  exit(arr);
+end;
+procedure doTrials(trials: integer; np: integer; strategy: string);
+begin
+  pardoned := 0;
+  t := 0;
+  while t < trials do begin
+  drawers := [];
+  i := 0;
+  while i < 100 do begin
+  drawers := concat(drawers, [i]);
+  i := i + 1;
+end;
+  drawers := shuffle(drawers);
+  p := 0;
+  success := true;
+  while p < np do begin
+  found := false;
+  if strategy = 'optimal' then begin
+  prev := p;
+  d := 0;
+  while d < 50 do begin
+  this := drawers[prev];
+  if this = p then begin
+  found := true;
+  break;
+end;
+  prev := this;
+  d := d + 1;
+end;
+end else begin
+  opened := [];
+  k := 0;
+  while k < 100 do begin
+  opened := concat(opened, [false]);
+  k := k + 1;
+end;
+  d := 0;
+  while d < 50 do begin
+  n := _now() mod 100;
+  while opened[n] do begin
+  n := _now() mod 100;
+end;
+  opened[n] := true;
+  if drawers[n] = p then begin
+  found := true;
+  break;
+end;
+  d := d + 1;
+end;
+end;
+  if not found then begin
+  success := false;
+  break;
+end;
+  p := p + 1;
+end;
+  if success then begin
+  pardoned := pardoned + 1;
+end;
+  t := t + 1;
+end;
+  rf := (pardoned div trials) * 100;
+  writeln(((((('  strategy = ' + strategy) + '  pardoned = ') + IntToStr(pardoned)) + ' relative frequency = ') + IntToStr(rf)) + '%');
+end;
+procedure main();
+begin
+  trials := 1000;
+  for np in [10, 100] do begin
+  writeln(((('Results from ' + IntToStr(trials)) + ' trials with ') + IntToStr(np)) + ' prisoners:' + #10 + '');
+  for strat in ['random', 'optimal'] do begin
+  doTrials(trials, np, strat);
+end;
+end;
+end;
+begin
+  init_now();
+  main();
+end.

--- a/transpiler/x/pas/README.md
+++ b/transpiler/x/pas/README.md
@@ -107,4 +107,4 @@ Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-22 16:22 UTC
+Last updated: 2025-07-23 11:36 +0700

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,11 +2,11 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (3/284) - updated 2025-07-22 16:22 UTC
+## Rosetta Checklist (4/284) - updated 2025-07-23 11:36 +0700
 - [x] (1) 100-doors-2
 - [x] (2) 100-doors-3
 - [x] (3) 100-doors
-- [ ] (4) 100-prisoners
+- [x] (4) 100-prisoners
 - [ ] (5) 15-puzzle-game
 - [ ] (6) 15-puzzle-solver
 - [ ] (7) 2048

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,3 +1,6 @@
+## Progress (2025-07-23 11:36 +0700)
+- python transpiler: handle null literal; add algebraic-data-types (progress 87/103)
+
 ## Progress (2025-07-22 16:22 UTC)
 - pascal: add indices to rosetta checklist (progress 87/103)
 

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -1461,6 +1461,7 @@ func convertBody(env *types.Env, body []*parser.Statement, varTypes map[string]s
 				if _, ok := varTypes[st.For.Name]; !ok {
 					varTypes[st.For.Name] = "integer"
 				}
+				setVarType(st.For.Name, varTypes[st.For.Name])
 			} else {
 				out = append(out, &ForEachStmt{Name: st.For.Name, Iterable: start, Body: body})
 				if _, ok := varTypes[st.For.Name]; !ok {
@@ -1477,6 +1478,7 @@ func convertBody(env *types.Env, body []*parser.Statement, varTypes map[string]s
 						varTypes[st.For.Name] = "integer"
 					}
 				}
+				setVarType(st.For.Name, varTypes[st.For.Name])
 			}
 		case st.While != nil:
 			cond, err := convertExpr(env, st.While.Cond)


### PR DESCRIPTION
## Summary
- handle variable declarations for `for ... in` loops in pascal transpiler
- regenerate Rosetta checklist
- add generated Pascal for 100-prisoners

## Testing
- `fpc tests/rosetta/transpiler/Pascal/100-prisoners.pas -o/tmp/prisoners` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_68806803b184832089050c74434479f1