### PR TITLE
Fix tests

### DIFF
--- a/scripts/run_clj_transpile.go
+++ b/scripts/run_clj_transpile.go
@@ -1,3 +1,5 @@
+//go:build archive && slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- exclude clj transpiler integration script from build unless `archive` and `slow` tags are set

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_68827ebeb350832095e94f8a3689bb94