### PR TITLE
Fix F# transpiler break handling

### DIFF
--- a/tests/rosetta/transpiler/FS/abbreviations-easy.fs
+++ b/tests/rosetta/transpiler/FS/abbreviations-easy.fs
@@ -1,0 +1,136 @@
+// Generated 2025-07-24 20:06 +0700
+
+exception Break
+exception Continue
+
+exception Return
+
+let rec fields (s: string) =
+    let mutable __ret : string array = Unchecked.defaultof<string array>
+    let mutable s = s
+    try
+        let mutable words: string array = [||]
+        let mutable cur: string = ""
+        let mutable i: int = 0
+        while i < (String.length s) do
+            let ch: string = s.Substring(i, (i + 1) - i)
+            if ((ch = " ") || (ch = "\n")) || (ch = "\t") then
+                if (String.length cur) > 0 then
+                    words <- Array.append words [|cur|]
+                    cur <- ""
+            else
+                cur <- cur + ch
+            i <- i + 1
+        if (String.length cur) > 0 then
+            words <- Array.append words [|cur|]
+        __ret <- words
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and padRight (s: string) (width: int) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable s = s
+    let mutable width = width
+    try
+        let mutable out: string = s
+        let mutable i: int = String.length s
+        while i < width do
+            out <- out + " "
+            i <- i + 1
+        __ret <- out
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and join (xs: string array) (sep: string) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable xs = xs
+    let mutable sep = sep
+    try
+        let mutable res: string = ""
+        let mutable i: int = 0
+        while i < (Seq.length xs) do
+            if i > 0 then
+                res <- res + sep
+            res <- res + (xs.[i])
+            i <- i + 1
+        __ret <- res
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and validate (commands: string array) (words: string array) (mins: int array) =
+    let mutable __ret : string array = Unchecked.defaultof<string array>
+    let mutable commands = commands
+    let mutable words = words
+    let mutable mins = mins
+    try
+        let mutable results: string array = [||]
+        if (Seq.length words) = 0 then
+            __ret <- results
+            raise Return
+        let mutable wi: int = 0
+        try
+            while wi < (Seq.length words) do
+                let w = words.[wi]
+                let mutable found: bool = false
+                let wlen: int = Seq.length w
+                let mutable ci: int = 0
+                try
+                    while ci < (Seq.length commands) do
+                        let cmd = commands.[ci]
+                        if (((mins.[ci]) <> 0) && (wlen >= (mins.[ci]))) && (wlen <= (Seq.length cmd)) then
+                            let c = cmd.ToUpper()
+                            let ww = w.ToUpper()
+                            if (c.Substring(0, wlen - 0)) = ww then
+                                results <- Array.append results [|c|]
+                                found <- true
+                                raise Break
+                        ci <- ci + 1
+                with
+                | Break -> ()
+                | Continue -> ()
+                if not found then
+                    results <- Array.append results [|"*error*"|]
+                wi <- wi + 1
+        with
+        | Break -> ()
+        | Continue -> ()
+        __ret <- results
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : obj = Unchecked.defaultof<obj>
+    try
+        let table: string = ((((("Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy " + "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find ") + "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput ") + " Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO ") + "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT ") + "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT ") + "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp "
+        let commands = fields table
+        let mutable mins: int array = [||]
+        let mutable i: int = 0
+        while i < (Seq.length commands) do
+            let mutable count: int = 0
+            let mutable j: int = 0
+            let cmd = commands.[i]
+            while j < (Seq.length cmd) do
+                let ch: string = cmd.Substring(j, (j + 1) - j)
+                if (ch >= "A") && (ch <= "Z") then
+                    count <- count + 1
+                j <- j + 1
+            mins <- Array.append mins [|count|]
+            i <- i + 1
+        let sentence: string = "riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin"
+        let words = fields sentence
+        let results = validate commands words mins
+        let mutable out1: string = "user words:  "
+        let mutable k: int = 0
+        while k < (Seq.length words) do
+            out1 <- (out1 + (padRight (words.[k]) (Seq.length (results.[k])))) + " "
+            k <- k + 1
+        printfn "%s" out1
+        printfn "%s" ("full words:  " + (join results " "))
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/abbreviations-easy.out
+++ b/tests/rosetta/transpiler/FS/abbreviations-easy.out
@@ -1,0 +1,2 @@
+user words:  riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin    
+full words:  RIGHT REPEAT *error* PUT MOVE RESTORE *error* *error* *error* POWERINPUT

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,11 +2,11 @@
 
 This file is auto-generated from rosetta tests.
 
-## Checklist (14/284)
+## Checklist (16/284)
 1. [x] 100-doors-2 (index 1)
 2. [x] 100-doors-3 (index 2)
 3. [x] 100-doors (index 3)
-4. [ ] 100-prisoners (index 4)
+4. [x] 100-prisoners (index 4)
 5. [x] 15-puzzle-game (index 5)
 6. [ ] 15-puzzle-solver (index 6)
 7. [x] 2048 (index 7)
@@ -20,7 +20,7 @@ This file is auto-generated from rosetta tests.
 15. [x] DNS-query (index 15)
 16. [x] a+b (index 16)
 17. [x] abbreviations-automatic (index 17)
-18. [ ] abbreviations-easy (index 18)
+18. [x] abbreviations-easy (index 18)
 19. [ ] abbreviations-simple (index 19)
 20. [ ] abc-problem (index 20)
 21. [ ] abelian-sandpile-model-identity (index 21)
@@ -288,4 +288,4 @@ This file is auto-generated from rosetta tests.
 283. [ ] define-a-primitive-data-type (index 283)
 284. [ ] md5 (index 284)
 
-Last updated: 2025-07-24 18:38 +0700
+Last updated: 2025-07-24 20:06 +0700

--- a/transpiler/x/fs/transpiler.go
+++ b/transpiler/x/fs/transpiler.go
@@ -967,16 +967,16 @@ type WhileStmt struct {
 }
 
 func (wst *WhileStmt) emit(w io.Writer) {
-	writeIndent(w)
-	io.WriteString(w, "while ")
-	wst.Cond.emit(w)
-	io.WriteString(w, " do\n")
-	indentLevel++
 	if wst.WithBreak {
 		writeIndent(w)
 		io.WriteString(w, "try\n")
 		indentLevel++
 	}
+	writeIndent(w)
+	io.WriteString(w, "while ")
+	wst.Cond.emit(w)
+	io.WriteString(w, " do\n")
+	indentLevel++
 	for i, st := range wst.Body {
 		st.emit(w)
 		if i < len(wst.Body)-1 {
@@ -2406,6 +2406,16 @@ func convertPrimary(p *parser.Primary) (Expr, error) {
 				return nil, fmt.Errorf("substring expects 3 args")
 			}
 			return &SubstringExpr{Str: args[0], Start: args[1], End: args[2]}, nil
+		case "upper":
+			if len(args) != 1 {
+				return nil, fmt.Errorf("upper expects 1 arg")
+			}
+			return &MethodCallExpr{Target: args[0], Name: "ToUpper"}, nil
+		case "lower":
+			if len(args) != 1 {
+				return nil, fmt.Errorf("lower expects 1 arg")
+			}
+			return &MethodCallExpr{Target: args[0], Name: "ToLower"}, nil
 		case "values":
 			if len(args) != 1 {
 				return nil, fmt.Errorf("values expects 1 arg")


### PR DESCRIPTION
## Summary
- adjust F# `WhileStmt` emitter so `try … with` wraps the loop
- support `upper`/`lower` string functions
- update Rosetta output for `abbreviations-easy`

## Testing
- `MOCHI_ROSETTA_INDEX=18 go test ./transpiler/x/fs -tags slow -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68822b99a3cc8320b535859647278e6e