### PR TITLE
Add initial long support for Java transpiler

### DIFF
--- a/tests/rosetta/transpiler/Java/aliquot-sequence-classifications.error
+++ b/tests/rosetta/transpiler/Java/aliquot-sequence-classifications.error
@@ -1,8 +1,37 @@
 compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Goldenaliquot-sequence-classifications3881237625/001/Main.java:2: error: integer number too large
-    static int THRESHOLD = 140737488355328;
-                           ^
-/tmp/TestJavaTranspiler_Rosetta_Goldenaliquot-sequence-classifications3881237625/001/Main.java:138: error: integer number too large
-        int big = 15355717786080;
-                  ^
-2 errors
+/tmp/TestJavaTranspiler_Rosetta_Goldenaliquot-sequence-classifications3786683302/001/Main.java:32: error: incompatible types: possible lossy conversion from double to long
+        long y = ((Number)((x + 1))).doubleValue() / 2;
+                                                   ^
+/tmp/TestJavaTranspiler_Rosetta_Goldenaliquot-sequence-classifications3786683302/001/Main.java:35: error: incompatible types: possible lossy conversion from double to long
+            y = ((Number)((x + n / x))).doubleValue() / 2;
+                                                      ^
+/tmp/TestJavaTranspiler_Rosetta_Goldenaliquot-sequence-classifications3786683302/001/Main.java:77: error: no suitable method found for copyOfRange(long[],int,long)
+            } else             if (contains(java.util.Arrays.copyOfRange(seq, 1, maxOf(1, n - 2)), last)) {
+                                                            ^
+    method Arrays.<T#1>copyOfRange(T#1[],int,int) is not applicable
+      (cannot infer type-variable(s) T#1
+        (argument mismatch; possible lossy conversion from long to int))
+    method Arrays.<T#2,U>copyOfRange(U[],int,int,Class<? extends T#2[]>) is not applicable
+      (cannot infer type-variable(s) T#2,U
+        (actual and formal argument lists differ in length))
+    method Arrays.copyOfRange(byte[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to byte[])
+    method Arrays.copyOfRange(short[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to short[])
+    method Arrays.copyOfRange(int[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to int[])
+    method Arrays.copyOfRange(long[],int,int) is not applicable
+      (argument mismatch; possible lossy conversion from long to int)
+    method Arrays.copyOfRange(char[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to char[])
+    method Arrays.copyOfRange(float[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to float[])
+    method Arrays.copyOfRange(double[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to double[])
+    method Arrays.copyOfRange(boolean[],int,int) is not applicable
+      (argument mismatch; long[] cannot be converted to boolean[])
+  where T#1,T#2,U are type-variables:
+    T#1 extends Object declared in method <T#1>copyOfRange(T#1[],int,int)
+    T#2 extends Object declared in method <T#2,U>copyOfRange(U[],int,int,Class<? extends T#2[]>)
+    U extends Object declared in method <T#2,U>copyOfRange(U[],int,int,Class<? extends T#2[]>)
+3 errors

--- a/tests/rosetta/transpiler/Java/aliquot-sequence-classifications.java
+++ b/tests/rosetta/transpiler/Java/aliquot-sequence-classifications.java
@@ -1,10 +1,10 @@
 public class Main {
-    static int THRESHOLD = 140737488355328;
+    static long THRESHOLD = 140737488355328L;
 
-    static int indexOf(int[] xs, int value) {
-        int i = 0;
+    static long indexOf(long[] xs, long value) {
+        long i = 0;
         while (i < xs.length) {
-            if (xs[i] == value) {
+            if (xs[(int)(i)] == value) {
                 return i;
             }
             i = i + 1;
@@ -12,11 +12,11 @@ public class Main {
         return 0 - 1;
     }
 
-    static boolean contains(int[] xs, int value) {
+    static boolean contains(long[] xs, long value) {
         return indexOf(xs, value) != 0 - 1;
     }
 
-    static int maxOf(int a, int b) {
+    static long maxOf(long a, long b) {
         if (a > b) {
             return a;
         } else {
@@ -24,26 +24,26 @@ public class Main {
         }
     }
 
-    static int intSqrt(int n) {
+    static long intSqrt(long n) {
         if (n == 0) {
             return 0;
         }
-        int x = n;
-        int y = (x + 1) / 2;
+        long x = n;
+        long y = ((Number)((x + 1))).doubleValue() / 2;
         while (y < x) {
             x = y;
-            y = (x + n / x) / 2;
+            y = ((Number)((x + n / x))).doubleValue() / 2;
         }
         return x;
     }
 
-    static int sumProperDivisors(int n) {
+    static long sumProperDivisors(long n) {
         if (n < 2) {
             return 0;
         }
-        int sqrt = intSqrt(n);
-        int sum = 1;
-        int i = 2;
+        long sqrt = intSqrt(n);
+        long sum = 1;
+        long i = 2;
         while (i <= sqrt) {
             if (n % i == 0) {
                 sum = sum + i + n / i;
@@ -56,13 +56,13 @@ public class Main {
         return sum;
     }
 
-    static java.util.Map<String,Object> classifySequence(int k) {
-        int last = k;
-        int[] seq = new int[]{k};
+    static java.util.Map<String,Object> classifySequence(long k) {
+        long last = k;
+        long[] seq = new long[]{k};
         while (true) {
             last = sumProperDivisors(last);
-            seq = java.util.stream.IntStream.concat(java.util.Arrays.stream(seq), java.util.stream.IntStream.of(last)).toArray();
-            int n = seq.length;
+            seq = java.util.stream.LongStream.concat(java.util.Arrays.stream(seq), java.util.stream.LongStream.of(last)).toArray();
+            long n = seq.length;
             String aliquot = "";
             if (last == 0) {
                 aliquot = "Terminating";
@@ -72,10 +72,10 @@ public class Main {
                 aliquot = "Amicable";
             } else             if (n >= 4 && last == k) {
                 aliquot = "Sociable[" + String.valueOf(n - 1) + "]";
-            } else             if (last == seq[n - 2]) {
+            } else             if (last == seq[(int)(n - 2)]) {
                 aliquot = "Aspiring";
             } else             if (contains(java.util.Arrays.copyOfRange(seq, 1, maxOf(1, n - 2)), last)) {
-                int idx = indexOf(seq, last);
+                long idx = indexOf(seq, last);
                 aliquot = "Cyclic[" + String.valueOf(n - 1 - idx) + "]";
             } else             if (n == 16 || last > THRESHOLD) {
                 aliquot = "Non-Terminating";
@@ -87,7 +87,7 @@ public class Main {
         return new java.util.LinkedHashMap<String, Object>(java.util.Map.of("seq", seq, "aliquot", ""));
     }
 
-    static String padLeft(int n, int w) {
+    static String padLeft(long n, long w) {
         String s = String.valueOf(n);
         while (s.length() < w) {
             s = " " + s;
@@ -95,7 +95,7 @@ public class Main {
         return s;
     }
 
-    static String padRight(String s, int w) {
+    static String padRight(String s, long w) {
         String r = s;
         while (r.length() < w) {
             r = r + " ";
@@ -103,11 +103,11 @@ public class Main {
         return r;
     }
 
-    static String joinWithCommas(int[] seq) {
+    static String joinWithCommas(long[] seq) {
         String s = "[";
-        int i = 0;
+        long i = 0;
         while (i < seq.length) {
-            s = s + String.valueOf(seq[i]);
+            s = s + String.valueOf(seq[(int)(i)]);
             if (i < seq.length - 1) {
                 s = s + ", ";
             }
@@ -119,25 +119,25 @@ public class Main {
 
     static void main() {
         System.out.println("Aliquot classifications - periods for Sociable/Cyclic in square brackets:\n");
-        int k = 1;
+        long k = 1;
         while (k <= 10) {
             java.util.Map<String,Object> res = classifySequence(k);
-            System.out.println(padLeft(k, 2) + ": " + padRight((String)(res.get("aliquot")), 15) + " " + joinWithCommas((int[])(res.get("seq"))));
+            System.out.println(padLeft(k, 2) + ": " + padRight((String)(((String)res.get("aliquot"))), 15) + " " + joinWithCommas((long[])(((long[])res.get("seq")))));
             k = k + 1;
         }
         System.out.println("");
-        int[] s = new int[]{11, 12, 28, 496, 220, 1184, 12496, 1264460, 790, 909, 562, 1064, 1488};
-        int i = 0;
+        long[] s = new long[]{11, 12, 28, 496, 220, 1184, 12496, 1264460, 790, 909, 562, 1064, 1488};
+        long i = 0;
         while (i < s.length) {
-            int val = s[i];
+            long val = s[(int)(i)];
             java.util.Map<String,Object> res = classifySequence(val);
-            System.out.println(padLeft(val, 7) + ": " + padRight((String)(res.get("aliquot")), 15) + " " + joinWithCommas((int[])(res.get("seq"))));
+            System.out.println(padLeft(val, 7) + ": " + padRight((String)(((String)res.get("aliquot"))), 15) + " " + joinWithCommas((long[])(((long[])res.get("seq")))));
             i = i + 1;
         }
         System.out.println("");
-        int big = 15355717786080;
+        long big = 15355717786080L;
         java.util.Map<String,Object> r = classifySequence(big);
-        System.out.println(String.valueOf(big) + ": " + padRight((String)(r.get("aliquot")), 15) + " " + joinWithCommas((int[])(r.get("seq"))));
+        System.out.println(String.valueOf(big) + ": " + padRight((String)(((String)r.get("aliquot"))), 15) + " " + joinWithCommas((long[])(((long[])r.get("seq")))));
     }
     public static void main(String[] args) {
         main();


### PR DESCRIPTION
## Summary
- enhance Java transpiler to start handling `long` values
- regenerate code for `aliquot-sequence-classifications` showing current status

## Testing
- `go test ./transpiler/x/java -tags slow -run Rosetta -index 41` *(fails: javac aliquot-sequence-classifications)*

------
https://chatgpt.com/codex/tasks/task_e_68827963e5008320bce889d52b76d1ad