### PR TITLE
Improve C# transpiler variable type persistence

### DIFF
--- a/transpiler/x/cs/README.md
+++ b/transpiler/x/cs/README.md
@@ -3,7 +3,7 @@
 Generated C# code for programs in `tests/vm/valid`. Each program has a `.cs` file produced by the transpiler and a `.out` file containing its runtime output. Compilation or execution errors are captured in a `.error` file placed next to the source.
 
 Compiled programs: 102/103
-Last updated: 2025-07-24 15:41 +0700
+Last updated: 2025-07-24 13:16 UTC
 
 ## Checklist
 - [x] append_builtin

--- a/transpiler/x/cs/ROSETTA.md
+++ b/transpiler/x/cs/ROSETTA.md
@@ -1,7 +1,7 @@
 # Rosetta C# Transpiler Output
 
-Completed programs: 35/284
-Last updated: 2025-07-24 18:38 +0700
+Completed programs: 36/284
+Last updated: 2025-07-24 13:16 UTC
 
 ## Checklist
 1. [x] 100-doors-2 (1)
@@ -40,7 +40,7 @@ Last updated: 2025-07-24 18:38 +0700
 34. [x] add-a-variable-to-a-class-instance-at-runtime (34)
 35. [x] additive-primes (35)
 36. [x] address-of-a-variable (36)
-37. [ ] adfgvx-cipher (37)
+37. [x] adfgvx-cipher (37)
 38. [ ] aks-test-for-primes (38)
 39. [ ] algebraic-data-types (39)
 40. [x] align-columns (40)

--- a/transpiler/x/cs/TASKS.md
+++ b/transpiler/x/cs/TASKS.md
@@ -1,3 +1,9 @@
+## Progress (2025-07-24 13:16 UTC)
+- Enhanced C# transpiler variable type tracking for Rosetta program 37. (progress 102/103)
+
+## Progress (2025-07-24 13:05 UTC)
+- Applying previous commit. (progress 102/103)
+
 ## Progress (2025-07-24 15:41 +0700)
 - transpiler/cs: support map types and upper/lower (progress 102/103)
 
@@ -217,6 +223,8 @@
 
 ## Progress (2025-07-22 03:14 +0000)
 - cs transpiler: 100/102 tests compiled
+
+
 
 
 


### PR DESCRIPTION
## Summary
- track local variable types for better string detection
- update Rosetta checklist for program 37

## Testing
- `go vet ./...`
- `MOCHI_ROSETTA_INDEX=37 go test ./transpiler/x/cs -tags slow -run Rosetta -count=1 -timeout=0`

------
https://chatgpt.com/codex/tasks/task_e_68822b186a888320afb975571104a661