### PR TITLE
Enhance Java transpiler benchmark support

### DIFF
--- a/tests/rosetta/transpiler/Java/100-prisoners.out
+++ b/tests/rosetta/transpiler/Java/100-prisoners.out
@@ -1,8 +1,9 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 1 relative frequency = 0.0%
-  strategy = optimal  pardoned = 295 relative frequency = 0.0%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0.0%
-  strategy = optimal  pardoned = 303 relative frequency = 0.0%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%
+


### PR DESCRIPTION
## Summary
- add benchMain flag and setter for Java transpiler
- update Rosetta test harness to support benchmark mode and new README table
- fix type conversion bug for boolean arrays
- update golden output for `100-prisoners`

## Testing
- `go test -tags slow ./transpiler/x/java -run Rosetta -index 1 -v`
- `ROSETTA_MAX=4 go test -tags slow ./transpiler/x/java -run Rosetta`


------
https://chatgpt.com/codex/tasks/task_e_6882dd2f93a0832085fa8d372ae8d9bf