### PR TITLE
docs: add release notes for v0.10.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # 📦 CHANGELOG.md
+## [0.10.39] – 2025-07-24T11:43:58+07:00
+
+### Added
+
+* BigInt operations in Dart with initial Go support
+* Balanced ternary, calendar helpers and struct methods in TypeScript
+* Deterministic `now` for PHP and C with slice defaults in C++
+* Null handling, generic casts and improved strings for Scala
+* `lower()` builtin and repeat helpers in ST
+* Partial returns and list concatenation in Prolog
+* Input builtins and union variants across Pascal, Swift, Scheme and Zig
+* Map generics and nested indexing for Kotlin plus open-ended slices in F#
+* Numerous Rosetta examples regenerated
+
+### Changed
+
+* Progress logs updated with index numbers across languages
+* Golden outputs refreshed across the repository
+
+### Fixed
+
+* Improved type inference for Haskell and Scala
+* PRNG overflow fixed in C# with map and index handling bugs resolved
 ## [0.10.38] – 2025-07-23T10:17:23+07:00
 
 ### Added

--- a/releases/v0.10.39.md
+++ b/releases/v0.10.39.md
@@ -1,0 +1,22 @@
+# Jul 2025 (v0.10.39)
+
+Released on Thu Jul 24 11:43:58 2025 +0700.
+
+Mochi v0.10.39 adds union features, deterministic builtins and BigInt support across many transpilers with numerous updated Rosetta examples.
+
+## Compilers
+
+- BigInt operations introduced for Dart with early Go support
+- Balanced ternary and calendar helpers plus struct methods for TypeScript
+- Deterministic `now` for PHP and C with slice defaults in C++
+- Null handling, generic casts and improved strings for Scala
+- `lower()` builtin for the ST transpiler and new repeat helpers
+- Partial returns and list concatenation added to Prolog
+- Input builtins and union variants across Pascal, Swift, Scheme and Zig
+- Map generics and nested indexing for Kotlin plus open-ended slices in F#
+- Numerous Rosetta programs regenerated for all languages
+
+## Documentation
+
+- Progress logs updated with index numbers for several languages
+- Golden outputs refreshed across the repository


### PR DESCRIPTION
## Summary
- add release file for `v0.10.39`
- update `CHANGELOG` with latest changes

## Testing
- `npm test` *(fails: Missing script)*
- `go test ./...` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6881ca8f5f24832088003f1bdaf788d7