### PR TITLE
Fix PHP transpiler now() determinism

### DIFF
--- a/tests/rosetta/transpiler/php/100-prisoners.out
+++ b/tests/rosetta/transpiler/php/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 2 relative frequency = 0.2%
-  strategy = optimal  pardoned = 333 relative frequency = 33.3%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 308 relative frequency = 30.8%
+  strategy = random  pardoned = 0 relative frequency = 0.0%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%

--- a/tests/rosetta/transpiler/php/100-prisoners.php
+++ b/tests/rosetta/transpiler/php/100-prisoners.php
@@ -1,10 +1,25 @@
 <?php
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
 function mochi_shuffle($xs) {
   global $doTrials, $main;
   $arr = $xs;
   $i = 99;
   while ($i > 0) {
-  $j = hrtime(true) % ($i + 1);
+  $j = _now() % ($i + 1);
   $tmp = $arr[$i];
   $arr[$i] = $arr[$j];
   $arr[$j] = $tmp;
@@ -49,9 +64,9 @@ function doTrials($trials, $np, $strategy) {
 };
   $d = 0;
   while ($d < 50) {
-  $n = hrtime(true) % 100;
+  $n = _now() % 100;
   while ($opened[$n]) {
-  $n = hrtime(true) % 100;
+  $n = _now() % 100;
 };
   $opened[$n] = true;
   if ($drawers[$n] == $p) {
@@ -73,13 +88,13 @@ function doTrials($trials, $np, $strategy) {
   $t = $t + 1;
 };
   $rf = ($pardoned) / ($trials) * 100.0;
-  echo "  strategy = " . $strategy . "  pardoned = " . strval($pardoned) . " relative frequency = " . strval($rf) . "%", PHP_EOL;
+  echo "  strategy = " . $strategy . "  pardoned = " . json_encode($pardoned, 1344) . " relative frequency = " . json_encode($rf, 1344) . "%", PHP_EOL;
 }
 function main() {
   global $mochi_shuffle, $doTrials;
   $trials = 1000;
   foreach ([10, 100] as $np) {
-  echo "Results from " . strval($trials) . " trials with " . strval($np) . " prisoners:\n", PHP_EOL;
+  echo "Results from " . json_encode($trials, 1344) . " trials with " . json_encode($np, 1344) . " prisoners:\n", PHP_EOL;
   foreach (["random", "optimal"] as $strat) {
   doTrials($trials, $np, $strat);
 };

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-23 11:36 +0700
+Last updated: 2025-07-23 12:23 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,13 +2,13 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-23 11:36 +0700
+Last updated: 2025-07-23 12:23 +0700
 
-## Checklist (20/284)
+## Checklist (21/284)
 - [x] 1 100-doors-2
 - [x] 2 100-doors-3
 - [x] 3 100-doors
-- [ ] 4 100-prisoners
+- [x] 4 100-prisoners
 - [x] 5 15-puzzle-game
 - [x] 6 15-puzzle-solver
 - [x] 7 2048

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-23 11:36 +0700)
+## Progress (2025-07-23 12:23 +0700)
 - Generated PHP for 102/103 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- update PHP transpiler to emit deterministic `_now()`
- refresh generated php/out for `100-prisoners`
- update transpiler README/TASKS/ROSETTA docs

## Testing
- `MOCHI_NOW_SEED=1 UPDATE=1 MOCHI_ROSETTA_INDEX=4 go test -tags slow -run Rosetta ./transpiler/x/php`


------
https://chatgpt.com/codex/tasks/task_e_688071d089788320ba5f006e04c6ac9b