### PR TITLE
Fix map detection in Java transpiler

### DIFF
--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Rosetta Checklist (8/284) - updated 2025-07-23 17:55 UTC
+## Rosetta Checklist (8/284) - updated 2025-07-24 00:47 UTC
 1. [x] 100-doors-2 (1)
 2. [x] 100-doors-3 (2)
 3. [x] 100-doors (3)

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -1696,11 +1696,17 @@ func isMapExpr(e Expr) bool {
 		return true
 	case *VarExpr:
 		if ex.Type != "" {
+			if strings.HasSuffix(ex.Type, "[]") {
+				break
+			}
 			if ex.Type == "map" || strings.Contains(ex.Type, "Map") {
 				return true
 			}
 		}
 		if t, ok := varTypes[ex.Name]; ok {
+			if strings.HasSuffix(t, "[]") {
+				break
+			}
 			if t == "map" || strings.Contains(t, "Map") {
 				return true
 			}


### PR DESCRIPTION
## Summary
- improve `isMapExpr` in the Java transpiler so arrays of maps are not treated as maps
- regenerate `ROSETTA.md` with an updated timestamp

## Testing
- `go test -tags slow ./transpiler/x/java -run Rosetta -index 9` *(fails: javac 24-game-solve)*

------
https://chatgpt.com/codex/tasks/task_e_68817eac70448320907099f54ec001b0