### PR TITLE
Add bench block support to Haskell transpiler

### DIFF
--- a/tests/transpiler/x/hs/bench_block.out
+++ b/tests/transpiler/x/hs/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}


### PR DESCRIPTION
## Summary
- support `bench` blocks in the Haskell transpiler
- pretty-print JSON using aeson-pretty
- copy expected output for `bench_block` test

## Testing
- `go test ./transpiler/x/hs -tags slow -run TestHSTranspiler_VMValid_Golden/bench_block -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882d3d27a188320ae2d8fa0027270e4