### PR TITLE
Implement bench block in Scala transpiler

### DIFF
--- a/tests/transpiler/x/scala/bench_block.out
+++ b/tests/transpiler/x/scala/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}


### PR DESCRIPTION
## Summary
- add `BenchStmt` for Scala codegen
- emit block benchmarking code
- convert bench blocks when transpiling
- add expected output for `bench_block` golden test

## Testing
- `MOCHI_NOW_SEED=1 go test ./transpiler/x/scala -tags slow -run TestScalaTranspiler_VMValid_Golden/bench_block -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68828120d0048320a149df2dbe5d98ae