### PR TITLE
Add bench block support to Zig transpiler

### DIFF
--- a/tests/transpiler/x/zig/bench_block.out
+++ b/tests/transpiler/x/zig/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}

--- a/transpiler/x/zig/vm_valid_golden_test.go
+++ b/transpiler/x/zig/vm_valid_golden_test.go
@@ -52,6 +52,7 @@ func TestZigTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		cmd := exec.Command("zig", "run", codePath)
+		cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- implement BenchStmt to generate benchmarking code in Zig
- enable `_mem` helper and call `_now` inside bench blocks
- ensure deterministic time output by setting `MOCHI_NOW_SEED` in tests
- add golden file for `bench_block`

## Testing
- `go test ./transpiler/x/zig -tags slow -run TestZigTranspiler_VMValid_Golden/bench_block -v`


------
https://chatgpt.com/codex/tasks/task_e_688281444ba483209e362fcace94d06e