### PR TITLE
Add bench mode to Smalltalk transpiler

### DIFF
--- a/transpiler/x/st/transpiler_test.go
+++ b/transpiler/x/st/transpiler_test.go
@@ -55,7 +55,7 @@ func TestTranspile_PrintHello(t *testing.T) {
 		t.Fatalf("transpile: %v", err)
 	}
 	var buf bytes.Buffer
-	if err := st.Emit(&buf, ast); err != nil {
+	if err := st.Emit(&buf, ast, false); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
 	code := buf.Bytes()

--- a/transpiler/x/st/vm_valid_golden_test.go
+++ b/transpiler/x/st/vm_valid_golden_test.go
@@ -67,7 +67,7 @@ func TestSmalltalkTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		var buf bytes.Buffer
-		if err := st.Emit(&buf, ast); err != nil {
+		if err := st.Emit(&buf, ast, false); err != nil {
 			_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- implement benchmark mode in `transpiler/x/st` emitter
- allow Rosetta tests to run with `MOCHI_BENCHMARK`
- update helper tests to use new `Emit` signature

## Testing
- `go test ./transpiler/x/st -run TestTranspile_PrintHello -tags slow`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/st -run Rosetta -tags slow`
- `MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/st -run Rosetta -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6882de65b6a483208a95df960c6de667