### PR TITLE
Add PHP str helper for rosetta task

### DIFF
--- a/tests/rosetta/transpiler/php/bitmap-histogram.out
+++ b/tests/rosetta/transpiler/php/bitmap-histogram.out
@@ -1,0 +1,5 @@
+Histogram: [3 0 6]
+Threshold: 21845
+000
+111
+111

--- a/tests/rosetta/transpiler/php/bitmap-histogram.php
+++ b/tests/rosetta/transpiler/php/bitmap-histogram.php
@@ -1,0 +1,115 @@
+<?php
+ini_set('memory_limit', '-1');
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+function image() {
+  global $histogram, $medianThreshold, $threshold, $printImage, $main;
+  return [[0, 0, 10000], [65535, 65535, 65535], [65535, 65535, 65535]];
+}
+function histogram($g, $bins) {
+  global $image, $medianThreshold, $threshold, $printImage, $main;
+  if ($bins <= 0) {
+  $bins = count($g[0]);
+}
+  $h = [];
+  $i = 0;
+  while ($i < $bins) {
+  $h = array_merge($h, [0]);
+  $i = $i + 1;
+};
+  $y = 0;
+  while ($y < count($g)) {
+  $row = $g[$y];
+  $x = 0;
+  while ($x < count($row)) {
+  $p = $row[$x];
+  $idx = intval((intdiv(($p * ($bins - 1)), 65535)));
+  $h[$idx] = $h[$idx] + 1;
+  $x = $x + 1;
+};
+  $y = $y + 1;
+};
+  return $h;
+}
+function medianThreshold($h) {
+  global $image, $histogram, $threshold, $printImage, $main;
+  $lb = 0;
+  $ub = count($h) - 1;
+  $lSum = 0;
+  $uSum = 0;
+  while ($lb <= $ub) {
+  if ($lSum + $h[$lb] < $uSum + $h[$ub]) {
+  $lSum = $lSum + $h[$lb];
+  $lb = $lb + 1;
+} else {
+  $uSum = $uSum + $h[$ub];
+  $ub = $ub - 1;
+}
+};
+  return intval((($ub * 65535) / count($h)));
+}
+function threshold($g, $t) {
+  global $image, $histogram, $medianThreshold, $printImage, $main;
+  $out = [];
+  $y = 0;
+  while ($y < count($g)) {
+  $row = $g[$y];
+  $newRow = [];
+  $x = 0;
+  while ($x < count($row)) {
+  if ($row[$x] < $t) {
+  $newRow = array_merge($newRow, [0]);
+} else {
+  $newRow = array_merge($newRow, [65535]);
+}
+  $x = $x + 1;
+};
+  $out = array_merge($out, [$newRow]);
+  $y = $y + 1;
+};
+  return $out;
+}
+function printImage($g) {
+  global $image, $histogram, $medianThreshold, $threshold, $main;
+  $y = 0;
+  while ($y < count($g)) {
+  $row = $g[$y];
+  $line = '';
+  $x = 0;
+  while ($x < count($row)) {
+  if ($row[$x] == 0) {
+  $line = $line . '0';
+} else {
+  $line = $line . '1';
+}
+  $x = $x + 1;
+};
+  echo rtrim($line), PHP_EOL;
+  $y = $y + 1;
+};
+}
+function main() {
+  global $image, $histogram, $medianThreshold, $threshold, $printImage;
+  $img = image();
+  $h = histogram($img, 0);
+  echo rtrim('Histogram: ' . _str($h)), PHP_EOL;
+  $t = medianThreshold($h);
+  echo rtrim('Threshold: ' . _str($t)), PHP_EOL;
+  $bw = threshold($img, $t);
+  printImage($bw);
+}
+main();

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-24 15:19 +0700
+Last updated: 2025-07-24 20:24 +0700
 
 ## VM Golden Test Checklist (102/103)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,13 +2,13 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-24 19:43 +0700
+Last updated: 2025-07-24 20:24 +0700
 
-## Checklist (117/284)
+## Checklist (119/284)
 - [x] 1 100-doors-2
 - [x] 2 100-doors-3
 - [x] 3 100-doors
-- [ ] 4 100-prisoners
+- [x] 4 100-prisoners
 - [x] 5 15-puzzle-game
 - [x] 6 15-puzzle-solver
 - [x] 7 2048
@@ -125,7 +125,7 @@ Last updated: 2025-07-24 19:43 +0700
 - [x] 118 bitmap-b-zier-curves-quadratic
 - [x] 119 bitmap-bresenhams-line-algorithm
 - [x] 120 bitmap-flood-fill
-- [ ] 121 bitmap-histogram
+- [x] 121 bitmap-histogram
 - [ ] 122 bitmap-midpoint-circle-algorithm
 - [ ] 123 bitmap-ppm-conversion-through-a-pipe
 - [ ] 124 bitmap-read-a-ppm-file

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-24 15:19 +0700)
+## Progress (2025-07-24 20:24 +0700)
 - Generated PHP for 102/103 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- add `_str` helper to PHP transpiler and wire it up
- generate bitmap-histogram PHP output

## Testing
- `MOCHI_ROSETTA_INDEX=121 go test ./transpiler/x/php -run Rosetta -tags slow -count=1`
- `MOCHI_ROSETTA_INDEX=122 go test ./transpiler/x/php -run Rosetta -tags slow -count=1`
- `MOCHI_ROSETTA_INDEX=123 go test ./transpiler/x/php -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688234056b4c8320a8aa432d899e3777