### PR TITLE
Add v0.10.40 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,21 @@
 # 📦 CHANGELOG.md
+
+## [0.10.40] – 2025-07-25T10:01:54+07:00
+
+### Added
+
+* Benchmark blocks and modes across many transpilers with memory measurement
+* Union pattern matching for Racket with improved map, list and struct handling
+* Extended BigInt and BigRat helpers plus numerous new Rosetta programs
+
+### Changed
+
+* `tap-gist` CLI rewritten using `fang`
+* Progress tables and golden outputs refreshed
+
+### Fixed
+
+* Benchmark output duration handling for PHP and assorted compiler bugs
 ## [0.10.39] – 2025-07-24T11:43:58+07:00
 
 ### Added

--- a/releases/v0.10.40.md
+++ b/releases/v0.10.40.md
@@ -1,0 +1,18 @@
+# Jul 2025 (v0.10.40)
+
+Released on Fri Jul 25 10:01:54 2025 +0700.
+
+Mochi v0.10.40 introduces benchmarking modes and wide-ranging compiler improvements alongside regenerated Rosetta examples.
+
+## Compilers
+
+- Benchmark blocks and modes implemented for C, C++, Dart, Erlang, Fortran, Go, Java, Kotlin, Lua, OCaml, Pascal, Python, Scala, Scheme, Swift and more
+- Memory measurement utilities with enhanced benchmark output handling
+- Union pattern matching for Racket with better map, list and struct handling across transpilers
+- BigInt and BigRat operations extended with various numeric and string helpers
+- Additional Rosetta tasks compiled across languages with refreshed outputs
+
+## Documentation
+
+- `tap-gist` CLI rewritten using `fang` with new usage instructions
+- Progress tables and golden outputs updated for the growing test suite


### PR DESCRIPTION
## Summary
- document changes for v0.10.40
- add new release notes file

## Testing
- `make test` *(fails: undefined: benchMain)*

------
https://chatgpt.com/codex/tasks/task_e_6882f4655a4083209c0249226491e0da