### PR TITLE
Add bench block support to Kotlin transpiler

### DIFF
--- a/tests/transpiler/x/kt/bench_block.out
+++ b/tests/transpiler/x/kt/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}


### PR DESCRIPTION
## Summary
- add new `BenchStmt` support to Kotlin transpiler
- emit benchmark blocks that compute duration and memory usage
- run Kotlin VM-valid golden tests using `golden.RunWithSummary`
- provide expected output for `bench_block.mochi`

## Testing
- `go test -tags=slow ./transpiler/x/kt -run TestTranspilePrograms -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_688280d124c0832091e65189d1a85121