### PR TITLE
Add release note for v0.10.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@
 * Additional Rosetta examples across C#, Lua, Racket and Swift
 * Map key handling for TypeScript with selector calls for Zig
 * Local variable tracking and typed call arguments in multiple backends
+* `padStart` helpers for Python, Ruby and Lua with integer and membership utilities
+* List parameter and nested literal support across transpilers
+* `net.LookupHost` for Erlang and OCaml plus map indexing in Swift and PHP
 
 ### Changed
 
 * Improved type inference for Kotlin and container metadata in Scala
 * Enhanced C++ variable management and indentation fixes in C#
+* Improved map handling for Java with additional Rosetta programs
+* Progress checklists updated across languages
 * Rosetta outputs regenerated and stored with source code
 
 ### Fixed
@@ -19,7 +24,8 @@
 * Deterministic `now` seeding for C++
 * Global variable rename issues in Rust
 * Miscellaneous compilation bugs across languages
-
+* Fixed string slice handling in the C# transpiler
+* Various minor issues across PHP and Ruby backends
 
 ## [0.10.37] – 2025-07-22T17:53:32+07:00
 

--- a/releases/v0.10.38.md
+++ b/releases/v0.10.38.md
@@ -15,6 +15,12 @@ Mochi v0.10.38 expands Rosetta examples and improves type handling across numero
 - Improved type inference for Kotlin and container type metadata for Scala
 - Typed call arguments handled in Go and various OCaml and Racket test additions
 
+- `padStart` helpers added for Python, Ruby and Lua with integer and membership runtime helpers
+- List parameter and nested literal support across transpilers with list casts for Lua
+- Map indexing and null-safe access for PHP and Swift plus `net.LookupHost` for Erlang and OCaml
+- Improved map handling and additional Rosetta programs in Java with updated outputs across languages
+- Fixed string slicing in the C# backend
+
 ## Documentation
 
 - Rosetta progress logs updated for many languages


### PR DESCRIPTION
## Summary
- document features for v0.10.38 in CHANGELOG and releases directory

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880a1fcce4c832088934e7a798f1870