### PR TITLE
Fix Java transpiler for function types

### DIFF
--- a/tests/rosetta/transpiler/Java/abc-problem.java
+++ b/tests/rosetta/transpiler/Java/abc-problem.java
@@ -1,0 +1,65 @@
+public class Main {
+
+    static String[] fields(String s) {
+        String[] res = new String[]{};
+        String cur = "";
+        int i = 0;
+        while (i < s.length()) {
+            String c = s.substring(i, i + 1);
+            if ((c.equals(" "))) {
+                if (cur.length() > 0) {
+                    res = java.util.stream.Stream.concat(java.util.Arrays.stream(res), java.util.stream.Stream.of(cur)).toArray(String[]::new);
+                    cur = "";
+                }
+            } else {
+                cur = cur + c;
+            }
+            i = i + 1;
+        }
+        if (cur.length() > 0) {
+            res = java.util.stream.Stream.concat(java.util.Arrays.stream(res), java.util.stream.Stream.of(cur)).toArray(String[]::new);
+        }
+        return res;
+    }
+
+    static boolean canSpell(String word, String[] blks) {
+        if (word.length() == 0) {
+            return true;
+        }
+        String c = word.substring(0, 1).toLowerCase();
+        int i = 0;
+        while (i < blks.length) {
+            String b = blks[i];
+            if (((c.equals(b.substring(0, 1).toLowerCase())) || c.equals(b.substring(1, 2).toLowerCase()))) {
+                String[] rest = new String[]{};
+                int j = 0;
+                while (j < blks.length) {
+                    if (j != i) {
+                        rest = java.util.stream.Stream.concat(java.util.Arrays.stream(rest), java.util.stream.Stream.of(blks[j])).toArray(String[]::new);
+                    }
+                    j = j + 1;
+                }
+                if (canSpell(word.substring(1, word.length()), rest)) {
+                    return true;
+                }
+            }
+            i = i + 1;
+        }
+        return false;
+    }
+
+    static java.util.function.Function<String,Boolean> newSpeller(String blocks) {
+        String[] bl = fields(blocks);
+        return (w) -> canSpell(w, bl);
+    }
+
+    static void main() {
+        java.util.function.Function<String,Boolean> sp = newSpeller("BO XK DQ CP NA GT RE TG QD FS JW HU VI AN OB ER FS LY PC ZM");
+        for (var word : new String[]{"A", "BARK", "BOOK", "TREAT", "COMMON", "SQUAD", "CONFUSE"}) {
+            System.out.println(word + " " + String.valueOf(sp.apply(word)));
+        }
+    }
+    public static void main(String[] args) {
+        main();
+    }
+}

--- a/tests/rosetta/transpiler/Java/abc-problem.out
+++ b/tests/rosetta/transpiler/Java/abc-problem.out
@@ -1,0 +1,7 @@
+A true
+BARK true
+BOOK false
+TREAT true
+COMMON false
+SQUAD true
+CONFUSE true

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## Rosetta Checklist (17/284) - updated 2025-07-24 09:48 UTC
+## Rosetta Checklist (18/284) - updated 2025-07-24 11:45 UTC
 1. [x] 100-doors-2 (1)
 2. [x] 100-doors-3 (2)
 3. [x] 100-doors (3)
@@ -22,7 +22,7 @@ Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a 
 17. [x] abbreviations-automatic (17)
 18. [x] abbreviations-easy (18)
 19. [x] abbreviations-simple (19)
-20. [ ] abc-problem (20)
+20. [x] abc-problem (20)
 21. [ ] abelian-sandpile-model-identity (21)
 22. [ ] abelian-sandpile-model (22)
 23. [ ] abstract-type (23)


### PR DESCRIPTION
## Summary
- update Java transpiler to support function types with generics
- mark compiled abc-problem program in Rosetta checklist
- generate Java code and output for abc-problem

## Testing
- `go test -tags=slow ./transpiler/x/java -run Rosetta -index 20`
- `go test -tags=slow ./transpiler/x/java -run Rosetta -index 23` *(fails: abstract-type)*

------
https://chatgpt.com/codex/tasks/task_e_6882192d6ec483209a993bd9e870d610