### PR TITLE
Update PHP transpiler with benchmark support

### DIFF
--- a/tests/rosetta/transpiler/php/100-doors-2.out
+++ b/tests/rosetta/transpiler/php/100-doors-2.out
@@ -98,3 +98,8 @@ Door 97 Closed
 Door 98 Closed
 Door 99 Closed
 Door 100 Open
+{
+  "duration_us": 571223,
+  "memory_bytes": 136,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/100-doors-2.php
+++ b/tests/rosetta/transpiler/php/100-doors-2.php
@@ -1,14 +1,56 @@
 <?php
-$door = 1;
-$incrementer = 0;
-for ($current = 1; $current < 101; $current++) {
-  $line = "Door " . strval($current) . " ";
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $door = 1;
+  $incrementer = 0;
+  for ($current = 1; $current < 101; $current++) {
+  $line = 'Door ' . _str($current) . ' ';
   if ($current == $door) {
-  $line = $line . "Open";
+  $line = $line . 'Open';
   $incrementer = $incrementer + 1;
   $door = $door + 2 * $incrementer + 1;
 } else {
-  $line = $line . "Closed";
+  $line = $line . 'Closed';
 }
-  echo $line, PHP_EOL;
+  echo rtrim($line), PHP_EOL;
 }
+$__end = _now();
+$__end_mem = memory_get_usage();
+$__duration = intdiv($__end - $__start, 1000);
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;;

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,13 +2,13 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-25 07:55 +0700
+Last updated: 2025-07-25 08:23 +0700
 
-## VM Golden Test Checklist (102/104)
+## VM Golden Test Checklist (103/104)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
-- [ ] bench_block
+- [x] bench_block
 - [x] binary_precedence
 - [x] bool_chain
 - [x] break_continue

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,290 +2,292 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-25 07:55 +0700
+Last updated: 2025-07-25 08:23 +0700
 
 ## Checklist (264/284)
-- [x] 1 100-doors-2
-- [x] 2 100-doors-3
-- [x] 3 100-doors
-- [x] 4 100-prisoners
-- [x] 5 15-puzzle-game
-- [x] 6 15-puzzle-solver
-- [x] 7 2048
-- [x] 8 21-game
-- [x] 9 24-game-solve
-- [x] 10 24-game
-- [x] 11 4-rings-or-4-squares-puzzle
-- [x] 12 9-billion-names-of-god-the-integer
-- [x] 13 99-bottles-of-beer-2
-- [x] 14 99-bottles-of-beer
-- [x] 15 DNS-query
-- [x] 16 a+b
-- [x] 17 abbreviations-automatic
-- [x] 18 abbreviations-easy
-- [x] 19 abbreviations-simple
-- [x] 20 abc-problem
-- [x] 21 abelian-sandpile-model-identity
-- [x] 22 abelian-sandpile-model
-- [x] 23 abstract-type
-- [x] 24 abundant-deficient-and-perfect-number-classifications
-- [x] 25 abundant-odd-numbers
-- [x] 26 accumulator-factory
-- [x] 27 achilles-numbers
-- [x] 28 ackermann-function-2
-- [x] 29 ackermann-function-3
-- [x] 30 ackermann-function
-- [x] 31 active-directory-connect
-- [x] 32 active-directory-search-for-a-user
-- [x] 33 active-object
-- [x] 34 add-a-variable-to-a-class-instance-at-runtime
-- [x] 35 additive-primes
-- [x] 36 address-of-a-variable
-- [x] 37 adfgvx-cipher
-- [x] 38 aks-test-for-primes
-- [x] 39 algebraic-data-types
-- [x] 40 align-columns
-- [x] 41 aliquot-sequence-classifications
-- [x] 42 almkvist-giullera-formula-for-pi
-- [x] 43 almost-prime
-- [x] 44 amb
-- [x] 45 amicable-pairs
-- [x] 46 anagrams-deranged-anagrams
-- [x] 47 anagrams
-- [x] 48 angle-difference-between-two-bearings-1
-- [x] 49 angle-difference-between-two-bearings-2
-- [x] 50 angles-geometric-normalization-and-conversion
-- [x] 51 animate-a-pendulum
-- [x] 52 animation
-- [x] 53 anonymous-recursion-1
-- [x] 54 anonymous-recursion-2
-- [x] 55 anonymous-recursion
-- [x] 56 anti-primes
-- [x] 57 append-a-record-to-the-end-of-a-text-file
-- [x] 58 apply-a-callback-to-an-array-1
-- [x] 59 apply-a-callback-to-an-array-2
-- [x] 60 apply-a-digital-filter-direct-form-ii-transposed-
-- [x] 61 approximate-equality
-- [x] 62 arbitrary-precision-integers-included-
-- [x] 63 archimedean-spiral
-- [x] 64 arena-storage-pool
-- [x] 65 arithmetic-complex
-- [x] 66 arithmetic-derivative
-- [x] 67 arithmetic-evaluation
-- [x] 68 arithmetic-geometric-mean-calculate-pi
-- [x] 69 arithmetic-geometric-mean
-- [x] 70 arithmetic-integer-1
-- [x] 71 arithmetic-integer-2
-- [ ] 72 arithmetic-numbers
-- [x] 73 arithmetic-rational
-- [x] 74 array-concatenation
-- [x] 75 array-length
-- [x] 76 arrays
-- [ ] 77 ascending-primes
-- [x] 78 ascii-art-diagram-converter
-- [x] 79 assertions
-- [x] 80 associative-array-creation
-- [x] 81 associative-array-iteration
-- [x] 82 associative-array-merging
-- [x] 83 atomic-updates
-- [x] 84 attractive-numbers
-- [x] 85 average-loop-length
-- [x] 86 averages-arithmetic-mean
-- [x] 87 averages-mean-time-of-day
-- [x] 88 averages-median-1
-- [x] 89 averages-median-2
-- [x] 90 averages-median-3
-- [x] 91 averages-mode
-- [x] 92 averages-pythagorean-means
-- [x] 93 averages-root-mean-square
-- [x] 94 averages-simple-moving-average
-- [x] 95 avl-tree
-- [x] 96 b-zier-curves-intersections
-- [x] 97 babbage-problem
-- [x] 98 babylonian-spiral
-- [x] 99 balanced-brackets
-- [x] 100 balanced-ternary
-- [x] 101 barnsley-fern
-- [x] 102 base64-decode-data
-- [x] 103 bell-numbers
-- [x] 104 benfords-law
-- [x] 105 bernoulli-numbers
-- [x] 106 best-shuffle
-- [x] 107 bifid-cipher
-- [x] 108 bin-given-limits
-- [x] 109 binary-digits
-- [x] 110 binary-search
-- [x] 111 binary-strings
-- [x] 112 bioinformatics-base-count
-- [x] 113 bioinformatics-global-alignment
-- [x] 114 bioinformatics-sequence-mutation
-- [x] 115 biorhythms
-- [x] 116 bitcoin-address-validation
-- [x] 117 bitmap-b-zier-curves-cubic
-- [x] 118 bitmap-b-zier-curves-quadratic
-- [x] 119 bitmap-bresenhams-line-algorithm
-- [x] 120 bitmap-flood-fill
-- [x] 121 bitmap-histogram
-- [x] 122 bitmap-midpoint-circle-algorithm
-- [x] 123 bitmap-ppm-conversion-through-a-pipe
-- [x] 124 bitmap-read-a-ppm-file
-- [x] 125 bitmap-read-an-image-through-a-pipe
-- [x] 126 bitmap-write-a-ppm-file
-- [x] 127 bitmap
-- [x] 128 bitwise-io-1
-- [x] 129 bitwise-io-2
-- [x] 130 bitwise-operations
-- [x] 131 blum-integer
-- [x] 132 boolean-values
-- [x] 133 box-the-compass
-- [x] 134 boyer-moore-string-search
-- [x] 135 brazilian-numbers
-- [x] 136 break-oo-privacy
-- [ ] 137 brilliant-numbers
-- [x] 138 brownian-tree
-- [x] 139 bulls-and-cows-player
-- [x] 140 bulls-and-cows
-- [x] 141 burrows-wheeler-transform
-- [x] 142 caesar-cipher-1
-- [x] 143 caesar-cipher-2
-- [x] 144 calculating-the-value-of-e
-- [x] 145 calendar---for-real-programmers-1
-- [x] 146 calendar---for-real-programmers-2
-- [x] 147 calendar
-- [x] 148 calkin-wilf-sequence
-- [x] 149 call-a-foreign-language-function
-- [x] 150 call-a-function-1
-- [x] 151 call-a-function-10
-- [x] 152 call-a-function-11
-- [x] 153 call-a-function-12
-- [x] 154 call-a-function-2
-- [x] 155 call-a-function-3
-- [x] 156 call-a-function-4
-- [x] 157 call-a-function-5
-- [x] 158 call-a-function-6
-- [x] 159 call-a-function-7
-- [x] 160 call-a-function-8
-- [x] 161 call-a-function-9
-- [ ] 162 call-an-object-method-1
-- [x] 163 call-an-object-method-2
-- [ ] 164 call-an-object-method-3
-- [ ] 165 call-an-object-method
-- [x] 166 camel-case-and-snake-case
-- [x] 167 canny-edge-detector
-- [ ] 168 canonicalize-cidr
-- [x] 169 cantor-set
-- [x] 170 carmichael-3-strong-pseudoprimes
-- [x] 171 cartesian-product-of-two-or-more-lists-1
-- [x] 172 cartesian-product-of-two-or-more-lists-2
-- [x] 173 cartesian-product-of-two-or-more-lists-3
-- [ ] 174 cartesian-product-of-two-or-more-lists-4
-- [x] 175 case-sensitivity-of-identifiers
-- [x] 176 casting-out-nines
-- [x] 177 catalan-numbers-1
-- [x] 178 catalan-numbers-2
-- [x] 179 catalan-numbers-pascals-triangle
-- [x] 180 catamorphism
-- [x] 181 catmull-clark-subdivision-surface
-- [x] 182 chaocipher
-- [x] 183 chaos-game
-- [x] 184 character-codes-1
-- [x] 185 character-codes-2
-- [x] 186 character-codes-3
-- [x] 187 character-codes-4
-- [x] 188 character-codes-5
-- [x] 189 chat-server
-- [x] 190 check-machin-like-formulas
-- [x] 191 check-that-file-exists
-- [x] 192 checkpoint-synchronization-1
-- [x] 193 checkpoint-synchronization-2
-- [x] 194 checkpoint-synchronization-3
-- [x] 195 checkpoint-synchronization-4
-- [x] 196 chernicks-carmichael-numbers
-- [x] 197 cheryls-birthday
-- [x] 198 chinese-remainder-theorem
-- [x] 199 chinese-zodiac
-- [x] 200 cholesky-decomposition-1
-- [x] 201 cholesky-decomposition
-- [x] 202 chowla-numbers
-- [x] 203 church-numerals-1
-- [x] 204 church-numerals-2
-- [x] 205 circles-of-given-radius-through-two-points
-- [x] 206 circular-primes
-- [x] 207 cistercian-numerals
-- [x] 208 comma-quibbling
-- [x] 209 compiler-virtual-machine-interpreter
-- [x] 210 composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
-- [x] 211 compound-data-type
-- [x] 212 concurrent-computing-1
-- [x] 213 concurrent-computing-2
-- [x] 214 concurrent-computing-3
-- [x] 215 conditional-structures-1
-- [x] 216 conditional-structures-10
-- [x] 217 conditional-structures-2
-- [x] 218 conditional-structures-3
-- [x] 219 conditional-structures-4
-- [x] 220 conditional-structures-5
-- [x] 221 conditional-structures-6
-- [x] 222 conditional-structures-7
-- [x] 223 conditional-structures-8
-- [x] 224 conditional-structures-9
-- [ ] 225 consecutive-primes-with-ascending-or-descending-differences
-- [x] 226 constrained-genericity-1
-- [x] 227 constrained-genericity-2
-- [x] 228 constrained-genericity-3
-- [x] 229 constrained-genericity-4
-- [x] 230 constrained-random-points-on-a-circle-1
-- [x] 231 constrained-random-points-on-a-circle-2
-- [x] 232 continued-fraction
-- [x] 233 convert-decimal-number-to-rational
-- [x] 234 convert-seconds-to-compound-duration
-- [x] 235 convex-hull
-- [x] 236 conways-game-of-life
-- [x] 237 copy-a-string-1
-- [x] 238 copy-a-string-2
-- [x] 239 copy-stdin-to-stdout-1
-- [x] 240 copy-stdin-to-stdout-2
-- [x] 241 count-in-factors
-- [x] 242 count-in-octal-1
-- [x] 243 count-in-octal-2
-- [ ] 244 count-in-octal-3
-- [ ] 245 count-in-octal-4
-- [x] 246 count-occurrences-of-a-substring
-- [x] 247 count-the-coins-1
-- [x] 248 count-the-coins-2
-- [x] 249 cramers-rule
-- [x] 250 crc-32-1
-- [x] 251 crc-32-2
-- [x] 252 create-a-file-on-magnetic-tape
-- [x] 253 create-a-file
-- [x] 254 create-a-two-dimensional-array-at-runtime-1
-- [x] 255 create-an-html-table
-- [x] 256 create-an-object-at-a-given-address
-- [x] 257 csv-data-manipulation
-- [x] 258 csv-to-html-translation-1
-- [x] 259 csv-to-html-translation-2
-- [x] 260 csv-to-html-translation-3
-- [x] 261 csv-to-html-translation-4
-- [x] 262 csv-to-html-translation-5
-- [ ] 263 cuban-primes
-- [x] 264 cullen-and-woodall-numbers
-- [x] 265 cumulative-standard-deviation
-- [x] 266 currency
-- [ ] 267 currying
-- [x] 268 curzon-numbers
-- [x] 269 cusip
-- [ ] 270 cyclops-numbers
-- [x] 271 damm-algorithm
-- [x] 272 date-format
-- [x] 273 date-manipulation
-- [x] 274 day-of-the-week
-- [x] 275 de-bruijn-sequences
-- [x] 276 deal-cards-for-freecell
-- [x] 277 death-star
-- [x] 278 deceptive-numbers
-- [ ] 279 deconvolution-1d-2
-- [ ] 280 deconvolution-1d-3
-- [ ] 281 deconvolution-1d
-- [ ] 282 deepcopy-1
-- [ ] 283 define-a-primitive-data-type
-- [ ] 284 md5
+| Index | Name | Status | Duration | Memory |
+|------:|------|:-----:|---------:|-------:|
+| 1 | 100-doors-2 | ✓ | 571.223ms | 136 B |
+| 2 | 100-doors-3 | ✓ |  |  |
+| 3 | 100-doors | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  |  |
+| 5 | 15-puzzle-game | ✓ |  |  |
+| 6 | 15-puzzle-solver | ✓ |  |  |
+| 7 | 2048 | ✓ |  |  |
+| 8 | 21-game | ✓ |  |  |
+| 9 | 24-game-solve | ✓ |  |  |
+| 10 | 24-game | ✓ |  |  |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ✓ |  |  |
+| 13 | 99-bottles-of-beer-2 | ✓ |  |  |
+| 14 | 99-bottles-of-beer | ✓ |  |  |
+| 15 | DNS-query | ✓ |  |  |
+| 16 | a+b | ✓ |  |  |
+| 17 | abbreviations-automatic | ✓ |  |  |
+| 18 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-simple | ✓ |  |  |
+| 20 | abc-problem | ✓ |  |  |
+| 21 | abelian-sandpile-model-identity | ✓ |  |  |
+| 22 | abelian-sandpile-model | ✓ |  |  |
+| 23 | abstract-type | ✓ |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
+| 25 | abundant-odd-numbers | ✓ |  |  |
+| 26 | accumulator-factory | ✓ |  |  |
+| 27 | achilles-numbers | ✓ |  |  |
+| 28 | ackermann-function-2 | ✓ |  |  |
+| 29 | ackermann-function-3 | ✓ |  |  |
+| 30 | ackermann-function | ✓ |  |  |
+| 31 | active-directory-connect | ✓ |  |  |
+| 32 | active-directory-search-for-a-user | ✓ |  |  |
+| 33 | active-object | ✓ |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ |  |  |
+| 35 | additive-primes | ✓ |  |  |
+| 36 | address-of-a-variable | ✓ |  |  |
+| 37 | adfgvx-cipher | ✓ |  |  |
+| 38 | aks-test-for-primes | ✓ |  |  |
+| 39 | algebraic-data-types | ✓ |  |  |
+| 40 | align-columns | ✓ |  |  |
+| 41 | aliquot-sequence-classifications | ✓ |  |  |
+| 42 | almkvist-giullera-formula-for-pi | ✓ |  |  |
+| 43 | almost-prime | ✓ |  |  |
+| 44 | amb | ✓ |  |  |
+| 45 | amicable-pairs | ✓ |  |  |
+| 46 | anagrams-deranged-anagrams | ✓ |  |  |
+| 47 | anagrams | ✓ |  |  |
+| 48 | angle-difference-between-two-bearings-1 | ✓ |  |  |
+| 49 | angle-difference-between-two-bearings-2 | ✓ |  |  |
+| 50 | angles-geometric-normalization-and-conversion | ✓ |  |  |
+| 51 | animate-a-pendulum | ✓ |  |  |
+| 52 | animation | ✓ |  |  |
+| 53 | anonymous-recursion-1 | ✓ |  |  |
+| 54 | anonymous-recursion-2 | ✓ |  |  |
+| 55 | anonymous-recursion | ✓ |  |  |
+| 56 | anti-primes | ✓ |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file | ✓ |  |  |
+| 58 | apply-a-callback-to-an-array-1 | ✓ |  |  |
+| 59 | apply-a-callback-to-an-array-2 | ✓ |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ |  |  |
+| 61 | approximate-equality | ✓ |  |  |
+| 62 | arbitrary-precision-integers-included- | ✓ |  |  |
+| 63 | archimedean-spiral | ✓ |  |  |
+| 64 | arena-storage-pool | ✓ |  |  |
+| 65 | arithmetic-complex | ✓ |  |  |
+| 66 | arithmetic-derivative | ✓ |  |  |
+| 67 | arithmetic-evaluation | ✓ |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
+| 69 | arithmetic-geometric-mean | ✓ |  |  |
+| 70 | arithmetic-integer-1 | ✓ |  |  |
+| 71 | arithmetic-integer-2 | ✓ |  |  |
+| 72 | arithmetic-numbers |   |  |  |
+| 73 | arithmetic-rational | ✓ |  |  |
+| 74 | array-concatenation | ✓ |  |  |
+| 75 | array-length | ✓ |  |  |
+| 76 | arrays | ✓ |  |  |
+| 77 | ascending-primes |   |  |  |
+| 78 | ascii-art-diagram-converter | ✓ |  |  |
+| 79 | assertions | ✓ |  |  |
+| 80 | associative-array-creation | ✓ |  |  |
+| 81 | associative-array-iteration | ✓ |  |  |
+| 82 | associative-array-merging | ✓ |  |  |
+| 83 | atomic-updates | ✓ |  |  |
+| 84 | attractive-numbers | ✓ |  |  |
+| 85 | average-loop-length | ✓ |  |  |
+| 86 | averages-arithmetic-mean | ✓ |  |  |
+| 87 | averages-mean-time-of-day | ✓ |  |  |
+| 88 | averages-median-1 | ✓ |  |  |
+| 89 | averages-median-2 | ✓ |  |  |
+| 90 | averages-median-3 | ✓ |  |  |
+| 91 | averages-mode | ✓ |  |  |
+| 92 | averages-pythagorean-means | ✓ |  |  |
+| 93 | averages-root-mean-square | ✓ |  |  |
+| 94 | averages-simple-moving-average | ✓ |  |  |
+| 95 | avl-tree | ✓ |  |  |
+| 96 | b-zier-curves-intersections | ✓ |  |  |
+| 97 | babbage-problem | ✓ |  |  |
+| 98 | babylonian-spiral | ✓ |  |  |
+| 99 | balanced-brackets | ✓ |  |  |
+| 100 | balanced-ternary | ✓ |  |  |
+| 101 | barnsley-fern | ✓ |  |  |
+| 102 | base64-decode-data | ✓ |  |  |
+| 103 | bell-numbers | ✓ |  |  |
+| 104 | benfords-law | ✓ |  |  |
+| 105 | bernoulli-numbers | ✓ |  |  |
+| 106 | best-shuffle | ✓ |  |  |
+| 107 | bifid-cipher | ✓ |  |  |
+| 108 | bin-given-limits | ✓ |  |  |
+| 109 | binary-digits | ✓ |  |  |
+| 110 | binary-search | ✓ |  |  |
+| 111 | binary-strings | ✓ |  |  |
+| 112 | bioinformatics-base-count | ✓ |  |  |
+| 113 | bioinformatics-global-alignment | ✓ |  |  |
+| 114 | bioinformatics-sequence-mutation | ✓ |  |  |
+| 115 | biorhythms | ✓ |  |  |
+| 116 | bitcoin-address-validation | ✓ |  |  |
+| 117 | bitmap-b-zier-curves-cubic | ✓ |  |  |
+| 118 | bitmap-b-zier-curves-quadratic | ✓ |  |  |
+| 119 | bitmap-bresenhams-line-algorithm | ✓ |  |  |
+| 120 | bitmap-flood-fill | ✓ |  |  |
+| 121 | bitmap-histogram | ✓ |  |  |
+| 122 | bitmap-midpoint-circle-algorithm | ✓ |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe | ✓ |  |  |
+| 124 | bitmap-read-a-ppm-file | ✓ |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe | ✓ |  |  |
+| 126 | bitmap-write-a-ppm-file | ✓ |  |  |
+| 127 | bitmap | ✓ |  |  |
+| 128 | bitwise-io-1 | ✓ |  |  |
+| 129 | bitwise-io-2 | ✓ |  |  |
+| 130 | bitwise-operations | ✓ |  |  |
+| 131 | blum-integer | ✓ |  |  |
+| 132 | boolean-values | ✓ |  |  |
+| 133 | box-the-compass | ✓ |  |  |
+| 134 | boyer-moore-string-search | ✓ |  |  |
+| 135 | brazilian-numbers | ✓ |  |  |
+| 136 | break-oo-privacy | ✓ |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree | ✓ |  |  |
+| 139 | bulls-and-cows-player | ✓ |  |  |
+| 140 | bulls-and-cows | ✓ |  |  |
+| 141 | burrows-wheeler-transform | ✓ |  |  |
+| 142 | caesar-cipher-1 | ✓ |  |  |
+| 143 | caesar-cipher-2 | ✓ |  |  |
+| 144 | calculating-the-value-of-e | ✓ |  |  |
+| 145 | calendar---for-real-programmers-1 | ✓ |  |  |
+| 146 | calendar---for-real-programmers-2 | ✓ |  |  |
+| 147 | calendar | ✓ |  |  |
+| 148 | calkin-wilf-sequence | ✓ |  |  |
+| 149 | call-a-foreign-language-function | ✓ |  |  |
+| 150 | call-a-function-1 | ✓ |  |  |
+| 151 | call-a-function-10 | ✓ |  |  |
+| 152 | call-a-function-11 | ✓ |  |  |
+| 153 | call-a-function-12 | ✓ |  |  |
+| 154 | call-a-function-2 | ✓ |  |  |
+| 155 | call-a-function-3 | ✓ |  |  |
+| 156 | call-a-function-4 | ✓ |  |  |
+| 157 | call-a-function-5 | ✓ |  |  |
+| 158 | call-a-function-6 | ✓ |  |  |
+| 159 | call-a-function-7 | ✓ |  |  |
+| 160 | call-a-function-8 | ✓ |  |  |
+| 161 | call-a-function-9 | ✓ |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 | ✓ |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case | ✓ |  |  |
+| 167 | canny-edge-detector | ✓ |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set | ✓ |  |  |
+| 170 | carmichael-3-strong-pseudoprimes | ✓ |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 | ✓ |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 | ✓ |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 | ✓ |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers | ✓ |  |  |
+| 176 | casting-out-nines | ✓ |  |  |
+| 177 | catalan-numbers-1 | ✓ |  |  |
+| 178 | catalan-numbers-2 | ✓ |  |  |
+| 179 | catalan-numbers-pascals-triangle | ✓ |  |  |
+| 180 | catamorphism | ✓ |  |  |
+| 181 | catmull-clark-subdivision-surface | ✓ |  |  |
+| 182 | chaocipher | ✓ |  |  |
+| 183 | chaos-game | ✓ |  |  |
+| 184 | character-codes-1 | ✓ |  |  |
+| 185 | character-codes-2 | ✓ |  |  |
+| 186 | character-codes-3 | ✓ |  |  |
+| 187 | character-codes-4 | ✓ |  |  |
+| 188 | character-codes-5 | ✓ |  |  |
+| 189 | chat-server | ✓ |  |  |
+| 190 | check-machin-like-formulas | ✓ |  |  |
+| 191 | check-that-file-exists | ✓ |  |  |
+| 192 | checkpoint-synchronization-1 | ✓ |  |  |
+| 193 | checkpoint-synchronization-2 | ✓ |  |  |
+| 194 | checkpoint-synchronization-3 | ✓ |  |  |
+| 195 | checkpoint-synchronization-4 | ✓ |  |  |
+| 196 | chernicks-carmichael-numbers | ✓ |  |  |
+| 197 | cheryls-birthday | ✓ |  |  |
+| 198 | chinese-remainder-theorem | ✓ |  |  |
+| 199 | chinese-zodiac | ✓ |  |  |
+| 200 | cholesky-decomposition-1 | ✓ |  |  |
+| 201 | cholesky-decomposition | ✓ |  |  |
+| 202 | chowla-numbers | ✓ |  |  |
+| 203 | church-numerals-1 | ✓ |  |  |
+| 204 | church-numerals-2 | ✓ |  |  |
+| 205 | circles-of-given-radius-through-two-points | ✓ |  |  |
+| 206 | circular-primes | ✓ |  |  |
+| 207 | cistercian-numerals | ✓ |  |  |
+| 208 | comma-quibbling | ✓ |  |  |
+| 209 | compiler-virtual-machine-interpreter | ✓ |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | ✓ |  |  |
+| 211 | compound-data-type | ✓ |  |  |
+| 212 | concurrent-computing-1 | ✓ |  |  |
+| 213 | concurrent-computing-2 | ✓ |  |  |
+| 214 | concurrent-computing-3 | ✓ |  |  |
+| 215 | conditional-structures-1 | ✓ |  |  |
+| 216 | conditional-structures-10 | ✓ |  |  |
+| 217 | conditional-structures-2 | ✓ |  |  |
+| 218 | conditional-structures-3 | ✓ |  |  |
+| 219 | conditional-structures-4 | ✓ |  |  |
+| 220 | conditional-structures-5 | ✓ |  |  |
+| 221 | conditional-structures-6 | ✓ |  |  |
+| 222 | conditional-structures-7 | ✓ |  |  |
+| 223 | conditional-structures-8 | ✓ |  |  |
+| 224 | conditional-structures-9 | ✓ |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 | ✓ |  |  |
+| 227 | constrained-genericity-2 | ✓ |  |  |
+| 228 | constrained-genericity-3 | ✓ |  |  |
+| 229 | constrained-genericity-4 | ✓ |  |  |
+| 230 | constrained-random-points-on-a-circle-1 | ✓ |  |  |
+| 231 | constrained-random-points-on-a-circle-2 | ✓ |  |  |
+| 232 | continued-fraction | ✓ |  |  |
+| 233 | convert-decimal-number-to-rational | ✓ |  |  |
+| 234 | convert-seconds-to-compound-duration | ✓ |  |  |
+| 235 | convex-hull | ✓ |  |  |
+| 236 | conways-game-of-life | ✓ |  |  |
+| 237 | copy-a-string-1 | ✓ |  |  |
+| 238 | copy-a-string-2 | ✓ |  |  |
+| 239 | copy-stdin-to-stdout-1 | ✓ |  |  |
+| 240 | copy-stdin-to-stdout-2 | ✓ |  |  |
+| 241 | count-in-factors | ✓ |  |  |
+| 242 | count-in-octal-1 | ✓ |  |  |
+| 243 | count-in-octal-2 | ✓ |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring | ✓ |  |  |
+| 247 | count-the-coins-1 | ✓ |  |  |
+| 248 | count-the-coins-2 | ✓ |  |  |
+| 249 | cramers-rule | ✓ |  |  |
+| 250 | crc-32-1 | ✓ |  |  |
+| 251 | crc-32-2 | ✓ |  |  |
+| 252 | create-a-file-on-magnetic-tape | ✓ |  |  |
+| 253 | create-a-file | ✓ |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 | ✓ |  |  |
+| 255 | create-an-html-table | ✓ |  |  |
+| 256 | create-an-object-at-a-given-address | ✓ |  |  |
+| 257 | csv-data-manipulation | ✓ |  |  |
+| 258 | csv-to-html-translation-1 | ✓ |  |  |
+| 259 | csv-to-html-translation-2 | ✓ |  |  |
+| 260 | csv-to-html-translation-3 | ✓ |  |  |
+| 261 | csv-to-html-translation-4 | ✓ |  |  |
+| 262 | csv-to-html-translation-5 | ✓ |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers | ✓ |  |  |
+| 265 | cumulative-standard-deviation | ✓ |  |  |
+| 266 | currency | ✓ |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers | ✓ |  |  |
+| 269 | cusip | ✓ |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm | ✓ |  |  |
+| 272 | date-format | ✓ |  |  |
+| 273 | date-manipulation | ✓ |  |  |
+| 274 | day-of-the-week | ✓ |  |  |
+| 275 | de-bruijn-sequences | ✓ |  |  |
+| 276 | deal-cards-for-freecell | ✓ |  |  |
+| 277 | death-star | ✓ |  |  |
+| 278 | deceptive-numbers | ✓ |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,5 +1,5 @@
-## Progress (2025-07-25 07:55 +0700)
-- Generated PHP for 102/104 programs
+## Progress (2025-07-25 08:23 +0700)
+- Generated PHP for 103/104 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format
 

--- a/transpiler/x/php/stub.go
+++ b/transpiler/x/php/stub.go
@@ -12,6 +12,12 @@ import (
 // Program is a minimal placeholder used when the real implementation is excluded by build tags.
 type Program struct{}
 
+// benchMain controls whether the main function is wrapped in a benchmark block.
+var benchMain bool
+
+// SetBenchMain is a no-op in the stub build.
+func SetBenchMain(v bool) { benchMain = v }
+
 // Transpile returns a placeholder program so dependent packages compile without the slow implementation.
 func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 	return &Program{}, nil


### PR DESCRIPTION
## Summary
- support benchmarking main function for PHP transpiler
- emit memory difference in benchmark block
- run Rosetta golden tests with `MOCHI_BENCHMARK`
- record benchmark info in PHP Rosetta checklist
- update generated PHP for `100-doors-2` with benchmark output

## Testing
- `ROSETTA_LIMIT=1 go test -tags slow ./transpiler/x/php -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/php -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882ddf4e13883208252791490ecab35