### PR TITLE
Add bench block golden test for F#

### DIFF
--- a/tests/transpiler/x/fs/bench_block.fs
+++ b/tests/transpiler/x/fs/bench_block.fs
@@ -1,0 +1,33 @@
+// Generated 2025-07-24 19:13 +0000
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+open System
+
+let __memStart = System.GC.GetTotalMemory(false)
+let __start = _now()
+let n: int = 1000
+let mutable s: int = 0
+for i in 1 .. (n - 1) do
+    s <- s + i
+let __end = _now()
+let __memEnd = System.GC.GetTotalMemory(false)
+let __dur_us = (__end - __start) / 1000
+let __mem_diff = __memEnd - __memStart
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"simple\"\n}" __dur_us __mem_diff

--- a/tests/transpiler/x/fs/bench_block.out
+++ b/tests/transpiler/x/fs/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,13 +2,14 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (102/103)
+## Golden Test Checklist (103/104)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
+- [x] bench_block.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
 - [x] break_continue.mochi
@@ -110,4 +111,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-07-25 01:11 +0700
+Last updated: 2025-07-24 19:13 +0000

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-24 19:13 +0000)
+- Applying previous commit.
+- Generated F# for 103/104 programs (103 passing)
+
 ## Progress (2025-07-25 01:11 +0700)
 - Update F# transpiler and generated outputs
 - Generated F# for 102/103 programs (102 passing)

--- a/transpiler/x/fs/vm_valid_golden_test.go
+++ b/transpiler/x/fs/vm_valid_golden_test.go
@@ -62,6 +62,7 @@ func TestFSTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		run := exec.Command("mono", exe)
+		run.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			run.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- add BenchStmt code generation for F# transpiler
- capture memory and time for bench blocks
- enable deterministic bench output in tests
- track bench_block test in README/TASKS
- commit generated bench_block.fs

## Testing
- `go vet ./...`
- `go test ./transpiler/x/fs -c -tags slow`
- `go test ./transpiler/x/fs -run VMValid/bench_block -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688280a4fc448320a5abd06c94656355