### PR TITLE
Update Kotlin transpiler for Rosetta programs

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/abbreviations-easy.kt
+++ b/tests/rosetta/transpiler/Kotlin/abbreviations-easy.kt
@@ -1,0 +1,112 @@
+fun fields(s: String): MutableList<String> {
+    var words: MutableList<String> = mutableListOf()
+    var cur: String = ""
+    var i: Int = 0
+    while (i < s.length) {
+        val ch: String = s.substring(i, i + 1)
+        if ((((ch == " ") || (ch == "\n") as Boolean)) || (ch == "\t")) {
+            if (cur.length > 0) {
+                words = run { val _tmp = words.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+                cur = ""
+            }
+        } else {
+            cur = cur + ch
+        }
+        i = i + 1
+    }
+    if (cur.length > 0) {
+        words = run { val _tmp = words.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+    }
+    return words as MutableList<String>
+}
+
+fun padRight(s: String, width: Int): String {
+    var out: String = s
+    var i: Int = s.length
+    while (i < width) {
+        out = out + " "
+        i = i + 1
+    }
+    return out as String
+}
+
+fun join(xs: MutableList<String>, sep: String): String {
+    var res: String = ""
+    var i: Int = 0
+    while (i < xs.size) {
+        if (i > 0) {
+            res = res + sep
+        }
+        res = res + xs[i]
+        i = i + 1
+    }
+    return res as String
+}
+
+fun validate(commands: MutableList<String>, words: MutableList<String>, mins: MutableList<Int>): MutableList<String> {
+    var results: MutableList<String> = mutableListOf()
+    if (words.size == 0) {
+        return results as MutableList<String>
+    }
+    var wi: Int = 0
+    while (wi < words.size) {
+        val w: String = words[wi]
+        var found: Boolean = false
+        val wlen: Int = w.length
+        var ci: Int = 0
+        while (ci < commands.size) {
+            val cmd: String = commands[ci]
+            if ((((mins[ci] != 0) && (wlen >= mins[ci]) as Boolean)) && (wlen <= cmd.length)) {
+                val c: String = cmd.toUpperCase()
+                val ww: String = w.toUpperCase()
+                if (c.substring(0, wlen) == ww) {
+                    results = run { val _tmp = results.toMutableList(); _tmp.add(c); _tmp } as MutableList<String>
+                    found = true
+                    break
+                }
+            }
+            ci = ci + 1
+        }
+        if (!found) {
+            results = run { val _tmp = results.toMutableList(); _tmp.add("*error*"); _tmp } as MutableList<String>
+        }
+        wi = wi + 1
+    }
+    return results as MutableList<String>
+}
+
+fun user_main(): Unit {
+    val table: String = ((((("Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy " + "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find ") + "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput ") + " Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO ") + "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT ") + "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT ") + "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp "
+    val commands: MutableList<String> = fields(table)
+    var mins: MutableList<Int> = mutableListOf()
+    var i: Int = 0
+    while (i < commands.size) {
+        var count: Int = 0
+        var j: Int = 0
+        val cmd: String = commands[i]
+        while (j < cmd.length) {
+            val ch: String = cmd.substring(j, j + 1)
+            if ((ch >= "A") && (ch <= "Z")) {
+                count = count + 1
+            }
+            j = j + 1
+        }
+        mins = run { val _tmp = mins.toMutableList(); _tmp.add(count); _tmp } as MutableList<Int>
+        i = i + 1
+    }
+    val sentence: String = "riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin"
+    val words: MutableList<String> = fields(sentence)
+    val results: MutableList<String> = validate(commands, words, mins)
+    var out1: String = "user words:  "
+    var k: Int = 0
+    while (k < words.size) {
+        out1 = (out1 + (padRight(words[k], results[k].length)).toString()) + " "
+        k = k + 1
+    }
+    println(out1)
+    println("full words:  " + (join(results, " ")).toString())
+}
+
+fun main() {
+    user_main()
+}

--- a/tests/rosetta/transpiler/Kotlin/abbreviations-easy.out
+++ b/tests/rosetta/transpiler/Kotlin/abbreviations-easy.out
@@ -1,0 +1,2 @@
+user words:  riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin    
+full words:  RIGHT REPEAT *error* PUT MOVE RESTORE *error* *error* *error* POWERINPUT

--- a/tests/rosetta/transpiler/Kotlin/abbreviations-simple.kt
+++ b/tests/rosetta/transpiler/Kotlin/abbreviations-simple.kt
@@ -1,0 +1,156 @@
+fun fields(s: String): MutableList<String> {
+    var words: MutableList<String> = mutableListOf()
+    var cur: String = ""
+    var i: Int = 0
+    while (i < s.length) {
+        val ch: String = s.substring(i, i + 1)
+        if ((((ch == " ") || (ch == "\n") as Boolean)) || (ch == "\t")) {
+            if (cur.length > 0) {
+                words = run { val _tmp = words.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+                cur = ""
+            }
+        } else {
+            cur = cur + ch
+        }
+        i = i + 1
+    }
+    if (cur.length > 0) {
+        words = run { val _tmp = words.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+    }
+    return words as MutableList<String>
+}
+
+fun padRight(s: String, width: Int): String {
+    var out: String = s
+    var i: Int = s.length
+    while (i < width) {
+        out = out + " "
+        i = i + 1
+    }
+    return out as String
+}
+
+fun join(xs: MutableList<String>, sep: String): String {
+    var res: String = ""
+    var i: Int = 0
+    while (i < xs.size) {
+        if (i > 0) {
+            res = res + sep
+        }
+        res = res + xs[i]
+        i = i + 1
+    }
+    return res as String
+}
+
+fun parseIntStr(str: String): Int {
+    var i: Int = 0
+    var neg: Boolean = false
+    if ((str.length > 0) && (str.substring(0, 1) == "-")) {
+        neg = true
+        i = 1
+    }
+    var n: Int = 0
+    val digits: MutableMap<String, Int> = mutableMapOf<String, Int>("0" to (0), "1" to (1), "2" to (2), "3" to (3), "4" to (4), "5" to (5), "6" to (6), "7" to (7), "8" to (8), "9" to (9))
+    while (i < str.length) {
+        n = (n * 10) + (digits)[str.substring(i, i + 1)] as Int
+        i = i + 1
+    }
+    if (neg as Boolean) {
+        n = 0 - n
+    }
+    return n as Int
+}
+
+fun isDigits(s: String): Boolean {
+    if (s.length == 0) {
+        return false as Boolean
+    }
+    var i: Int = 0
+    while (i < s.length) {
+        val ch: String = s.substring(i, i + 1)
+        if ((ch < "0") || (ch > "9")) {
+            return false as Boolean
+        }
+        i = i + 1
+    }
+    return true as Boolean
+}
+
+fun readTable(table: String): MutableMap<String, Any> {
+    val toks: MutableList<String> = fields(table)
+    var cmds: MutableList<String> = mutableListOf()
+    var mins: MutableList<Int> = mutableListOf()
+    var i: Int = 0
+    while (i < toks.size) {
+        val cmd: String = toks[i]
+        var minlen: Int = cmd.length
+        i = i + 1
+        if ((i < toks.size) && (isDigits(toks[i]) as Boolean)) {
+            val num: Int = parseIntStr(toks[i])
+            if ((num >= 1) && (num < cmd.length)) {
+                minlen = num
+                i = i + 1
+            }
+        }
+        cmds = run { val _tmp = cmds.toMutableList(); _tmp.add(cmd); _tmp } as MutableList<String>
+        mins = run { val _tmp = mins.toMutableList(); _tmp.add(minlen); _tmp } as MutableList<Int>
+    }
+    return mutableMapOf<String, Any>("commands" to (cmds), "mins" to (mins)) as MutableMap<String, Any>
+}
+
+fun validate(commands: MutableList<String>, mins: MutableList<Int>, words: MutableList<String>): MutableList<String> {
+    var results: MutableList<String> = mutableListOf()
+    var wi: Int = 0
+    while (wi < words.size) {
+        val w: String = words[wi]
+        var found: Boolean = false
+        val wlen: Int = w.length
+        var ci: Int = 0
+        while (ci < commands.size) {
+            val cmd: String = commands[ci]
+            if ((((mins[ci] != 0) && (wlen >= mins[ci]) as Boolean)) && (wlen <= cmd.length)) {
+                val c: String = cmd.toUpperCase()
+                val ww: String = w.toUpperCase()
+                if (c.substring(0, wlen) == ww) {
+                    results = run { val _tmp = results.toMutableList(); _tmp.add(c); _tmp } as MutableList<String>
+                    found = true
+                    break
+                }
+            }
+            ci = ci + 1
+        }
+        if (!found) {
+            results = run { val _tmp = results.toMutableList(); _tmp.add("*error*"); _tmp } as MutableList<String>
+        }
+        wi = wi + 1
+    }
+    return results as MutableList<String>
+}
+
+fun user_main(): Unit {
+    val table: String = ((((((("" + "add 1  alter 3  backup 2  bottom 1  Cappend 2  change 1  Schange  Cinsert 2  Clast 3 ") + "compress 4 copy 2 count 3 Coverlay 3 cursor 3  delete 3 Cdelete 2  down 1  duplicate ") + "3 xEdit 1 expand 3 extract 3  find 1 Nfind 2 Nfindup 6 NfUP 3 Cfind 2 findUP 3 fUP 2 ") + "forward 2  get  help 1 hexType 4  input 1 powerInput 3  join 1 split 2 spltJOIN load ") + "locate 1 Clocate 2 lowerCase 3 upperCase 3 Lprefix 2  macro  merge 2 modify 3 move 2 ") + "msg  next 1 overlay 1 parse preserve 4 purge 3 put putD query 1 quit  read recover 3 ") + "refresh renum 3 repeat 3 replace 1 Creplace 2 reset 3 restore 4 rgtLEFT right 2 left ") + "2  save  set  shift 2  si  sort  sos  stack 3 status 4 top  transfer 3  type 1  up 1 "
+    val sentence: String = "riG   rePEAT copies  put mo   rest    types   fup.    6\npoweRin"
+    val tbl: MutableMap<String, Any> = readTable(table)
+    val commands: MutableList<String> = (tbl)["commands"]!! as MutableList<String>
+    val mins: MutableList<Int> = (tbl)["mins"]!! as MutableList<Int>
+    val words: MutableList<String> = fields(sentence)
+    val results: MutableList<String> = validate(commands, mins, words)
+    var out1: String = "user words:"
+    var k: Int = 0
+    while (k < words.size) {
+        out1 = out1 + " "
+        if (k < (words.size - 1)) {
+            out1 = out1 + (padRight(words[k], results[k].length)).toString()
+        } else {
+            out1 = out1 + words[k]
+        }
+        k = k + 1
+    }
+    println(out1)
+    println("full words: " + (join(results, " ")).toString())
+}
+
+fun main() {
+    user_main()
+}

--- a/tests/rosetta/transpiler/Kotlin/abbreviations-simple.out
+++ b/tests/rosetta/transpiler/Kotlin/abbreviations-simple.out
@@ -1,0 +1,2 @@
+user words: riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin
+full words: RIGHT REPEAT *error* PUT MOVE RESTORE *error* *error* *error* POWERINPUT

--- a/tests/rosetta/transpiler/Kotlin/abc-problem.kt
+++ b/tests/rosetta/transpiler/Kotlin/abc-problem.kt
@@ -1,0 +1,63 @@
+fun fields(s: String): MutableList<String> {
+    var res: MutableList<String> = mutableListOf()
+    var cur: String = ""
+    var i: Int = 0
+    while (i < s.length) {
+        val c: String = s.substring(i, i + 1)
+        if (c == " ") {
+            if (cur.length > 0) {
+                res = run { val _tmp = res.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+                cur = ""
+            }
+        } else {
+            cur = cur + c
+        }
+        i = i + 1
+    }
+    if (cur.length > 0) {
+        res = run { val _tmp = res.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
+    }
+    return res as MutableList<String>
+}
+
+fun canSpell(word: String, blks: MutableList<String>): Boolean {
+    if (word.length == 0) {
+        return true as Boolean
+    }
+    val c: String = word.substring(0, 1).toLowerCase()
+    var i: Int = 0
+    while (i < blks.size) {
+        val b: String = blks[i]
+        if ((c == b.substring(0, 1).toLowerCase()) || (c == b.substring(1, 2).toLowerCase())) {
+            var rest: MutableList<String> = mutableListOf()
+            var j: Int = 0
+            while (j < blks.size) {
+                if (j != i) {
+                    rest = run { val _tmp = rest.toMutableList(); _tmp.add(blks[j]); _tmp } as MutableList<String>
+                }
+                j = j + 1
+            }
+            if (canSpell(word.substring(1, word.length), rest) as Boolean) {
+                return true as Boolean
+            }
+        }
+        i = i + 1
+    }
+    return false as Boolean
+}
+
+fun newSpeller(blocks: String): (String) -> Boolean {
+    val bl: MutableList<String> = fields(blocks)
+    return { w: String -> canSpell(w, bl) } as (String) -> Boolean
+}
+
+fun user_main(): Unit {
+    val sp: (String) -> Boolean = newSpeller("BO XK DQ CP NA GT RE TG QD FS JW HU VI AN OB ER FS LY PC ZM")
+    for (word in mutableListOf("A", "BARK", "BOOK", "TREAT", "COMMON", "SQUAD", "CONFUSE")) {
+        println((word + " ") + sp(word).toString())
+    }
+}
+
+fun main() {
+    user_main()
+}

--- a/tests/rosetta/transpiler/Kotlin/abc-problem.out
+++ b/tests/rosetta/transpiler/Kotlin/abc-problem.out
@@ -1,0 +1,7 @@
+A true
+BARK true
+BOOK false
+TREAT true
+COMMON false
+SQUAD true
+CONFUSE true

--- a/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model-identity.kt
+++ b/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model-identity.kt
@@ -1,0 +1,91 @@
+var s4: MutableList<Int> = mutableListOf(4, 3, 3, 3, 1, 2, 0, 2, 3)
+var s1: MutableList<Int> = mutableListOf(1, 2, 0, 2, 1, 1, 0, 1, 3)
+var s2: MutableList<Int> = mutableListOf(2, 1, 3, 1, 0, 1, 0, 1, 0)
+var s3_a: MutableList<Int> = plus(s1, s2)
+var s3_b: MutableList<Int> = plus(s2, s1)
+var s3: MutableList<Int> = mutableListOf(3, 3, 3, 3, 3, 3, 3, 3, 3)
+var s3_id: MutableList<Int> = mutableListOf(2, 1, 2, 1, 0, 1, 2, 1, 2)
+var s4b: MutableList<Int> = plus(s3, s3_id)
+var s5: MutableList<Int> = plus(s3_id, s3_id)
+fun neighborsList(): MutableList<MutableList<Int>> {
+    return mutableListOf(mutableListOf(1, 3), mutableListOf(0, 2, 4), mutableListOf(1, 5), mutableListOf(0, 4, 6), mutableListOf(1, 3, 5, 7), mutableListOf(2, 4, 8), mutableListOf(3, 7), mutableListOf(4, 6, 8), mutableListOf(5, 7)) as MutableList<MutableList<Int>>
+}
+
+fun plus(a: MutableList<Int>, b: MutableList<Int>): MutableList<Int> {
+    var res: MutableList<Int> = mutableListOf()
+    var i: Int = 0
+    while (i < a.size) {
+        res = run { val _tmp = res.toMutableList(); _tmp.add(a[i] + b[i]); _tmp } as MutableList<Int>
+        i = i + 1
+    }
+    return res as MutableList<Int>
+}
+
+fun isStable(p: MutableList<Int>): Boolean {
+    for (v in p) {
+        if (v > 3) {
+            return false as Boolean
+        }
+    }
+    return true as Boolean
+}
+
+fun topple(p: MutableList<Int>): Int {
+    val neighbors: MutableList<MutableList<Int>> = neighborsList()
+    var i: Int = 0
+    while (i < p.size) {
+        if (p[i] > 3) {
+            p[i] = p[i] - 4
+            val nbs = neighbors[i]
+            for (j in nbs) {
+                p[j] = (p)[j] as Int + 1
+            }
+            return 0 as Int
+        }
+        i = i + 1
+    }
+    return 0 as Int
+}
+
+fun pileString(p: MutableList<Int>): String {
+    var s: String = ""
+    var r: Int = 0
+    while (r < 3) {
+        var c: Int = 0
+        while (c < 3) {
+            s = (s + p[(3 * r) + c].toString()) + " "
+            c = c + 1
+        }
+        s = s + "\n"
+        r = r + 1
+    }
+    return s as String
+}
+
+fun main() {
+    println("Avalanche of topplings:\n")
+    println(pileString(s4))
+    while (!(isStable(s4) as Boolean)) {
+        topple(s4)
+        println(pileString(s4))
+    }
+    println("Commutative additions:\n")
+    while (!(isStable(s3_a) as Boolean)) {
+        topple(s3_a)
+    }
+    while (!(isStable(s3_b) as Boolean)) {
+        topple(s3_b)
+    }
+    println(((((pileString(s1)).toString() + "\nplus\n\n") + (pileString(s2)).toString()) + "\nequals\n\n") + (pileString(s3_a)).toString())
+    println((((("and\n\n" + (pileString(s2)).toString()) + "\nplus\n\n") + (pileString(s1)).toString()) + "\nalso equals\n\n") + (pileString(s3_b)).toString())
+    println("Addition of identity sandpile:\n")
+    while (!(isStable(s4b) as Boolean)) {
+        topple(s4b)
+    }
+    println(((((pileString(s3)).toString() + "\nplus\n\n") + (pileString(s3_id)).toString()) + "\nequals\n\n") + (pileString(s4b)).toString())
+    println("Addition of identities:\n")
+    while (!(isStable(s5) as Boolean)) {
+        topple(s5)
+    }
+    println(((((pileString(s3_id)).toString() + "\nplus\n\n") + (pileString(s3_id)).toString()) + "\nequals\n\n") + (pileString(s5)).toString())
+}

--- a/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model-identity.out
+++ b/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model-identity.out
@@ -1,0 +1,93 @@
+Avalanche of topplings:
+
+4 3 3 
+3 1 2 
+0 2 3 
+
+0 4 3 
+4 1 2 
+0 2 3 
+
+1 0 4 
+4 2 2 
+0 2 3 
+
+1 1 0 
+4 2 3 
+0 2 3 
+
+2 1 0 
+0 3 3 
+1 2 3 
+
+Commutative additions:
+
+1 2 0 
+2 1 1 
+0 1 3 
+
+plus
+
+2 1 3 
+1 0 1 
+0 1 0 
+
+equals
+
+3 3 3 
+3 1 2 
+0 2 3 
+
+and
+
+2 1 3 
+1 0 1 
+0 1 0 
+
+plus
+
+1 2 0 
+2 1 1 
+0 1 3 
+
+also equals
+
+3 3 3 
+3 1 2 
+0 2 3 
+
+Addition of identity sandpile:
+
+3 3 3 
+3 3 3 
+3 3 3 
+
+plus
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+equals
+
+3 3 3 
+3 3 3 
+3 3 3 
+
+Addition of identities:
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+plus
+
+2 1 2 
+1 0 1 
+2 1 2 
+
+equals
+
+2 1 2 
+1 0 1 
+2 1 2

--- a/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model.error
+++ b/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model.error
@@ -1,0 +1,4 @@
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model.kt:74:12: error: type mismatch: inferred type is MutableList<Any> but MutableList<MutableList<Int>> was expected
+    pile = handlePile(pile as MutableList<MutableList<Int>>, hdim, hdim) as MutableList<MutableList<Int>> as MutableList<Any>
+           ^

--- a/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model.kt
+++ b/tests/rosetta/transpiler/Kotlin/abelian-sandpile-model.kt
@@ -1,0 +1,80 @@
+val dim: Int = 16
+fun newPile(d: Int): MutableList<MutableList<Int>> {
+    var b: MutableList<MutableList<Int>> = mutableListOf()
+    var y: Int = 0
+    while (y < d) {
+        var row: MutableList<Int> = mutableListOf()
+        var x: Int = 0
+        while (x < d) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+            x = x + 1
+        }
+        b = run { val _tmp = b.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Int>>
+        y = y + 1
+    }
+    return b as MutableList<MutableList<Int>>
+}
+
+fun handlePile(pile: MutableList<MutableList<Int>>, x: Int, y: Int): MutableList<MutableList<Int>> {
+    var pile: MutableList<MutableList<Int>> = pile
+    if (pile[y][x] >= 4) {
+        pile[y][x] = pile[y][x] - 4
+        if (y > 0) {
+            pile[y - 1][x] = pile[y - 1][x] + 1
+            if (pile[y - 1][x] >= 4) {
+                pile = handlePile(pile, x, y - 1) as MutableList<MutableList<Int>>
+            }
+        }
+        if (x > 0) {
+            pile[y][x - 1] = pile[y][x - 1] + 1
+            if (pile[y][x - 1] >= 4) {
+                pile = handlePile(pile, x - 1, y) as MutableList<MutableList<Int>>
+            }
+        }
+        if (y < (dim - 1)) {
+            pile[y + 1][x] = pile[y + 1][x] + 1
+            if (pile[y + 1][x] >= 4) {
+                pile = handlePile(pile, x, y + 1) as MutableList<MutableList<Int>>
+            }
+        }
+        if (x < (dim - 1)) {
+            pile[y][x + 1] = pile[y][x + 1] + 1
+            if (pile[y][x + 1] >= 4) {
+                pile = handlePile(pile, x + 1, y) as MutableList<MutableList<Int>>
+            }
+        }
+        pile = handlePile(pile, x, y) as MutableList<MutableList<Int>>
+    }
+    return pile as MutableList<MutableList<Int>>
+}
+
+fun drawPile(pile: MutableList<MutableList<Int>>, d: Int): Unit {
+    val chars: MutableList<String> = mutableListOf(" ", "░", "▓", "█")
+    var row: Int = 0
+    while (row < d) {
+        var line: String = ""
+        var col: Int = 0
+        while (col < d) {
+            var v: Int = pile[row][col]
+            if (v > 3) {
+                v = 3
+            }
+            line = line + chars[v]
+            col = col + 1
+        }
+        println(line)
+        row = row + 1
+    }
+}
+
+fun user_main(): Unit {
+    var pile: MutableList<MutableList<Int>> = newPile(16) as MutableList<MutableList<Int>>
+    val hdim: Int = 7
+    pile[hdim][hdim] = 16
+    pile = handlePile(pile as MutableList<MutableList<Int>>, hdim, hdim) as MutableList<MutableList<Int>> as MutableList<Any>
+    drawPile(pile as MutableList<MutableList<Int>>, 16)
+}
+
+fun main() {
+    user_main()
+}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-23 17:13 +0700
+Last updated: 2025-07-23 18:30 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-23 17:13 +0700
+Last updated: 2025-07-23 18:30 +0700
 
-Completed tasks: **17/284**
+Completed tasks: **21/284**
 
 ### Checklist
 1. [x] `100-doors-2`
@@ -24,10 +24,10 @@ Completed tasks: **17/284**
 15. [x] `DNS-query`
 16. [x] `a+b`
 17. [x] `abbreviations-automatic`
-18. [ ] `abbreviations-easy`
-19. [ ] `abbreviations-simple`
-20. [ ] `abc-problem`
-21. [ ] `abelian-sandpile-model-identity`
+18. [x] `abbreviations-easy`
+19. [x] `abbreviations-simple`
+20. [x] `abc-problem`
+21. [x] `abelian-sandpile-model-identity`
 22. [ ] `abelian-sandpile-model`
 23. [ ] `abstract-type`
 24. [ ] `abundant-deficient-and-perfect-number-classifications`

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,54 @@
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:30 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:29 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:29 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:29 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:27 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:27 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:22 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-23 18:22 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-23 17:13 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- extend Kotlin transpiler with new helper cases
- support generic type casts and lower builtin
- generate Kotlin sources and outputs for new Rosetta examples
- improve type detection for index expressions
- update Rosetta progress checklist

## Testing
- `ROSETTA_INDEX=18 go test ./transpiler/x/kt -run RosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=19 go test ./transpiler/x/kt -run RosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=20 go test ./transpiler/x/kt -run RosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=21 go test ./transpiler/x/kt -run RosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=22 go test ./transpiler/x/kt -run RosettaKotlin -tags=slow -count=1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6880c5f300f48320808f357fcb164625