### PR TITLE
Add bench block support in Ex transpiler

### DIFF
--- a/tests/transpiler/x/ex/bench_block.out
+++ b/tests/transpiler/x/ex/bench_block.out
@@ -1,0 +1,33 @@
+warning: variable "seed" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
+    │
+ 14 │               seed = v
+    │               ~
+    │
+    └─ /workspace/mochi/tests/transpiler/x/ex/bench_block.exs:14:15: Main._now/0
+
+    warning: variable "seeded" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
+    │
+ 15 │               seeded = true
+    │               ~
+    │
+    └─ /workspace/mochi/tests/transpiler/x/ex/bench_block.exs:15:15: Main._now/0
+
+    warning: variable "s" is unused (there is a variable with the same name in the context, use the pin operator (^) to match on it or prefix this variable with underscore if it is not meant to be used)
+    │
+ 45 │     {s} = Enum.reduce((1..(n - 1)), {s}, fn i, {s} ->
+    │      ~
+    │
+    └─ /workspace/mochi/tests/transpiler/x/ex/bench_block.exs:45:6: Main.main/0
+
+    warning: function _lookup_host/1 is unused
+    │
+ 31 │   defp _lookup_host(host) do
+    │        ~
+    │
+    └─ /workspace/mochi/tests/transpiler/x/ex/bench_block.exs:31:8: Main (module)
+
+{
+  "duration_us": -1753384192378074,
+  "memory_bytes": 535344,
+  "name": "simple"
+}

--- a/transpiler/x/ex/vm_valid_golden_test.go
+++ b/transpiler/x/ex/vm_valid_golden_test.go
@@ -57,6 +57,7 @@ func TestExTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		cmd := exec.Command("elixir", codePath)
+		cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- implement bench block handling in Elixir transpiler
- generate helper for memory measurement
- run Elixir with MOCHI_NOW_SEED for deterministic time
- include bench_block.out for transpiler tests

## Testing
- `go test ./transpiler/x/ex -run TestExTranspiler_VMValid_Golden/bench_block -tags=slow -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688280922fec83209b2786fba1f68c64