### PR TITLE
Fix Zig stub build bench flag

### DIFF
--- a/transpiler/x/zig/stub.go
+++ b/transpiler/x/zig/stub.go
@@ -7,6 +7,12 @@ import (
 	"mochi/types"
 )
 
+// benchMain tracks whether generated programs should wrap main in a benchmark
+// block. It exists in the stub build so callers can set the value without
+// referencing an undefined symbol when the real implementation is excluded by
+// build tags.
+var benchMain bool
+
 // Program is a placeholder used when the real implementation is excluded by build tags.
 type Program struct{}
 


### PR DESCRIPTION
## Summary
- fix `benchMain` variable in the Zig transpiler stub build so tests compile

## Testing
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=true go test ./transpiler/x/zig -run Rosetta -tags slow -count=1 -v` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6882e59bd9748320a3785278b3a39a01