### PR TITLE
Enable bench mode for Kotlin Rosetta tests

### DIFF
--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,16 +2,17 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-24 18:57 +0700
+Last updated: 2025-07-25 09:05 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 
-Completed golden tests: **102/103** (auto-generated)
+Completed golden tests: **102/104** (auto-generated)
 
 ### Golden test checklist
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi
+- [ ] bench_block.mochi
 - [x] binary_precedence.mochi
 - [x] bool_chain.mochi
 - [x] break_continue.mochi

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-25 08:40 +0700
+Last updated: 2025-07-25 09:05 +0700
 
-Completed tasks: **53/284**
+Completed tasks: **52/284**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -14,7 +14,7 @@ Completed tasks: **53/284**
 | 3 | 100-doors | ✓ |  |  |
 | 4 | 100-prisoners |  |  |  |
 | 5 | 15-puzzle-game | ✓ |  |  |
-| 6 | 15-puzzle-solver | ✓ |  |  |
+| 6 | 15-puzzle-solver |  |  |  |
 | 7 | 2048 | ✓ |  |  |
 | 8 | 21-game | ✓ |  |  |
 | 9 | 24-game-solve | ✓ |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,159 @@
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 09:05 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-24 18:57 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/rosetta_test.go
+++ b/transpiler/x/kt/rosetta_test.go
@@ -79,9 +79,11 @@ func TestRosettaKotlin(t *testing.T) {
 			t.Fatalf("kotlinc: %v", err)
 		}
 		cmd := exec.Command("java", "-jar", jar)
-		runEnv := append(os.Environ(), "MOCHI_ROOT="+root, "MOCHI_NOW_SEED=1")
+		runEnv := append(os.Environ(), "MOCHI_ROOT="+root)
 		if bench {
 			runEnv = append(runEnv, "MOCHI_BENCHMARK=1")
+		} else {
+			runEnv = append(runEnv, "MOCHI_NOW_SEED=1")
 		}
 		cmd.Env = runEnv
 		if inData, err := os.ReadFile(filepath.Join(srcDir, name+".in")); err == nil {


### PR DESCRIPTION
## Summary
- add benchmark environment toggle to rosetta tests
- regenerate Kotlin README, ROSETTA checklist and TASKS docs
- run first Rosetta program in benchmark mode

## Testing
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=1 go test -tags slow ./transpiler/x/kt -run RosettaKotlin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882e663359c832099a0e863c62823c7