### PR TITLE
Add bench block support in F# transpiler

### DIFF
--- a/tests/transpiler/x/fs/bench_block.fs
+++ b/tests/transpiler/x/fs/bench_block.fs
@@ -1,0 +1,27 @@
+// Generated 2025-07-25 07:54 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let n: int = 1000
+let mutable s: int = 0
+for i in 1 .. (n - 1) do
+    s <- s + i
+let __bench_end = _now()
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": 0,\n  \"name\": \"simple\"\n}" ((__bench_end - __bench_start) / 1000)

--- a/tests/transpiler/x/fs/bench_block.out
+++ b/tests/transpiler/x/fs/bench_block.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "simple"
+}

--- a/transpiler/x/fs/vm_valid_golden_test.go
+++ b/transpiler/x/fs/vm_valid_golden_test.go
@@ -62,6 +62,7 @@ func TestFSTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		run := exec.Command("mono", exe)
+		run.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			run.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- implement BenchStmt in the F# transpiler
- convert `bench` blocks from parser to BenchStmt
- run F# programs with deterministic time seed in tests
- add golden output for `bench_block`

## Testing
- `go test -tags slow ./transpiler/x/fs -run TestFSTranspiler_VMValid_Golden/bench_block -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882d608e70883208e93e19f202f614e