### PR TITLE
Add Kotlin benchmark wrapping and checklist table

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -791,7 +791,8 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return javatr.Emit(p), nil
 	case "kotlin", "kt":
-		p, err := kt.Transpile(env, prog)
+		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
+		p, err := kt.Transpile(env, prog, bench)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/gen_kt_golden.go
+++ b/scripts/gen_kt_golden.go
@@ -38,7 +38,7 @@ func runCase(name string) error {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		return fmt.Errorf("type: %v", errs[0])
 	}
-	ast, err := kt.Transpile(env, prog)
+	ast, err := kt.Transpile(env, prog, false)
 	if err != nil {
 		return fmt.Errorf("transpile: %v", err)
 	}

--- a/tests/rosetta/transpiler/Kotlin/100-doors-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/100-doors-2.kt
@@ -1,15 +1,51 @@
-fun main() {
-    var door: Int = 1
-    var incrementer: Int = 0
-    for (current in 1 until 101) {
-        var line: String = ("Door " + (current.toString()).toString()) + " "
-        if (current == door) {
-            line = line + "Open"
-            incrementer = incrementer + 1
-            door = (door + (2 * incrementer)) + 1
-        } else {
-            line = line + "Closed"
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Int {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
         }
-        println(line)
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        _nowSeed.toInt()
+    } else {
+        System.nanoTime().toInt()
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+var door: Int = 1
+var incrementer: Int = 0
+fun main() {
+    run {
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (current in 1 until 101) {
+            var line: String = ("Door " + current.toString()) + " "
+            if (current == door) {
+                line = line + "Open"
+                incrementer = incrementer + 1
+                door = (door + (2 * incrementer)) + 1
+            } else {
+                line = line + "Closed"
+            }
+            println(line)
+        }
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = _endMem - _startMem
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/100-doors-2.out
+++ b/tests/rosetta/transpiler/Kotlin/100-doors-2.out
@@ -98,3 +98,4 @@ Door 97 Closed
 Door 98 Closed
 Door 99 Closed
 Door 100 Open
+{"duration_us":571223, "memory_bytes":441784, "name":"main"}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,16 +2,17 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-24 18:57 +0700
+Last updated: 2025-07-25 08:23 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **102/103** (auto-generated)
+Completed golden tests: **102/104** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
+- [ ] bench_block.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
 - [x] break_continue.mochi

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -1,293 +1,292 @@
 # Kotlin Rosetta Transpiler
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
+Last updated: 2025-07-25 01:39 UTC
 
-Last updated: 2025-07-24 18:57 +0700
-
-Completed tasks: **54/284**
-
-### Checklist
-1. [x] `100-doors-2` (1)
-2. [x] `100-doors-3` (2)
-3. [x] `100-doors` (3)
-4. [x] `100-prisoners` (4)
-5. [x] `15-puzzle-game` (5)
-6. [x] `15-puzzle-solver` (6)
-7. [x] `2048` (7)
-8. [x] `21-game` (8)
-9. [x] `24-game-solve` (9)
-10. [x] `24-game` (10)
-11. [x] `4-rings-or-4-squares-puzzle` (11)
-12. [x] `9-billion-names-of-god-the-integer` (12)
-13. [x] `99-bottles-of-beer-2` (13)
-14. [x] `99-bottles-of-beer` (14)
-15. [x] `DNS-query` (15)
-16. [x] `a+b` (16)
-17. [x] `abbreviations-automatic` (17)
-18. [x] `abbreviations-easy` (18)
-19. [x] `abbreviations-simple` (19)
-20. [x] `abc-problem` (20)
-21. [x] `abelian-sandpile-model-identity` (21)
-22. [x] `abelian-sandpile-model` (22)
-23. [x] `abstract-type` (23)
-24. [x] `abundant-deficient-and-perfect-number-classifications` (24)
-25. [x] `abundant-odd-numbers` (25)
-26. [x] `accumulator-factory` (26)
-27. [ ] `achilles-numbers` (27)
-28. [x] `ackermann-function-2` (28)
-29. [x] `ackermann-function-3` (29)
-30. [x] `ackermann-function` (30)
-31. [x] `active-directory-connect` (31)
-32. [x] `active-directory-search-for-a-user` (32)
-33. [x] `active-object` (33)
-34. [x] `add-a-variable-to-a-class-instance-at-runtime` (34)
-35. [x] `additive-primes` (35)
-36. [x] `address-of-a-variable` (36)
-37. [ ] `adfgvx-cipher` (37)
-38. [x] `aks-test-for-primes` (38)
-39. [x] `algebraic-data-types` (39)
-40. [ ] `align-columns` (40)
-41. [ ] `aliquot-sequence-classifications` (41)
-42. [ ] `almkvist-giullera-formula-for-pi` (42)
-43. [x] `almost-prime` (43)
-44. [x] `amb` (44)
-45. [x] `amicable-pairs` (45)
-46. [ ] `anagrams-deranged-anagrams` (46)
-47. [ ] `anagrams` (47)
-48. [x] `angle-difference-between-two-bearings-1` (48)
-49. [x] `angle-difference-between-two-bearings-2` (49)
-50. [x] `angles-geometric-normalization-and-conversion` (50)
-51. [ ] `animate-a-pendulum` (51)
-52. [ ] `animation` (52)
-53. [ ] `anonymous-recursion-1` (53)
-54. [ ] `anonymous-recursion-2` (54)
-55. [x] `anonymous-recursion` (55)
-56. [x] `anti-primes` (56)
-57. [x] `append-a-record-to-the-end-of-a-text-file` (57)
-58. [x] `apply-a-callback-to-an-array-1` (58)
-59. [x] `apply-a-callback-to-an-array-2` (59)
-60. [x] `apply-a-digital-filter-direct-form-ii-transposed-` (60)
-61. [x] `approximate-equality` (61)
-62. [x] `arbitrary-precision-integers-included-` (62)
-63. [x] `archimedean-spiral` (63)
-64. [ ] `arena-storage-pool` (64)
-65. [x] `arithmetic-complex` (65)
-66. [ ] `arithmetic-derivative` (66)
-67. [ ] `arithmetic-evaluation` (67)
-68. [x] `arithmetic-geometric-mean-calculate-pi` (68)
-69. [ ] `arithmetic-geometric-mean` (69)
-70. [ ] `arithmetic-integer-1` (70)
-71. [ ] `arithmetic-integer-2` (71)
-72. [ ] `arithmetic-numbers` (72)
-73. [ ] `arithmetic-rational` (73)
-74. [ ] `array-concatenation` (74)
-75. [ ] `array-length` (75)
-76. [ ] `arrays` (76)
-77. [ ] `ascending-primes` (77)
-78. [ ] `ascii-art-diagram-converter` (78)
-79. [ ] `assertions` (79)
-80. [ ] `associative-array-creation` (80)
-81. [ ] `associative-array-iteration` (81)
-82. [ ] `associative-array-merging` (82)
-83. [ ] `atomic-updates` (83)
-84. [ ] `attractive-numbers` (84)
-85. [ ] `average-loop-length` (85)
-86. [ ] `averages-arithmetic-mean` (86)
-87. [ ] `averages-mean-time-of-day` (87)
-88. [ ] `averages-median-1` (88)
-89. [ ] `averages-median-2` (89)
-90. [ ] `averages-median-3` (90)
-91. [ ] `averages-mode` (91)
-92. [ ] `averages-pythagorean-means` (92)
-93. [ ] `averages-root-mean-square` (93)
-94. [ ] `averages-simple-moving-average` (94)
-95. [ ] `avl-tree` (95)
-96. [ ] `b-zier-curves-intersections` (96)
-97. [ ] `babbage-problem` (97)
-98. [ ] `babylonian-spiral` (98)
-99. [ ] `balanced-brackets` (99)
-100. [ ] `balanced-ternary` (100)
-101. [ ] `barnsley-fern` (101)
-102. [ ] `base64-decode-data` (102)
-103. [ ] `bell-numbers` (103)
-104. [ ] `benfords-law` (104)
-105. [ ] `bernoulli-numbers` (105)
-106. [ ] `best-shuffle` (106)
-107. [ ] `bifid-cipher` (107)
-108. [ ] `bin-given-limits` (108)
-109. [ ] `binary-digits` (109)
-110. [ ] `binary-search` (110)
-111. [ ] `binary-strings` (111)
-112. [ ] `bioinformatics-base-count` (112)
-113. [ ] `bioinformatics-global-alignment` (113)
-114. [ ] `bioinformatics-sequence-mutation` (114)
-115. [ ] `biorhythms` (115)
-116. [ ] `bitcoin-address-validation` (116)
-117. [ ] `bitmap-b-zier-curves-cubic` (117)
-118. [ ] `bitmap-b-zier-curves-quadratic` (118)
-119. [ ] `bitmap-bresenhams-line-algorithm` (119)
-120. [ ] `bitmap-flood-fill` (120)
-121. [ ] `bitmap-histogram` (121)
-122. [ ] `bitmap-midpoint-circle-algorithm` (122)
-123. [ ] `bitmap-ppm-conversion-through-a-pipe` (123)
-124. [ ] `bitmap-read-a-ppm-file` (124)
-125. [ ] `bitmap-read-an-image-through-a-pipe` (125)
-126. [ ] `bitmap-write-a-ppm-file` (126)
-127. [ ] `bitmap` (127)
-128. [ ] `bitwise-io-1` (128)
-129. [ ] `bitwise-io-2` (129)
-130. [ ] `bitwise-operations` (130)
-131. [ ] `blum-integer` (131)
-132. [ ] `boolean-values` (132)
-133. [ ] `box-the-compass` (133)
-134. [ ] `boyer-moore-string-search` (134)
-135. [ ] `brazilian-numbers` (135)
-136. [ ] `break-oo-privacy` (136)
-137. [ ] `brilliant-numbers` (137)
-138. [ ] `brownian-tree` (138)
-139. [ ] `bulls-and-cows-player` (139)
-140. [ ] `bulls-and-cows` (140)
-141. [ ] `burrows-wheeler-transform` (141)
-142. [ ] `caesar-cipher-1` (142)
-143. [ ] `caesar-cipher-2` (143)
-144. [ ] `calculating-the-value-of-e` (144)
-145. [ ] `calendar---for-real-programmers-1` (145)
-146. [ ] `calendar---for-real-programmers-2` (146)
-147. [ ] `calendar` (147)
-148. [ ] `calkin-wilf-sequence` (148)
-149. [ ] `call-a-foreign-language-function` (149)
-150. [ ] `call-a-function-1` (150)
-151. [ ] `call-a-function-10` (151)
-152. [ ] `call-a-function-11` (152)
-153. [ ] `call-a-function-12` (153)
-154. [ ] `call-a-function-2` (154)
-155. [ ] `call-a-function-3` (155)
-156. [ ] `call-a-function-4` (156)
-157. [ ] `call-a-function-5` (157)
-158. [ ] `call-a-function-6` (158)
-159. [ ] `call-a-function-7` (159)
-160. [ ] `call-a-function-8` (160)
-161. [ ] `call-a-function-9` (161)
-162. [ ] `call-an-object-method-1` (162)
-163. [ ] `call-an-object-method-2` (163)
-164. [ ] `call-an-object-method-3` (164)
-165. [ ] `call-an-object-method` (165)
-166. [ ] `camel-case-and-snake-case` (166)
-167. [ ] `canny-edge-detector` (167)
-168. [ ] `canonicalize-cidr` (168)
-169. [ ] `cantor-set` (169)
-170. [ ] `carmichael-3-strong-pseudoprimes` (170)
-171. [ ] `cartesian-product-of-two-or-more-lists-1` (171)
-172. [ ] `cartesian-product-of-two-or-more-lists-2` (172)
-173. [ ] `cartesian-product-of-two-or-more-lists-3` (173)
-174. [ ] `cartesian-product-of-two-or-more-lists-4` (174)
-175. [ ] `case-sensitivity-of-identifiers` (175)
-176. [ ] `casting-out-nines` (176)
-177. [ ] `catalan-numbers-1` (177)
-178. [ ] `catalan-numbers-2` (178)
-179. [ ] `catalan-numbers-pascals-triangle` (179)
-180. [ ] `catamorphism` (180)
-181. [ ] `catmull-clark-subdivision-surface` (181)
-182. [ ] `chaocipher` (182)
-183. [ ] `chaos-game` (183)
-184. [ ] `character-codes-1` (184)
-185. [ ] `character-codes-2` (185)
-186. [ ] `character-codes-3` (186)
-187. [ ] `character-codes-4` (187)
-188. [ ] `character-codes-5` (188)
-189. [ ] `chat-server` (189)
-190. [ ] `check-machin-like-formulas` (190)
-191. [ ] `check-that-file-exists` (191)
-192. [ ] `checkpoint-synchronization-1` (192)
-193. [ ] `checkpoint-synchronization-2` (193)
-194. [ ] `checkpoint-synchronization-3` (194)
-195. [ ] `checkpoint-synchronization-4` (195)
-196. [ ] `chernicks-carmichael-numbers` (196)
-197. [ ] `cheryls-birthday` (197)
-198. [ ] `chinese-remainder-theorem` (198)
-199. [ ] `chinese-zodiac` (199)
-200. [ ] `cholesky-decomposition-1` (200)
-201. [ ] `cholesky-decomposition` (201)
-202. [ ] `chowla-numbers` (202)
-203. [ ] `church-numerals-1` (203)
-204. [ ] `church-numerals-2` (204)
-205. [ ] `circles-of-given-radius-through-two-points` (205)
-206. [ ] `circular-primes` (206)
-207. [ ] `cistercian-numerals` (207)
-208. [ ] `comma-quibbling` (208)
-209. [ ] `compiler-virtual-machine-interpreter` (209)
-210. [ ] `composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k` (210)
-211. [ ] `compound-data-type` (211)
-212. [ ] `concurrent-computing-1` (212)
-213. [ ] `concurrent-computing-2` (213)
-214. [ ] `concurrent-computing-3` (214)
-215. [ ] `conditional-structures-1` (215)
-216. [ ] `conditional-structures-10` (216)
-217. [ ] `conditional-structures-2` (217)
-218. [ ] `conditional-structures-3` (218)
-219. [ ] `conditional-structures-4` (219)
-220. [ ] `conditional-structures-5` (220)
-221. [ ] `conditional-structures-6` (221)
-222. [ ] `conditional-structures-7` (222)
-223. [ ] `conditional-structures-8` (223)
-224. [ ] `conditional-structures-9` (224)
-225. [ ] `consecutive-primes-with-ascending-or-descending-differences` (225)
-226. [ ] `constrained-genericity-1` (226)
-227. [ ] `constrained-genericity-2` (227)
-228. [ ] `constrained-genericity-3` (228)
-229. [ ] `constrained-genericity-4` (229)
-230. [ ] `constrained-random-points-on-a-circle-1` (230)
-231. [ ] `constrained-random-points-on-a-circle-2` (231)
-232. [ ] `continued-fraction` (232)
-233. [ ] `convert-decimal-number-to-rational` (233)
-234. [ ] `convert-seconds-to-compound-duration` (234)
-235. [ ] `convex-hull` (235)
-236. [ ] `conways-game-of-life` (236)
-237. [ ] `copy-a-string-1` (237)
-238. [ ] `copy-a-string-2` (238)
-239. [ ] `copy-stdin-to-stdout-1` (239)
-240. [ ] `copy-stdin-to-stdout-2` (240)
-241. [ ] `count-in-factors` (241)
-242. [ ] `count-in-octal-1` (242)
-243. [ ] `count-in-octal-2` (243)
-244. [ ] `count-in-octal-3` (244)
-245. [ ] `count-in-octal-4` (245)
-246. [ ] `count-occurrences-of-a-substring` (246)
-247. [ ] `count-the-coins-1` (247)
-248. [ ] `count-the-coins-2` (248)
-249. [ ] `cramers-rule` (249)
-250. [ ] `crc-32-1` (250)
-251. [ ] `crc-32-2` (251)
-252. [ ] `create-a-file-on-magnetic-tape` (252)
-253. [ ] `create-a-file` (253)
-254. [ ] `create-a-two-dimensional-array-at-runtime-1` (254)
-255. [ ] `create-an-html-table` (255)
-256. [ ] `create-an-object-at-a-given-address` (256)
-257. [ ] `csv-data-manipulation` (257)
-258. [ ] `csv-to-html-translation-1` (258)
-259. [ ] `csv-to-html-translation-2` (259)
-260. [ ] `csv-to-html-translation-3` (260)
-261. [ ] `csv-to-html-translation-4` (261)
-262. [ ] `csv-to-html-translation-5` (262)
-263. [ ] `cuban-primes` (263)
-264. [ ] `cullen-and-woodall-numbers` (264)
-265. [ ] `cumulative-standard-deviation` (265)
-266. [ ] `currency` (266)
-267. [ ] `currying` (267)
-268. [ ] `curzon-numbers` (268)
-269. [ ] `cusip` (269)
-270. [ ] `cyclops-numbers` (270)
-271. [ ] `damm-algorithm` (271)
-272. [ ] `date-format` (272)
-273. [ ] `date-manipulation` (273)
-274. [ ] `day-of-the-week` (274)
-275. [ ] `de-bruijn-sequences` (275)
-276. [ ] `deal-cards-for-freecell` (276)
-277. [ ] `death-star` (277)
-278. [ ] `deceptive-numbers` (278)
-279. [ ] `deconvolution-1d-2` (279)
-280. [ ] `deconvolution-1d-3` (280)
-281. [ ] `deconvolution-1d` (281)
-282. [ ] `deepcopy-1` (282)
-283. [ ] `define-a-primitive-data-type` (283)
-284. [ ] `md5` (284)
+## Rosetta Golden Test Checklist (54/284)
+| Index | Name | Status | Duration | Memory |
+|------:|------|:-----:|---------:|-------:|
+| 1 | 100-doors-2 | ✓ | 571.223ms | 431.4 KB |
+| 2 | 100-doors-3 | ✓ |  |  |
+| 3 | 100-doors | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  |  |
+| 5 | 15-puzzle-game | ✓ |  |  |
+| 6 | 15-puzzle-solver | ✓ |  |  |
+| 7 | 2048 | ✓ |  |  |
+| 8 | 21-game | ✓ |  |  |
+| 9 | 24-game-solve | ✓ |  |  |
+| 10 | 24-game | ✓ |  |  |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ✓ |  |  |
+| 13 | 99-bottles-of-beer-2 | ✓ |  |  |
+| 14 | 99-bottles-of-beer | ✓ |  |  |
+| 15 | DNS-query | ✓ |  |  |
+| 16 | a+b | ✓ |  |  |
+| 17 | abbreviations-automatic | ✓ |  |  |
+| 18 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-simple | ✓ |  |  |
+| 20 | abc-problem | ✓ |  |  |
+| 21 | abelian-sandpile-model-identity | ✓ |  |  |
+| 22 | abelian-sandpile-model | ✓ |  |  |
+| 23 | abstract-type | ✓ |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
+| 25 | abundant-odd-numbers | ✓ |  |  |
+| 26 | accumulator-factory | ✓ |  |  |
+| 27 | achilles-numbers |   |  |  |
+| 28 | ackermann-function-2 | ✓ |  |  |
+| 29 | ackermann-function-3 | ✓ |  |  |
+| 30 | ackermann-function | ✓ |  |  |
+| 31 | active-directory-connect | ✓ |  |  |
+| 32 | active-directory-search-for-a-user | ✓ |  |  |
+| 33 | active-object | ✓ |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ |  |  |
+| 35 | additive-primes | ✓ |  |  |
+| 36 | address-of-a-variable | ✓ |  |  |
+| 37 | adfgvx-cipher |   |  |  |
+| 38 | aks-test-for-primes | ✓ |  |  |
+| 39 | algebraic-data-types | ✓ |  |  |
+| 40 | align-columns |   |  |  |
+| 41 | aliquot-sequence-classifications |   |  |  |
+| 42 | almkvist-giullera-formula-for-pi |   |  |  |
+| 43 | almost-prime | ✓ |  |  |
+| 44 | amb | ✓ |  |  |
+| 45 | amicable-pairs | ✓ |  |  |
+| 46 | anagrams-deranged-anagrams |   |  |  |
+| 47 | anagrams |   |  |  |
+| 48 | angle-difference-between-two-bearings-1 | ✓ |  |  |
+| 49 | angle-difference-between-two-bearings-2 | ✓ |  |  |
+| 50 | angles-geometric-normalization-and-conversion | ✓ |  |  |
+| 51 | animate-a-pendulum |   |  |  |
+| 52 | animation |   |  |  |
+| 53 | anonymous-recursion-1 |   |  |  |
+| 54 | anonymous-recursion-2 |   |  |  |
+| 55 | anonymous-recursion | ✓ |  |  |
+| 56 | anti-primes | ✓ |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file | ✓ |  |  |
+| 58 | apply-a-callback-to-an-array-1 | ✓ |  |  |
+| 59 | apply-a-callback-to-an-array-2 | ✓ |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ |  |  |
+| 61 | approximate-equality | ✓ |  |  |
+| 62 | arbitrary-precision-integers-included- | ✓ |  |  |
+| 63 | archimedean-spiral | ✓ |  |  |
+| 64 | arena-storage-pool |   |  |  |
+| 65 | arithmetic-complex | ✓ |  |  |
+| 66 | arithmetic-derivative |   |  |  |
+| 67 | arithmetic-evaluation |   |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
+| 69 | arithmetic-geometric-mean |   |  |  |
+| 70 | arithmetic-integer-1 |   |  |  |
+| 71 | arithmetic-integer-2 |   |  |  |
+| 72 | arithmetic-numbers |   |  |  |
+| 73 | arithmetic-rational |   |  |  |
+| 74 | array-concatenation |   |  |  |
+| 75 | array-length |   |  |  |
+| 76 | arrays |   |  |  |
+| 77 | ascending-primes |   |  |  |
+| 78 | ascii-art-diagram-converter |   |  |  |
+| 79 | assertions |   |  |  |
+| 80 | associative-array-creation |   |  |  |
+| 81 | associative-array-iteration |   |  |  |
+| 82 | associative-array-merging |   |  |  |
+| 83 | atomic-updates |   |  |  |
+| 84 | attractive-numbers |   |  |  |
+| 85 | average-loop-length |   |  |  |
+| 86 | averages-arithmetic-mean |   |  |  |
+| 87 | averages-mean-time-of-day |   |  |  |
+| 88 | averages-median-1 |   |  |  |
+| 89 | averages-median-2 |   |  |  |
+| 90 | averages-median-3 |   |  |  |
+| 91 | averages-mode |   |  |  |
+| 92 | averages-pythagorean-means |   |  |  |
+| 93 | averages-root-mean-square |   |  |  |
+| 94 | averages-simple-moving-average |   |  |  |
+| 95 | avl-tree |   |  |  |
+| 96 | b-zier-curves-intersections |   |  |  |
+| 97 | babbage-problem |   |  |  |
+| 98 | babylonian-spiral |   |  |  |
+| 99 | balanced-brackets |   |  |  |
+| 100 | balanced-ternary |   |  |  |
+| 101 | barnsley-fern |   |  |  |
+| 102 | base64-decode-data |   |  |  |
+| 103 | bell-numbers |   |  |  |
+| 104 | benfords-law |   |  |  |
+| 105 | bernoulli-numbers |   |  |  |
+| 106 | best-shuffle |   |  |  |
+| 107 | bifid-cipher |   |  |  |
+| 108 | bin-given-limits |   |  |  |
+| 109 | binary-digits |   |  |  |
+| 110 | binary-search |   |  |  |
+| 111 | binary-strings |   |  |  |
+| 112 | bioinformatics-base-count |   |  |  |
+| 113 | bioinformatics-global-alignment |   |  |  |
+| 114 | bioinformatics-sequence-mutation |   |  |  |
+| 115 | biorhythms |   |  |  |
+| 116 | bitcoin-address-validation |   |  |  |
+| 117 | bitmap-b-zier-curves-cubic |   |  |  |
+| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
+| 119 | bitmap-bresenhams-line-algorithm |   |  |  |
+| 120 | bitmap-flood-fill |   |  |  |
+| 121 | bitmap-histogram |   |  |  |
+| 122 | bitmap-midpoint-circle-algorithm |   |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 124 | bitmap-read-a-ppm-file |   |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 126 | bitmap-write-a-ppm-file |   |  |  |
+| 127 | bitmap |   |  |  |
+| 128 | bitwise-io-1 |   |  |  |
+| 129 | bitwise-io-2 |   |  |  |
+| 130 | bitwise-operations |   |  |  |
+| 131 | blum-integer |   |  |  |
+| 132 | boolean-values |   |  |  |
+| 133 | box-the-compass |   |  |  |
+| 134 | boyer-moore-string-search |   |  |  |
+| 135 | brazilian-numbers |   |  |  |
+| 136 | break-oo-privacy |   |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree |   |  |  |
+| 139 | bulls-and-cows-player |   |  |  |
+| 140 | bulls-and-cows |   |  |  |
+| 141 | burrows-wheeler-transform |   |  |  |
+| 142 | caesar-cipher-1 |   |  |  |
+| 143 | caesar-cipher-2 |   |  |  |
+| 144 | calculating-the-value-of-e |   |  |  |
+| 145 | calendar---for-real-programmers-1 |   |  |  |
+| 146 | calendar---for-real-programmers-2 |   |  |  |
+| 147 | calendar |   |  |  |
+| 148 | calkin-wilf-sequence |   |  |  |
+| 149 | call-a-foreign-language-function |   |  |  |
+| 150 | call-a-function-1 |   |  |  |
+| 151 | call-a-function-10 |   |  |  |
+| 152 | call-a-function-11 |   |  |  |
+| 153 | call-a-function-12 |   |  |  |
+| 154 | call-a-function-2 |   |  |  |
+| 155 | call-a-function-3 |   |  |  |
+| 156 | call-a-function-4 |   |  |  |
+| 157 | call-a-function-5 |   |  |  |
+| 158 | call-a-function-6 |   |  |  |
+| 159 | call-a-function-7 |   |  |  |
+| 160 | call-a-function-8 |   |  |  |
+| 161 | call-a-function-9 |   |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case |   |  |  |
+| 167 | canny-edge-detector |   |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set |   |  |  |
+| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers |   |  |  |
+| 176 | casting-out-nines |   |  |  |
+| 177 | catalan-numbers-1 |   |  |  |
+| 178 | catalan-numbers-2 |   |  |  |
+| 179 | catalan-numbers-pascals-triangle |   |  |  |
+| 180 | catamorphism |   |  |  |
+| 181 | catmull-clark-subdivision-surface |   |  |  |
+| 182 | chaocipher |   |  |  |
+| 183 | chaos-game |   |  |  |
+| 184 | character-codes-1 |   |  |  |
+| 185 | character-codes-2 |   |  |  |
+| 186 | character-codes-3 |   |  |  |
+| 187 | character-codes-4 |   |  |  |
+| 188 | character-codes-5 |   |  |  |
+| 189 | chat-server |   |  |  |
+| 190 | check-machin-like-formulas |   |  |  |
+| 191 | check-that-file-exists |   |  |  |
+| 192 | checkpoint-synchronization-1 |   |  |  |
+| 193 | checkpoint-synchronization-2 |   |  |  |
+| 194 | checkpoint-synchronization-3 |   |  |  |
+| 195 | checkpoint-synchronization-4 |   |  |  |
+| 196 | chernicks-carmichael-numbers |   |  |  |
+| 197 | cheryls-birthday |   |  |  |
+| 198 | chinese-remainder-theorem |   |  |  |
+| 199 | chinese-zodiac |   |  |  |
+| 200 | cholesky-decomposition-1 |   |  |  |
+| 201 | cholesky-decomposition |   |  |  |
+| 202 | chowla-numbers |   |  |  |
+| 203 | church-numerals-1 |   |  |  |
+| 204 | church-numerals-2 |   |  |  |
+| 205 | circles-of-given-radius-through-two-points |   |  |  |
+| 206 | circular-primes |   |  |  |
+| 207 | cistercian-numerals |   |  |  |
+| 208 | comma-quibbling |   |  |  |
+| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 211 | compound-data-type |   |  |  |
+| 212 | concurrent-computing-1 |   |  |  |
+| 213 | concurrent-computing-2 |   |  |  |
+| 214 | concurrent-computing-3 |   |  |  |
+| 215 | conditional-structures-1 |   |  |  |
+| 216 | conditional-structures-10 |   |  |  |
+| 217 | conditional-structures-2 |   |  |  |
+| 218 | conditional-structures-3 |   |  |  |
+| 219 | conditional-structures-4 |   |  |  |
+| 220 | conditional-structures-5 |   |  |  |
+| 221 | conditional-structures-6 |   |  |  |
+| 222 | conditional-structures-7 |   |  |  |
+| 223 | conditional-structures-8 |   |  |  |
+| 224 | conditional-structures-9 |   |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 |   |  |  |
+| 227 | constrained-genericity-2 |   |  |  |
+| 228 | constrained-genericity-3 |   |  |  |
+| 229 | constrained-genericity-4 |   |  |  |
+| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 232 | continued-fraction |   |  |  |
+| 233 | convert-decimal-number-to-rational |   |  |  |
+| 234 | convert-seconds-to-compound-duration |   |  |  |
+| 235 | convex-hull |   |  |  |
+| 236 | conways-game-of-life |   |  |  |
+| 237 | copy-a-string-1 |   |  |  |
+| 238 | copy-a-string-2 |   |  |  |
+| 239 | copy-stdin-to-stdout-1 |   |  |  |
+| 240 | copy-stdin-to-stdout-2 |   |  |  |
+| 241 | count-in-factors |   |  |  |
+| 242 | count-in-octal-1 |   |  |  |
+| 243 | count-in-octal-2 |   |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring |   |  |  |
+| 247 | count-the-coins-1 |   |  |  |
+| 248 | count-the-coins-2 |   |  |  |
+| 249 | cramers-rule |   |  |  |
+| 250 | crc-32-1 |   |  |  |
+| 251 | crc-32-2 |   |  |  |
+| 252 | create-a-file-on-magnetic-tape |   |  |  |
+| 253 | create-a-file |   |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 255 | create-an-html-table |   |  |  |
+| 256 | create-an-object-at-a-given-address |   |  |  |
+| 257 | csv-data-manipulation |   |  |  |
+| 258 | csv-to-html-translation-1 |   |  |  |
+| 259 | csv-to-html-translation-2 |   |  |  |
+| 260 | csv-to-html-translation-3 |   |  |  |
+| 261 | csv-to-html-translation-4 |   |  |  |
+| 262 | csv-to-html-translation-5 |   |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers |   |  |  |
+| 265 | cumulative-standard-deviation |   |  |  |
+| 266 | currency |   |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers |   |  |  |
+| 269 | cusip |   |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm |   |  |  |
+| 272 | date-format |   |  |  |
+| 273 | date-manipulation |   |  |  |
+| 274 | day-of-the-week |   |  |  |
+| 275 | de-bruijn-sequences |   |  |  |
+| 276 | deal-cards-for-freecell |   |  |  |
+| 277 | death-star |   |  |  |
+| 278 | deceptive-numbers |   |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,9 @@
+## VM Golden Progress (2025-07-25 08:23 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 08:23 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-24 18:57 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -2265,7 +2265,7 @@ func handleImport(env *types.Env, im *parser.ImportStmt) bool {
 }
 
 // Transpile converts a Mochi program to a simple Kotlin AST.
-func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
+func Transpile(env *types.Env, prog *parser.Program, benchMain bool) (*Program, error) {
 	extraDecls = nil
 	extraUnions = nil
 	extraHelpers = nil
@@ -2561,6 +2561,11 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 		default:
 			return nil, fmt.Errorf("unsupported statement")
 		}
+	}
+	if benchMain {
+		useHelper("_now")
+		useHelper("toJson")
+		p.Stmts = []Stmt{&BenchStmt{Name: "main", Body: p.Stmts}}
 	}
 	p.Structs = extraDecls
 	p.Unions = extraUnions

--- a/transpiler/x/kt/transpiler_test.go
+++ b/transpiler/x/kt/transpiler_test.go
@@ -61,7 +61,8 @@ func TestTranspilePrograms(t *testing.T) {
 			_ = os.WriteFile(errPath, []byte("type: "+errs[0].Error()), 0o644)
 			return nil, errs[0]
 		}
-		ast, err := kt.Transpile(env, prog)
+		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
+		ast, err := kt.Transpile(env, prog, bench)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
 			return nil, err


### PR DESCRIPTION
## Summary
- add benchMain flag to Kotlin transpiler and wrap main body in a Bench block
- update rosetta helpers to keep progress in a table format with duration/memory stats
- support MOCHI_BENCHMARK env in Kotlin rosetta and golden tests
- update CLI generation logic for kotlin
- regenerate golden files and progress data

## Testing
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/kt -run TestRosettaKotlin -count=1 -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_6882ddcf0f648320aabbede07fc2893d