### PR TITLE
Add benchmark mode to OCaml transpiler

### DIFF
--- a/tests/rosetta/transpiler/OCaml/100-doors-2.bench
+++ b/tests/rosetta/transpiler/OCaml/100-doors-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 134,
+  "memory_bytes": 11344,
+  "name": "main"
+}

--- a/transpiler/x/ocaml/ROSETTA.md
+++ b/transpiler/x/ocaml/ROSETTA.md
@@ -6,7 +6,7 @@ Completed programs: 40/284
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ |  |  |
+| 1 | 100-doors-2 | ✓ | 134.0µs | 11.08KB |
 | 2 | 100-doors-3 | ✓ |  |  |
 | 3 | 100-doors | ✓ |  |  |
 | 4 | 100-prisoners | ✓ |  |  |
@@ -290,4 +290,4 @@ Completed programs: 40/284
 | 282 | deepcopy-1 |   |  |  |
 | 283 | define-a-primitive-data-type |   |  |  |
 | 284 | md5 |   |  |  |
-Last updated 2025-07-25 08:23 +0700
+Last updated 2025-07-25 08:49 +0700


### PR DESCRIPTION
## Summary
- support benchmarking in the OCaml transpiler and tests
- record benchmark stats in ROSETTA doc
- provide StrJoin node for list->string conversions
- output example benchmark for `100-doors-2`

## Testing
- `ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/ocaml -tags='rosetta slow' -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882e2a6d070832092899db57fc0b0c2