### PR TITLE
Improve any-type checks

### DIFF
--- a/types/check.go
+++ b/types/check.go
@@ -1400,10 +1400,20 @@ func checkBinaryExpr(b *parser.BinaryExpr, env *Env) (Type, error) {
 
 func applyBinaryType(pos lexer.Position, op string, left, right Type) (Type, error) {
 	if _, ok := left.(AnyType); ok {
-		return AnyType{}, nil
+		switch op {
+		case "+", "-", "*", "/", "%", "<", "<=", ">", ">=", "==", "!=", "&&", "||", "in":
+			return nil, errAnyOperator(pos, op)
+		default:
+			return AnyType{}, nil
+		}
 	}
 	if _, ok := right.(AnyType); ok {
-		return AnyType{}, nil
+		switch op {
+		case "+", "-", "*", "/", "%", "<", "<=", ">", ">=", "==", "!=", "&&", "||", "in":
+			return nil, errAnyOperator(pos, op)
+		default:
+			return AnyType{}, nil
+		}
 	}
 	if op == "+" || op == "union" || op == "union_all" || op == "except" || op == "intersect" {
 		if llist, ok := left.(ListType); ok {

--- a/types/errors.go
+++ b/types/errors.go
@@ -32,6 +32,7 @@ var Errors = map[string]diagnostic.Template{
 	"T014": {Code: "T014", Message: "invalid primary expression", Help: "Expected a complete value or expression (e.g., literal, variable, function)."},
 	"T020": {Code: "T020", Message: "operator `%s` cannot be used on types %s and %s", Help: "Choose an operator that supports these operand types."},
 	"T021": {Code: "T021", Message: "unsupported operator: `%s`", Help: "Use a valid operator like +, -, ==, or <."},
+	"T043": {Code: "T043", Message: "operator `%s` cannot be used with `any`", Help: "Cast values to concrete types before using `%s`."},
 
 	// --- Indexing ---
 	"T015": {Code: "T015", Message: "index must be an integer", Help: "Use an `int` value for indexing (e.g., `list[0]`)."},
@@ -153,6 +154,10 @@ func errOperatorMismatch(pos lexer.Position, op string, left, right Type) error 
 
 func errUnsupportedOperator(pos lexer.Position, op string) error {
 	return Errors["T021"].New(pos, op)
+}
+
+func errAnyOperator(pos lexer.Position, op string) error {
+	return Errors["T043"].New(pos, op, op)
 }
 
 func errCannotIterate(pos lexer.Position, typ Type) error {


### PR DESCRIPTION
## Summary
- add error code T043 for operators used with `any` type
- flag comparisons or arithmetic on `any` in the type checker

## Testing
- `go build ./cmd/mochi`
- `MOCHI_NOW_SEED=1 go run ./cmd/mochi run tests/rosetta/x/Mochi/2048.mochi < tests/rosetta/x/Mochi/2048.in > /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_68811619572883209614e694b480b412