### PR TITLE
Add benchmark option for Scala transpiler

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -861,7 +861,7 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return rs.Emit(p), nil
 	case "scala":
-		p, err := scalat.Transpile(prog, env)
+		p, err := scalat.Transpile(prog, env, false)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/gen_scala_golden.go
+++ b/scripts/gen_scala_golden.go
@@ -106,7 +106,7 @@ func runCase(name string) error {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		return fmt.Errorf("type: %v", errs[0])
 	}
-	ast, err := scalat.Transpile(prog, env)
+	ast, err := scalat.Transpile(prog, env, false)
 	if err != nil {
 		return fmt.Errorf("transpile: %v", err)
 	}

--- a/transpiler/x/scala/transpiler_test.go
+++ b/transpiler/x/scala/transpiler_test.go
@@ -35,7 +35,7 @@ func TestScalaTranspiler_PrintHello(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	ast, err := scalat.Transpile(prog, env)
+	ast, err := scalat.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestScalaTranspiler_BasicCompare(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	ast, err := scalat.Transpile(prog, env)
+	ast, err := scalat.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestScalaTranspiler_StringConcat(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	ast, err := scalat.Transpile(prog, env)
+	ast, err := scalat.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestScalaTranspiler_StringCompare(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	ast, err := scalat.Transpile(prog, env)
+	ast, err := scalat.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}

--- a/transpiler/x/scala/vm_valid_golden_test.go
+++ b/transpiler/x/scala/vm_valid_golden_test.go
@@ -51,7 +51,7 @@ func TestScalaTranspiler_VMValid_Golden(t *testing.T) {
 			_ = os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
 			return nil, errs[0]
 		}
-		ast, err := scalat.Transpile(prog, env)
+		ast, err := scalat.Transpile(prog, env, false)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 			return nil, err


### PR DESCRIPTION
## Summary
- update Scala transpiler to optionally wrap `main` in a benchmark block
- pass benchmark flag from rosetta tests and CLI helpers
- extend Rosetta checklist writer to show duration and memory in table form
- adjust tests for new `Transpile` signature

## Testing
- `go test -tags slow ./transpiler/x/scala -run TestScalaTranspiler_Rosetta_Golden -count=1`
- `for i in $(seq 1 50); do MOCHI_ROSETTA_INDEX=$i go test -tags slow ./transpiler/x/scala -run TestScalaTranspiler_Rosetta_Golden -count=1; done`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/scala -run TestScalaTranspiler_Rosetta_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882de5134708320925be72004d14ad2