### PR TITLE
Update scheme rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/scheme/24-game.out
+++ b/tests/rosetta/transpiler/scheme/24-game.out
@@ -1,5 +1,5 @@
 WARNING: reference to undefined variable: float
-Your numbers: 6666
+Your numbers: 1336
 
 Enter RPN: 
 invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)

--- a/tests/rosetta/transpiler/scheme/24-game.scm
+++ b/tests/rosetta/transpiler/scheme/24-game.scm
@@ -1,8 +1,21 @@
-;; Generated on 2025-07-23 13:04 +0700
-(import (only (scheme base) call/cc list-ref list-set! list))
+;; Generated on 2025-07-24 08:13 +0700
+(import (only (scheme base) call/cc when list-ref list-set! list))
 (import (scheme time))
 (import (chibi io))
-(define (to-str x)
+(import (chibi time) (srfi 98))
+(define _now_seeded #f)
+(define _now_seed 0)
+(define (now)
+  (when (not _now_seeded)
+    (let ((s (get-environment-variable "MOCHI_NOW_SEED")))
+      (when (and s (string->number s))
+        (set! _now_seed (string->number s))
+        (set! _now_seeded #t))))
+  (if _now_seeded
+      (begin
+        (set! _now_seed (modulo (+ (* _now_seed 1664525) 1013904223) 2147483647))
+        _now_seed)
+      (* (current-seconds) 1000000000)))(define (to-str x)
   (cond ((pair? x)
          (string-append "[" (string-join (map to-str x) ", ") "]"))
         ((string? x) x)
@@ -13,7 +26,7 @@
     (if (eof-object? l) "" l)))
 (define (randDigit)
  (call/cc (lambda (ret1)
- (ret1 (+ (modulo (current-jiffy)
+ (ret1 (+ (modulo (now)
  9)
  1)
 )

--- a/transpiler/x/scheme/README.md
+++ b/transpiler/x/scheme/README.md
@@ -3,7 +3,7 @@
 Generated Scheme code for programs in `tests/vm/valid`. Each program has a `.scm` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
 ## VM Golden Test Checklist (79/103)
-Last updated: 2025-07-24 00:31 UTC
+Last updated: 2025-07-24 01:13 UTC
 
 - [x] append_builtin
 - [x] avg_builtin

--- a/transpiler/x/scheme/ROSETTA.md
+++ b/transpiler/x/scheme/ROSETTA.md
@@ -3,7 +3,7 @@
 Generated Scheme code for Rosetta Code tasks under `tests/rosetta/x/Mochi`.
 
 ## Checklist (12/284)
-Last updated: 2025-07-24 00:31 UTC
+Last updated: 2025-07-24 01:13 UTC
 
 1. [x] 100-doors-2
 2. [x] 100-doors-3

--- a/transpiler/x/scheme/TASKS.md
+++ b/transpiler/x/scheme/TASKS.md
@@ -1,5 +1,5 @@
-## Progress (2025-07-24 00:44 +0700)
-- Commit b27d72d2c5: transpiler(py): add rosetta outputs up to index 164
+## Progress (2025-07-24 08:13 +0700)
+- Commit 88733123ff: Update TS transpiled code for rosetta program 9
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
@@ -28,8 +28,8 @@
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 
-## Progress (2025-07-23 13:04 +0700)
-- Commit f5a7f1bd3d: scheme transpiler: handle bool equality
+## Progress (2025-07-24 00:44 +0700)
+- Commit b27d72d2c5: transpiler(py): add rosetta outputs up to index 164
 - Generated Scheme for 77/100 programs
 - Updated README checklist and outputs
 


### PR DESCRIPTION
## Summary
- regenerate transpiled Scheme for the `24-game` program (index 10)
- refresh Scheme transpiler progress docs

## Testing
- `MOCHI_ROSETTA_INDEX=10 go test ./transpiler/x/scheme -run TestSchemeTranspiler_Rosetta_Golden -tags=slow -update-rosetta-scheme -v`


------
https://chatgpt.com/codex/tasks/task_e_68818a19b45c83208e139587b2a9eaf3