### PR TITLE
Fix go build/test by updating Zig stub

### DIFF
--- a/transpiler/x/zig/stub.go
+++ b/transpiler/x/zig/stub.go
@@ -10,6 +10,9 @@ import (
 // Program is a placeholder used when the real implementation is excluded by build tags.
 type Program struct{}
 
+// benchMain controls whether the main function is wrapped in a benchmark block.
+var benchMain bool
+
 // SetBenchMain is a no-op in the stub build.
 func SetBenchMain(v bool) { benchMain = v }
 


### PR DESCRIPTION
## Summary
- declare `benchMain` in `transpiler/x/zig/stub.go`

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6882f3563d308320a51ce453035b0c50