### PR TITLE
Add Pascal bench mode

### DIFF
--- a/tests/rosetta/transpiler/Pascal/100-doors-2.out
+++ b/tests/rosetta/transpiler/Pascal/100-doors-2.out
@@ -98,3 +98,8 @@ Door 97 Closed
 Door 98 Closed
 Door 99 Closed
 Door 100 Open
+{
+  "duration_us": 0,
+  "memory_bytes": 128,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/100-doors-2.pas
+++ b/tests/rosetta/transpiler/Pascal/100-doors-2.pas
@@ -1,12 +1,46 @@
 {$mode objfpc}
 program Main;
 uses SysUtils;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
 var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
   door: integer;
   incrementer: integer;
   current: integer;
   line: string;
 begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _now();
   door := 1;
   incrementer := 0;
   for current := 1 to (101 - 1) do begin
@@ -20,4 +54,11 @@ end else begin
 end;
   writeln(line);
 end;
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
 end.

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,288 +2,290 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (10/284) - updated 2025-07-24 14:14 UTC
-- [x] (1) 100-doors-2
-- [x] (2) 100-doors-3
-- [x] (3) 100-doors
-- [x] (4) 100-prisoners
-- [ ] (5) 15-puzzle-game
-- [ ] (6) 15-puzzle-solver
-- [x] (7) 2048
-- [ ] (8) 21-game
-- [ ] (9) 24-game-solve
-- [ ] (10) 24-game
-- [ ] (11) 4-rings-or-4-squares-puzzle
-- [ ] (12) 9-billion-names-of-god-the-integer
-- [x] (13) 99-bottles-of-beer-2
-- [x] (14) 99-bottles-of-beer
-- [x] (15) DNS-query
-- [x] (16) a+b
-- [ ] (17) abbreviations-automatic
-- [x] (18) abbreviations-easy
-- [ ] (19) abbreviations-simple
-- [ ] (20) abc-problem
-- [ ] (21) abelian-sandpile-model-identity
-- [ ] (22) abelian-sandpile-model
-- [ ] (23) abstract-type
-- [ ] (24) abundant-deficient-and-perfect-number-classifications
-- [ ] (25) abundant-odd-numbers
-- [ ] (26) accumulator-factory
-- [ ] (27) achilles-numbers
-- [ ] (28) ackermann-function-2
-- [ ] (29) ackermann-function-3
-- [ ] (30) ackermann-function
-- [ ] (31) active-directory-connect
-- [ ] (32) active-directory-search-for-a-user
-- [ ] (33) active-object
-- [ ] (34) add-a-variable-to-a-class-instance-at-runtime
-- [ ] (35) additive-primes
-- [ ] (36) address-of-a-variable
-- [ ] (37) adfgvx-cipher
-- [ ] (38) aks-test-for-primes
-- [ ] (39) algebraic-data-types
-- [ ] (40) align-columns
-- [ ] (41) aliquot-sequence-classifications
-- [ ] (42) almkvist-giullera-formula-for-pi
-- [ ] (43) almost-prime
-- [ ] (44) amb
-- [ ] (45) amicable-pairs
-- [ ] (46) anagrams-deranged-anagrams
-- [ ] (47) anagrams
-- [ ] (48) angle-difference-between-two-bearings-1
-- [ ] (49) angle-difference-between-two-bearings-2
-- [ ] (50) angles-geometric-normalization-and-conversion
-- [ ] (51) animate-a-pendulum
-- [ ] (52) animation
-- [ ] (53) anonymous-recursion-1
-- [ ] (54) anonymous-recursion-2
-- [ ] (55) anonymous-recursion
-- [ ] (56) anti-primes
-- [ ] (57) append-a-record-to-the-end-of-a-text-file
-- [ ] (58) apply-a-callback-to-an-array-1
-- [ ] (59) apply-a-callback-to-an-array-2
-- [ ] (60) apply-a-digital-filter-direct-form-ii-transposed-
-- [ ] (61) approximate-equality
-- [ ] (62) arbitrary-precision-integers-included-
-- [ ] (63) archimedean-spiral
-- [ ] (64) arena-storage-pool
-- [ ] (65) arithmetic-complex
-- [ ] (66) arithmetic-derivative
-- [ ] (67) arithmetic-evaluation
-- [ ] (68) arithmetic-geometric-mean-calculate-pi
-- [ ] (69) arithmetic-geometric-mean
-- [ ] (70) arithmetic-integer-1
-- [ ] (71) arithmetic-integer-2
-- [ ] (72) arithmetic-numbers
-- [ ] (73) arithmetic-rational
-- [ ] (74) array-concatenation
-- [ ] (75) array-length
-- [ ] (76) arrays
-- [ ] (77) ascending-primes
-- [ ] (78) ascii-art-diagram-converter
-- [ ] (79) assertions
-- [ ] (80) associative-array-creation
-- [ ] (81) associative-array-iteration
-- [ ] (82) associative-array-merging
-- [ ] (83) atomic-updates
-- [ ] (84) attractive-numbers
-- [ ] (85) average-loop-length
-- [ ] (86) averages-arithmetic-mean
-- [ ] (87) averages-mean-time-of-day
-- [ ] (88) averages-median-1
-- [ ] (89) averages-median-2
-- [ ] (90) averages-median-3
-- [ ] (91) averages-mode
-- [ ] (92) averages-pythagorean-means
-- [ ] (93) averages-root-mean-square
-- [ ] (94) averages-simple-moving-average
-- [ ] (95) avl-tree
-- [ ] (96) b-zier-curves-intersections
-- [ ] (97) babbage-problem
-- [ ] (98) babylonian-spiral
-- [ ] (99) balanced-brackets
-- [ ] (100) balanced-ternary
-- [ ] (101) barnsley-fern
-- [ ] (102) base64-decode-data
-- [ ] (103) bell-numbers
-- [ ] (104) benfords-law
-- [ ] (105) bernoulli-numbers
-- [ ] (106) best-shuffle
-- [ ] (107) bifid-cipher
-- [ ] (108) bin-given-limits
-- [ ] (109) binary-digits
-- [ ] (110) binary-search
-- [ ] (111) binary-strings
-- [ ] (112) bioinformatics-base-count
-- [ ] (113) bioinformatics-global-alignment
-- [ ] (114) bioinformatics-sequence-mutation
-- [ ] (115) biorhythms
-- [ ] (116) bitcoin-address-validation
-- [ ] (117) bitmap-b-zier-curves-cubic
-- [ ] (118) bitmap-b-zier-curves-quadratic
-- [ ] (119) bitmap-bresenhams-line-algorithm
-- [ ] (120) bitmap-flood-fill
-- [ ] (121) bitmap-histogram
-- [ ] (122) bitmap-midpoint-circle-algorithm
-- [ ] (123) bitmap-ppm-conversion-through-a-pipe
-- [ ] (124) bitmap-read-a-ppm-file
-- [ ] (125) bitmap-read-an-image-through-a-pipe
-- [ ] (126) bitmap-write-a-ppm-file
-- [ ] (127) bitmap
-- [ ] (128) bitwise-io-1
-- [ ] (129) bitwise-io-2
-- [ ] (130) bitwise-operations
-- [ ] (131) blum-integer
-- [ ] (132) boolean-values
-- [ ] (133) box-the-compass
-- [ ] (134) boyer-moore-string-search
-- [ ] (135) brazilian-numbers
-- [ ] (136) break-oo-privacy
-- [ ] (137) brilliant-numbers
-- [ ] (138) brownian-tree
-- [ ] (139) bulls-and-cows-player
-- [ ] (140) bulls-and-cows
-- [ ] (141) burrows-wheeler-transform
-- [ ] (142) caesar-cipher-1
-- [ ] (143) caesar-cipher-2
-- [ ] (144) calculating-the-value-of-e
-- [ ] (145) calendar---for-real-programmers-1
-- [ ] (146) calendar---for-real-programmers-2
-- [ ] (147) calendar
-- [ ] (148) calkin-wilf-sequence
-- [ ] (149) call-a-foreign-language-function
-- [ ] (150) call-a-function-1
-- [ ] (151) call-a-function-10
-- [ ] (152) call-a-function-11
-- [ ] (153) call-a-function-12
-- [ ] (154) call-a-function-2
-- [ ] (155) call-a-function-3
-- [ ] (156) call-a-function-4
-- [ ] (157) call-a-function-5
-- [ ] (158) call-a-function-6
-- [ ] (159) call-a-function-7
-- [ ] (160) call-a-function-8
-- [ ] (161) call-a-function-9
-- [ ] (162) call-an-object-method-1
-- [ ] (163) call-an-object-method-2
-- [ ] (164) call-an-object-method-3
-- [ ] (165) call-an-object-method
-- [ ] (166) camel-case-and-snake-case
-- [ ] (167) canny-edge-detector
-- [ ] (168) canonicalize-cidr
-- [ ] (169) cantor-set
-- [ ] (170) carmichael-3-strong-pseudoprimes
-- [ ] (171) cartesian-product-of-two-or-more-lists-1
-- [ ] (172) cartesian-product-of-two-or-more-lists-2
-- [ ] (173) cartesian-product-of-two-or-more-lists-3
-- [ ] (174) cartesian-product-of-two-or-more-lists-4
-- [ ] (175) case-sensitivity-of-identifiers
-- [ ] (176) casting-out-nines
-- [ ] (177) catalan-numbers-1
-- [ ] (178) catalan-numbers-2
-- [ ] (179) catalan-numbers-pascals-triangle
-- [ ] (180) catamorphism
-- [ ] (181) catmull-clark-subdivision-surface
-- [ ] (182) chaocipher
-- [ ] (183) chaos-game
-- [ ] (184) character-codes-1
-- [ ] (185) character-codes-2
-- [ ] (186) character-codes-3
-- [ ] (187) character-codes-4
-- [ ] (188) character-codes-5
-- [ ] (189) chat-server
-- [ ] (190) check-machin-like-formulas
-- [ ] (191) check-that-file-exists
-- [ ] (192) checkpoint-synchronization-1
-- [ ] (193) checkpoint-synchronization-2
-- [ ] (194) checkpoint-synchronization-3
-- [ ] (195) checkpoint-synchronization-4
-- [ ] (196) chernicks-carmichael-numbers
-- [ ] (197) cheryls-birthday
-- [ ] (198) chinese-remainder-theorem
-- [ ] (199) chinese-zodiac
-- [ ] (200) cholesky-decomposition-1
-- [ ] (201) cholesky-decomposition
-- [ ] (202) chowla-numbers
-- [ ] (203) church-numerals-1
-- [ ] (204) church-numerals-2
-- [ ] (205) circles-of-given-radius-through-two-points
-- [ ] (206) circular-primes
-- [ ] (207) cistercian-numerals
-- [ ] (208) comma-quibbling
-- [ ] (209) compiler-virtual-machine-interpreter
-- [ ] (210) composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k
-- [ ] (211) compound-data-type
-- [ ] (212) concurrent-computing-1
-- [ ] (213) concurrent-computing-2
-- [ ] (214) concurrent-computing-3
-- [ ] (215) conditional-structures-1
-- [ ] (216) conditional-structures-10
-- [ ] (217) conditional-structures-2
-- [ ] (218) conditional-structures-3
-- [ ] (219) conditional-structures-4
-- [ ] (220) conditional-structures-5
-- [ ] (221) conditional-structures-6
-- [ ] (222) conditional-structures-7
-- [ ] (223) conditional-structures-8
-- [ ] (224) conditional-structures-9
-- [ ] (225) consecutive-primes-with-ascending-or-descending-differences
-- [ ] (226) constrained-genericity-1
-- [ ] (227) constrained-genericity-2
-- [ ] (228) constrained-genericity-3
-- [ ] (229) constrained-genericity-4
-- [ ] (230) constrained-random-points-on-a-circle-1
-- [ ] (231) constrained-random-points-on-a-circle-2
-- [ ] (232) continued-fraction
-- [ ] (233) convert-decimal-number-to-rational
-- [ ] (234) convert-seconds-to-compound-duration
-- [ ] (235) convex-hull
-- [ ] (236) conways-game-of-life
-- [ ] (237) copy-a-string-1
-- [ ] (238) copy-a-string-2
-- [ ] (239) copy-stdin-to-stdout-1
-- [ ] (240) copy-stdin-to-stdout-2
-- [ ] (241) count-in-factors
-- [ ] (242) count-in-octal-1
-- [ ] (243) count-in-octal-2
-- [ ] (244) count-in-octal-3
-- [ ] (245) count-in-octal-4
-- [ ] (246) count-occurrences-of-a-substring
-- [ ] (247) count-the-coins-1
-- [ ] (248) count-the-coins-2
-- [ ] (249) cramers-rule
-- [ ] (250) crc-32-1
-- [ ] (251) crc-32-2
-- [ ] (252) create-a-file-on-magnetic-tape
-- [ ] (253) create-a-file
-- [ ] (254) create-a-two-dimensional-array-at-runtime-1
-- [ ] (255) create-an-html-table
-- [ ] (256) create-an-object-at-a-given-address
-- [ ] (257) csv-data-manipulation
-- [ ] (258) csv-to-html-translation-1
-- [ ] (259) csv-to-html-translation-2
-- [ ] (260) csv-to-html-translation-3
-- [ ] (261) csv-to-html-translation-4
-- [ ] (262) csv-to-html-translation-5
-- [ ] (263) cuban-primes
-- [ ] (264) cullen-and-woodall-numbers
-- [ ] (265) cumulative-standard-deviation
-- [ ] (266) currency
-- [ ] (267) currying
-- [ ] (268) curzon-numbers
-- [ ] (269) cusip
-- [ ] (270) cyclops-numbers
-- [ ] (271) damm-algorithm
-- [ ] (272) date-format
-- [ ] (273) date-manipulation
-- [ ] (274) day-of-the-week
-- [ ] (275) de-bruijn-sequences
-- [ ] (276) deal-cards-for-freecell
-- [ ] (277) death-star
-- [ ] (278) deceptive-numbers
-- [ ] (279) deconvolution-1d-2
-- [ ] (280) deconvolution-1d-3
-- [ ] (281) deconvolution-1d
-- [ ] (282) deepcopy-1
-- [ ] (283) define-a-primitive-data-type
-- [ ] (284) md5
+## Rosetta Checklist (11/284) - updated 2025-07-25 02:16 UTC
+| Index | Name | Status | Duration | Memory |
+|------:|------|:-----:|---------:|-------:|
+| 1 | 100-doors-2 | ✓ |  |  |
+| 2 | 100-doors-3 | ✓ |  |  |
+| 3 | 100-doors | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  |  |
+| 5 | 15-puzzle-game |   |  |  |
+| 6 | 15-puzzle-solver |   |  |  |
+| 7 | 2048 | ✓ |  |  |
+| 8 | 21-game |   |  |  |
+| 9 | 24-game-solve |   |  |  |
+| 10 | 24-game |   |  |  |
+| 11 | 4-rings-or-4-squares-puzzle |   |  |  |
+| 12 | 9-billion-names-of-god-the-integer |   |  |  |
+| 13 | 99-bottles-of-beer-2 | ✓ |  |  |
+| 14 | 99-bottles-of-beer | ✓ |  |  |
+| 15 | DNS-query | ✓ |  |  |
+| 16 | a+b | ✓ |  |  |
+| 17 | abbreviations-automatic | ✓ |  |  |
+| 18 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-simple |   |  |  |
+| 20 | abc-problem |   |  |  |
+| 21 | abelian-sandpile-model-identity |   |  |  |
+| 22 | abelian-sandpile-model |   |  |  |
+| 23 | abstract-type |   |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications |   |  |  |
+| 25 | abundant-odd-numbers |   |  |  |
+| 26 | accumulator-factory |   |  |  |
+| 27 | achilles-numbers |   |  |  |
+| 28 | ackermann-function-2 |   |  |  |
+| 29 | ackermann-function-3 |   |  |  |
+| 30 | ackermann-function |   |  |  |
+| 31 | active-directory-connect |   |  |  |
+| 32 | active-directory-search-for-a-user |   |  |  |
+| 33 | active-object |   |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime |   |  |  |
+| 35 | additive-primes |   |  |  |
+| 36 | address-of-a-variable |   |  |  |
+| 37 | adfgvx-cipher |   |  |  |
+| 38 | aks-test-for-primes |   |  |  |
+| 39 | algebraic-data-types |   |  |  |
+| 40 | align-columns |   |  |  |
+| 41 | aliquot-sequence-classifications |   |  |  |
+| 42 | almkvist-giullera-formula-for-pi |   |  |  |
+| 43 | almost-prime |   |  |  |
+| 44 | amb |   |  |  |
+| 45 | amicable-pairs |   |  |  |
+| 46 | anagrams-deranged-anagrams |   |  |  |
+| 47 | anagrams |   |  |  |
+| 48 | angle-difference-between-two-bearings-1 |   |  |  |
+| 49 | angle-difference-between-two-bearings-2 |   |  |  |
+| 50 | angles-geometric-normalization-and-conversion |   |  |  |
+| 51 | animate-a-pendulum |   |  |  |
+| 52 | animation |   |  |  |
+| 53 | anonymous-recursion-1 |   |  |  |
+| 54 | anonymous-recursion-2 |   |  |  |
+| 55 | anonymous-recursion |   |  |  |
+| 56 | anti-primes |   |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file |   |  |  |
+| 58 | apply-a-callback-to-an-array-1 |   |  |  |
+| 59 | apply-a-callback-to-an-array-2 |   |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- |   |  |  |
+| 61 | approximate-equality |   |  |  |
+| 62 | arbitrary-precision-integers-included- |   |  |  |
+| 63 | archimedean-spiral |   |  |  |
+| 64 | arena-storage-pool |   |  |  |
+| 65 | arithmetic-complex |   |  |  |
+| 66 | arithmetic-derivative |   |  |  |
+| 67 | arithmetic-evaluation |   |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi |   |  |  |
+| 69 | arithmetic-geometric-mean |   |  |  |
+| 70 | arithmetic-integer-1 |   |  |  |
+| 71 | arithmetic-integer-2 |   |  |  |
+| 72 | arithmetic-numbers |   |  |  |
+| 73 | arithmetic-rational |   |  |  |
+| 74 | array-concatenation |   |  |  |
+| 75 | array-length |   |  |  |
+| 76 | arrays |   |  |  |
+| 77 | ascending-primes |   |  |  |
+| 78 | ascii-art-diagram-converter |   |  |  |
+| 79 | assertions |   |  |  |
+| 80 | associative-array-creation |   |  |  |
+| 81 | associative-array-iteration |   |  |  |
+| 82 | associative-array-merging |   |  |  |
+| 83 | atomic-updates |   |  |  |
+| 84 | attractive-numbers |   |  |  |
+| 85 | average-loop-length |   |  |  |
+| 86 | averages-arithmetic-mean |   |  |  |
+| 87 | averages-mean-time-of-day |   |  |  |
+| 88 | averages-median-1 |   |  |  |
+| 89 | averages-median-2 |   |  |  |
+| 90 | averages-median-3 |   |  |  |
+| 91 | averages-mode |   |  |  |
+| 92 | averages-pythagorean-means |   |  |  |
+| 93 | averages-root-mean-square |   |  |  |
+| 94 | averages-simple-moving-average |   |  |  |
+| 95 | avl-tree |   |  |  |
+| 96 | b-zier-curves-intersections |   |  |  |
+| 97 | babbage-problem |   |  |  |
+| 98 | babylonian-spiral |   |  |  |
+| 99 | balanced-brackets |   |  |  |
+| 100 | balanced-ternary |   |  |  |
+| 101 | barnsley-fern |   |  |  |
+| 102 | base64-decode-data |   |  |  |
+| 103 | bell-numbers |   |  |  |
+| 104 | benfords-law |   |  |  |
+| 105 | bernoulli-numbers |   |  |  |
+| 106 | best-shuffle |   |  |  |
+| 107 | bifid-cipher |   |  |  |
+| 108 | bin-given-limits |   |  |  |
+| 109 | binary-digits |   |  |  |
+| 110 | binary-search |   |  |  |
+| 111 | binary-strings |   |  |  |
+| 112 | bioinformatics-base-count |   |  |  |
+| 113 | bioinformatics-global-alignment |   |  |  |
+| 114 | bioinformatics-sequence-mutation |   |  |  |
+| 115 | biorhythms |   |  |  |
+| 116 | bitcoin-address-validation |   |  |  |
+| 117 | bitmap-b-zier-curves-cubic |   |  |  |
+| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
+| 119 | bitmap-bresenhams-line-algorithm |   |  |  |
+| 120 | bitmap-flood-fill |   |  |  |
+| 121 | bitmap-histogram |   |  |  |
+| 122 | bitmap-midpoint-circle-algorithm |   |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 124 | bitmap-read-a-ppm-file |   |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 126 | bitmap-write-a-ppm-file |   |  |  |
+| 127 | bitmap |   |  |  |
+| 128 | bitwise-io-1 |   |  |  |
+| 129 | bitwise-io-2 |   |  |  |
+| 130 | bitwise-operations |   |  |  |
+| 131 | blum-integer |   |  |  |
+| 132 | boolean-values |   |  |  |
+| 133 | box-the-compass |   |  |  |
+| 134 | boyer-moore-string-search |   |  |  |
+| 135 | brazilian-numbers |   |  |  |
+| 136 | break-oo-privacy |   |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree |   |  |  |
+| 139 | bulls-and-cows-player |   |  |  |
+| 140 | bulls-and-cows |   |  |  |
+| 141 | burrows-wheeler-transform |   |  |  |
+| 142 | caesar-cipher-1 |   |  |  |
+| 143 | caesar-cipher-2 |   |  |  |
+| 144 | calculating-the-value-of-e |   |  |  |
+| 145 | calendar---for-real-programmers-1 |   |  |  |
+| 146 | calendar---for-real-programmers-2 |   |  |  |
+| 147 | calendar |   |  |  |
+| 148 | calkin-wilf-sequence |   |  |  |
+| 149 | call-a-foreign-language-function |   |  |  |
+| 150 | call-a-function-1 |   |  |  |
+| 151 | call-a-function-10 |   |  |  |
+| 152 | call-a-function-11 |   |  |  |
+| 153 | call-a-function-12 |   |  |  |
+| 154 | call-a-function-2 |   |  |  |
+| 155 | call-a-function-3 |   |  |  |
+| 156 | call-a-function-4 |   |  |  |
+| 157 | call-a-function-5 |   |  |  |
+| 158 | call-a-function-6 |   |  |  |
+| 159 | call-a-function-7 |   |  |  |
+| 160 | call-a-function-8 |   |  |  |
+| 161 | call-a-function-9 |   |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case |   |  |  |
+| 167 | canny-edge-detector |   |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set |   |  |  |
+| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers |   |  |  |
+| 176 | casting-out-nines |   |  |  |
+| 177 | catalan-numbers-1 |   |  |  |
+| 178 | catalan-numbers-2 |   |  |  |
+| 179 | catalan-numbers-pascals-triangle |   |  |  |
+| 180 | catamorphism |   |  |  |
+| 181 | catmull-clark-subdivision-surface |   |  |  |
+| 182 | chaocipher |   |  |  |
+| 183 | chaos-game |   |  |  |
+| 184 | character-codes-1 |   |  |  |
+| 185 | character-codes-2 |   |  |  |
+| 186 | character-codes-3 |   |  |  |
+| 187 | character-codes-4 |   |  |  |
+| 188 | character-codes-5 |   |  |  |
+| 189 | chat-server |   |  |  |
+| 190 | check-machin-like-formulas |   |  |  |
+| 191 | check-that-file-exists |   |  |  |
+| 192 | checkpoint-synchronization-1 |   |  |  |
+| 193 | checkpoint-synchronization-2 |   |  |  |
+| 194 | checkpoint-synchronization-3 |   |  |  |
+| 195 | checkpoint-synchronization-4 |   |  |  |
+| 196 | chernicks-carmichael-numbers |   |  |  |
+| 197 | cheryls-birthday |   |  |  |
+| 198 | chinese-remainder-theorem |   |  |  |
+| 199 | chinese-zodiac |   |  |  |
+| 200 | cholesky-decomposition-1 |   |  |  |
+| 201 | cholesky-decomposition |   |  |  |
+| 202 | chowla-numbers |   |  |  |
+| 203 | church-numerals-1 |   |  |  |
+| 204 | church-numerals-2 |   |  |  |
+| 205 | circles-of-given-radius-through-two-points |   |  |  |
+| 206 | circular-primes |   |  |  |
+| 207 | cistercian-numerals |   |  |  |
+| 208 | comma-quibbling |   |  |  |
+| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 211 | compound-data-type |   |  |  |
+| 212 | concurrent-computing-1 |   |  |  |
+| 213 | concurrent-computing-2 |   |  |  |
+| 214 | concurrent-computing-3 |   |  |  |
+| 215 | conditional-structures-1 |   |  |  |
+| 216 | conditional-structures-10 |   |  |  |
+| 217 | conditional-structures-2 |   |  |  |
+| 218 | conditional-structures-3 |   |  |  |
+| 219 | conditional-structures-4 |   |  |  |
+| 220 | conditional-structures-5 |   |  |  |
+| 221 | conditional-structures-6 |   |  |  |
+| 222 | conditional-structures-7 |   |  |  |
+| 223 | conditional-structures-8 |   |  |  |
+| 224 | conditional-structures-9 |   |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 |   |  |  |
+| 227 | constrained-genericity-2 |   |  |  |
+| 228 | constrained-genericity-3 |   |  |  |
+| 229 | constrained-genericity-4 |   |  |  |
+| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 232 | continued-fraction |   |  |  |
+| 233 | convert-decimal-number-to-rational |   |  |  |
+| 234 | convert-seconds-to-compound-duration |   |  |  |
+| 235 | convex-hull |   |  |  |
+| 236 | conways-game-of-life |   |  |  |
+| 237 | copy-a-string-1 |   |  |  |
+| 238 | copy-a-string-2 |   |  |  |
+| 239 | copy-stdin-to-stdout-1 |   |  |  |
+| 240 | copy-stdin-to-stdout-2 |   |  |  |
+| 241 | count-in-factors |   |  |  |
+| 242 | count-in-octal-1 |   |  |  |
+| 243 | count-in-octal-2 |   |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring |   |  |  |
+| 247 | count-the-coins-1 |   |  |  |
+| 248 | count-the-coins-2 |   |  |  |
+| 249 | cramers-rule |   |  |  |
+| 250 | crc-32-1 |   |  |  |
+| 251 | crc-32-2 |   |  |  |
+| 252 | create-a-file-on-magnetic-tape |   |  |  |
+| 253 | create-a-file |   |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 255 | create-an-html-table |   |  |  |
+| 256 | create-an-object-at-a-given-address |   |  |  |
+| 257 | csv-data-manipulation |   |  |  |
+| 258 | csv-to-html-translation-1 |   |  |  |
+| 259 | csv-to-html-translation-2 |   |  |  |
+| 260 | csv-to-html-translation-3 |   |  |  |
+| 261 | csv-to-html-translation-4 |   |  |  |
+| 262 | csv-to-html-translation-5 |   |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers |   |  |  |
+| 265 | cumulative-standard-deviation |   |  |  |
+| 266 | currency |   |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers |   |  |  |
+| 269 | cusip |   |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm |   |  |  |
+| 272 | date-format |   |  |  |
+| 273 | date-manipulation |   |  |  |
+| 274 | day-of-the-week |   |  |  |
+| 275 | de-bruijn-sequences |   |  |  |
+| 276 | deal-cards-for-freecell |   |  |  |
+| 277 | death-star |   |  |  |
+| 278 | deceptive-numbers |   |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |

--- a/transpiler/x/pas/stub.go
+++ b/transpiler/x/pas/stub.go
@@ -15,5 +15,8 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 	return &Program{}, nil
 }
 
+// SetBenchMain is a no-op in the stub build.
+func SetBenchMain(v bool) {}
+
 // Emit returns an empty byte slice. It is a no-op replacement for the real function.
 func (p *Program) Emit() []byte { return nil }


### PR DESCRIPTION
## Summary
- improve Pascal transpiler with benchmark mode and memory helper
- support MOCHI_BENCHMARK in Pascal rosetta tests
- update Pascal Rosetta checklist
- regenerate Pascal output for `100-doors-2`

## Testing
- `MOCHI_BENCHMARK=1 ROSETTA_INDEX=1 go test ./transpiler/x/pas -run Rosetta -tags=slow -count=1 -update-rosetta-pas -v`

------
https://chatgpt.com/codex/tasks/task_e_6882e39b345c8320acb4847e2da4b723