### PR TITLE
Add bench block support in Java transpiler

### DIFF
--- a/tests/transpiler/x/java/bench_block.java
+++ b/tests/transpiler/x/java/bench_block.java
@@ -1,0 +1,43 @@
+public class Main {
+
+    public static void main(String[] args) {
+        {
+            int _benchStart = _now();
+            int _benchMem = _mem();
+            int n = 1000;
+            int s = 0;
+            for (int i = 1; i < n; i++) {
+                s = s + i;
+            }
+            int _benchDuration = (_now() - _benchStart) / 1000;
+            int _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"simple\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)System.currentTimeMillis();
+    }
+
+    static int _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return (int)(rt.totalMemory() - rt.freeMemory());
+    }
+}

--- a/tests/transpiler/x/java/bench_block.out
+++ b/tests/transpiler/x/java/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}

--- a/transpiler/x/java/vm_valid_golden_test.go
+++ b/transpiler/x/java/vm_valid_golden_test.go
@@ -65,6 +65,7 @@ func TestJavaTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		cmd = exec.Command("java", "-cp", outDir, "Main")
+		cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- support `bench` blocks in the Java transpiler
- emit helper function `_mem` for memory usage
- update golden test harness to seed timestamps
- include golden output for `bench_block.mochi`

## Testing
- `go test -tags slow ./transpiler/x/java -run TestJavaTranspiler_VMValid_Golden/bench_block -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688280c88ae48320b6771db3a342085d