### PR TITLE
Add Fang-based gist CLI

### DIFF
--- a/cmd/tap-gist/README.md
+++ b/cmd/tap-gist/README.md
@@ -1,0 +1,13 @@
+# tap-gist
+
+Create a GitHub gist from one or more files or from standard input.
+
+```bash
+tap-gist [-m message] [--public] [--token TOKEN] <file|-> [file ...]
+```
+
+- `-m` sets the gist description.
+- `--public` creates a public gist (private by default).
+- `--token` overrides the GitHub token (defaults to the `GITHUB_TOKEN` environment variable).
+
+The `GITHUB_TOKEN` variable is already set in this repository.

--- a/cmd/tap-gist/main.go
+++ b/cmd/tap-gist/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/fang"
+	"github.com/spf13/cobra"
+
+	"mochi/tools/tap/github"
+)
+
+var (
+	version   = "dev"
+	gitCommit = ""
+)
+
+type rootFlags struct {
+	Message string
+	Public  bool
+	Token   string
+}
+
+func newRootCmd() *cobra.Command {
+	var flags rootFlags
+	cmd := &cobra.Command{
+		Use:   "tap-gist <file|-> [file ...]",
+		Short: "Create a GitHub gist from files or stdin",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			files := make(map[string][]byte)
+			for _, arg := range args {
+				var (
+					data []byte
+					err  error
+					name string
+				)
+				if arg == "-" {
+					data, err = io.ReadAll(cmd.InOrStdin())
+					name = "stdin"
+				} else {
+					data, err = os.ReadFile(arg)
+					name = filepath.Base(arg)
+				}
+				if err != nil {
+					return err
+				}
+				files[name] = data
+			}
+			g, err := github.Create(cmd.Context(), flags.Token, flags.Message, flags.Public, files)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), g.HTMLURL)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&flags.Message, "message", "m", "", "gist description")
+	cmd.Flags().BoolVar(&flags.Public, "public", false, "create public gist")
+	cmd.Flags().StringVar(&flags.Token, "token", "", "GitHub token ($GITHUB_TOKEN if empty)")
+	return cmd
+}
+
+func main() {
+	root := newRootCmd()
+	if err := fang.Execute(
+		context.Background(),
+		root,
+		fang.WithVersion(version),
+		fang.WithCommit(gitCommit),
+	); err != nil {
+		os.Exit(1)
+	}
+}

--- a/tools/tap/github/gist.go
+++ b/tools/tap/github/gist.go
@@ -1,0 +1,73 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// File represents a single file in a gist.
+type File struct {
+	Content string `json:"content"`
+}
+
+// Gist contains the minimal fields returned by the GitHub API when creating a gist.
+type Gist struct {
+	ID      string `json:"id"`
+	HTMLURL string `json:"html_url"`
+}
+
+// Create creates a new GitHub gist with the given files.
+// If token is empty, the GITHUB_TOKEN or GITHUB_GIST_TOKEN environment variable is used.
+// The returned Gist contains the ID and HTMLURL of the created gist.
+func Create(ctx context.Context, token, description string, public bool, files map[string][]byte) (*Gist, error) {
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	if token == "" {
+		token = os.Getenv("GITHUB_GIST_TOKEN")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("github gist: missing token")
+	}
+
+	gf := make(map[string]File, len(files))
+	for name, data := range files {
+		gf[name] = File{Content: string(data)}
+	}
+	payload := struct {
+		Description string          `json:"description,omitempty"`
+		Public      bool            `json:"public"`
+		Files       map[string]File `json:"files"`
+	}{description, public, gf}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.github.com/gists", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		data, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("create gist: %s: %s", resp.Status, data)
+	}
+	var g Gist
+	if err := json.NewDecoder(resp.Body).Decode(&g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}


### PR DESCRIPTION
## Summary
- add `cmd/tap-gist/README.md` with basic instructions
- rewrite `tap-gist` command using Cobra + fang

## Testing
- `go vet ./cmd/tap-gist ./tools/tap/...`
- `go test ./cmd/tap-gist ./tools/tap/...`


------
https://chatgpt.com/codex/tasks/task_e_68827a008d488320a13ccb3deaf8f50b