### PR TITLE
Fix typed 24-game solver

### DIFF
--- a/core/mochi/types/check.mochi
+++ b/core/mochi/types/check.mochi
@@ -56,10 +56,16 @@ fun exprType(node: any, env: map<string,string>, funcs: map<string,FunInfo>): Re
   if node.kind == "call" {
     if node.value in funcs {
       var errs: list<string> = []
-      for arg in node.children {
-        let r = exprType(arg, env, funcs)
+      let fn = funcs[node.value]
+      if len(node.children) != len(fn.params) {
+        errs = errs + ["wrong number of args to " + node.value]
+      }
+      var i = 0
+      while i < len(node.children) {
+        let r = exprType(node.children[i], env, funcs)
         if count(r.errs) > 0 { errs = errs + r.errs }
         if r.typ != "int" { errs = errs + ["type mismatch in call to " + node.value] }
+        i = i + 1
       }
       return Result{ typ: "int", errs: errs }
     }

--- a/tests/rosetta/x/Mochi/24-game-solve.mochi
+++ b/tests/rosetta/x/Mochi/24-game-solve.mochi
@@ -1,53 +1,69 @@
-// Mochi implementation of Rosetta "24 game Solve" task
-// Translated from Go version in tests/rosetta/x/Go/24-game-solve.go
+type Rational {
+  num: int
+  denom: int
+}
 
-let OP_NUM = 0
 let OP_ADD = 1
 let OP_SUB = 2
 let OP_MUL = 3
 let OP_DIV = 4
 
-fun newNum(n: int): map<string, any> {
-  return {"op": OP_NUM, "value": {"num": n, "denom": 1}}
+type Expr =
+  Num(value: Rational)
+  | Bin(op: int, left: Expr, right: Expr)
+
+fun binEval(op: int, l: Expr, r: Expr): Rational {
+  let lv = exprEval(l)
+  let rv = exprEval(r)
+  if op == OP_ADD {
+    return Rational { num: lv.num*rv.denom + lv.denom*rv.num, denom: lv.denom*rv.denom }
+  }
+  if op == OP_SUB {
+    return Rational { num: lv.num*rv.denom - lv.denom*rv.num, denom: lv.denom*rv.denom }
+  }
+  if op == OP_MUL {
+    return Rational { num: lv.num*rv.num, denom: lv.denom*rv.denom }
+  }
+  return Rational { num: lv.num*rv.denom, denom: lv.denom*rv.num }
 }
 
-fun exprEval(x: map<string, any>): map<string, int> {
-  if x["op"] == OP_NUM { return x["value"] }
-  let l = exprEval(x["left"])
-  let r = exprEval(x["right"])
-  if x["op"] == OP_ADD {
-    return {"num": l["num"]*r["denom"] + l["denom"]*r["num"], "denom": l["denom"]*r["denom"]}
-  }
-  if x["op"] == OP_SUB {
-    return {"num": l["num"]*r["denom"] - l["denom"]*r["num"], "denom": l["denom"]*r["denom"]}
-  }
-  if x["op"] == OP_MUL {
-    return {"num": l["num"]*r["num"], "denom": l["denom"]*r["denom"]}
-  }
-  // divide
-  return {"num": l["num"]*r["denom"], "denom": l["denom"]*r["num"]}
-}
-
-fun exprString(x: map<string, any>): string {
-  if x["op"] == OP_NUM { return str(x["value"]["num"]) }
-  let ls = exprString(x["left"])
-  let rs = exprString(x["right"])
+fun binString(op: int, l: Expr, r: Expr): string {
+  let ls = exprString(l)
+  let rs = exprString(r)
   var opstr = ""
-  if x["op"] == OP_ADD { opstr = " + " }
-  else if x["op"] == OP_SUB { opstr = " - " }
-  else if x["op"] == OP_MUL { opstr = " * " }
+  if op == OP_ADD { opstr = " + " }
+  else if op == OP_SUB { opstr = " - " }
+  else if op == OP_MUL { opstr = " * " }
   else { opstr = " / " }
   return "(" + ls + opstr + rs + ")"
+}
+
+fun newNum(n: int): Expr {
+  return Num { value: Rational { num: n, denom: 1 } }
+}
+
+fun exprEval(x: Expr): Rational {
+  return match x {
+    Num(v) => v
+    Bin(op, l, r) => binEval(op, l, r)
+  }
+}
+
+fun exprString(x: Expr): string {
+  return match x {
+    Num(v) => str(v.num)
+    Bin(op, l, r) => binString(op, l, r)
+  }
 }
 
 let n_cards = 4
 let goal = 24
 let digit_range = 9
 
-fun solve(xs: list<map<string, any>>): bool {
+fun solve(xs: list<Expr>): bool {
   if len(xs) == 1 {
     let f = exprEval(xs[0])
-    if f["denom"] != 0 && f["num"] == f["denom"]*goal {
+    if f.denom != 0 && f.num == f.denom * goal {
       print(exprString(xs[0]))
       return true
     }
@@ -57,7 +73,7 @@ fun solve(xs: list<map<string, any>>): bool {
   while i < len(xs) {
     var j = i + 1
     while j < len(xs) {
-      var rest: list<map<string, any>> = []
+      var rest: list<Expr> = []
       var k = 0
       while k < len(xs) {
         if k != i && k != j { rest = append(rest, xs[k]) }
@@ -66,12 +82,12 @@ fun solve(xs: list<map<string, any>>): bool {
       let a = xs[i]
       let b = xs[j]
       for op in [OP_ADD, OP_SUB, OP_MUL, OP_DIV] {
-        var node = {"op": op, "left": a, "right": b}
+        var node = Bin { op: op, left: a, right: b }
         if solve(append(rest, node)) { return true }
       }
-      var node = {"op": OP_SUB, "left": b, "right": a}
+      var node = Bin { op: OP_SUB, left: b, right: a }
       if solve(append(rest, node)) { return true }
-      node = {"op": OP_DIV, "left": b, "right": a}
+      node = Bin { op: OP_DIV, left: b, right: a }
       if solve(append(rest, node)) { return true }
       j = j + 1
     }
@@ -83,7 +99,7 @@ fun solve(xs: list<map<string, any>>): bool {
 fun main() {
   var iter = 0
   while iter < 10 {
-    var cards: list<map<string, any>> = []
+    var cards: list<Expr> = []
     var i = 0
     while i < n_cards {
       let n = (now() % (digit_range - 1)) + 1


### PR DESCRIPTION
## Summary
- rewrite `24-game-solve.mochi` to use typed structs and unions
- improve toy type checker to validate argument counts

## Testing
- `go test ./types -tags slow` *(fails: index must be an integer)*
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/24-game-solve.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68810e8de15c8320b80d940ebdd05edd