### PR TITLE
Fix CS rosetta test seeding

### DIFF
--- a/transpiler/x/cs/rosetta_test.go
+++ b/transpiler/x/cs/rosetta_test.go
@@ -90,7 +90,7 @@ func TestCSTranspiler_Rosetta_Golden(t *testing.T) {
 			return nil, err
 		}
 		cmd := exec.Command("dotnet", "run", "--project", proj)
-		cmd.Env = append(os.Environ(), "DOTNET_NOLOGO=1", "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1")
+               cmd.Env = append(os.Environ(), "DOTNET_NOLOGO=1", "DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1", "MOCHI_NOW_SEED=1")
 		inPath := filepath.Join(srcDir, base+".in")
 		if data, err := os.ReadFile(inPath); err == nil {
 			env := "MOCHI_INPUT_FILE=" + inPath


### PR DESCRIPTION
## Summary
- seed `dotnet` runs for Rosetta tests so programs with randomness use a fixed seed

## Testing
- `MOCHI_ROSETTA_INDEX=7 go test -tags=slow ./transpiler/x/cs -run Rosetta -count=1 -v` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68811f2ccf808320bfddaae0a5b7e8c7