### PR TITLE
Fix Java transpiler output for 15‑puzzle and update checklist

### DIFF
--- a/tests/rosetta/transpiler/Java/15-puzzle-game.java
+++ b/tests/rosetta/transpiler/Java/15-puzzle-game.java
@@ -4,6 +4,18 @@ public class Main {
     static int empty = 15;
     static int moves = 0;
     static boolean quit = false;
+    static class MoveResult {
+        int idx;
+        boolean ok;
+        MoveResult(int idx, boolean ok) {
+            this.idx = idx;
+            this.ok = ok;
+        }
+        @Override public String toString() {
+            return String.format("{'idx': %s, 'ok': %s}", String.valueOf(idx), String.valueOf(ok));
+        }
+    }
+
 
     static java.util.Scanner _scanner = new java.util.Scanner(System.in);
 
@@ -22,29 +34,29 @@ public class Main {
         return true;
     }
 
-    static java.util.Map<String,Object> isValidMove(int m) {
+    static MoveResult isValidMove(int m) {
         if (m == 0) {
-            return new java.util.LinkedHashMap<String, Object>() {{ put("idx", empty - 4); put("ok", empty / 4 > 0); }};
+            return new MoveResult(empty - 4, empty / 4 > 0);
         }
         if (m == 1) {
-            return new java.util.LinkedHashMap<String, Object>() {{ put("idx", empty + 4); put("ok", empty / 4 < 3); }};
+            return new MoveResult(empty + 4, empty / 4 < 3);
         }
         if (m == 2) {
-            return new java.util.LinkedHashMap<String, Object>() {{ put("idx", empty + 1); put("ok", empty % 4 < 3); }};
+            return new MoveResult(empty + 1, empty % 4 < 3);
         }
         if (m == 3) {
-            return new java.util.LinkedHashMap<String, Object>() {{ put("idx", empty - 1); put("ok", empty % 4 > 0); }};
+            return new MoveResult(empty - 1, empty % 4 > 0);
         }
-        return new java.util.LinkedHashMap<String, Object>() {{ put("idx", 0); put("ok", false); }};
+        return new MoveResult(0, false);
     }
 
     static boolean doMove(int m) {
-        java.util.Map<String,Object> r = isValidMove(m);
-        if (!(Boolean)r.get("ok")) {
+        MoveResult r = isValidMove(m);
+        if (!(Boolean)r.ok) {
             return false;
         }
         int i = empty;
-        int j = ((Number)(r.get("idx"))).intValue();
+        int j = r.idx;
         int tmp = board[i];
 board[i] = board[j];
 board[j] = tmp;

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -2,288 +2,288 @@
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Rosetta Checklist (8/284) - updated 2025-07-23 07:04 UTC
-1. [x] 100-doors-2
-2. [x] 100-doors-3
-3. [x] 100-doors
-4. [x] 100-prisoners
-5. [x] 15-puzzle-game
-6. [x] 15-puzzle-solver
-7. [x] 2048
-8. [x] 21-game
-9. [ ] 24-game-solve
-10. [ ] 24-game
-11. [ ] 4-rings-or-4-squares-puzzle
-12. [ ] 9-billion-names-of-god-the-integer
-13. [ ] 99-bottles-of-beer-2
-14. [ ] 99-bottles-of-beer
-15. [ ] DNS-query
-16. [ ] a+b
-17. [ ] abbreviations-automatic
-18. [ ] abbreviations-easy
-19. [ ] abbreviations-simple
-20. [ ] abc-problem
-21. [ ] abelian-sandpile-model-identity
-22. [ ] abelian-sandpile-model
-23. [ ] abstract-type
-24. [ ] abundant-deficient-and-perfect-number-classifications
-25. [ ] abundant-odd-numbers
-26. [ ] accumulator-factory
-27. [ ] achilles-numbers
-28. [ ] ackermann-function-2
-29. [ ] ackermann-function-3
-30. [ ] ackermann-function
-31. [ ] active-directory-connect
-32. [ ] active-directory-search-for-a-user
-33. [ ] active-object
-34. [ ] add-a-variable-to-a-class-instance-at-runtime
-35. [ ] additive-primes
-36. [ ] address-of-a-variable
-37. [ ] adfgvx-cipher
-38. [ ] aks-test-for-primes
-39. [ ] algebraic-data-types
-40. [ ] align-columns
-41. [ ] aliquot-sequence-classifications
-42. [ ] almkvist-giullera-formula-for-pi
-43. [ ] almost-prime
-44. [ ] amb
-45. [ ] amicable-pairs
-46. [ ] anagrams-deranged-anagrams
-47. [ ] anagrams
-48. [ ] angle-difference-between-two-bearings-1
-49. [ ] angle-difference-between-two-bearings-2
-50. [ ] angles-geometric-normalization-and-conversion
-51. [ ] animate-a-pendulum
-52. [ ] animation
-53. [ ] anonymous-recursion-1
-54. [ ] anonymous-recursion-2
-55. [ ] anonymous-recursion
-56. [ ] anti-primes
-57. [ ] append-a-record-to-the-end-of-a-text-file
-58. [ ] apply-a-callback-to-an-array-1
-59. [ ] apply-a-callback-to-an-array-2
-60. [ ] apply-a-digital-filter-direct-form-ii-transposed-
-61. [ ] approximate-equality
-62. [ ] arbitrary-precision-integers-included-
-63. [ ] archimedean-spiral
-64. [ ] arena-storage-pool
-65. [ ] arithmetic-complex
-66. [ ] arithmetic-derivative
-67. [ ] arithmetic-evaluation
-68. [ ] arithmetic-geometric-mean-calculate-pi
-69. [ ] arithmetic-geometric-mean
-70. [ ] arithmetic-integer-1
-71. [ ] arithmetic-integer-2
-72. [ ] arithmetic-numbers
-73. [ ] arithmetic-rational
-74. [ ] array-concatenation
-75. [ ] array-length
-76. [ ] arrays
-77. [ ] ascending-primes
-78. [ ] ascii-art-diagram-converter
-79. [ ] assertions
-80. [ ] associative-array-creation
-81. [ ] associative-array-iteration
-82. [ ] associative-array-merging
-83. [ ] atomic-updates
-84. [ ] attractive-numbers
-85. [ ] average-loop-length
-86. [ ] averages-arithmetic-mean
-87. [ ] averages-mean-time-of-day
-88. [ ] averages-median-1
-89. [ ] averages-median-2
-90. [ ] averages-median-3
-91. [ ] averages-mode
-92. [ ] averages-pythagorean-means
-93. [ ] averages-root-mean-square
-94. [ ] averages-simple-moving-average
-95. [ ] avl-tree
-96. [ ] b-zier-curves-intersections
-97. [ ] babbage-problem
-98. [ ] babylonian-spiral
-99. [ ] balanced-brackets
-100. [ ] balanced-ternary
-101. [ ] barnsley-fern
-102. [ ] base64-decode-data
-103. [ ] bell-numbers
-104. [ ] benfords-law
-105. [ ] bernoulli-numbers
-106. [ ] best-shuffle
-107. [ ] bifid-cipher
-108. [ ] bin-given-limits
-109. [ ] binary-digits
-110. [ ] binary-search
-111. [ ] binary-strings
-112. [ ] bioinformatics-base-count
-113. [ ] bioinformatics-global-alignment
-114. [ ] bioinformatics-sequence-mutation
-115. [ ] biorhythms
-116. [ ] bitcoin-address-validation
-117. [ ] bitmap-b-zier-curves-cubic
-118. [ ] bitmap-b-zier-curves-quadratic
-119. [ ] bitmap-bresenhams-line-algorithm
-120. [ ] bitmap-flood-fill
-121. [ ] bitmap-histogram
-122. [ ] bitmap-midpoint-circle-algorithm
-123. [ ] bitmap-ppm-conversion-through-a-pipe
-124. [ ] bitmap-read-a-ppm-file
-125. [ ] bitmap-read-an-image-through-a-pipe
-126. [ ] bitmap-write-a-ppm-file
-127. [ ] bitmap
-128. [ ] bitwise-io-1
-129. [ ] bitwise-io-2
-130. [ ] bitwise-operations
-131. [ ] blum-integer
-132. [ ] boolean-values
-133. [ ] box-the-compass
-134. [ ] boyer-moore-string-search
-135. [ ] brazilian-numbers
-136. [ ] break-oo-privacy
-137. [ ] brilliant-numbers
-138. [ ] brownian-tree
-139. [ ] bulls-and-cows-player
-140. [ ] bulls-and-cows
-141. [ ] burrows-wheeler-transform
-142. [ ] caesar-cipher-1
-143. [ ] caesar-cipher-2
-144. [ ] calculating-the-value-of-e
-145. [ ] calendar---for-real-programmers-1
-146. [ ] calendar---for-real-programmers-2
-147. [ ] calendar
-148. [ ] calkin-wilf-sequence
-149. [ ] call-a-foreign-language-function
-150. [ ] call-a-function-1
-151. [ ] call-a-function-10
-152. [ ] call-a-function-11
-153. [ ] call-a-function-12
-154. [ ] call-a-function-2
-155. [ ] call-a-function-3
-156. [ ] call-a-function-4
-157. [ ] call-a-function-5
-158. [ ] call-a-function-6
-159. [ ] call-a-function-7
-160. [ ] call-a-function-8
-161. [ ] call-a-function-9
-162. [ ] call-an-object-method-1
-163. [ ] call-an-object-method-2
-164. [ ] call-an-object-method-3
-165. [ ] call-an-object-method
-166. [ ] camel-case-and-snake-case
-167. [ ] canny-edge-detector
-168. [ ] canonicalize-cidr
-169. [ ] cantor-set
-170. [ ] carmichael-3-strong-pseudoprimes
-171. [ ] cartesian-product-of-two-or-more-lists-1
-172. [ ] cartesian-product-of-two-or-more-lists-2
-173. [ ] cartesian-product-of-two-or-more-lists-3
-174. [ ] cartesian-product-of-two-or-more-lists-4
-175. [ ] case-sensitivity-of-identifiers
-176. [ ] casting-out-nines
-177. [ ] catalan-numbers-1
-178. [ ] catalan-numbers-2
-179. [ ] catalan-numbers-pascals-triangle
-180. [ ] catamorphism
-181. [ ] catmull-clark-subdivision-surface
-182. [ ] chaocipher
-183. [ ] chaos-game
-184. [ ] character-codes-1
-185. [ ] character-codes-2
-186. [ ] character-codes-3
-187. [ ] character-codes-4
-188. [ ] character-codes-5
-189. [ ] chat-server
-190. [ ] check-machin-like-formulas
-191. [ ] check-that-file-exists
-192. [ ] checkpoint-synchronization-1
-193. [ ] checkpoint-synchronization-2
-194. [ ] checkpoint-synchronization-3
-195. [ ] checkpoint-synchronization-4
-196. [ ] chernicks-carmichael-numbers
-197. [ ] cheryls-birthday
-198. [ ] chinese-remainder-theorem
-199. [ ] chinese-zodiac
-200. [ ] cholesky-decomposition-1
-201. [ ] cholesky-decomposition
-202. [ ] chowla-numbers
-203. [ ] church-numerals-1
-204. [ ] church-numerals-2
-205. [ ] circles-of-given-radius-through-two-points
-206. [ ] circular-primes
-207. [ ] cistercian-numerals
-208. [ ] comma-quibbling
-209. [ ] compiler-virtual-machine-interpreter
-210. [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
-211. [ ] compound-data-type
-212. [ ] concurrent-computing-1
-213. [ ] concurrent-computing-2
-214. [ ] concurrent-computing-3
-215. [ ] conditional-structures-1
-216. [ ] conditional-structures-10
-217. [ ] conditional-structures-2
-218. [ ] conditional-structures-3
-219. [ ] conditional-structures-4
-220. [ ] conditional-structures-5
-221. [ ] conditional-structures-6
-222. [ ] conditional-structures-7
-223. [ ] conditional-structures-8
-224. [ ] conditional-structures-9
-225. [ ] consecutive-primes-with-ascending-or-descending-differences
-226. [ ] constrained-genericity-1
-227. [ ] constrained-genericity-2
-228. [ ] constrained-genericity-3
-229. [ ] constrained-genericity-4
-230. [ ] constrained-random-points-on-a-circle-1
-231. [ ] constrained-random-points-on-a-circle-2
-232. [ ] continued-fraction
-233. [ ] convert-decimal-number-to-rational
-234. [ ] convert-seconds-to-compound-duration
-235. [ ] convex-hull
-236. [ ] conways-game-of-life
-237. [ ] copy-a-string-1
-238. [ ] copy-a-string-2
-239. [ ] copy-stdin-to-stdout-1
-240. [ ] copy-stdin-to-stdout-2
-241. [ ] count-in-factors
-242. [ ] count-in-octal-1
-243. [ ] count-in-octal-2
-244. [ ] count-in-octal-3
-245. [ ] count-in-octal-4
-246. [ ] count-occurrences-of-a-substring
-247. [ ] count-the-coins-1
-248. [ ] count-the-coins-2
-249. [ ] cramers-rule
-250. [ ] crc-32-1
-251. [ ] crc-32-2
-252. [ ] create-a-file-on-magnetic-tape
-253. [ ] create-a-file
-254. [ ] create-a-two-dimensional-array-at-runtime-1
-255. [ ] create-an-html-table
-256. [ ] create-an-object-at-a-given-address
-257. [ ] csv-data-manipulation
-258. [ ] csv-to-html-translation-1
-259. [ ] csv-to-html-translation-2
-260. [ ] csv-to-html-translation-3
-261. [ ] csv-to-html-translation-4
-262. [ ] csv-to-html-translation-5
-263. [ ] cuban-primes
-264. [ ] cullen-and-woodall-numbers
-265. [ ] cumulative-standard-deviation
-266. [ ] currency
-267. [ ] currying
-268. [ ] curzon-numbers
-269. [ ] cusip
-270. [ ] cyclops-numbers
-271. [ ] damm-algorithm
-272. [ ] date-format
-273. [ ] date-manipulation
-274. [ ] day-of-the-week
-275. [ ] de-bruijn-sequences
-276. [ ] deal-cards-for-freecell
-277. [ ] death-star
-278. [ ] deceptive-numbers
-279. [ ] deconvolution-1d-2
-280. [ ] deconvolution-1d-3
-281. [ ] deconvolution-1d
-282. [ ] deepcopy-1
-283. [ ] define-a-primitive-data-type
-284. [ ] md5
+## Rosetta Checklist (8/284) - updated 2025-07-23 16:48 UTC
+1. [x] 100-doors-2 (1)
+2. [x] 100-doors-3 (2)
+3. [x] 100-doors (3)
+4. [x] 100-prisoners (4)
+5. [x] 15-puzzle-game (5)
+6. [x] 15-puzzle-solver (6)
+7. [x] 2048 (7)
+8. [x] 21-game (8)
+9. [ ] 24-game-solve (9)
+10. [ ] 24-game (10)
+11. [ ] 4-rings-or-4-squares-puzzle (11)
+12. [ ] 9-billion-names-of-god-the-integer (12)
+13. [ ] 99-bottles-of-beer-2 (13)
+14. [ ] 99-bottles-of-beer (14)
+15. [ ] DNS-query (15)
+16. [ ] a+b (16)
+17. [ ] abbreviations-automatic (17)
+18. [ ] abbreviations-easy (18)
+19. [ ] abbreviations-simple (19)
+20. [ ] abc-problem (20)
+21. [ ] abelian-sandpile-model-identity (21)
+22. [ ] abelian-sandpile-model (22)
+23. [ ] abstract-type (23)
+24. [ ] abundant-deficient-and-perfect-number-classifications (24)
+25. [ ] abundant-odd-numbers (25)
+26. [ ] accumulator-factory (26)
+27. [ ] achilles-numbers (27)
+28. [ ] ackermann-function-2 (28)
+29. [ ] ackermann-function-3 (29)
+30. [ ] ackermann-function (30)
+31. [ ] active-directory-connect (31)
+32. [ ] active-directory-search-for-a-user (32)
+33. [ ] active-object (33)
+34. [ ] add-a-variable-to-a-class-instance-at-runtime (34)
+35. [ ] additive-primes (35)
+36. [ ] address-of-a-variable (36)
+37. [ ] adfgvx-cipher (37)
+38. [ ] aks-test-for-primes (38)
+39. [ ] algebraic-data-types (39)
+40. [ ] align-columns (40)
+41. [ ] aliquot-sequence-classifications (41)
+42. [ ] almkvist-giullera-formula-for-pi (42)
+43. [ ] almost-prime (43)
+44. [ ] amb (44)
+45. [ ] amicable-pairs (45)
+46. [ ] anagrams-deranged-anagrams (46)
+47. [ ] anagrams (47)
+48. [ ] angle-difference-between-two-bearings-1 (48)
+49. [ ] angle-difference-between-two-bearings-2 (49)
+50. [ ] angles-geometric-normalization-and-conversion (50)
+51. [ ] animate-a-pendulum (51)
+52. [ ] animation (52)
+53. [ ] anonymous-recursion-1 (53)
+54. [ ] anonymous-recursion-2 (54)
+55. [ ] anonymous-recursion (55)
+56. [ ] anti-primes (56)
+57. [ ] append-a-record-to-the-end-of-a-text-file (57)
+58. [ ] apply-a-callback-to-an-array-1 (58)
+59. [ ] apply-a-callback-to-an-array-2 (59)
+60. [ ] apply-a-digital-filter-direct-form-ii-transposed- (60)
+61. [ ] approximate-equality (61)
+62. [ ] arbitrary-precision-integers-included- (62)
+63. [ ] archimedean-spiral (63)
+64. [ ] arena-storage-pool (64)
+65. [ ] arithmetic-complex (65)
+66. [ ] arithmetic-derivative (66)
+67. [ ] arithmetic-evaluation (67)
+68. [ ] arithmetic-geometric-mean-calculate-pi (68)
+69. [ ] arithmetic-geometric-mean (69)
+70. [ ] arithmetic-integer-1 (70)
+71. [ ] arithmetic-integer-2 (71)
+72. [ ] arithmetic-numbers (72)
+73. [ ] arithmetic-rational (73)
+74. [ ] array-concatenation (74)
+75. [ ] array-length (75)
+76. [ ] arrays (76)
+77. [ ] ascending-primes (77)
+78. [ ] ascii-art-diagram-converter (78)
+79. [ ] assertions (79)
+80. [ ] associative-array-creation (80)
+81. [ ] associative-array-iteration (81)
+82. [ ] associative-array-merging (82)
+83. [ ] atomic-updates (83)
+84. [ ] attractive-numbers (84)
+85. [ ] average-loop-length (85)
+86. [ ] averages-arithmetic-mean (86)
+87. [ ] averages-mean-time-of-day (87)
+88. [ ] averages-median-1 (88)
+89. [ ] averages-median-2 (89)
+90. [ ] averages-median-3 (90)
+91. [ ] averages-mode (91)
+92. [ ] averages-pythagorean-means (92)
+93. [ ] averages-root-mean-square (93)
+94. [ ] averages-simple-moving-average (94)
+95. [ ] avl-tree (95)
+96. [ ] b-zier-curves-intersections (96)
+97. [ ] babbage-problem (97)
+98. [ ] babylonian-spiral (98)
+99. [ ] balanced-brackets (99)
+100. [ ] balanced-ternary (100)
+101. [ ] barnsley-fern (101)
+102. [ ] base64-decode-data (102)
+103. [ ] bell-numbers (103)
+104. [ ] benfords-law (104)
+105. [ ] bernoulli-numbers (105)
+106. [ ] best-shuffle (106)
+107. [ ] bifid-cipher (107)
+108. [ ] bin-given-limits (108)
+109. [ ] binary-digits (109)
+110. [ ] binary-search (110)
+111. [ ] binary-strings (111)
+112. [ ] bioinformatics-base-count (112)
+113. [ ] bioinformatics-global-alignment (113)
+114. [ ] bioinformatics-sequence-mutation (114)
+115. [ ] biorhythms (115)
+116. [ ] bitcoin-address-validation (116)
+117. [ ] bitmap-b-zier-curves-cubic (117)
+118. [ ] bitmap-b-zier-curves-quadratic (118)
+119. [ ] bitmap-bresenhams-line-algorithm (119)
+120. [ ] bitmap-flood-fill (120)
+121. [ ] bitmap-histogram (121)
+122. [ ] bitmap-midpoint-circle-algorithm (122)
+123. [ ] bitmap-ppm-conversion-through-a-pipe (123)
+124. [ ] bitmap-read-a-ppm-file (124)
+125. [ ] bitmap-read-an-image-through-a-pipe (125)
+126. [ ] bitmap-write-a-ppm-file (126)
+127. [ ] bitmap (127)
+128. [ ] bitwise-io-1 (128)
+129. [ ] bitwise-io-2 (129)
+130. [ ] bitwise-operations (130)
+131. [ ] blum-integer (131)
+132. [ ] boolean-values (132)
+133. [ ] box-the-compass (133)
+134. [ ] boyer-moore-string-search (134)
+135. [ ] brazilian-numbers (135)
+136. [ ] break-oo-privacy (136)
+137. [ ] brilliant-numbers (137)
+138. [ ] brownian-tree (138)
+139. [ ] bulls-and-cows-player (139)
+140. [ ] bulls-and-cows (140)
+141. [ ] burrows-wheeler-transform (141)
+142. [ ] caesar-cipher-1 (142)
+143. [ ] caesar-cipher-2 (143)
+144. [ ] calculating-the-value-of-e (144)
+145. [ ] calendar---for-real-programmers-1 (145)
+146. [ ] calendar---for-real-programmers-2 (146)
+147. [ ] calendar (147)
+148. [ ] calkin-wilf-sequence (148)
+149. [ ] call-a-foreign-language-function (149)
+150. [ ] call-a-function-1 (150)
+151. [ ] call-a-function-10 (151)
+152. [ ] call-a-function-11 (152)
+153. [ ] call-a-function-12 (153)
+154. [ ] call-a-function-2 (154)
+155. [ ] call-a-function-3 (155)
+156. [ ] call-a-function-4 (156)
+157. [ ] call-a-function-5 (157)
+158. [ ] call-a-function-6 (158)
+159. [ ] call-a-function-7 (159)
+160. [ ] call-a-function-8 (160)
+161. [ ] call-a-function-9 (161)
+162. [ ] call-an-object-method-1 (162)
+163. [ ] call-an-object-method-2 (163)
+164. [ ] call-an-object-method-3 (164)
+165. [ ] call-an-object-method (165)
+166. [ ] camel-case-and-snake-case (166)
+167. [ ] canny-edge-detector (167)
+168. [ ] canonicalize-cidr (168)
+169. [ ] cantor-set (169)
+170. [ ] carmichael-3-strong-pseudoprimes (170)
+171. [ ] cartesian-product-of-two-or-more-lists-1 (171)
+172. [ ] cartesian-product-of-two-or-more-lists-2 (172)
+173. [ ] cartesian-product-of-two-or-more-lists-3 (173)
+174. [ ] cartesian-product-of-two-or-more-lists-4 (174)
+175. [ ] case-sensitivity-of-identifiers (175)
+176. [ ] casting-out-nines (176)
+177. [ ] catalan-numbers-1 (177)
+178. [ ] catalan-numbers-2 (178)
+179. [ ] catalan-numbers-pascals-triangle (179)
+180. [ ] catamorphism (180)
+181. [ ] catmull-clark-subdivision-surface (181)
+182. [ ] chaocipher (182)
+183. [ ] chaos-game (183)
+184. [ ] character-codes-1 (184)
+185. [ ] character-codes-2 (185)
+186. [ ] character-codes-3 (186)
+187. [ ] character-codes-4 (187)
+188. [ ] character-codes-5 (188)
+189. [ ] chat-server (189)
+190. [ ] check-machin-like-formulas (190)
+191. [ ] check-that-file-exists (191)
+192. [ ] checkpoint-synchronization-1 (192)
+193. [ ] checkpoint-synchronization-2 (193)
+194. [ ] checkpoint-synchronization-3 (194)
+195. [ ] checkpoint-synchronization-4 (195)
+196. [ ] chernicks-carmichael-numbers (196)
+197. [ ] cheryls-birthday (197)
+198. [ ] chinese-remainder-theorem (198)
+199. [ ] chinese-zodiac (199)
+200. [ ] cholesky-decomposition-1 (200)
+201. [ ] cholesky-decomposition (201)
+202. [ ] chowla-numbers (202)
+203. [ ] church-numerals-1 (203)
+204. [ ] church-numerals-2 (204)
+205. [ ] circles-of-given-radius-through-two-points (205)
+206. [ ] circular-primes (206)
+207. [ ] cistercian-numerals (207)
+208. [ ] comma-quibbling (208)
+209. [ ] compiler-virtual-machine-interpreter (209)
+210. [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k (210)
+211. [ ] compound-data-type (211)
+212. [ ] concurrent-computing-1 (212)
+213. [ ] concurrent-computing-2 (213)
+214. [ ] concurrent-computing-3 (214)
+215. [ ] conditional-structures-1 (215)
+216. [ ] conditional-structures-10 (216)
+217. [ ] conditional-structures-2 (217)
+218. [ ] conditional-structures-3 (218)
+219. [ ] conditional-structures-4 (219)
+220. [ ] conditional-structures-5 (220)
+221. [ ] conditional-structures-6 (221)
+222. [ ] conditional-structures-7 (222)
+223. [ ] conditional-structures-8 (223)
+224. [ ] conditional-structures-9 (224)
+225. [ ] consecutive-primes-with-ascending-or-descending-differences (225)
+226. [ ] constrained-genericity-1 (226)
+227. [ ] constrained-genericity-2 (227)
+228. [ ] constrained-genericity-3 (228)
+229. [ ] constrained-genericity-4 (229)
+230. [ ] constrained-random-points-on-a-circle-1 (230)
+231. [ ] constrained-random-points-on-a-circle-2 (231)
+232. [ ] continued-fraction (232)
+233. [ ] convert-decimal-number-to-rational (233)
+234. [ ] convert-seconds-to-compound-duration (234)
+235. [ ] convex-hull (235)
+236. [ ] conways-game-of-life (236)
+237. [ ] copy-a-string-1 (237)
+238. [ ] copy-a-string-2 (238)
+239. [ ] copy-stdin-to-stdout-1 (239)
+240. [ ] copy-stdin-to-stdout-2 (240)
+241. [ ] count-in-factors (241)
+242. [ ] count-in-octal-1 (242)
+243. [ ] count-in-octal-2 (243)
+244. [ ] count-in-octal-3 (244)
+245. [ ] count-in-octal-4 (245)
+246. [ ] count-occurrences-of-a-substring (246)
+247. [ ] count-the-coins-1 (247)
+248. [ ] count-the-coins-2 (248)
+249. [ ] cramers-rule (249)
+250. [ ] crc-32-1 (250)
+251. [ ] crc-32-2 (251)
+252. [ ] create-a-file-on-magnetic-tape (252)
+253. [ ] create-a-file (253)
+254. [ ] create-a-two-dimensional-array-at-runtime-1 (254)
+255. [ ] create-an-html-table (255)
+256. [ ] create-an-object-at-a-given-address (256)
+257. [ ] csv-data-manipulation (257)
+258. [ ] csv-to-html-translation-1 (258)
+259. [ ] csv-to-html-translation-2 (259)
+260. [ ] csv-to-html-translation-3 (260)
+261. [ ] csv-to-html-translation-4 (261)
+262. [ ] csv-to-html-translation-5 (262)
+263. [ ] cuban-primes (263)
+264. [ ] cullen-and-woodall-numbers (264)
+265. [ ] cumulative-standard-deviation (265)
+266. [ ] currency (266)
+267. [ ] currying (267)
+268. [ ] curzon-numbers (268)
+269. [ ] cusip (269)
+270. [ ] cyclops-numbers (270)
+271. [ ] damm-algorithm (271)
+272. [ ] date-format (272)
+273. [ ] date-manipulation (273)
+274. [ ] day-of-the-week (274)
+275. [ ] de-bruijn-sequences (275)
+276. [ ] deal-cards-for-freecell (276)
+277. [ ] death-star (277)
+278. [ ] deceptive-numbers (278)
+279. [ ] deconvolution-1d-2 (279)
+280. [ ] deconvolution-1d-3 (280)
+281. [ ] deconvolution-1d (281)
+282. [ ] deepcopy-1 (282)
+283. [ ] define-a-primitive-data-type (283)
+284. [ ] md5 (284)

--- a/transpiler/x/java/rosetta_test.go
+++ b/transpiler/x/java/rosetta_test.go
@@ -162,7 +162,7 @@ func updateRosetta() {
 				mark = "[x]"
 			}
 		}
-		lines = append(lines, fmt.Sprintf("%d. %s %s", i+1, mark, name))
+		lines = append(lines, fmt.Sprintf("%d. %s %s (%d)", i+1, mark, name, i+1))
 	}
 	ts := time.Now().Format("2006-01-02 15:04 MST")
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- add Rosetta index numbers to java ROSETTA.md generation
- regenerate output for the 15-puzzle-game example
- update Java Rosetta checklist with index numbers

## Testing
- `go test -tags slow -run Rosetta -index 5 -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6881104481208320b604ff256278d79f