### PR TITLE
Enhance Go transpiler with benchmark mode

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -696,7 +696,8 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		if err != nil {
 			return nil, err
 		}
-		return gotrans.Emit(p), nil
+		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
+		return gotrans.Emit(p, bench), nil
 	case "ts":
 		p, err := tstranspiler.Transpile(prog, env)
 		if err != nil {

--- a/transpiler/x/go/transpiler_test.go
+++ b/transpiler/x/go/transpiler_test.go
@@ -54,7 +54,7 @@ func TestTranspilePrintHello(t *testing.T) {
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
-	code := gotrans.Emit(gprog)
+	code := gotrans.Emit(gprog, false)
 	goFile := filepath.Join(outDir, "print_hello.go")
 	if err := os.WriteFile(goFile, code, 0o644); err != nil {
 		t.Fatalf("write: %v", err)

--- a/transpiler/x/go/vm_valid_golden_test.go
+++ b/transpiler/x/go/vm_valid_golden_test.go
@@ -47,7 +47,7 @@ func TestGoTranspiler_VMValid_Golden(t *testing.T) {
 			_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 			return nil, err
 		}
-		code := gotrans.Emit(gprog)
+		code := gotrans.Emit(gprog, os.Getenv("MOCHI_BENCHMARK") == "true")
 		if err := os.WriteFile(codePath, code, 0o644); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- add benchmark support for Go transpiler
- wrap main body in BenchStmt when flag is enabled
- update CLI and tests for new Emit signature
- add helpers in rosetta tests for benchmark runs
- support `map.keys()` method

## Testing
- `go test ./transpiler/x/go -tags=slow -run TestTranspilePrintHello -count=1`
- `MOCHI_ROSETTA_INDEX=27 go test ./transpiler/x/go -tags=slow -run Rosetta -update -count=1` *(fails: unsupported method keys before fix, then passes)*


------
https://chatgpt.com/codex/tasks/task_e_6882db66924c83208c52b73fa231287a