### PR TITLE
Add benchmark wrapper for F# transpiler

### DIFF
--- a/tests/rosetta/transpiler/FS/100-doors-2.fs
+++ b/tests/rosetta/transpiler/FS/100-doors-2.fs
@@ -1,5 +1,25 @@
-// Generated 2025-07-22 22:23 +0700
+// Generated 2025-07-25 01:38 +0000
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
 let mutable door: int = 1
 let mutable incrementer: int = 0
 for current in 1 .. (101 - 1) do
@@ -11,3 +31,6 @@ for current in 1 .. (101 - 1) do
     else
         line <- line + "Closed"
     printfn "%s" line
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/100-doors-2.out
+++ b/tests/rosetta/transpiler/FS/100-doors-2.out
@@ -98,3 +98,8 @@ Door 97 Closed
 Door 98 Closed
 Door 99 Closed
 Door 100 Open
+{
+  "duration_us": 339,
+  "memory_bytes": 46304,
+  "name": "main"
+}

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -2,13 +2,14 @@
 
 This folder contains an experimental transpiler that converts Mochi source code into F#.
 
-## Golden Test Checklist (102/103)
+## Golden Test Checklist (103/104)
 
 The list below tracks Mochi programs under `tests/vm/valid` that should successfully transpile. Checked items indicate tests known to work.
 
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
+- [x] bench_block.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
 - [x] break_continue.mochi
@@ -110,4 +111,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-07-24 18:50 +0000
+Last updated: 2025-07-25 01:38 +0000

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,290 +2,292 @@
 
 This file is auto-generated from rosetta tests.
 
-## Checklist (66/284)
-1. [x] 100-doors-2 (index 1)
-2. [x] 100-doors-3 (index 2)
-3. [x] 100-doors (index 3)
-4. [x] 100-prisoners (index 4)
-5. [x] 15-puzzle-game (index 5)
-6. [ ] 15-puzzle-solver (index 6)
-7. [x] 2048 (index 7)
-8. [ ] 21-game (index 8)
-9. [x] 24-game-solve (index 9)
-10. [x] 24-game (index 10)
-11. [x] 4-rings-or-4-squares-puzzle (index 11)
-12. [x] 9-billion-names-of-god-the-integer (index 12)
-13. [x] 99-bottles-of-beer-2 (index 13)
-14. [x] 99-bottles-of-beer (index 14)
-15. [x] DNS-query (index 15)
-16. [x] a+b (index 16)
-17. [x] abbreviations-automatic (index 17)
-18. [x] abbreviations-easy (index 18)
-19. [x] abbreviations-simple (index 19)
-20. [ ] abc-problem (index 20)
-21. [x] abelian-sandpile-model-identity (index 21)
-22. [x] abelian-sandpile-model (index 22)
-23. [x] abstract-type (index 23)
-24. [x] abundant-deficient-and-perfect-number-classifications (index 24)
-25. [x] abundant-odd-numbers (index 25)
-26. [ ] accumulator-factory (index 26)
-27. [ ] achilles-numbers (index 27)
-28. [ ] ackermann-function-2 (index 28)
-29. [ ] ackermann-function-3 (index 29)
-30. [x] ackermann-function (index 30)
-31. [x] active-directory-connect (index 31)
-32. [x] active-directory-search-for-a-user (index 32)
-33. [x] active-object (index 33)
-34. [ ] add-a-variable-to-a-class-instance-at-runtime (index 34)
-35. [x] additive-primes (index 35)
-36. [x] address-of-a-variable (index 36)
-37. [ ] adfgvx-cipher (index 37)
-38. [x] aks-test-for-primes (index 38)
-39. [ ] algebraic-data-types (index 39)
-40. [x] align-columns (index 40)
-41. [ ] aliquot-sequence-classifications (index 41)
-42. [ ] almkvist-giullera-formula-for-pi (index 42)
-43. [x] almost-prime (index 43)
-44. [ ] amb (index 44)
-45. [x] amicable-pairs (index 45)
-46. [x] anagrams-deranged-anagrams (index 46)
-47. [x] anagrams (index 47)
-48. [ ] angle-difference-between-two-bearings-1 (index 48)
-49. [ ] angle-difference-between-two-bearings-2 (index 49)
-50. [x] angles-geometric-normalization-and-conversion (index 50)
-51. [x] animate-a-pendulum (index 51)
-52. [x] animation (index 52)
-53. [x] anonymous-recursion-1 (index 53)
-54. [x] anonymous-recursion-2 (index 54)
-55. [x] anonymous-recursion (index 55)
-56. [x] anti-primes (index 56)
-57. [x] append-a-record-to-the-end-of-a-text-file (index 57)
-58. [x] apply-a-callback-to-an-array-1 (index 58)
-59. [x] apply-a-callback-to-an-array-2 (index 59)
-60. [x] apply-a-digital-filter-direct-form-ii-transposed- (index 60)
-61. [x] approximate-equality (index 61)
-62. [x] arbitrary-precision-integers-included- (index 62)
-63. [x] archimedean-spiral (index 63)
-64. [x] arena-storage-pool (index 64)
-65. [x] arithmetic-complex (index 65)
-66. [x] arithmetic-derivative (index 66)
-67. [x] arithmetic-evaluation (index 67)
-68. [x] arithmetic-geometric-mean-calculate-pi (index 68)
-69. [x] arithmetic-geometric-mean (index 69)
-70. [x] arithmetic-integer-1 (index 70)
-71. [x] arithmetic-integer-2 (index 71)
-72. [ ] arithmetic-numbers (index 72)
-73. [x] arithmetic-rational (index 73)
-74. [x] array-concatenation (index 74)
-75. [x] array-length (index 75)
-76. [x] arrays (index 76)
-77. [x] ascending-primes (index 77)
-78. [x] ascii-art-diagram-converter (index 78)
-79. [x] assertions (index 79)
-80. [x] associative-array-creation (index 80)
-81. [x] associative-array-iteration (index 81)
-82. [x] associative-array-merging (index 82)
-83. [ ] atomic-updates (index 83)
-84. [ ] attractive-numbers (index 84)
-85. [ ] average-loop-length (index 85)
-86. [ ] averages-arithmetic-mean (index 86)
-87. [ ] averages-mean-time-of-day (index 87)
-88. [ ] averages-median-1 (index 88)
-89. [ ] averages-median-2 (index 89)
-90. [ ] averages-median-3 (index 90)
-91. [ ] averages-mode (index 91)
-92. [ ] averages-pythagorean-means (index 92)
-93. [ ] averages-root-mean-square (index 93)
-94. [ ] averages-simple-moving-average (index 94)
-95. [ ] avl-tree (index 95)
-96. [ ] b-zier-curves-intersections (index 96)
-97. [ ] babbage-problem (index 97)
-98. [ ] babylonian-spiral (index 98)
-99. [ ] balanced-brackets (index 99)
-100. [ ] balanced-ternary (index 100)
-101. [ ] barnsley-fern (index 101)
-102. [ ] base64-decode-data (index 102)
-103. [ ] bell-numbers (index 103)
-104. [ ] benfords-law (index 104)
-105. [ ] bernoulli-numbers (index 105)
-106. [ ] best-shuffle (index 106)
-107. [ ] bifid-cipher (index 107)
-108. [ ] bin-given-limits (index 108)
-109. [ ] binary-digits (index 109)
-110. [ ] binary-search (index 110)
-111. [ ] binary-strings (index 111)
-112. [ ] bioinformatics-base-count (index 112)
-113. [ ] bioinformatics-global-alignment (index 113)
-114. [ ] bioinformatics-sequence-mutation (index 114)
-115. [ ] biorhythms (index 115)
-116. [ ] bitcoin-address-validation (index 116)
-117. [ ] bitmap-b-zier-curves-cubic (index 117)
-118. [ ] bitmap-b-zier-curves-quadratic (index 118)
-119. [ ] bitmap-bresenhams-line-algorithm (index 119)
-120. [ ] bitmap-flood-fill (index 120)
-121. [ ] bitmap-histogram (index 121)
-122. [ ] bitmap-midpoint-circle-algorithm (index 122)
-123. [ ] bitmap-ppm-conversion-through-a-pipe (index 123)
-124. [ ] bitmap-read-a-ppm-file (index 124)
-125. [ ] bitmap-read-an-image-through-a-pipe (index 125)
-126. [ ] bitmap-write-a-ppm-file (index 126)
-127. [ ] bitmap (index 127)
-128. [ ] bitwise-io-1 (index 128)
-129. [ ] bitwise-io-2 (index 129)
-130. [ ] bitwise-operations (index 130)
-131. [ ] blum-integer (index 131)
-132. [ ] boolean-values (index 132)
-133. [ ] box-the-compass (index 133)
-134. [ ] boyer-moore-string-search (index 134)
-135. [ ] brazilian-numbers (index 135)
-136. [ ] break-oo-privacy (index 136)
-137. [ ] brilliant-numbers (index 137)
-138. [ ] brownian-tree (index 138)
-139. [ ] bulls-and-cows-player (index 139)
-140. [ ] bulls-and-cows (index 140)
-141. [ ] burrows-wheeler-transform (index 141)
-142. [ ] caesar-cipher-1 (index 142)
-143. [ ] caesar-cipher-2 (index 143)
-144. [ ] calculating-the-value-of-e (index 144)
-145. [ ] calendar---for-real-programmers-1 (index 145)
-146. [ ] calendar---for-real-programmers-2 (index 146)
-147. [ ] calendar (index 147)
-148. [ ] calkin-wilf-sequence (index 148)
-149. [ ] call-a-foreign-language-function (index 149)
-150. [ ] call-a-function-1 (index 150)
-151. [ ] call-a-function-10 (index 151)
-152. [ ] call-a-function-11 (index 152)
-153. [ ] call-a-function-12 (index 153)
-154. [ ] call-a-function-2 (index 154)
-155. [ ] call-a-function-3 (index 155)
-156. [ ] call-a-function-4 (index 156)
-157. [ ] call-a-function-5 (index 157)
-158. [ ] call-a-function-6 (index 158)
-159. [ ] call-a-function-7 (index 159)
-160. [ ] call-a-function-8 (index 160)
-161. [ ] call-a-function-9 (index 161)
-162. [ ] call-an-object-method-1 (index 162)
-163. [ ] call-an-object-method-2 (index 163)
-164. [ ] call-an-object-method-3 (index 164)
-165. [ ] call-an-object-method (index 165)
-166. [ ] camel-case-and-snake-case (index 166)
-167. [ ] canny-edge-detector (index 167)
-168. [ ] canonicalize-cidr (index 168)
-169. [ ] cantor-set (index 169)
-170. [ ] carmichael-3-strong-pseudoprimes (index 170)
-171. [ ] cartesian-product-of-two-or-more-lists-1 (index 171)
-172. [ ] cartesian-product-of-two-or-more-lists-2 (index 172)
-173. [ ] cartesian-product-of-two-or-more-lists-3 (index 173)
-174. [ ] cartesian-product-of-two-or-more-lists-4 (index 174)
-175. [ ] case-sensitivity-of-identifiers (index 175)
-176. [ ] casting-out-nines (index 176)
-177. [ ] catalan-numbers-1 (index 177)
-178. [ ] catalan-numbers-2 (index 178)
-179. [ ] catalan-numbers-pascals-triangle (index 179)
-180. [ ] catamorphism (index 180)
-181. [ ] catmull-clark-subdivision-surface (index 181)
-182. [ ] chaocipher (index 182)
-183. [ ] chaos-game (index 183)
-184. [ ] character-codes-1 (index 184)
-185. [ ] character-codes-2 (index 185)
-186. [ ] character-codes-3 (index 186)
-187. [ ] character-codes-4 (index 187)
-188. [ ] character-codes-5 (index 188)
-189. [ ] chat-server (index 189)
-190. [ ] check-machin-like-formulas (index 190)
-191. [ ] check-that-file-exists (index 191)
-192. [ ] checkpoint-synchronization-1 (index 192)
-193. [ ] checkpoint-synchronization-2 (index 193)
-194. [ ] checkpoint-synchronization-3 (index 194)
-195. [ ] checkpoint-synchronization-4 (index 195)
-196. [ ] chernicks-carmichael-numbers (index 196)
-197. [ ] cheryls-birthday (index 197)
-198. [ ] chinese-remainder-theorem (index 198)
-199. [ ] chinese-zodiac (index 199)
-200. [ ] cholesky-decomposition-1 (index 200)
-201. [ ] cholesky-decomposition (index 201)
-202. [ ] chowla-numbers (index 202)
-203. [ ] church-numerals-1 (index 203)
-204. [ ] church-numerals-2 (index 204)
-205. [ ] circles-of-given-radius-through-two-points (index 205)
-206. [ ] circular-primes (index 206)
-207. [ ] cistercian-numerals (index 207)
-208. [ ] comma-quibbling (index 208)
-209. [ ] compiler-virtual-machine-interpreter (index 209)
-210. [ ] composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k (index 210)
-211. [ ] compound-data-type (index 211)
-212. [ ] concurrent-computing-1 (index 212)
-213. [ ] concurrent-computing-2 (index 213)
-214. [ ] concurrent-computing-3 (index 214)
-215. [ ] conditional-structures-1 (index 215)
-216. [ ] conditional-structures-10 (index 216)
-217. [ ] conditional-structures-2 (index 217)
-218. [ ] conditional-structures-3 (index 218)
-219. [ ] conditional-structures-4 (index 219)
-220. [ ] conditional-structures-5 (index 220)
-221. [ ] conditional-structures-6 (index 221)
-222. [ ] conditional-structures-7 (index 222)
-223. [ ] conditional-structures-8 (index 223)
-224. [ ] conditional-structures-9 (index 224)
-225. [ ] consecutive-primes-with-ascending-or-descending-differences (index 225)
-226. [ ] constrained-genericity-1 (index 226)
-227. [ ] constrained-genericity-2 (index 227)
-228. [ ] constrained-genericity-3 (index 228)
-229. [ ] constrained-genericity-4 (index 229)
-230. [ ] constrained-random-points-on-a-circle-1 (index 230)
-231. [ ] constrained-random-points-on-a-circle-2 (index 231)
-232. [ ] continued-fraction (index 232)
-233. [ ] convert-decimal-number-to-rational (index 233)
-234. [ ] convert-seconds-to-compound-duration (index 234)
-235. [ ] convex-hull (index 235)
-236. [ ] conways-game-of-life (index 236)
-237. [ ] copy-a-string-1 (index 237)
-238. [ ] copy-a-string-2 (index 238)
-239. [ ] copy-stdin-to-stdout-1 (index 239)
-240. [ ] copy-stdin-to-stdout-2 (index 240)
-241. [ ] count-in-factors (index 241)
-242. [ ] count-in-octal-1 (index 242)
-243. [ ] count-in-octal-2 (index 243)
-244. [ ] count-in-octal-3 (index 244)
-245. [ ] count-in-octal-4 (index 245)
-246. [ ] count-occurrences-of-a-substring (index 246)
-247. [ ] count-the-coins-1 (index 247)
-248. [ ] count-the-coins-2 (index 248)
-249. [ ] cramers-rule (index 249)
-250. [ ] crc-32-1 (index 250)
-251. [ ] crc-32-2 (index 251)
-252. [ ] create-a-file-on-magnetic-tape (index 252)
-253. [ ] create-a-file (index 253)
-254. [ ] create-a-two-dimensional-array-at-runtime-1 (index 254)
-255. [ ] create-an-html-table (index 255)
-256. [ ] create-an-object-at-a-given-address (index 256)
-257. [ ] csv-data-manipulation (index 257)
-258. [ ] csv-to-html-translation-1 (index 258)
-259. [ ] csv-to-html-translation-2 (index 259)
-260. [ ] csv-to-html-translation-3 (index 260)
-261. [ ] csv-to-html-translation-4 (index 261)
-262. [ ] csv-to-html-translation-5 (index 262)
-263. [ ] cuban-primes (index 263)
-264. [ ] cullen-and-woodall-numbers (index 264)
-265. [ ] cumulative-standard-deviation (index 265)
-266. [ ] currency (index 266)
-267. [ ] currying (index 267)
-268. [ ] curzon-numbers (index 268)
-269. [ ] cusip (index 269)
-270. [ ] cyclops-numbers (index 270)
-271. [ ] damm-algorithm (index 271)
-272. [ ] date-format (index 272)
-273. [ ] date-manipulation (index 273)
-274. [ ] day-of-the-week (index 274)
-275. [ ] de-bruijn-sequences (index 275)
-276. [ ] deal-cards-for-freecell (index 276)
-277. [ ] death-star (index 277)
-278. [ ] deceptive-numbers (index 278)
-279. [ ] deconvolution-1d-2 (index 279)
-280. [ ] deconvolution-1d-3 (index 280)
-281. [ ] deconvolution-1d (index 281)
-282. [ ] deepcopy-1 (index 282)
-283. [ ] define-a-primitive-data-type (index 283)
-284. [ ] md5 (index 284)
+## Rosetta Golden Test Checklist (67/284)
+| Index | Name | Status | Duration | Memory |
+|------:|------|:-----:|---------:|-------:|
+| 1 | 100-doors-2 | ✓ | 339µs | 45.2 KB |
+| 2 | 100-doors-3 | ✓ |  |  |
+| 3 | 100-doors | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  |  |
+| 5 | 15-puzzle-game | ✓ |  |  |
+| 6 | 15-puzzle-solver |   |  |  |
+| 7 | 2048 | ✓ |  |  |
+| 8 | 21-game |   |  |  |
+| 9 | 24-game-solve | ✓ |  |  |
+| 10 | 24-game | ✓ |  |  |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ✓ |  |  |
+| 13 | 99-bottles-of-beer-2 | ✓ |  |  |
+| 14 | 99-bottles-of-beer | ✓ |  |  |
+| 15 | DNS-query | ✓ |  |  |
+| 16 | a+b | ✓ |  |  |
+| 17 | abbreviations-automatic | ✓ |  |  |
+| 18 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-simple | ✓ |  |  |
+| 20 | abc-problem |   |  |  |
+| 21 | abelian-sandpile-model-identity | ✓ |  |  |
+| 22 | abelian-sandpile-model | ✓ |  |  |
+| 23 | abstract-type | ✓ |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
+| 25 | abundant-odd-numbers | ✓ |  |  |
+| 26 | accumulator-factory |   |  |  |
+| 27 | achilles-numbers |   |  |  |
+| 28 | ackermann-function-2 |   |  |  |
+| 29 | ackermann-function-3 |   |  |  |
+| 30 | ackermann-function | ✓ |  |  |
+| 31 | active-directory-connect | ✓ |  |  |
+| 32 | active-directory-search-for-a-user | ✓ |  |  |
+| 33 | active-object | ✓ |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime |   |  |  |
+| 35 | additive-primes | ✓ |  |  |
+| 36 | address-of-a-variable | ✓ |  |  |
+| 37 | adfgvx-cipher |   |  |  |
+| 38 | aks-test-for-primes | ✓ |  |  |
+| 39 | algebraic-data-types |   |  |  |
+| 40 | align-columns | ✓ |  |  |
+| 41 | aliquot-sequence-classifications |   |  |  |
+| 42 | almkvist-giullera-formula-for-pi |   |  |  |
+| 43 | almost-prime | ✓ |  |  |
+| 44 | amb |   |  |  |
+| 45 | amicable-pairs | ✓ |  |  |
+| 46 | anagrams-deranged-anagrams | ✓ |  |  |
+| 47 | anagrams | ✓ |  |  |
+| 48 | angle-difference-between-two-bearings-1 |   |  |  |
+| 49 | angle-difference-between-two-bearings-2 |   |  |  |
+| 50 | angles-geometric-normalization-and-conversion | ✓ |  |  |
+| 51 | animate-a-pendulum | ✓ |  |  |
+| 52 | animation | ✓ |  |  |
+| 53 | anonymous-recursion-1 | ✓ |  |  |
+| 54 | anonymous-recursion-2 | ✓ |  |  |
+| 55 | anonymous-recursion | ✓ |  |  |
+| 56 | anti-primes | ✓ |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file | ✓ |  |  |
+| 58 | apply-a-callback-to-an-array-1 | ✓ |  |  |
+| 59 | apply-a-callback-to-an-array-2 | ✓ |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ |  |  |
+| 61 | approximate-equality | ✓ |  |  |
+| 62 | arbitrary-precision-integers-included- | ✓ |  |  |
+| 63 | archimedean-spiral | ✓ |  |  |
+| 64 | arena-storage-pool | ✓ |  |  |
+| 65 | arithmetic-complex | ✓ |  |  |
+| 66 | arithmetic-derivative | ✓ |  |  |
+| 67 | arithmetic-evaluation | ✓ |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
+| 69 | arithmetic-geometric-mean | ✓ |  |  |
+| 70 | arithmetic-integer-1 | ✓ |  |  |
+| 71 | arithmetic-integer-2 | ✓ |  |  |
+| 72 | arithmetic-numbers | ✓ |  |  |
+| 73 | arithmetic-rational | ✓ |  |  |
+| 74 | array-concatenation | ✓ |  |  |
+| 75 | array-length | ✓ |  |  |
+| 76 | arrays | ✓ |  |  |
+| 77 | ascending-primes | ✓ |  |  |
+| 78 | ascii-art-diagram-converter | ✓ |  |  |
+| 79 | assertions | ✓ |  |  |
+| 80 | associative-array-creation | ✓ |  |  |
+| 81 | associative-array-iteration | ✓ |  |  |
+| 82 | associative-array-merging | ✓ |  |  |
+| 83 | atomic-updates |   |  |  |
+| 84 | attractive-numbers |   |  |  |
+| 85 | average-loop-length |   |  |  |
+| 86 | averages-arithmetic-mean |   |  |  |
+| 87 | averages-mean-time-of-day |   |  |  |
+| 88 | averages-median-1 |   |  |  |
+| 89 | averages-median-2 |   |  |  |
+| 90 | averages-median-3 |   |  |  |
+| 91 | averages-mode |   |  |  |
+| 92 | averages-pythagorean-means |   |  |  |
+| 93 | averages-root-mean-square |   |  |  |
+| 94 | averages-simple-moving-average |   |  |  |
+| 95 | avl-tree |   |  |  |
+| 96 | b-zier-curves-intersections |   |  |  |
+| 97 | babbage-problem |   |  |  |
+| 98 | babylonian-spiral |   |  |  |
+| 99 | balanced-brackets |   |  |  |
+| 100 | balanced-ternary |   |  |  |
+| 101 | barnsley-fern |   |  |  |
+| 102 | base64-decode-data |   |  |  |
+| 103 | bell-numbers |   |  |  |
+| 104 | benfords-law |   |  |  |
+| 105 | bernoulli-numbers |   |  |  |
+| 106 | best-shuffle |   |  |  |
+| 107 | bifid-cipher |   |  |  |
+| 108 | bin-given-limits |   |  |  |
+| 109 | binary-digits |   |  |  |
+| 110 | binary-search |   |  |  |
+| 111 | binary-strings |   |  |  |
+| 112 | bioinformatics-base-count |   |  |  |
+| 113 | bioinformatics-global-alignment |   |  |  |
+| 114 | bioinformatics-sequence-mutation |   |  |  |
+| 115 | biorhythms |   |  |  |
+| 116 | bitcoin-address-validation |   |  |  |
+| 117 | bitmap-b-zier-curves-cubic |   |  |  |
+| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
+| 119 | bitmap-bresenhams-line-algorithm |   |  |  |
+| 120 | bitmap-flood-fill |   |  |  |
+| 121 | bitmap-histogram |   |  |  |
+| 122 | bitmap-midpoint-circle-algorithm |   |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 124 | bitmap-read-a-ppm-file |   |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 126 | bitmap-write-a-ppm-file |   |  |  |
+| 127 | bitmap |   |  |  |
+| 128 | bitwise-io-1 |   |  |  |
+| 129 | bitwise-io-2 |   |  |  |
+| 130 | bitwise-operations |   |  |  |
+| 131 | blum-integer |   |  |  |
+| 132 | boolean-values |   |  |  |
+| 133 | box-the-compass |   |  |  |
+| 134 | boyer-moore-string-search |   |  |  |
+| 135 | brazilian-numbers |   |  |  |
+| 136 | break-oo-privacy |   |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree |   |  |  |
+| 139 | bulls-and-cows-player |   |  |  |
+| 140 | bulls-and-cows |   |  |  |
+| 141 | burrows-wheeler-transform |   |  |  |
+| 142 | caesar-cipher-1 |   |  |  |
+| 143 | caesar-cipher-2 |   |  |  |
+| 144 | calculating-the-value-of-e |   |  |  |
+| 145 | calendar---for-real-programmers-1 |   |  |  |
+| 146 | calendar---for-real-programmers-2 |   |  |  |
+| 147 | calendar |   |  |  |
+| 148 | calkin-wilf-sequence |   |  |  |
+| 149 | call-a-foreign-language-function |   |  |  |
+| 150 | call-a-function-1 |   |  |  |
+| 151 | call-a-function-10 |   |  |  |
+| 152 | call-a-function-11 |   |  |  |
+| 153 | call-a-function-12 |   |  |  |
+| 154 | call-a-function-2 |   |  |  |
+| 155 | call-a-function-3 |   |  |  |
+| 156 | call-a-function-4 |   |  |  |
+| 157 | call-a-function-5 |   |  |  |
+| 158 | call-a-function-6 |   |  |  |
+| 159 | call-a-function-7 |   |  |  |
+| 160 | call-a-function-8 |   |  |  |
+| 161 | call-a-function-9 |   |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case |   |  |  |
+| 167 | canny-edge-detector |   |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set |   |  |  |
+| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers |   |  |  |
+| 176 | casting-out-nines |   |  |  |
+| 177 | catalan-numbers-1 |   |  |  |
+| 178 | catalan-numbers-2 |   |  |  |
+| 179 | catalan-numbers-pascals-triangle |   |  |  |
+| 180 | catamorphism |   |  |  |
+| 181 | catmull-clark-subdivision-surface |   |  |  |
+| 182 | chaocipher |   |  |  |
+| 183 | chaos-game |   |  |  |
+| 184 | character-codes-1 |   |  |  |
+| 185 | character-codes-2 |   |  |  |
+| 186 | character-codes-3 |   |  |  |
+| 187 | character-codes-4 |   |  |  |
+| 188 | character-codes-5 |   |  |  |
+| 189 | chat-server |   |  |  |
+| 190 | check-machin-like-formulas |   |  |  |
+| 191 | check-that-file-exists |   |  |  |
+| 192 | checkpoint-synchronization-1 |   |  |  |
+| 193 | checkpoint-synchronization-2 |   |  |  |
+| 194 | checkpoint-synchronization-3 |   |  |  |
+| 195 | checkpoint-synchronization-4 |   |  |  |
+| 196 | chernicks-carmichael-numbers |   |  |  |
+| 197 | cheryls-birthday |   |  |  |
+| 198 | chinese-remainder-theorem |   |  |  |
+| 199 | chinese-zodiac |   |  |  |
+| 200 | cholesky-decomposition-1 |   |  |  |
+| 201 | cholesky-decomposition |   |  |  |
+| 202 | chowla-numbers |   |  |  |
+| 203 | church-numerals-1 |   |  |  |
+| 204 | church-numerals-2 |   |  |  |
+| 205 | circles-of-given-radius-through-two-points |   |  |  |
+| 206 | circular-primes |   |  |  |
+| 207 | cistercian-numerals |   |  |  |
+| 208 | comma-quibbling |   |  |  |
+| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 211 | compound-data-type |   |  |  |
+| 212 | concurrent-computing-1 |   |  |  |
+| 213 | concurrent-computing-2 |   |  |  |
+| 214 | concurrent-computing-3 |   |  |  |
+| 215 | conditional-structures-1 |   |  |  |
+| 216 | conditional-structures-10 |   |  |  |
+| 217 | conditional-structures-2 |   |  |  |
+| 218 | conditional-structures-3 |   |  |  |
+| 219 | conditional-structures-4 |   |  |  |
+| 220 | conditional-structures-5 |   |  |  |
+| 221 | conditional-structures-6 |   |  |  |
+| 222 | conditional-structures-7 |   |  |  |
+| 223 | conditional-structures-8 |   |  |  |
+| 224 | conditional-structures-9 |   |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 |   |  |  |
+| 227 | constrained-genericity-2 |   |  |  |
+| 228 | constrained-genericity-3 |   |  |  |
+| 229 | constrained-genericity-4 |   |  |  |
+| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 232 | continued-fraction |   |  |  |
+| 233 | convert-decimal-number-to-rational |   |  |  |
+| 234 | convert-seconds-to-compound-duration |   |  |  |
+| 235 | convex-hull |   |  |  |
+| 236 | conways-game-of-life |   |  |  |
+| 237 | copy-a-string-1 |   |  |  |
+| 238 | copy-a-string-2 |   |  |  |
+| 239 | copy-stdin-to-stdout-1 |   |  |  |
+| 240 | copy-stdin-to-stdout-2 |   |  |  |
+| 241 | count-in-factors |   |  |  |
+| 242 | count-in-octal-1 |   |  |  |
+| 243 | count-in-octal-2 |   |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring |   |  |  |
+| 247 | count-the-coins-1 |   |  |  |
+| 248 | count-the-coins-2 |   |  |  |
+| 249 | cramers-rule |   |  |  |
+| 250 | crc-32-1 |   |  |  |
+| 251 | crc-32-2 |   |  |  |
+| 252 | create-a-file-on-magnetic-tape |   |  |  |
+| 253 | create-a-file |   |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 255 | create-an-html-table |   |  |  |
+| 256 | create-an-object-at-a-given-address |   |  |  |
+| 257 | csv-data-manipulation |   |  |  |
+| 258 | csv-to-html-translation-1 |   |  |  |
+| 259 | csv-to-html-translation-2 |   |  |  |
+| 260 | csv-to-html-translation-3 |   |  |  |
+| 261 | csv-to-html-translation-4 |   |  |  |
+| 262 | csv-to-html-translation-5 |   |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers |   |  |  |
+| 265 | cumulative-standard-deviation |   |  |  |
+| 266 | currency |   |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers |   |  |  |
+| 269 | cusip |   |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm |   |  |  |
+| 272 | date-format |   |  |  |
+| 273 | date-manipulation |   |  |  |
+| 274 | day-of-the-week |   |  |  |
+| 275 | de-bruijn-sequences |   |  |  |
+| 276 | deal-cards-for-freecell |   |  |  |
+| 277 | death-star |   |  |  |
+| 278 | deceptive-numbers |   |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |
 
-Last updated: 2025-07-24 18:50 +0000
+Last updated: 2025-07-25 01:38 +0000

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-07-25 01:38 +0000)
+- Applying previous commit.
+- Generated F# for 103/104 programs (103 passing)
+
+## Progress (2025-07-25 08:23 +0700)
+- dart: add bench main support
+- Generated F# for 103/104 programs (103 passing)
+
 ## Progress (2025-07-24 18:50 +0000)
 - fs transpiler: fix map lookup typing
 - Generated F# for 102/103 programs (102 passing)

--- a/transpiler/x/fs/stub.go
+++ b/transpiler/x/fs/stub.go
@@ -14,6 +14,11 @@ import (
 // excluded by build tags.
 type Program struct{}
 
+var benchMain bool
+
+// SetBenchMain is a no-op in the stub build.
+func SetBenchMain(v bool) { benchMain = v }
+
 // Transpile returns a nil program and no error. It exists so packages depending
 // on fstrans compile without requiring the slow implementation.
 func Transpile(_ *parser.Program, _ *types.Env) (*Program, error) {


### PR DESCRIPTION
## Summary
- support benchmark wrapping for main function in fs transpiler
- update fs stub and rosetta tests for benchmark mode
- regenerate benchmarked output for `100-doors-2`
- reformat F# Rosetta checklist with timing/memory columns
- fix benchmark seeding so runtime uses real clock

## Testing
- `MOCHI_ROSETTA_INDEX=1 UPDATE=1 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/fs -run Rosetta -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6882dcf114b08320ba0474680fcdce3f