### PR TITLE
Fix bare return handling in pascal transpiler

### DIFF
--- a/tests/rosetta/transpiler/Pascal/24-game.error
+++ b/tests/rosetta/transpiler/Pascal/24-game.error
@@ -1,0 +1,12 @@
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling /workspace/mochi/tests/rosetta/transpiler/Pascal/24-game.pas
+24-game.pas(51,51) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of LongInt" expected "{Dynamic} Array Of Boolean"
+24-game.pas(51,39) Error: Incompatible types: got "LongInt" expected "Boolean"
+24-game.pas(55,55) Error: Incompatible type for arg no. 1: Got "Boolean", expected "QWord"
+24-game.pas(75,44) Error: Incompatible type for arg no. 1: Got "ShortString", expected "Extended"
+24-game.pas(75,55) Error: Incompatible type for arg no. 1: Got "Char", expected "Extended"
+24-game.pas(82,46) Fatal: Syntax error, ";" expected but ")" found
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/24-game.pas
+++ b/tests/rosetta/transpiler/Pascal/24-game.pas
@@ -1,0 +1,110 @@
+{$mode objfpc}
+program Main;
+uses SysUtils;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64());
+  end;
+end;
+function _input(): string;
+var s: string;
+begin
+  if EOF(Input) then s := '' else ReadLn(s);
+  _input := s;
+end;
+var
+  main_digits: array of boolean;
+  i: integer;
+  main_numstr: string;
+  main_expr: string;
+  main_stack: array of boolean;
+  main_i: integer;
+  main_valid: boolean;
+  main_ch: string;
+  main_j: integer;
+  main_b: boolean;
+  main_a: boolean;
+function randDigit(): integer;
+begin
+  exit((_now() mod 9) + 1);
+end;
+procedure main();
+begin
+  main_digits := [];
+  for i := 0 to (4 - 1) do begin
+  main_digits := concat(main_digits, [randDigit()]);
+end;
+  main_numstr := '';
+  for i := 0 to (4 - 1) do begin
+  main_numstr := main_numstr + IntToStr(main_digits[i]);
+end;
+  writeln(('Your numbers: ' + main_numstr) + '' + #10 + '');
+  writeln('Enter RPN: ');
+  main_expr := _input();
+  if Length(main_expr) <> 7 then begin
+  writeln('invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)');
+  exit();
+end;
+  main_stack := [];
+  main_i := 0;
+  main_valid := true;
+  while main_i < Length(main_expr) do begin
+  main_ch := copy(main_expr, main_i+1, (main_i + 1 - (main_i)));
+  if (main_ch >= '0') and (main_ch <= '9') then begin
+  if Length(main_digits) = 0 then begin
+  writeln('too many numbers.');
+  exit();
+end;
+  main_j := 0;
+  while main_digits[main_j] <> (int(main_ch) - int('0')) do begin
+  main_j := main_j + 1;
+  if main_j = Length(main_digits) then begin
+  writeln('wrong numbers.');
+  exit();
+end;
+end;
+  main_digits := copy(main_digits, 0, main_j)) + copy(main_digits, main_j + 1, Length(main_digits));
+  main_stack := concat(main_stack, [float(int(main_ch) - int('0'))]);
+end else begin
+  if Length(main_stack) < 2 then begin
+  writeln('invalid expression syntax.');
+  main_valid := false;
+  break;
+end;
+  main_b := main_stack[Length(main_stack) - 1];
+  main_a := main_stack[Length(main_stack) - 2];
+  if main_ch = '+' then begin
+  main_stack[Length(main_stack) - 2] := main_a + main_b;
+end;
+  main_stack := copy(main_stack, 0, Length(main_stack) - 1));
+end;
+  main_i := main_i + 1;
+end;
+  if main_valid then begin
+  if abs(main_stack[0] - 24) > 1e-06 then begin
+  writeln(('incorrect. ' + IntToStr(main_stack[0])) + ' != 24');
+end else begin
+  writeln('correct.');
+end;
+end;
+end;
+begin
+  init_now();
+  main();
+end.

--- a/transpiler/x/pas/transpiler.go
+++ b/transpiler/x/pas/transpiler.go
@@ -1293,11 +1293,15 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 				funcReturns[st.Fun.Name] = rt
 			}
 		case st.Return != nil:
-			ex, err := convertExpr(env, st.Return.Value)
-			if err != nil {
-				return nil, err
+			if st.Return.Value != nil {
+				ex, err := convertExpr(env, st.Return.Value)
+				if err != nil {
+					return nil, err
+				}
+				pr.Stmts = append(pr.Stmts, &ReturnStmt{Expr: ex})
+			} else {
+				pr.Stmts = append(pr.Stmts, &ReturnStmt{Expr: nil})
 			}
-			pr.Stmts = append(pr.Stmts, &ReturnStmt{Expr: ex})
 		case st.Import != nil:
 			continue
 		case st.ExternFun != nil:
@@ -1557,11 +1561,15 @@ func convertBody(env *types.Env, body []*parser.Statement, varTypes map[string]s
 			}
 			out = append(out, &IfStmt{Cond: cond, Then: thenBody, Else: elseBody})
 		case st.Return != nil:
-			ex, err := convertExpr(env, st.Return.Value)
-			if err != nil {
-				return nil, err
+			if st.Return.Value != nil {
+				ex, err := convertExpr(env, st.Return.Value)
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, &ReturnStmt{Expr: ex})
+			} else {
+				out = append(out, &ReturnStmt{Expr: nil})
 			}
-			out = append(out, &ReturnStmt{Expr: ex})
 		case st.Import != nil:
 			continue
 		case st.ExternFun != nil:


### PR DESCRIPTION
## Summary
- handle bare `return` statements in the Pascal transpiler
- add generated files for the failing `24-game` Rosetta example

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688189e2902c83209931b0bd44ed61f7