### PR TITLE
Lua transpiler benchmark support

### DIFF
--- a/tests/rosetta/transpiler/Lua/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Lua/100-doors-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 176,
+  "memory_bytes": 102,
+  "name": "main"
+}

--- a/transpiler/x/lua/ROSETTA.md
+++ b/transpiler/x/lua/ROSETTA.md
@@ -4,18 +4,18 @@ Generated Lua code for programs in `tests/rosetta/x/Mochi`. Each program has a `
 
 Transpiled programs: 237/284
 
-Last updated: 2025-07-25 08:43 GMT+7
+Last updated: 2025-07-25 10:01 GMT+7
 
 Checklist:
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 158µs | 102 B |
+| 1 | 100-doors-2 | ✓ | 176µs | 102 B |
 | 2 | 100-doors-3 | ✓ |  |  |
 | 3 | 100-doors | ✓ |  |  |
 | 4 | 100-prisoners | ✓ |  |  |
 | 5 | 15-puzzle-game | ✓ |  |  |
-| 6 | 15-puzzle-solver | ✓ |  |  |
+| 6 | 15-puzzle-solver |   |  |  |
 | 7 | 2048 | ✓ |  |  |
 | 8 | 21-game | ✓ |  |  |
 | 9 | 24-game-solve | ✓ |  |  |
@@ -35,7 +35,7 @@ Checklist:
 | 23 | abstract-type | ✓ |  |  |
 | 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
 | 25 | abundant-odd-numbers | ✓ |  |  |
-| 26 | accumulator-factory |   |  |  |
+| 26 | accumulator-factory | ✓ |  |  |
 | 27 | achilles-numbers | ✓ |  |  |
 | 28 | ackermann-function-2 | ✓ |  |  |
 | 29 | ackermann-function-3 | ✓ |  |  |
@@ -48,9 +48,9 @@ Checklist:
 | 36 | address-of-a-variable | ✓ |  |  |
 | 37 | adfgvx-cipher | ✓ |  |  |
 | 38 | aks-test-for-primes | ✓ |  |  |
-| 39 | algebraic-data-types |   |  |  |
+| 39 | algebraic-data-types | ✓ |  |  |
 | 40 | align-columns | ✓ |  |  |
-| 41 | aliquot-sequence-classifications | ✓ |  |  |
+| 41 | aliquot-sequence-classifications |   |  |  |
 | 42 | almkvist-giullera-formula-for-pi | ✓ |  |  |
 | 43 | almost-prime | ✓ |  |  |
 | 44 | amb | ✓ |  |  |

--- a/transpiler/x/lua/transpiler.go
+++ b/transpiler/x/lua/transpiler.go
@@ -27,6 +27,12 @@ var loopCounter int
 var continueLabels []string
 var structCount int
 var funcDepth int
+var benchMainFlag bool
+
+// SetBenchMain configures whether the generated main function is wrapped in a
+// benchmark block when emitting code. When enabled, programs print a JSON
+// object with duration and memory statistics on completion.
+func SetBenchMain(v bool) { benchMainFlag = v }
 
 const helperNow = `
 local _now_seed = 0
@@ -3471,7 +3477,7 @@ func Transpile(prog *parser.Program, env *types.Env, benchMain bool) (*Program, 
 			lp.Stmts = append(lp.Stmts, s)
 		}
 	}
-	if benchMain {
+	if benchMain || benchMainFlag {
 		lp.Stmts = []Stmt{&BenchStmt{Name: "main", Body: lp.Stmts}}
 	}
 	currentEnv = nil

--- a/transpiler/x/lua/vm_valid_golden_test.go
+++ b/transpiler/x/lua/vm_valid_golden_test.go
@@ -56,6 +56,13 @@ func TestLuaTranspiler_VMValid_Golden(t *testing.T) {
 		cmd := exec.Command("lua", codePath)
 		runEnv := append(os.Environ(), "MOCHI_NOW_SEED=1")
 		if bench {
+			// allow real timing when benchmarking
+			for i, v := range runEnv {
+				if strings.HasPrefix(v, "MOCHI_NOW_SEED=") {
+					runEnv = append(runEnv[:i], runEnv[i+1:]...)
+					break
+				}
+			}
 			runEnv = append(runEnv, "MOCHI_BENCHMARK=1")
 		}
 		cmd.Env = runEnv


### PR DESCRIPTION
## Summary
- add `SetBenchMain` global flag for Lua transpiler
- support `.bench` files in Lua Rosetta tests
- skip `MOCHI_NOW_SEED` in benchmark mode for VM tests
- update Lua ROSETTA progress for program 1

## Testing
- `go test -tags slow ./transpiler/x/lua -run Rosetta -index=1 -count=1`
- `MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/lua -run Rosetta -index=1 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882f3fa8d2483209e771c5379d23c5a