### PR TITLE
Fix struct field indexing in C transpiler

### DIFF
--- a/transpiler/x/c/transpiler.go
+++ b/transpiler/x/c/transpiler.go
@@ -649,6 +649,17 @@ type IndexExpr struct {
 }
 
 func (i *IndexExpr) emitExpr(w io.Writer) {
+	if key, ok := evalString(i.Index); ok {
+		tname := inferExprType(currentEnv, i.Target)
+		if st, ok2 := currentEnv.GetStruct(tname); ok2 {
+			if _, ok3 := st.Fields[key]; ok3 {
+				i.Target.emitExpr(w)
+				io.WriteString(w, ".")
+				io.WriteString(w, key)
+				return
+			}
+		}
+	}
 	if exprIsString(i.Target) {
 		io.WriteString(w, "(const char[]){")
 		i.Target.emitExpr(w)


### PR DESCRIPTION
## Summary
- handle map-like indexing for structs in C transpiler

## Testing
- `MOCHI_ROSETTA_INDEX=7 go test ./transpiler/x/c -tags slow -run Rosetta -ctrans_update -count=1` *(fails: first failing program: 2048)*

------
https://chatgpt.com/codex/tasks/task_e_6880e0420288832086b60c164970c686