### PR TITLE
Fix parsing and type resolution tests

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -540,8 +540,8 @@ type FunExpr struct {
 	Pos       lexer.Position
 	Params    []*Param     `parser:"'fun' '(' [ @@ { ',' @@ } ] ')'"`
 	Return    *TypeRef     `parser:"[ ':' @@ ]"`
-	BlockBody []*Statement `parser:"'{' @@* '}'"`
-	ExprBody  *Expr        `parser:"| '=>' @@"`
+	BlockBody []*Statement `parser:"[ '{' @@* '}' ]"`
+	ExprBody  *Expr        `parser:"[ '=>' @@ ]"`
 }
 
 // --- Atoms ---

--- a/types/check.go
+++ b/types/check.go
@@ -1301,17 +1301,17 @@ func resolveTypeRef(t *parser.TypeRef, env *Env) Type {
 		case "bool":
 			return BoolType{}
 		default:
-			if typ, ok := env.LookupType(*t.Simple); ok {
-				return typ
-			}
 			if ut, ok := env.GetUnion(*t.Simple); ok {
-				return ut
-			}
-			if ut, ok := env.FindUnionByVariant(*t.Simple); ok {
 				return ut
 			}
 			if st, ok := env.GetStruct(*t.Simple); ok {
 				return st
+			}
+			if typ, ok := env.LookupType(*t.Simple); ok {
+				return typ
+			}
+			if ut, ok := env.FindUnionByVariant(*t.Simple); ok {
+				return ut
 			}
 			return AnyType{}
 		}


### PR DESCRIPTION
## Summary
- allow function expressions to omit block bodies in grammar
- resolve simple type names to structs before variables

## Testing
- `go test ./parser ./types`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6880ecef69008320891a6bf45090b204