### PR TITLE
Update Lua transpiler Rosetta checklist format

### DIFF
--- a/transpiler/x/lua/ROSETTA.md
+++ b/transpiler/x/lua/ROSETTA.md
@@ -4,291 +4,291 @@ Generated Lua code for programs in `tests/rosetta/x/Mochi`. Each program has a `
 
 Transpiled programs: 101/284
 
-Last updated: 2025-07-24 00:44 GMT+7
+Last updated: 2025-07-24 00:28 GMT+7
 
 Checklist:
 
-1. [x] 100-doors-2
-2. [x] 100-doors-3
-3. [x] 100-doors
-4. [x] 100-prisoners
-5. [x] 15-puzzle-game
-6. [x] 15-puzzle-solver
-7. [x] 2048
-8. [x] 21-game
-9. [x] 24-game-solve
-10. [x] 24-game
-11. [x] 4-rings-or-4-squares-puzzle
-12. [x] 9-billion-names-of-god-the-integer
-13. [x] 99-bottles-of-beer-2
-14. [x] 99-bottles-of-beer
-15. [x] DNS-query
-16. [x] a+b
-17. [x] abbreviations-automatic
-18. [x] abbreviations-easy
-19. [x] abbreviations-simple
-20. [x] abc-problem
-21. [x] abelian-sandpile-model-identity
-22. [x] abelian-sandpile-model
-23. [x] abstract-type
-24. [x] abundant-deficient-and-perfect-number-classifications
-25. [x] abundant-odd-numbers
-26. [x] accumulator-factory
-27. [x] achilles-numbers
-28. [x] ackermann-function-2
-29. [x] ackermann-function-3
-30. [x] ackermann-function
-31. [x] active-directory-connect
-32. [x] active-directory-search-for-a-user
-33. [x] active-object
-34. [x] add-a-variable-to-a-class-instance-at-runtime
-35. [x] additive-primes
-36. [x] address-of-a-variable
-37. [x] adfgvx-cipher
-38. [x] aks-test-for-primes
-39. [x] algebraic-data-types
-40. [x] align-columns
-41. [x] aliquot-sequence-classifications
-42. [x] almkvist-giullera-formula-for-pi
-43. [x] almost-prime
-44. [x] amb
-45. [x] amicable-pairs
-46. [x] anagrams-deranged-anagrams
-47. [x] anagrams
-48. [x] angle-difference-between-two-bearings-1
-49. [x] angle-difference-between-two-bearings-2
-50. [x] angles-geometric-normalization-and-conversion
-51. [x] animate-a-pendulum
-52. [x] animation
-53. [x] anonymous-recursion-1
-54. [x] anonymous-recursion-2
-55. [x] anonymous-recursion
-56. [x] anti-primes
-57. [x] append-a-record-to-the-end-of-a-text-file
-58. [x] apply-a-callback-to-an-array-1
-59. [x] apply-a-callback-to-an-array-2
-60. [x] apply-a-digital-filter-direct-form-ii-transposed-
-61. [x] approximate-equality
-62. [x] arbitrary-precision-integers-included-
-63. [x] archimedean-spiral
-64. [x] arena-storage-pool
-65. [x] arithmetic-complex
-66. [x] arithmetic-derivative
-67. [ ] arithmetic-evaluation
-68. [x] arithmetic-geometric-mean-calculate-pi
-69. [x] arithmetic-geometric-mean
-70. [x] arithmetic-integer-1
-71. [x] arithmetic-integer-2
-72. [ ] arithmetic-numbers
-73. [x] arithmetic-rational
-74. [x] array-concatenation
-75. [x] array-length
-76. [x] arrays
-77. [x] ascending-primes
-78. [x] ascii-art-diagram-converter
-79. [x] assertions
-80. [x] associative-array-creation
-81. [x] associative-array-iteration
-82. [x] associative-array-merging
-83. [x] atomic-updates
-84. [x] attractive-numbers
-85. [x] average-loop-length
-86. [x] averages-arithmetic-mean
-87. [x] averages-mean-time-of-day
-88. [x] averages-median-1
-89. [x] averages-median-2
-90. [x] averages-median-3
-91. [x] averages-mode
-92. [x] averages-pythagorean-means
-93. [x] averages-root-mean-square
-94. [x] averages-simple-moving-average
-95. [x] avl-tree
-96. [x] b-zier-curves-intersections
-97. [x] babbage-problem
-98. [x] babylonian-spiral
-99. [x] balanced-brackets
-100. [x] balanced-ternary
-101. [x] barnsley-fern
-102. [x] base64-decode-data
-103. [x] bell-numbers
-104. [ ] benfords-law
-105. [ ] bernoulli-numbers
-106. [ ] best-shuffle
-107. [ ] bifid-cipher
-108. [ ] bin-given-limits
-109. [ ] binary-digits
-110. [ ] binary-search
-111. [ ] binary-strings
-112. [ ] bioinformatics-base-count
-113. [ ] bioinformatics-global-alignment
-114. [ ] bioinformatics-sequence-mutation
-115. [ ] biorhythms
-116. [ ] bitcoin-address-validation
-117. [ ] bitmap-b-zier-curves-cubic
-118. [ ] bitmap-b-zier-curves-quadratic
-119. [ ] bitmap-bresenhams-line-algorithm
-120. [ ] bitmap-flood-fill
-121. [ ] bitmap-histogram
-122. [ ] bitmap-midpoint-circle-algorithm
-123. [ ] bitmap-ppm-conversion-through-a-pipe
-124. [ ] bitmap-read-a-ppm-file
-125. [ ] bitmap-read-an-image-through-a-pipe
-126. [ ] bitmap-write-a-ppm-file
-127. [ ] bitmap
-128. [ ] bitwise-io-1
-129. [ ] bitwise-io-2
-130. [ ] bitwise-operations
-131. [ ] blum-integer
-132. [ ] boolean-values
-133. [ ] box-the-compass
-134. [ ] boyer-moore-string-search
-135. [ ] brazilian-numbers
-136. [ ] break-oo-privacy
-137. [ ] brilliant-numbers
-138. [ ] brownian-tree
-139. [ ] bulls-and-cows-player
-140. [ ] bulls-and-cows
-141. [ ] burrows-wheeler-transform
-142. [ ] caesar-cipher-1
-143. [ ] caesar-cipher-2
-144. [ ] calculating-the-value-of-e
-145. [ ] calendar---for-real-programmers-1
-146. [ ] calendar---for-real-programmers-2
-147. [ ] calendar
-148. [ ] calkin-wilf-sequence
-149. [ ] call-a-foreign-language-function
-150. [ ] call-a-function-1
-151. [ ] call-a-function-10
-152. [ ] call-a-function-11
-153. [ ] call-a-function-12
-154. [ ] call-a-function-2
-155. [ ] call-a-function-3
-156. [ ] call-a-function-4
-157. [ ] call-a-function-5
-158. [ ] call-a-function-6
-159. [ ] call-a-function-7
-160. [ ] call-a-function-8
-161. [ ] call-a-function-9
-162. [ ] call-an-object-method-1
-163. [ ] call-an-object-method-2
-164. [ ] call-an-object-method-3
-165. [ ] call-an-object-method
-166. [ ] camel-case-and-snake-case
-167. [ ] canny-edge-detector
-168. [ ] canonicalize-cidr
-169. [ ] cantor-set
-170. [ ] carmichael-3-strong-pseudoprimes
-171. [ ] cartesian-product-of-two-or-more-lists-1
-172. [ ] cartesian-product-of-two-or-more-lists-2
-173. [ ] cartesian-product-of-two-or-more-lists-3
-174. [ ] cartesian-product-of-two-or-more-lists-4
-175. [ ] case-sensitivity-of-identifiers
-176. [ ] casting-out-nines
-177. [ ] catalan-numbers-1
-178. [ ] catalan-numbers-2
-179. [ ] catalan-numbers-pascals-triangle
-180. [ ] catamorphism
-181. [ ] catmull-clark-subdivision-surface
-182. [ ] chaocipher
-183. [ ] chaos-game
-184. [ ] character-codes-1
-185. [ ] character-codes-2
-186. [ ] character-codes-3
-187. [ ] character-codes-4
-188. [ ] character-codes-5
-189. [ ] chat-server
-190. [ ] check-machin-like-formulas
-191. [ ] check-that-file-exists
-192. [ ] checkpoint-synchronization-1
-193. [ ] checkpoint-synchronization-2
-194. [ ] checkpoint-synchronization-3
-195. [ ] checkpoint-synchronization-4
-196. [ ] chernicks-carmichael-numbers
-197. [ ] cheryls-birthday
-198. [ ] chinese-remainder-theorem
-199. [ ] chinese-zodiac
-200. [ ] cholesky-decomposition-1
-201. [ ] cholesky-decomposition
-202. [ ] chowla-numbers
-203. [ ] church-numerals-1
-204. [ ] church-numerals-2
-205. [ ] circles-of-given-radius-through-two-points
-206. [ ] circular-primes
-207. [ ] cistercian-numerals
-208. [ ] comma-quibbling
-209. [ ] compiler-virtual-machine-interpreter
-210. [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
-211. [ ] compound-data-type
-212. [ ] concurrent-computing-1
-213. [ ] concurrent-computing-2
-214. [ ] concurrent-computing-3
-215. [ ] conditional-structures-1
-216. [ ] conditional-structures-10
-217. [ ] conditional-structures-2
-218. [ ] conditional-structures-3
-219. [ ] conditional-structures-4
-220. [ ] conditional-structures-5
-221. [ ] conditional-structures-6
-222. [ ] conditional-structures-7
-223. [ ] conditional-structures-8
-224. [ ] conditional-structures-9
-225. [ ] consecutive-primes-with-ascending-or-descending-differences
-226. [ ] constrained-genericity-1
-227. [ ] constrained-genericity-2
-228. [ ] constrained-genericity-3
-229. [ ] constrained-genericity-4
-230. [ ] constrained-random-points-on-a-circle-1
-231. [ ] constrained-random-points-on-a-circle-2
-232. [ ] continued-fraction
-233. [ ] convert-decimal-number-to-rational
-234. [ ] convert-seconds-to-compound-duration
-235. [ ] convex-hull
-236. [ ] conways-game-of-life
-237. [ ] copy-a-string-1
-238. [ ] copy-a-string-2
-239. [ ] copy-stdin-to-stdout-1
-240. [ ] copy-stdin-to-stdout-2
-241. [ ] count-in-factors
-242. [ ] count-in-octal-1
-243. [ ] count-in-octal-2
-244. [ ] count-in-octal-3
-245. [ ] count-in-octal-4
-246. [ ] count-occurrences-of-a-substring
-247. [ ] count-the-coins-1
-248. [ ] count-the-coins-2
-249. [ ] cramers-rule
-250. [ ] crc-32-1
-251. [ ] crc-32-2
-252. [ ] create-a-file-on-magnetic-tape
-253. [ ] create-a-file
-254. [ ] create-a-two-dimensional-array-at-runtime-1
-255. [ ] create-an-html-table
-256. [ ] create-an-object-at-a-given-address
-257. [ ] csv-data-manipulation
-258. [ ] csv-to-html-translation-1
-259. [ ] csv-to-html-translation-2
-260. [ ] csv-to-html-translation-3
-261. [ ] csv-to-html-translation-4
-262. [ ] csv-to-html-translation-5
-263. [ ] cuban-primes
-264. [ ] cullen-and-woodall-numbers
-265. [ ] cumulative-standard-deviation
-266. [ ] currency
-267. [ ] currying
-268. [ ] curzon-numbers
-269. [ ] cusip
-270. [ ] cyclops-numbers
-271. [ ] damm-algorithm
-272. [ ] date-format
-273. [ ] date-manipulation
-274. [ ] day-of-the-week
-275. [ ] de-bruijn-sequences
-276. [ ] deal-cards-for-freecell
-277. [ ] death-star
-278. [ ] deceptive-numbers
-279. [ ] deconvolution-1d-2
-280. [ ] deconvolution-1d-3
-281. [ ] deconvolution-1d
-282. [ ] deepcopy-1
-283. [ ] define-a-primitive-data-type
-284. [ ] md5
+1. [x] `1 100-doors-2`
+2. [x] `2 100-doors-3`
+3. [x] `3 100-doors`
+4. [x] `4 100-prisoners`
+5. [x] `5 15-puzzle-game`
+6. [x] `6 15-puzzle-solver`
+7. [x] `7 2048`
+8. [x] `8 21-game`
+9. [x] `9 24-game-solve`
+10. [x] `10 24-game`
+11. [x] `11 4-rings-or-4-squares-puzzle`
+12. [x] `12 9-billion-names-of-god-the-integer`
+13. [x] `13 99-bottles-of-beer-2`
+14. [x] `14 99-bottles-of-beer`
+15. [x] `15 DNS-query`
+16. [x] `16 a+b`
+17. [x] `17 abbreviations-automatic`
+18. [x] `18 abbreviations-easy`
+19. [x] `19 abbreviations-simple`
+20. [x] `20 abc-problem`
+21. [x] `21 abelian-sandpile-model-identity`
+22. [x] `22 abelian-sandpile-model`
+23. [x] `23 abstract-type`
+24. [x] `24 abundant-deficient-and-perfect-number-classifications`
+25. [x] `25 abundant-odd-numbers`
+26. [x] `26 accumulator-factory`
+27. [x] `27 achilles-numbers`
+28. [x] `28 ackermann-function-2`
+29. [x] `29 ackermann-function-3`
+30. [x] `30 ackermann-function`
+31. [x] `31 active-directory-connect`
+32. [x] `32 active-directory-search-for-a-user`
+33. [x] `33 active-object`
+34. [x] `34 add-a-variable-to-a-class-instance-at-runtime`
+35. [x] `35 additive-primes`
+36. [x] `36 address-of-a-variable`
+37. [x] `37 adfgvx-cipher`
+38. [x] `38 aks-test-for-primes`
+39. [x] `39 algebraic-data-types`
+40. [x] `40 align-columns`
+41. [x] `41 aliquot-sequence-classifications`
+42. [x] `42 almkvist-giullera-formula-for-pi`
+43. [x] `43 almost-prime`
+44. [x] `44 amb`
+45. [x] `45 amicable-pairs`
+46. [x] `46 anagrams-deranged-anagrams`
+47. [x] `47 anagrams`
+48. [x] `48 angle-difference-between-two-bearings-1`
+49. [x] `49 angle-difference-between-two-bearings-2`
+50. [x] `50 angles-geometric-normalization-and-conversion`
+51. [x] `51 animate-a-pendulum`
+52. [x] `52 animation`
+53. [x] `53 anonymous-recursion-1`
+54. [x] `54 anonymous-recursion-2`
+55. [x] `55 anonymous-recursion`
+56. [x] `56 anti-primes`
+57. [x] `57 append-a-record-to-the-end-of-a-text-file`
+58. [x] `58 apply-a-callback-to-an-array-1`
+59. [x] `59 apply-a-callback-to-an-array-2`
+60. [x] `60 apply-a-digital-filter-direct-form-ii-transposed-`
+61. [x] `61 approximate-equality`
+62. [x] `62 arbitrary-precision-integers-included-`
+63. [x] `63 archimedean-spiral`
+64. [x] `64 arena-storage-pool`
+65. [x] `65 arithmetic-complex`
+66. [x] `66 arithmetic-derivative`
+67. [ ] `67 arithmetic-evaluation`
+68. [x] `68 arithmetic-geometric-mean-calculate-pi`
+69. [x] `69 arithmetic-geometric-mean`
+70. [x] `70 arithmetic-integer-1`
+71. [x] `71 arithmetic-integer-2`
+72. [ ] `72 arithmetic-numbers`
+73. [x] `73 arithmetic-rational`
+74. [x] `74 array-concatenation`
+75. [x] `75 array-length`
+76. [x] `76 arrays`
+77. [x] `77 ascending-primes`
+78. [x] `78 ascii-art-diagram-converter`
+79. [x] `79 assertions`
+80. [x] `80 associative-array-creation`
+81. [x] `81 associative-array-iteration`
+82. [x] `82 associative-array-merging`
+83. [x] `83 atomic-updates`
+84. [x] `84 attractive-numbers`
+85. [x] `85 average-loop-length`
+86. [x] `86 averages-arithmetic-mean`
+87. [x] `87 averages-mean-time-of-day`
+88. [x] `88 averages-median-1`
+89. [x] `89 averages-median-2`
+90. [x] `90 averages-median-3`
+91. [x] `91 averages-mode`
+92. [x] `92 averages-pythagorean-means`
+93. [x] `93 averages-root-mean-square`
+94. [x] `94 averages-simple-moving-average`
+95. [x] `95 avl-tree`
+96. [x] `96 b-zier-curves-intersections`
+97. [x] `97 babbage-problem`
+98. [x] `98 babylonian-spiral`
+99. [x] `99 balanced-brackets`
+100. [x] `100 balanced-ternary`
+101. [x] `101 barnsley-fern`
+102. [x] `102 base64-decode-data`
+103. [x] `103 bell-numbers`
+104. [ ] `104 benfords-law`
+105. [ ] `105 bernoulli-numbers`
+106. [ ] `106 best-shuffle`
+107. [ ] `107 bifid-cipher`
+108. [ ] `108 bin-given-limits`
+109. [ ] `109 binary-digits`
+110. [ ] `110 binary-search`
+111. [ ] `111 binary-strings`
+112. [ ] `112 bioinformatics-base-count`
+113. [ ] `113 bioinformatics-global-alignment`
+114. [ ] `114 bioinformatics-sequence-mutation`
+115. [ ] `115 biorhythms`
+116. [ ] `116 bitcoin-address-validation`
+117. [ ] `117 bitmap-b-zier-curves-cubic`
+118. [ ] `118 bitmap-b-zier-curves-quadratic`
+119. [ ] `119 bitmap-bresenhams-line-algorithm`
+120. [ ] `120 bitmap-flood-fill`
+121. [ ] `121 bitmap-histogram`
+122. [ ] `122 bitmap-midpoint-circle-algorithm`
+123. [ ] `123 bitmap-ppm-conversion-through-a-pipe`
+124. [ ] `124 bitmap-read-a-ppm-file`
+125. [ ] `125 bitmap-read-an-image-through-a-pipe`
+126. [ ] `126 bitmap-write-a-ppm-file`
+127. [ ] `127 bitmap`
+128. [ ] `128 bitwise-io-1`
+129. [ ] `129 bitwise-io-2`
+130. [ ] `130 bitwise-operations`
+131. [ ] `131 blum-integer`
+132. [ ] `132 boolean-values`
+133. [ ] `133 box-the-compass`
+134. [ ] `134 boyer-moore-string-search`
+135. [ ] `135 brazilian-numbers`
+136. [ ] `136 break-oo-privacy`
+137. [ ] `137 brilliant-numbers`
+138. [ ] `138 brownian-tree`
+139. [ ] `139 bulls-and-cows-player`
+140. [ ] `140 bulls-and-cows`
+141. [ ] `141 burrows-wheeler-transform`
+142. [ ] `142 caesar-cipher-1`
+143. [ ] `143 caesar-cipher-2`
+144. [ ] `144 calculating-the-value-of-e`
+145. [ ] `145 calendar---for-real-programmers-1`
+146. [ ] `146 calendar---for-real-programmers-2`
+147. [ ] `147 calendar`
+148. [ ] `148 calkin-wilf-sequence`
+149. [ ] `149 call-a-foreign-language-function`
+150. [ ] `150 call-a-function-1`
+151. [ ] `151 call-a-function-10`
+152. [ ] `152 call-a-function-11`
+153. [ ] `153 call-a-function-12`
+154. [ ] `154 call-a-function-2`
+155. [ ] `155 call-a-function-3`
+156. [ ] `156 call-a-function-4`
+157. [ ] `157 call-a-function-5`
+158. [ ] `158 call-a-function-6`
+159. [ ] `159 call-a-function-7`
+160. [ ] `160 call-a-function-8`
+161. [ ] `161 call-a-function-9`
+162. [ ] `162 call-an-object-method-1`
+163. [ ] `163 call-an-object-method-2`
+164. [ ] `164 call-an-object-method-3`
+165. [ ] `165 call-an-object-method`
+166. [ ] `166 camel-case-and-snake-case`
+167. [ ] `167 canny-edge-detector`
+168. [ ] `168 canonicalize-cidr`
+169. [ ] `169 cantor-set`
+170. [ ] `170 carmichael-3-strong-pseudoprimes`
+171. [ ] `171 cartesian-product-of-two-or-more-lists-1`
+172. [ ] `172 cartesian-product-of-two-or-more-lists-2`
+173. [ ] `173 cartesian-product-of-two-or-more-lists-3`
+174. [ ] `174 cartesian-product-of-two-or-more-lists-4`
+175. [ ] `175 case-sensitivity-of-identifiers`
+176. [ ] `176 casting-out-nines`
+177. [ ] `177 catalan-numbers-1`
+178. [ ] `178 catalan-numbers-2`
+179. [ ] `179 catalan-numbers-pascals-triangle`
+180. [ ] `180 catamorphism`
+181. [ ] `181 catmull-clark-subdivision-surface`
+182. [ ] `182 chaocipher`
+183. [ ] `183 chaos-game`
+184. [ ] `184 character-codes-1`
+185. [ ] `185 character-codes-2`
+186. [ ] `186 character-codes-3`
+187. [ ] `187 character-codes-4`
+188. [ ] `188 character-codes-5`
+189. [ ] `189 chat-server`
+190. [ ] `190 check-machin-like-formulas`
+191. [ ] `191 check-that-file-exists`
+192. [ ] `192 checkpoint-synchronization-1`
+193. [ ] `193 checkpoint-synchronization-2`
+194. [ ] `194 checkpoint-synchronization-3`
+195. [ ] `195 checkpoint-synchronization-4`
+196. [ ] `196 chernicks-carmichael-numbers`
+197. [ ] `197 cheryls-birthday`
+198. [ ] `198 chinese-remainder-theorem`
+199. [ ] `199 chinese-zodiac`
+200. [ ] `200 cholesky-decomposition-1`
+201. [ ] `201 cholesky-decomposition`
+202. [ ] `202 chowla-numbers`
+203. [ ] `203 church-numerals-1`
+204. [ ] `204 church-numerals-2`
+205. [ ] `205 circles-of-given-radius-through-two-points`
+206. [ ] `206 circular-primes`
+207. [ ] `207 cistercian-numerals`
+208. [ ] `208 comma-quibbling`
+209. [ ] `209 compiler-virtual-machine-interpreter`
+210. [ ] `210 composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k`
+211. [ ] `211 compound-data-type`
+212. [ ] `212 concurrent-computing-1`
+213. [ ] `213 concurrent-computing-2`
+214. [ ] `214 concurrent-computing-3`
+215. [ ] `215 conditional-structures-1`
+216. [ ] `216 conditional-structures-10`
+217. [ ] `217 conditional-structures-2`
+218. [ ] `218 conditional-structures-3`
+219. [ ] `219 conditional-structures-4`
+220. [ ] `220 conditional-structures-5`
+221. [ ] `221 conditional-structures-6`
+222. [ ] `222 conditional-structures-7`
+223. [ ] `223 conditional-structures-8`
+224. [ ] `224 conditional-structures-9`
+225. [ ] `225 consecutive-primes-with-ascending-or-descending-differences`
+226. [ ] `226 constrained-genericity-1`
+227. [ ] `227 constrained-genericity-2`
+228. [ ] `228 constrained-genericity-3`
+229. [ ] `229 constrained-genericity-4`
+230. [ ] `230 constrained-random-points-on-a-circle-1`
+231. [ ] `231 constrained-random-points-on-a-circle-2`
+232. [ ] `232 continued-fraction`
+233. [ ] `233 convert-decimal-number-to-rational`
+234. [ ] `234 convert-seconds-to-compound-duration`
+235. [ ] `235 convex-hull`
+236. [ ] `236 conways-game-of-life`
+237. [ ] `237 copy-a-string-1`
+238. [ ] `238 copy-a-string-2`
+239. [ ] `239 copy-stdin-to-stdout-1`
+240. [ ] `240 copy-stdin-to-stdout-2`
+241. [ ] `241 count-in-factors`
+242. [ ] `242 count-in-octal-1`
+243. [ ] `243 count-in-octal-2`
+244. [ ] `244 count-in-octal-3`
+245. [ ] `245 count-in-octal-4`
+246. [ ] `246 count-occurrences-of-a-substring`
+247. [ ] `247 count-the-coins-1`
+248. [ ] `248 count-the-coins-2`
+249. [ ] `249 cramers-rule`
+250. [ ] `250 crc-32-1`
+251. [ ] `251 crc-32-2`
+252. [ ] `252 create-a-file-on-magnetic-tape`
+253. [ ] `253 create-a-file`
+254. [ ] `254 create-a-two-dimensional-array-at-runtime-1`
+255. [ ] `255 create-an-html-table`
+256. [ ] `256 create-an-object-at-a-given-address`
+257. [ ] `257 csv-data-manipulation`
+258. [ ] `258 csv-to-html-translation-1`
+259. [ ] `259 csv-to-html-translation-2`
+260. [ ] `260 csv-to-html-translation-3`
+261. [ ] `261 csv-to-html-translation-4`
+262. [ ] `262 csv-to-html-translation-5`
+263. [ ] `263 cuban-primes`
+264. [ ] `264 cullen-and-woodall-numbers`
+265. [ ] `265 cumulative-standard-deviation`
+266. [ ] `266 currency`
+267. [ ] `267 currying`
+268. [ ] `268 curzon-numbers`
+269. [ ] `269 cusip`
+270. [ ] `270 cyclops-numbers`
+271. [ ] `271 damm-algorithm`
+272. [ ] `272 date-format`
+273. [ ] `273 date-manipulation`
+274. [ ] `274 day-of-the-week`
+275. [ ] `275 de-bruijn-sequences`
+276. [ ] `276 deal-cards-for-freecell`
+277. [ ] `277 death-star`
+278. [ ] `278 deceptive-numbers`
+279. [ ] `279 deconvolution-1d-2`
+280. [ ] `280 deconvolution-1d-3`
+281. [ ] `281 deconvolution-1d`
+282. [ ] `282 deepcopy-1`
+283. [ ] `283 define-a-primitive-data-type`
+284. [ ] `284 md5`

--- a/transpiler/x/lua/rosetta_test.go
+++ b/transpiler/x/lua/rosetta_test.go
@@ -191,7 +191,7 @@ func updateRosettaReadme() {
 				mark = "[x]"
 			}
 		}
-		lines = append(lines, fmt.Sprintf("%d. %s %s", i+1, mark, name))
+		lines = append(lines, fmt.Sprintf("%d. %s `%d %s`", i+1, mark, i+1, name))
 	}
 	ts := ""
 	if out, err := exec.Command("git", "log", "-1", "--format=%cI").Output(); err == nil {


### PR DESCRIPTION
## Summary
- include index numbers in Lua ROSETTA checklist generation
- regenerate `transpiler/x/lua/ROSETTA.md` with the new format

## Testing
- `go test -tags slow ./transpiler/x/lua -run Rosetta -index 9`

------
https://chatgpt.com/codex/tasks/task_e_68817eb509648320a15ade0a5ec417b4