### PR TITLE
Add benchmark support for F# rosetta tests

### DIFF
--- a/tests/rosetta/transpiler/FS/100-doors-2.bench
+++ b/tests/rosetta/transpiler/FS/100-doors-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 162,
+  "memory_bytes": 45312,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/100-doors-2.fs
+++ b/tests/rosetta/transpiler/FS/100-doors-2.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-25 08:50 +0700
+// Generated 2025-07-25 10:01 +0700
 
 let mutable _nowSeed:int64 = 0L
 let mutable _nowSeeded = false

--- a/tests/rosetta/transpiler/FS/100-doors-2.out
+++ b/tests/rosetta/transpiler/FS/100-doors-2.out
@@ -98,8 +98,3 @@ Door 97 Closed
 Door 98 Closed
 Door 99 Closed
 Door 100 Open
-{
-  "duration_us": 325,
-  "memory_bytes": 42272,
-  "name": "main"
-}

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -5,7 +5,7 @@ This file is auto-generated from rosetta tests.
 ## Rosetta Golden Test Checklist (67/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 325µs | 41.3 KB |
+| 1 | 100-doors-2 | ✓ | 162µs | 44.2 KB |
 | 2 | 100-doors-3 | ✓ | 325µs | 45.8 KB |
 | 3 | 100-doors | ✓ | 328µs | 45.6 KB |
 | 4 | 100-prisoners | ✓ |  |  |
@@ -290,4 +290,4 @@ This file is auto-generated from rosetta tests.
 | 283 | define-a-primitive-data-type |   |  |  |
 | 284 | md5 |   |  |  |
 
-Last updated: 2025-07-25 08:50 +0700
+Last updated: 2025-07-25 10:01 +0700


### PR DESCRIPTION
## Summary
- update the F# Rosetta test harness to optionally write `.bench` files
- parse benchmark files when generating the progress checklist
- regenerate code for `100-doors-2` with benchmark run

## Testing
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run Rosetta -count=1 -tags=slow`

------
https://chatgpt.com/codex/tasks/task_e_6882f3ebb59883208bd8a02fd0e7abbd