### PR TITLE
Fix Kotlin transpiler integer casting

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.error
+++ b/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.error
@@ -1,34 +1,4 @@
 OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:137:78: error: expecting function type
-        println((((padLeft(k, 2) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:137:78: error: 'infix' modifier is required on 'toString' in 'kotlin.Function1'
-        println((((padLeft(k, 2) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                             ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:137:87: error: expecting an expression
-        println((((padLeft(k, 2) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                                      ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:146:81: error: expecting function type
-        println((((padLeft(_val, 7) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:146:81: error: 'infix' modifier is required on 'toString' in 'kotlin.Function1'
-        println((((padLeft(_val, 7) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                                ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:146:90: error: expecting an expression
-        println((((padLeft(_val, 7) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
-                                                                                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:152:73: error: expecting function type
-    println((((big.toString() + ": ") + padRight((r)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((r)["seq"] as Any? as MutableList<Int>))
-                                                                        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:152:73: error: 'infix' modifier is required on 'toString' in 'kotlin.Function1'
-    println((((big.toString() + ": ") + padRight((r)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((r)["seq"] as Any? as MutableList<Int>))
-                                                                        ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:152:82: error: expecting an expression
-    println((((big.toString() + ": ") + padRight((r)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((r)["seq"] as Any? as MutableList<Int>))
-                                                                                 ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:3:22: error: the integer literal does not conform to the expected type Int
-val THRESHOLD: Int = 140737488355328
-                     ^
 /workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:32:25: error: type mismatch: inferred type is Int but BigInteger was expected
     var y: BigInteger = (x + 1) / 2
                         ^

--- a/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt
+++ b/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt
@@ -1,6 +1,6 @@
 import java.math.BigInteger
 
-val THRESHOLD: Int = 140737488355328
+val THRESHOLD: Long = 140737488355328
 fun indexOf(xs: MutableList<Int>, value: Int): Int {
     var i: Int = 0
     while (i < xs.size) {
@@ -79,7 +79,7 @@ fun classifySequence(k: Int): MutableMap<String, Any?> {
                         if (last == seq[n - 2]) {
                             aliquot = "Aspiring"
                         } else {
-                            if (contains(seq.subList(1, maxOf(1, n - 2)), last) as Boolean) {
+                            if ((contains(seq.subList(1, maxOf(1, n - 2)), last)) as Boolean) {
                                 val idx: Int = indexOf(seq, last)
                                 aliquot = ("Cyclic[" + ((n - 1) - idx).toString()) + "]"
                             } else {
@@ -134,7 +134,7 @@ fun user_main(): Unit {
     var k: Int = 1
     while (k <= 10) {
         val res: MutableMap<String, Any?> = classifySequence(k)
-        println((((padLeft(k, 2) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
+        println((((padLeft(k, 2) + ": ") + padRight(((res)["aliquot"] as Any?).toString(), 15)) + " ") + joinWithCommas(((res)["seq"] as Any?) as MutableList<Int>))
         k = k + 1
     }
     println("")
@@ -143,13 +143,13 @@ fun user_main(): Unit {
     while (i < s.size) {
         val _val: Int = s[i]
         val res: MutableMap<String, Any?> = classifySequence(_val)
-        println((((padLeft(_val, 7) + ": ") + padRight((res)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((res)["seq"] as Any? as MutableList<Int>))
+        println((((padLeft(_val, 7) + ": ") + padRight(((res)["aliquot"] as Any?).toString(), 15)) + " ") + joinWithCommas(((res)["seq"] as Any?) as MutableList<Int>))
         i = i + 1
     }
     println("")
     val big: Int = 15355717786080
     val r: MutableMap<String, Any?> = classifySequence(big)
-    println((((big.toString() + ": ") + padRight((r)["aliquot"] as Any?.toString(), 15)) + " ") + joinWithCommas((r)["seq"] as Any? as MutableList<Int>))
+    println((((big.toString() + ": ") + padRight(((r)["aliquot"] as Any?).toString(), 15)) + " ") + joinWithCommas(((r)["seq"] as Any?) as MutableList<Int>))
 }
 
 fun main() {

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-24 16:14 +0700
+Last updated: 2025-07-24 18:57 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-24 16:14 +0700
+Last updated: 2025-07-24 18:57 +0700
 
 Completed tasks: **54/284**
 

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,12 @@
+## VM Golden Progress (2025-07-24 18:57 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-24 18:57 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-24 18:57 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-24 16:14 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- refine int64 handling for Kotlin transpiler
- parenthesise complex expressions when emitting cast
- regenerate Kotlin source for `aliquot-sequence-classifications`
- update Kotlin ROSETTA checklist

## Testing
- `ROSETTA_INDEX=41 go test ./transpiler/x/kt -run Rosetta -count=1 -tags slow` *(fails: kotlinc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68821f264de0832096eec6b940f04938