### PR TITLE
Add bench-main support for Smalltalk transpiler

### DIFF
--- a/transpiler/x/st/README.md
+++ b/transpiler/x/st/README.md
@@ -1,12 +1,13 @@
 # Smalltalk Transpiler
 
 This directory holds an experimental transpiler that converts a small subset of Mochi into Smalltalk. The generated sources for the golden tests live under `tests/transpiler/x/st`.
-Last updated: 2025-07-24 18:38 +0700
+Last updated: 2025-07-25 08:59 +0700
 
-## VM Golden Test Checklist (103/103)
+## VM Golden Test Checklist (104/104)
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
+- [x] bench_block
 - [x] binary_precedence
 - [x] bool_chain
 - [x] break_continue

--- a/transpiler/x/st/ROSETTA.md
+++ b/transpiler/x/st/ROSETTA.md
@@ -1,290 +1,292 @@
 # Smalltalk Transpiler Rosetta Results
 
 This checklist tracks the Rosetta Code programs transpiled into Smalltalk under `tests/rosetta/transpiler/st`.
-Last updated: 2025-07-24 20:52 +0700
+Last updated: 2025-07-25 08:59 +0700
 
 ## Rosetta Golden Test Checklist (24/284)
-1. [x] 1 100-doors-2
-2. [x] 2 100-doors-3
-3. [x] 3 100-doors
-4. [x] 4 100-prisoners
-5. [ ] 5 15-puzzle-game
-6. [x] 6 15-puzzle-solver
-7. [x] 7 2048
-8. [ ] 8 21-game
-9. [x] 9 24-game-solve
-10. [x] 10 24-game
-11. [x] 11 4-rings-or-4-squares-puzzle
-12. [x] 12 9-billion-names-of-god-the-integer
-13. [x] 13 99-bottles-of-beer-2
-14. [x] 14 99-bottles-of-beer
-15. [x] 15 DNS-query
-16. [x] 16 a+b
-17. [x] 17 abbreviations-automatic
-18. [ ] 18 abbreviations-easy
-19. [ ] 19 abbreviations-simple
-20. [x] 20 abc-problem
-21. [x] 21 abelian-sandpile-model-identity
-22. [x] 22 abelian-sandpile-model
-23. [x] 23 abstract-type
-24. [ ] 24 abundant-deficient-and-perfect-number-classifications
-25. [ ] 25 abundant-odd-numbers
-26. [ ] 26 accumulator-factory
-27. [ ] 27 achilles-numbers
-28. [x] 28 ackermann-function-2
-29. [ ] 29 ackermann-function-3
-30. [ ] 30 ackermann-function
-31. [x] 31 active-directory-connect
-32. [x] 32 active-directory-search-for-a-user
-33. [x] 33 active-object
-34. [ ] 34 add-a-variable-to-a-class-instance-at-runtime
-35. [x] 35 additive-primes
-36. [ ] 36 address-of-a-variable
-37. [ ] 37 adfgvx-cipher
-38. [ ] 38 aks-test-for-primes
-39. [ ] 39 algebraic-data-types
-40. [ ] 40 align-columns
-41. [ ] 41 aliquot-sequence-classifications
-42. [ ] 42 almkvist-giullera-formula-for-pi
-43. [ ] 43 almost-prime
-44. [ ] 44 amb
-45. [ ] 45 amicable-pairs
-46. [ ] 46 anagrams-deranged-anagrams
-47. [ ] 47 anagrams
-48. [ ] 48 angle-difference-between-two-bearings-1
-49. [ ] 49 angle-difference-between-two-bearings-2
-50. [ ] 50 angles-geometric-normalization-and-conversion
-51. [ ] 51 animate-a-pendulum
-52. [ ] 52 animation
-53. [ ] 53 anonymous-recursion-1
-54. [ ] 54 anonymous-recursion-2
-55. [ ] 55 anonymous-recursion
-56. [ ] 56 anti-primes
-57. [ ] 57 append-a-record-to-the-end-of-a-text-file
-58. [ ] 58 apply-a-callback-to-an-array-1
-59. [ ] 59 apply-a-callback-to-an-array-2
-60. [ ] 60 apply-a-digital-filter-direct-form-ii-transposed-
-61. [ ] 61 approximate-equality
-62. [ ] 62 arbitrary-precision-integers-included-
-63. [ ] 63 archimedean-spiral
-64. [ ] 64 arena-storage-pool
-65. [ ] 65 arithmetic-complex
-66. [ ] 66 arithmetic-derivative
-67. [ ] 67 arithmetic-evaluation
-68. [ ] 68 arithmetic-geometric-mean-calculate-pi
-69. [ ] 69 arithmetic-geometric-mean
-70. [ ] 70 arithmetic-integer-1
-71. [ ] 71 arithmetic-integer-2
-72. [ ] 72 arithmetic-numbers
-73. [ ] 73 arithmetic-rational
-74. [ ] 74 array-concatenation
-75. [ ] 75 array-length
-76. [ ] 76 arrays
-77. [ ] 77 ascending-primes
-78. [ ] 78 ascii-art-diagram-converter
-79. [ ] 79 assertions
-80. [ ] 80 associative-array-creation
-81. [ ] 81 associative-array-iteration
-82. [ ] 82 associative-array-merging
-83. [ ] 83 atomic-updates
-84. [ ] 84 attractive-numbers
-85. [ ] 85 average-loop-length
-86. [ ] 86 averages-arithmetic-mean
-87. [ ] 87 averages-mean-time-of-day
-88. [ ] 88 averages-median-1
-89. [ ] 89 averages-median-2
-90. [ ] 90 averages-median-3
-91. [ ] 91 averages-mode
-92. [ ] 92 averages-pythagorean-means
-93. [ ] 93 averages-root-mean-square
-94. [ ] 94 averages-simple-moving-average
-95. [ ] 95 avl-tree
-96. [ ] 96 b-zier-curves-intersections
-97. [ ] 97 babbage-problem
-98. [ ] 98 babylonian-spiral
-99. [ ] 99 balanced-brackets
-100. [ ] 100 balanced-ternary
-101. [ ] 101 barnsley-fern
-102. [ ] 102 base64-decode-data
-103. [ ] 103 bell-numbers
-104. [ ] 104 benfords-law
-105. [ ] 105 bernoulli-numbers
-106. [ ] 106 best-shuffle
-107. [ ] 107 bifid-cipher
-108. [ ] 108 bin-given-limits
-109. [ ] 109 binary-digits
-110. [ ] 110 binary-search
-111. [ ] 111 binary-strings
-112. [ ] 112 bioinformatics-base-count
-113. [ ] 113 bioinformatics-global-alignment
-114. [ ] 114 bioinformatics-sequence-mutation
-115. [ ] 115 biorhythms
-116. [ ] 116 bitcoin-address-validation
-117. [ ] 117 bitmap-b-zier-curves-cubic
-118. [ ] 118 bitmap-b-zier-curves-quadratic
-119. [ ] 119 bitmap-bresenhams-line-algorithm
-120. [ ] 120 bitmap-flood-fill
-121. [ ] 121 bitmap-histogram
-122. [ ] 122 bitmap-midpoint-circle-algorithm
-123. [ ] 123 bitmap-ppm-conversion-through-a-pipe
-124. [ ] 124 bitmap-read-a-ppm-file
-125. [ ] 125 bitmap-read-an-image-through-a-pipe
-126. [ ] 126 bitmap-write-a-ppm-file
-127. [ ] 127 bitmap
-128. [ ] 128 bitwise-io-1
-129. [ ] 129 bitwise-io-2
-130. [ ] 130 bitwise-operations
-131. [ ] 131 blum-integer
-132. [ ] 132 boolean-values
-133. [ ] 133 box-the-compass
-134. [ ] 134 boyer-moore-string-search
-135. [ ] 135 brazilian-numbers
-136. [ ] 136 break-oo-privacy
-137. [ ] 137 brilliant-numbers
-138. [ ] 138 brownian-tree
-139. [ ] 139 bulls-and-cows-player
-140. [ ] 140 bulls-and-cows
-141. [ ] 141 burrows-wheeler-transform
-142. [ ] 142 caesar-cipher-1
-143. [ ] 143 caesar-cipher-2
-144. [ ] 144 calculating-the-value-of-e
-145. [ ] 145 calendar---for-real-programmers-1
-146. [ ] 146 calendar---for-real-programmers-2
-147. [ ] 147 calendar
-148. [ ] 148 calkin-wilf-sequence
-149. [ ] 149 call-a-foreign-language-function
-150. [ ] 150 call-a-function-1
-151. [ ] 151 call-a-function-10
-152. [ ] 152 call-a-function-11
-153. [ ] 153 call-a-function-12
-154. [ ] 154 call-a-function-2
-155. [ ] 155 call-a-function-3
-156. [ ] 156 call-a-function-4
-157. [ ] 157 call-a-function-5
-158. [ ] 158 call-a-function-6
-159. [ ] 159 call-a-function-7
-160. [ ] 160 call-a-function-8
-161. [ ] 161 call-a-function-9
-162. [ ] 162 call-an-object-method-1
-163. [ ] 163 call-an-object-method-2
-164. [ ] 164 call-an-object-method-3
-165. [ ] 165 call-an-object-method
-166. [ ] 166 camel-case-and-snake-case
-167. [ ] 167 canny-edge-detector
-168. [ ] 168 canonicalize-cidr
-169. [ ] 169 cantor-set
-170. [ ] 170 carmichael-3-strong-pseudoprimes
-171. [ ] 171 cartesian-product-of-two-or-more-lists-1
-172. [ ] 172 cartesian-product-of-two-or-more-lists-2
-173. [ ] 173 cartesian-product-of-two-or-more-lists-3
-174. [ ] 174 cartesian-product-of-two-or-more-lists-4
-175. [ ] 175 case-sensitivity-of-identifiers
-176. [ ] 176 casting-out-nines
-177. [ ] 177 catalan-numbers-1
-178. [ ] 178 catalan-numbers-2
-179. [ ] 179 catalan-numbers-pascals-triangle
-180. [ ] 180 catamorphism
-181. [ ] 181 catmull-clark-subdivision-surface
-182. [ ] 182 chaocipher
-183. [ ] 183 chaos-game
-184. [ ] 184 character-codes-1
-185. [ ] 185 character-codes-2
-186. [ ] 186 character-codes-3
-187. [ ] 187 character-codes-4
-188. [ ] 188 character-codes-5
-189. [ ] 189 chat-server
-190. [ ] 190 check-machin-like-formulas
-191. [ ] 191 check-that-file-exists
-192. [ ] 192 checkpoint-synchronization-1
-193. [ ] 193 checkpoint-synchronization-2
-194. [ ] 194 checkpoint-synchronization-3
-195. [ ] 195 checkpoint-synchronization-4
-196. [ ] 196 chernicks-carmichael-numbers
-197. [ ] 197 cheryls-birthday
-198. [ ] 198 chinese-remainder-theorem
-199. [ ] 199 chinese-zodiac
-200. [ ] 200 cholesky-decomposition-1
-201. [ ] 201 cholesky-decomposition
-202. [ ] 202 chowla-numbers
-203. [ ] 203 church-numerals-1
-204. [ ] 204 church-numerals-2
-205. [ ] 205 circles-of-given-radius-through-two-points
-206. [ ] 206 circular-primes
-207. [ ] 207 cistercian-numerals
-208. [ ] 208 comma-quibbling
-209. [ ] 209 compiler-virtual-machine-interpreter
-210. [ ] 210 composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
-211. [ ] 211 compound-data-type
-212. [ ] 212 concurrent-computing-1
-213. [ ] 213 concurrent-computing-2
-214. [ ] 214 concurrent-computing-3
-215. [ ] 215 conditional-structures-1
-216. [ ] 216 conditional-structures-10
-217. [ ] 217 conditional-structures-2
-218. [ ] 218 conditional-structures-3
-219. [ ] 219 conditional-structures-4
-220. [ ] 220 conditional-structures-5
-221. [ ] 221 conditional-structures-6
-222. [ ] 222 conditional-structures-7
-223. [ ] 223 conditional-structures-8
-224. [ ] 224 conditional-structures-9
-225. [ ] 225 consecutive-primes-with-ascending-or-descending-differences
-226. [ ] 226 constrained-genericity-1
-227. [ ] 227 constrained-genericity-2
-228. [ ] 228 constrained-genericity-3
-229. [ ] 229 constrained-genericity-4
-230. [ ] 230 constrained-random-points-on-a-circle-1
-231. [ ] 231 constrained-random-points-on-a-circle-2
-232. [ ] 232 continued-fraction
-233. [ ] 233 convert-decimal-number-to-rational
-234. [ ] 234 convert-seconds-to-compound-duration
-235. [ ] 235 convex-hull
-236. [ ] 236 conways-game-of-life
-237. [ ] 237 copy-a-string-1
-238. [ ] 238 copy-a-string-2
-239. [ ] 239 copy-stdin-to-stdout-1
-240. [ ] 240 copy-stdin-to-stdout-2
-241. [ ] 241 count-in-factors
-242. [ ] 242 count-in-octal-1
-243. [ ] 243 count-in-octal-2
-244. [ ] 244 count-in-octal-3
-245. [ ] 245 count-in-octal-4
-246. [ ] 246 count-occurrences-of-a-substring
-247. [ ] 247 count-the-coins-1
-248. [ ] 248 count-the-coins-2
-249. [ ] 249 cramers-rule
-250. [ ] 250 crc-32-1
-251. [ ] 251 crc-32-2
-252. [ ] 252 create-a-file-on-magnetic-tape
-253. [ ] 253 create-a-file
-254. [ ] 254 create-a-two-dimensional-array-at-runtime-1
-255. [ ] 255 create-an-html-table
-256. [ ] 256 create-an-object-at-a-given-address
-257. [ ] 257 csv-data-manipulation
-258. [ ] 258 csv-to-html-translation-1
-259. [ ] 259 csv-to-html-translation-2
-260. [ ] 260 csv-to-html-translation-3
-261. [ ] 261 csv-to-html-translation-4
-262. [ ] 262 csv-to-html-translation-5
-263. [ ] 263 cuban-primes
-264. [ ] 264 cullen-and-woodall-numbers
-265. [ ] 265 cumulative-standard-deviation
-266. [ ] 266 currency
-267. [ ] 267 currying
-268. [ ] 268 curzon-numbers
-269. [ ] 269 cusip
-270. [ ] 270 cyclops-numbers
-271. [ ] 271 damm-algorithm
-272. [ ] 272 date-format
-273. [ ] 273 date-manipulation
-274. [ ] 274 day-of-the-week
-275. [ ] 275 de-bruijn-sequences
-276. [ ] 276 deal-cards-for-freecell
-277. [ ] 277 death-star
-278. [ ] 278 deceptive-numbers
-279. [ ] 279 deconvolution-1d-2
-280. [ ] 280 deconvolution-1d-3
-281. [ ] 281 deconvolution-1d
-282. [ ] 282 deepcopy-1
-283. [ ] 283 define-a-primitive-data-type
-284. [ ] 284 md5
+| Index | Name | Status | Duration | Memory |
+|------:|------|--------|---------:|-------:|
+| 1 | 100-doors-2 | ok |  |  |
+| 2 | 100-doors-3 | ok |  |  |
+| 3 | 100-doors | ok |  |  |
+| 4 | 100-prisoners | ok |  |  |
+| 5 | 15-puzzle-game | error |  |  |
+| 6 | 15-puzzle-solver | ok |  |  |
+| 7 | 2048 | ok |  |  |
+| 8 | 21-game | error |  |  |
+| 9 | 24-game-solve | ok |  |  |
+| 10 | 24-game | ok |  |  |
+| 11 | 4-rings-or-4-squares-puzzle | ok |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ok |  |  |
+| 13 | 99-bottles-of-beer-2 | ok |  |  |
+| 14 | 99-bottles-of-beer | ok |  |  |
+| 15 | DNS-query | ok |  |  |
+| 16 | a+b | ok |  |  |
+| 17 | abbreviations-automatic | ok |  |  |
+| 18 | abbreviations-easy | error |  |  |
+| 19 | abbreviations-simple | error |  |  |
+| 20 | abc-problem | ok |  |  |
+| 21 | abelian-sandpile-model-identity | ok |  |  |
+| 22 | abelian-sandpile-model | ok |  |  |
+| 23 | abstract-type | ok |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications |   |  |  |
+| 25 | abundant-odd-numbers |   |  |  |
+| 26 | accumulator-factory | error |  |  |
+| 27 | achilles-numbers | error |  |  |
+| 28 | ackermann-function-2 | ok |  |  |
+| 29 | ackermann-function-3 | error |  |  |
+| 30 | ackermann-function |   |  |  |
+| 31 | active-directory-connect | ok |  |  |
+| 32 | active-directory-search-for-a-user | ok |  |  |
+| 33 | active-object | ok |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime |   |  |  |
+| 35 | additive-primes | ok |  |  |
+| 36 | address-of-a-variable |   |  |  |
+| 37 | adfgvx-cipher |   |  |  |
+| 38 | aks-test-for-primes |   |  |  |
+| 39 | algebraic-data-types |   |  |  |
+| 40 | align-columns |   |  |  |
+| 41 | aliquot-sequence-classifications |   |  |  |
+| 42 | almkvist-giullera-formula-for-pi |   |  |  |
+| 43 | almost-prime |   |  |  |
+| 44 | amb |   |  |  |
+| 45 | amicable-pairs |   |  |  |
+| 46 | anagrams-deranged-anagrams |   |  |  |
+| 47 | anagrams |   |  |  |
+| 48 | angle-difference-between-two-bearings-1 |   |  |  |
+| 49 | angle-difference-between-two-bearings-2 |   |  |  |
+| 50 | angles-geometric-normalization-and-conversion |   |  |  |
+| 51 | animate-a-pendulum |   |  |  |
+| 52 | animation |   |  |  |
+| 53 | anonymous-recursion-1 |   |  |  |
+| 54 | anonymous-recursion-2 |   |  |  |
+| 55 | anonymous-recursion |   |  |  |
+| 56 | anti-primes |   |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file |   |  |  |
+| 58 | apply-a-callback-to-an-array-1 |   |  |  |
+| 59 | apply-a-callback-to-an-array-2 |   |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- |   |  |  |
+| 61 | approximate-equality |   |  |  |
+| 62 | arbitrary-precision-integers-included- |   |  |  |
+| 63 | archimedean-spiral |   |  |  |
+| 64 | arena-storage-pool |   |  |  |
+| 65 | arithmetic-complex |   |  |  |
+| 66 | arithmetic-derivative |   |  |  |
+| 67 | arithmetic-evaluation |   |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi |   |  |  |
+| 69 | arithmetic-geometric-mean |   |  |  |
+| 70 | arithmetic-integer-1 |   |  |  |
+| 71 | arithmetic-integer-2 |   |  |  |
+| 72 | arithmetic-numbers |   |  |  |
+| 73 | arithmetic-rational |   |  |  |
+| 74 | array-concatenation |   |  |  |
+| 75 | array-length |   |  |  |
+| 76 | arrays |   |  |  |
+| 77 | ascending-primes |   |  |  |
+| 78 | ascii-art-diagram-converter |   |  |  |
+| 79 | assertions |   |  |  |
+| 80 | associative-array-creation |   |  |  |
+| 81 | associative-array-iteration |   |  |  |
+| 82 | associative-array-merging |   |  |  |
+| 83 | atomic-updates |   |  |  |
+| 84 | attractive-numbers |   |  |  |
+| 85 | average-loop-length |   |  |  |
+| 86 | averages-arithmetic-mean |   |  |  |
+| 87 | averages-mean-time-of-day |   |  |  |
+| 88 | averages-median-1 |   |  |  |
+| 89 | averages-median-2 |   |  |  |
+| 90 | averages-median-3 |   |  |  |
+| 91 | averages-mode |   |  |  |
+| 92 | averages-pythagorean-means |   |  |  |
+| 93 | averages-root-mean-square |   |  |  |
+| 94 | averages-simple-moving-average |   |  |  |
+| 95 | avl-tree |   |  |  |
+| 96 | b-zier-curves-intersections |   |  |  |
+| 97 | babbage-problem |   |  |  |
+| 98 | babylonian-spiral |   |  |  |
+| 99 | balanced-brackets |   |  |  |
+| 100 | balanced-ternary |   |  |  |
+| 101 | barnsley-fern |   |  |  |
+| 102 | base64-decode-data |   |  |  |
+| 103 | bell-numbers |   |  |  |
+| 104 | benfords-law |   |  |  |
+| 105 | bernoulli-numbers |   |  |  |
+| 106 | best-shuffle |   |  |  |
+| 107 | bifid-cipher |   |  |  |
+| 108 | bin-given-limits |   |  |  |
+| 109 | binary-digits |   |  |  |
+| 110 | binary-search |   |  |  |
+| 111 | binary-strings |   |  |  |
+| 112 | bioinformatics-base-count |   |  |  |
+| 113 | bioinformatics-global-alignment |   |  |  |
+| 114 | bioinformatics-sequence-mutation |   |  |  |
+| 115 | biorhythms |   |  |  |
+| 116 | bitcoin-address-validation |   |  |  |
+| 117 | bitmap-b-zier-curves-cubic |   |  |  |
+| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
+| 119 | bitmap-bresenhams-line-algorithm |   |  |  |
+| 120 | bitmap-flood-fill |   |  |  |
+| 121 | bitmap-histogram |   |  |  |
+| 122 | bitmap-midpoint-circle-algorithm |   |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 124 | bitmap-read-a-ppm-file |   |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 126 | bitmap-write-a-ppm-file |   |  |  |
+| 127 | bitmap |   |  |  |
+| 128 | bitwise-io-1 |   |  |  |
+| 129 | bitwise-io-2 |   |  |  |
+| 130 | bitwise-operations |   |  |  |
+| 131 | blum-integer |   |  |  |
+| 132 | boolean-values |   |  |  |
+| 133 | box-the-compass |   |  |  |
+| 134 | boyer-moore-string-search |   |  |  |
+| 135 | brazilian-numbers |   |  |  |
+| 136 | break-oo-privacy |   |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree |   |  |  |
+| 139 | bulls-and-cows-player |   |  |  |
+| 140 | bulls-and-cows |   |  |  |
+| 141 | burrows-wheeler-transform |   |  |  |
+| 142 | caesar-cipher-1 |   |  |  |
+| 143 | caesar-cipher-2 |   |  |  |
+| 144 | calculating-the-value-of-e |   |  |  |
+| 145 | calendar---for-real-programmers-1 |   |  |  |
+| 146 | calendar---for-real-programmers-2 |   |  |  |
+| 147 | calendar |   |  |  |
+| 148 | calkin-wilf-sequence |   |  |  |
+| 149 | call-a-foreign-language-function |   |  |  |
+| 150 | call-a-function-1 |   |  |  |
+| 151 | call-a-function-10 |   |  |  |
+| 152 | call-a-function-11 |   |  |  |
+| 153 | call-a-function-12 |   |  |  |
+| 154 | call-a-function-2 |   |  |  |
+| 155 | call-a-function-3 |   |  |  |
+| 156 | call-a-function-4 |   |  |  |
+| 157 | call-a-function-5 |   |  |  |
+| 158 | call-a-function-6 |   |  |  |
+| 159 | call-a-function-7 |   |  |  |
+| 160 | call-a-function-8 |   |  |  |
+| 161 | call-a-function-9 |   |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case |   |  |  |
+| 167 | canny-edge-detector |   |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set |   |  |  |
+| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers |   |  |  |
+| 176 | casting-out-nines |   |  |  |
+| 177 | catalan-numbers-1 |   |  |  |
+| 178 | catalan-numbers-2 |   |  |  |
+| 179 | catalan-numbers-pascals-triangle |   |  |  |
+| 180 | catamorphism |   |  |  |
+| 181 | catmull-clark-subdivision-surface |   |  |  |
+| 182 | chaocipher |   |  |  |
+| 183 | chaos-game |   |  |  |
+| 184 | character-codes-1 |   |  |  |
+| 185 | character-codes-2 |   |  |  |
+| 186 | character-codes-3 |   |  |  |
+| 187 | character-codes-4 |   |  |  |
+| 188 | character-codes-5 |   |  |  |
+| 189 | chat-server |   |  |  |
+| 190 | check-machin-like-formulas |   |  |  |
+| 191 | check-that-file-exists |   |  |  |
+| 192 | checkpoint-synchronization-1 |   |  |  |
+| 193 | checkpoint-synchronization-2 |   |  |  |
+| 194 | checkpoint-synchronization-3 |   |  |  |
+| 195 | checkpoint-synchronization-4 |   |  |  |
+| 196 | chernicks-carmichael-numbers |   |  |  |
+| 197 | cheryls-birthday |   |  |  |
+| 198 | chinese-remainder-theorem |   |  |  |
+| 199 | chinese-zodiac |   |  |  |
+| 200 | cholesky-decomposition-1 |   |  |  |
+| 201 | cholesky-decomposition |   |  |  |
+| 202 | chowla-numbers |   |  |  |
+| 203 | church-numerals-1 |   |  |  |
+| 204 | church-numerals-2 |   |  |  |
+| 205 | circles-of-given-radius-through-two-points |   |  |  |
+| 206 | circular-primes |   |  |  |
+| 207 | cistercian-numerals |   |  |  |
+| 208 | comma-quibbling |   |  |  |
+| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 211 | compound-data-type |   |  |  |
+| 212 | concurrent-computing-1 |   |  |  |
+| 213 | concurrent-computing-2 |   |  |  |
+| 214 | concurrent-computing-3 |   |  |  |
+| 215 | conditional-structures-1 |   |  |  |
+| 216 | conditional-structures-10 |   |  |  |
+| 217 | conditional-structures-2 |   |  |  |
+| 218 | conditional-structures-3 |   |  |  |
+| 219 | conditional-structures-4 |   |  |  |
+| 220 | conditional-structures-5 |   |  |  |
+| 221 | conditional-structures-6 |   |  |  |
+| 222 | conditional-structures-7 |   |  |  |
+| 223 | conditional-structures-8 |   |  |  |
+| 224 | conditional-structures-9 |   |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 |   |  |  |
+| 227 | constrained-genericity-2 |   |  |  |
+| 228 | constrained-genericity-3 |   |  |  |
+| 229 | constrained-genericity-4 |   |  |  |
+| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 232 | continued-fraction |   |  |  |
+| 233 | convert-decimal-number-to-rational |   |  |  |
+| 234 | convert-seconds-to-compound-duration |   |  |  |
+| 235 | convex-hull |   |  |  |
+| 236 | conways-game-of-life |   |  |  |
+| 237 | copy-a-string-1 |   |  |  |
+| 238 | copy-a-string-2 |   |  |  |
+| 239 | copy-stdin-to-stdout-1 |   |  |  |
+| 240 | copy-stdin-to-stdout-2 |   |  |  |
+| 241 | count-in-factors |   |  |  |
+| 242 | count-in-octal-1 |   |  |  |
+| 243 | count-in-octal-2 |   |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring |   |  |  |
+| 247 | count-the-coins-1 |   |  |  |
+| 248 | count-the-coins-2 |   |  |  |
+| 249 | cramers-rule |   |  |  |
+| 250 | crc-32-1 |   |  |  |
+| 251 | crc-32-2 |   |  |  |
+| 252 | create-a-file-on-magnetic-tape |   |  |  |
+| 253 | create-a-file |   |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 255 | create-an-html-table |   |  |  |
+| 256 | create-an-object-at-a-given-address |   |  |  |
+| 257 | csv-data-manipulation |   |  |  |
+| 258 | csv-to-html-translation-1 |   |  |  |
+| 259 | csv-to-html-translation-2 |   |  |  |
+| 260 | csv-to-html-translation-3 |   |  |  |
+| 261 | csv-to-html-translation-4 |   |  |  |
+| 262 | csv-to-html-translation-5 |   |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers |   |  |  |
+| 265 | cumulative-standard-deviation |   |  |  |
+| 266 | currency |   |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers |   |  |  |
+| 269 | cusip |   |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm |   |  |  |
+| 272 | date-format |   |  |  |
+| 273 | date-manipulation |   |  |  |
+| 274 | day-of-the-week |   |  |  |
+| 275 | de-bruijn-sequences |   |  |  |
+| 276 | deal-cards-for-freecell |   |  |  |
+| 277 | death-star |   |  |  |
+| 278 | deceptive-numbers |   |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |

--- a/transpiler/x/st/TASKS.md
+++ b/transpiler/x/st/TASKS.md
@@ -1,6 +1,6 @@
-## Progress (2025-07-24 18:38 +0700)
-- Commit b41f3403cf: ctrans: add atoi helper and update rosetta
-- Generated Smalltalk for 103/103 programs
+## Progress (2025-07-25 08:59 +0700)
+- Commit ed437477b4: st: add bench mode support
+- Generated Smalltalk for 104/104 programs
 - Updated README checklist and outputs
 - Added support for break and continue statements
 

--- a/transpiler/x/st/rosetta_test.go
+++ b/transpiler/x/st/rosetta_test.go
@@ -59,6 +59,7 @@ func TestSmalltalkRosetta(t *testing.T) {
 	}
 
 	bench := os.Getenv("MOCHI_BENCHMARK") == "true" || os.Getenv("MOCHI_BENCHMARK") == "1"
+	st.SetBenchMain(bench)
 
 	for i, srcPath := range files {
 		name := strings.TrimSuffix(filepath.Base(srcPath), ".mochi")
@@ -92,7 +93,7 @@ func TestSmalltalkRosetta(t *testing.T) {
 				return
 			}
 			var buf bytes.Buffer
-			if err := st.Emit(&buf, ast, bench); err != nil {
+			if err := st.Emit(&buf, ast, false); err != nil {
 				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 				t.Skip("emit error")
 				return


### PR DESCRIPTION
## Summary
- add `benchMain` flag to Smalltalk transpiler
- expose `SetBenchMain` helper
- wrap program lines in benchmark block when enabled
- enable bench mode handling in Smalltalk rosetta tests
- update generated docs and checklist

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test -tags slow ./transpiler/x/st -run TestSmalltalkRosetta -count=1 -v`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/st -run TestSmalltalkRosetta -count=1 -v` *(fails: gst not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882e515a4988320846924ff51e358c9