### PR TITLE
Update Dart transpiler benchmarking

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -722,7 +722,7 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return cljt.Format(cljt.EmitString(p)), nil
 	case "dart":
-		p, err := dartt.Transpile(prog, env, false)
+		p, err := dartt.Transpile(prog, env, false, false)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/rosetta/transpiler/Dart/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Dart/100-doors-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":10076,"memory_bytes":1441792,"name":"main"}

--- a/tools/gendart.go
+++ b/tools/gendart.go
@@ -28,7 +28,7 @@ func main() {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		panic(errs[0])
 	}
-	ast, err := dart.Transpile(prog, env, false)
+	ast, err := dart.Transpile(prog, env, false, false)
 	if err != nil {
 		panic(err)
 	}

--- a/transpiler/x/dart/ROSETTA.md
+++ b/transpiler/x/dart/ROSETTA.md
@@ -6,290 +6,290 @@ Compiled and ran: 124/284
 
 ## Checklist
 | Index | Name | Status | Duration | Memory |
-| --- | --- | --- | --- | --- |
-| 1 | 100-doors-2 | [x] | 2.158ms | 640.0 KB |
-| 2 | 100-doors-3 | [x] |  |  |
-| 3 | 100-doors | [x] |  |  |
-| 4 | 100-prisoners | [x] |  |  |
-| 5 | 15-puzzle-game | [x] |  |  |
-| 6 | 15-puzzle-solver | [x] |  |  |
-| 7 | 2048 | [x] |  |  |
-| 8 | 21-game | [x] |  |  |
-| 9 | 24-game-solve | [x] |  |  |
-| 10 | 24-game | [x] |  |  |
-| 11 | 4-rings-or-4-squares-puzzle | [x] |  |  |
-| 12 | 9-billion-names-of-god-the-integer | [x] |  |  |
-| 13 | 99-bottles-of-beer-2 | [x] |  |  |
-| 14 | 99-bottles-of-beer | [x] |  |  |
-| 15 | DNS-query | [x] |  |  |
-| 16 | a+b | [x] |  |  |
-| 17 | abbreviations-automatic | [x] |  |  |
-| 18 | abbreviations-easy | [x] |  |  |
-| 19 | abbreviations-simple | [x] |  |  |
-| 20 | abc-problem | [x] |  |  |
-| 21 | abelian-sandpile-model-identity | [x] |  |  |
-| 22 | abelian-sandpile-model | [x] |  |  |
-| 23 | abstract-type | [x] |  |  |
-| 24 | abundant-deficient-and-perfect-number-classifications | [x] |  |  |
-| 25 | abundant-odd-numbers | [x] |  |  |
-| 26 | accumulator-factory | [x] |  |  |
-| 27 | achilles-numbers | [ ] |  |  |
-| 28 | ackermann-function-2 | [x] |  |  |
-| 29 | ackermann-function-3 | [x] |  |  |
-| 30 | ackermann-function | [x] |  |  |
-| 31 | active-directory-connect | [x] |  |  |
-| 32 | active-directory-search-for-a-user | [x] |  |  |
-| 33 | active-object | [x] |  |  |
-| 34 | add-a-variable-to-a-class-instance-at-runtime | [x] |  |  |
-| 35 | additive-primes | [x] |  |  |
-| 36 | address-of-a-variable | [x] |  |  |
-| 37 | adfgvx-cipher | [x] |  |  |
-| 38 | aks-test-for-primes | [x] |  |  |
-| 39 | algebraic-data-types | [x] |  |  |
-| 40 | align-columns | [x] |  |  |
-| 41 | aliquot-sequence-classifications | [x] |  |  |
-| 42 | almkvist-giullera-formula-for-pi | [x] |  |  |
-| 43 | almost-prime | [x] |  |  |
-| 44 | amb | [x] |  |  |
-| 45 | amicable-pairs | [x] |  |  |
-| 46 | anagrams-deranged-anagrams | [x] |  |  |
-| 47 | anagrams | [x] |  |  |
-| 48 | angle-difference-between-two-bearings-1 | [x] |  |  |
-| 49 | angle-difference-between-two-bearings-2 | [x] |  |  |
-| 50 | angles-geometric-normalization-and-conversion | [x] |  |  |
-| 51 | animate-a-pendulum | [x] |  |  |
-| 52 | animation | [x] |  |  |
-| 53 | anonymous-recursion-1 | [x] |  |  |
-| 54 | anonymous-recursion-2 | [x] |  |  |
-| 55 | anonymous-recursion | [x] |  |  |
-| 56 | anti-primes | [x] |  |  |
-| 57 | append-a-record-to-the-end-of-a-text-file | [x] |  |  |
-| 58 | apply-a-callback-to-an-array-1 | [x] |  |  |
-| 59 | apply-a-callback-to-an-array-2 | [x] |  |  |
-| 60 | apply-a-digital-filter-direct-form-ii-transposed- | [x] |  |  |
-| 61 | approximate-equality | [x] |  |  |
-| 62 | arbitrary-precision-integers-included- | [x] |  |  |
-| 63 | archimedean-spiral | [x] |  |  |
-| 64 | arena-storage-pool | [x] |  |  |
-| 65 | arithmetic-complex | [x] |  |  |
-| 66 | arithmetic-derivative | [x] |  |  |
-| 67 | arithmetic-evaluation | [x] |  |  |
-| 68 | arithmetic-geometric-mean-calculate-pi | [x] |  |  |
-| 69 | arithmetic-geometric-mean | [x] |  |  |
-| 70 | arithmetic-integer-1 | [x] |  |  |
-| 71 | arithmetic-integer-2 | [x] |  |  |
-| 72 | arithmetic-numbers | [x] |  |  |
-| 73 | arithmetic-rational | [x] |  |  |
-| 74 | array-concatenation | [x] |  |  |
-| 75 | array-length | [x] |  |  |
-| 76 | arrays | [x] |  |  |
-| 77 | ascending-primes | [x] |  |  |
-| 78 | ascii-art-diagram-converter | [x] |  |  |
-| 79 | assertions | [x] |  |  |
-| 80 | associative-array-creation | [x] |  |  |
-| 81 | associative-array-iteration | [x] |  |  |
-| 82 | associative-array-merging | [x] |  |  |
-| 83 | atomic-updates | [x] |  |  |
-| 84 | attractive-numbers | [x] |  |  |
-| 85 | average-loop-length | [x] |  |  |
-| 86 | averages-arithmetic-mean | [x] |  |  |
-| 87 | averages-mean-time-of-day | [x] |  |  |
-| 88 | averages-median-1 | [x] |  |  |
-| 89 | averages-median-2 | [x] |  |  |
-| 90 | averages-median-3 | [x] |  |  |
-| 91 | averages-mode | [x] |  |  |
-| 92 | averages-pythagorean-means | [x] |  |  |
-| 93 | averages-root-mean-square | [x] |  |  |
-| 94 | averages-simple-moving-average | [x] |  |  |
-| 95 | avl-tree | [x] |  |  |
-| 96 | b-zier-curves-intersections | [x] |  |  |
-| 97 | babbage-problem | [x] |  |  |
-| 98 | babylonian-spiral | [x] |  |  |
-| 99 | balanced-brackets | [x] |  |  |
-| 100 | balanced-ternary | [x] |  |  |
-| 101 | barnsley-fern | [x] |  |  |
-| 102 | base64-decode-data | [x] |  |  |
-| 103 | bell-numbers | [x] |  |  |
-| 104 | benfords-law | [x] |  |  |
-| 105 | bernoulli-numbers | [x] |  |  |
-| 106 | best-shuffle | [x] |  |  |
-| 107 | bifid-cipher | [x] |  |  |
-| 108 | bin-given-limits | [x] |  |  |
-| 109 | binary-digits | [x] |  |  |
-| 110 | binary-search | [x] |  |  |
-| 111 | binary-strings | [x] |  |  |
-| 112 | bioinformatics-base-count | [x] |  |  |
-| 113 | bioinformatics-global-alignment | [ ] |  |  |
-| 114 | bioinformatics-sequence-mutation | [x] |  |  |
-| 115 | biorhythms | [ ] |  |  |
-| 116 | bitcoin-address-validation | [ ] |  |  |
-| 117 | bitmap-b-zier-curves-cubic | [ ] |  |  |
-| 118 | bitmap-b-zier-curves-quadratic | [ ] |  |  |
-| 119 | bitmap-bresenhams-line-algorithm | [x] |  |  |
-| 120 | bitmap-flood-fill | [x] |  |  |
-| 121 | bitmap-histogram | [x] |  |  |
-| 122 | bitmap-midpoint-circle-algorithm | [x] |  |  |
-| 123 | bitmap-ppm-conversion-through-a-pipe | [x] |  |  |
-| 124 | bitmap-read-a-ppm-file | [ ] |  |  |
-| 125 | bitmap-read-an-image-through-a-pipe | [x] |  |  |
-| 126 | bitmap-write-a-ppm-file | [x] |  |  |
-| 127 | bitmap | [x] |  |  |
-| 128 | bitwise-io-1 | [x] |  |  |
-| 129 | bitwise-io-2 | [ ] |  |  |
-| 130 | bitwise-operations | [x] |  |  |
-| 131 | blum-integer | [x] |  |  |
-| 132 | boolean-values | [x] |  |  |
-| 133 | box-the-compass | [ ] |  |  |
-| 134 | boyer-moore-string-search | [ ] |  |  |
-| 135 | brazilian-numbers | [ ] |  |  |
-| 136 | break-oo-privacy | [ ] |  |  |
-| 137 | brilliant-numbers | [ ] |  |  |
-| 138 | brownian-tree | [ ] |  |  |
-| 139 | bulls-and-cows-player | [ ] |  |  |
-| 140 | bulls-and-cows | [ ] |  |  |
-| 141 | burrows-wheeler-transform | [ ] |  |  |
-| 142 | caesar-cipher-1 | [ ] |  |  |
-| 143 | caesar-cipher-2 | [ ] |  |  |
-| 144 | calculating-the-value-of-e | [ ] |  |  |
-| 145 | calendar---for-real-programmers-1 | [ ] |  |  |
-| 146 | calendar---for-real-programmers-2 | [ ] |  |  |
-| 147 | calendar | [ ] |  |  |
-| 148 | calkin-wilf-sequence | [ ] |  |  |
-| 149 | call-a-foreign-language-function | [ ] |  |  |
-| 150 | call-a-function-1 | [ ] |  |  |
-| 151 | call-a-function-10 | [ ] |  |  |
-| 152 | call-a-function-11 | [ ] |  |  |
-| 153 | call-a-function-12 | [ ] |  |  |
-| 154 | call-a-function-2 | [ ] |  |  |
-| 155 | call-a-function-3 | [ ] |  |  |
-| 156 | call-a-function-4 | [ ] |  |  |
-| 157 | call-a-function-5 | [ ] |  |  |
-| 158 | call-a-function-6 | [ ] |  |  |
-| 159 | call-a-function-7 | [ ] |  |  |
-| 160 | call-a-function-8 | [ ] |  |  |
-| 161 | call-a-function-9 | [ ] |  |  |
-| 162 | call-an-object-method-1 | [ ] |  |  |
-| 163 | call-an-object-method-2 | [ ] |  |  |
-| 164 | call-an-object-method-3 | [ ] |  |  |
-| 165 | call-an-object-method | [ ] |  |  |
-| 166 | camel-case-and-snake-case | [ ] |  |  |
-| 167 | canny-edge-detector | [ ] |  |  |
-| 168 | canonicalize-cidr | [ ] |  |  |
-| 169 | cantor-set | [ ] |  |  |
-| 170 | carmichael-3-strong-pseudoprimes | [ ] |  |  |
-| 171 | cartesian-product-of-two-or-more-lists-1 | [ ] |  |  |
-| 172 | cartesian-product-of-two-or-more-lists-2 | [ ] |  |  |
-| 173 | cartesian-product-of-two-or-more-lists-3 | [ ] |  |  |
-| 174 | cartesian-product-of-two-or-more-lists-4 | [ ] |  |  |
-| 175 | case-sensitivity-of-identifiers | [ ] |  |  |
-| 176 | casting-out-nines | [ ] |  |  |
-| 177 | catalan-numbers-1 | [ ] |  |  |
-| 178 | catalan-numbers-2 | [ ] |  |  |
-| 179 | catalan-numbers-pascals-triangle | [ ] |  |  |
-| 180 | catamorphism | [ ] |  |  |
-| 181 | catmull-clark-subdivision-surface | [ ] |  |  |
-| 182 | chaocipher | [ ] |  |  |
-| 183 | chaos-game | [ ] |  |  |
-| 184 | character-codes-1 | [ ] |  |  |
-| 185 | character-codes-2 | [ ] |  |  |
-| 186 | character-codes-3 | [ ] |  |  |
-| 187 | character-codes-4 | [ ] |  |  |
-| 188 | character-codes-5 | [ ] |  |  |
-| 189 | chat-server | [ ] |  |  |
-| 190 | check-machin-like-formulas | [ ] |  |  |
-| 191 | check-that-file-exists | [ ] |  |  |
-| 192 | checkpoint-synchronization-1 | [ ] |  |  |
-| 193 | checkpoint-synchronization-2 | [ ] |  |  |
-| 194 | checkpoint-synchronization-3 | [ ] |  |  |
-| 195 | checkpoint-synchronization-4 | [ ] |  |  |
-| 196 | chernicks-carmichael-numbers | [ ] |  |  |
-| 197 | cheryls-birthday | [ ] |  |  |
-| 198 | chinese-remainder-theorem | [ ] |  |  |
-| 199 | chinese-zodiac | [ ] |  |  |
-| 200 | cholesky-decomposition-1 | [ ] |  |  |
-| 201 | cholesky-decomposition | [ ] |  |  |
-| 202 | chowla-numbers | [ ] |  |  |
-| 203 | church-numerals-1 | [ ] |  |  |
-| 204 | church-numerals-2 | [ ] |  |  |
-| 205 | circles-of-given-radius-through-two-points | [ ] |  |  |
-| 206 | circular-primes | [ ] |  |  |
-| 207 | cistercian-numerals | [ ] |  |  |
-| 208 | comma-quibbling | [ ] |  |  |
-| 209 | compiler-virtual-machine-interpreter | [ ] |  |  |
-| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | [ ] |  |  |
-| 211 | compound-data-type | [ ] |  |  |
-| 212 | concurrent-computing-1 | [ ] |  |  |
-| 213 | concurrent-computing-2 | [ ] |  |  |
-| 214 | concurrent-computing-3 | [ ] |  |  |
-| 215 | conditional-structures-1 | [ ] |  |  |
-| 216 | conditional-structures-10 | [ ] |  |  |
-| 217 | conditional-structures-2 | [ ] |  |  |
-| 218 | conditional-structures-3 | [ ] |  |  |
-| 219 | conditional-structures-4 | [ ] |  |  |
-| 220 | conditional-structures-5 | [ ] |  |  |
-| 221 | conditional-structures-6 | [ ] |  |  |
-| 222 | conditional-structures-7 | [ ] |  |  |
-| 223 | conditional-structures-8 | [ ] |  |  |
-| 224 | conditional-structures-9 | [ ] |  |  |
-| 225 | consecutive-primes-with-ascending-or-descending-differences | [ ] |  |  |
-| 226 | constrained-genericity-1 | [ ] |  |  |
-| 227 | constrained-genericity-2 | [ ] |  |  |
-| 228 | constrained-genericity-3 | [ ] |  |  |
-| 229 | constrained-genericity-4 | [ ] |  |  |
-| 230 | constrained-random-points-on-a-circle-1 | [ ] |  |  |
-| 231 | constrained-random-points-on-a-circle-2 | [ ] |  |  |
-| 232 | continued-fraction | [ ] |  |  |
-| 233 | convert-decimal-number-to-rational | [ ] |  |  |
-| 234 | convert-seconds-to-compound-duration | [ ] |  |  |
-| 235 | convex-hull | [ ] |  |  |
-| 236 | conways-game-of-life | [ ] |  |  |
-| 237 | copy-a-string-1 | [ ] |  |  |
-| 238 | copy-a-string-2 | [ ] |  |  |
-| 239 | copy-stdin-to-stdout-1 | [ ] |  |  |
-| 240 | copy-stdin-to-stdout-2 | [ ] |  |  |
-| 241 | count-in-factors | [ ] |  |  |
-| 242 | count-in-octal-1 | [ ] |  |  |
-| 243 | count-in-octal-2 | [ ] |  |  |
-| 244 | count-in-octal-3 | [ ] |  |  |
-| 245 | count-in-octal-4 | [ ] |  |  |
-| 246 | count-occurrences-of-a-substring | [ ] |  |  |
-| 247 | count-the-coins-1 | [ ] |  |  |
-| 248 | count-the-coins-2 | [ ] |  |  |
-| 249 | cramers-rule | [ ] |  |  |
-| 250 | crc-32-1 | [ ] |  |  |
-| 251 | crc-32-2 | [ ] |  |  |
-| 252 | create-a-file-on-magnetic-tape | [ ] |  |  |
-| 253 | create-a-file | [ ] |  |  |
-| 254 | create-a-two-dimensional-array-at-runtime-1 | [ ] |  |  |
-| 255 | create-an-html-table | [ ] |  |  |
-| 256 | create-an-object-at-a-given-address | [ ] |  |  |
-| 257 | csv-data-manipulation | [ ] |  |  |
-| 258 | csv-to-html-translation-1 | [ ] |  |  |
-| 259 | csv-to-html-translation-2 | [ ] |  |  |
-| 260 | csv-to-html-translation-3 | [ ] |  |  |
-| 261 | csv-to-html-translation-4 | [ ] |  |  |
-| 262 | csv-to-html-translation-5 | [ ] |  |  |
-| 263 | cuban-primes | [ ] |  |  |
-| 264 | cullen-and-woodall-numbers | [ ] |  |  |
-| 265 | cumulative-standard-deviation | [ ] |  |  |
-| 266 | currency | [ ] |  |  |
-| 267 | currying | [ ] |  |  |
-| 268 | curzon-numbers | [ ] |  |  |
-| 269 | cusip | [ ] |  |  |
-| 270 | cyclops-numbers | [ ] |  |  |
-| 271 | damm-algorithm | [ ] |  |  |
-| 272 | date-format | [ ] |  |  |
-| 273 | date-manipulation | [ ] |  |  |
-| 274 | day-of-the-week | [ ] |  |  |
-| 275 | de-bruijn-sequences | [ ] |  |  |
-| 276 | deal-cards-for-freecell | [ ] |  |  |
-| 277 | death-star | [ ] |  |  |
-| 278 | deceptive-numbers | [ ] |  |  |
-| 279 | deconvolution-1d-2 | [ ] |  |  |
-| 280 | deconvolution-1d-3 | [ ] |  |  |
-| 281 | deconvolution-1d | [ ] |  |  |
-| 282 | deepcopy-1 | [ ] |  |  |
-| 283 | define-a-primitive-data-type | [ ] |  |  |
-| 284 | md5 | [ ] |  |  |
+|------:|------|:-----:|---------:|-------:|
+| 1 | 100-doors-2 | ✓ | 10.076ms | 1.4 MB |
+| 2 | 100-doors-3 | ✓ |  |  |
+| 3 | 100-doors | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  |  |
+| 5 | 15-puzzle-game | ✓ |  |  |
+| 6 | 15-puzzle-solver | ✓ |  |  |
+| 7 | 2048 | ✓ |  |  |
+| 8 | 21-game | ✓ |  |  |
+| 9 | 24-game-solve | ✓ |  |  |
+| 10 | 24-game | ✓ |  |  |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ✓ |  |  |
+| 13 | 99-bottles-of-beer-2 | ✓ |  |  |
+| 14 | 99-bottles-of-beer | ✓ |  |  |
+| 15 | DNS-query | ✓ |  |  |
+| 16 | a+b | ✓ |  |  |
+| 17 | abbreviations-automatic | ✓ |  |  |
+| 18 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-simple | ✓ |  |  |
+| 20 | abc-problem | ✓ |  |  |
+| 21 | abelian-sandpile-model-identity | ✓ |  |  |
+| 22 | abelian-sandpile-model | ✓ |  |  |
+| 23 | abstract-type | ✓ |  |  |
+| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
+| 25 | abundant-odd-numbers | ✓ |  |  |
+| 26 | accumulator-factory | ✓ |  |  |
+| 27 | achilles-numbers |   |  |  |
+| 28 | ackermann-function-2 | ✓ |  |  |
+| 29 | ackermann-function-3 | ✓ |  |  |
+| 30 | ackermann-function | ✓ |  |  |
+| 31 | active-directory-connect | ✓ |  |  |
+| 32 | active-directory-search-for-a-user | ✓ |  |  |
+| 33 | active-object | ✓ |  |  |
+| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ |  |  |
+| 35 | additive-primes | ✓ |  |  |
+| 36 | address-of-a-variable | ✓ |  |  |
+| 37 | adfgvx-cipher | ✓ |  |  |
+| 38 | aks-test-for-primes | ✓ |  |  |
+| 39 | algebraic-data-types | ✓ |  |  |
+| 40 | align-columns | ✓ |  |  |
+| 41 | aliquot-sequence-classifications | ✓ |  |  |
+| 42 | almkvist-giullera-formula-for-pi | ✓ |  |  |
+| 43 | almost-prime | ✓ |  |  |
+| 44 | amb | ✓ |  |  |
+| 45 | amicable-pairs | ✓ |  |  |
+| 46 | anagrams-deranged-anagrams | ✓ |  |  |
+| 47 | anagrams | ✓ |  |  |
+| 48 | angle-difference-between-two-bearings-1 | ✓ |  |  |
+| 49 | angle-difference-between-two-bearings-2 | ✓ |  |  |
+| 50 | angles-geometric-normalization-and-conversion | ✓ |  |  |
+| 51 | animate-a-pendulum | ✓ |  |  |
+| 52 | animation | ✓ |  |  |
+| 53 | anonymous-recursion-1 | ✓ |  |  |
+| 54 | anonymous-recursion-2 | ✓ |  |  |
+| 55 | anonymous-recursion | ✓ |  |  |
+| 56 | anti-primes | ✓ |  |  |
+| 57 | append-a-record-to-the-end-of-a-text-file | ✓ |  |  |
+| 58 | apply-a-callback-to-an-array-1 | ✓ |  |  |
+| 59 | apply-a-callback-to-an-array-2 | ✓ |  |  |
+| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ |  |  |
+| 61 | approximate-equality | ✓ |  |  |
+| 62 | arbitrary-precision-integers-included- | ✓ |  |  |
+| 63 | archimedean-spiral | ✓ |  |  |
+| 64 | arena-storage-pool | ✓ |  |  |
+| 65 | arithmetic-complex | ✓ |  |  |
+| 66 | arithmetic-derivative | ✓ |  |  |
+| 67 | arithmetic-evaluation | ✓ |  |  |
+| 68 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
+| 69 | arithmetic-geometric-mean | ✓ |  |  |
+| 70 | arithmetic-integer-1 | ✓ |  |  |
+| 71 | arithmetic-integer-2 | ✓ |  |  |
+| 72 | arithmetic-numbers | ✓ |  |  |
+| 73 | arithmetic-rational | ✓ |  |  |
+| 74 | array-concatenation | ✓ |  |  |
+| 75 | array-length | ✓ |  |  |
+| 76 | arrays | ✓ |  |  |
+| 77 | ascending-primes | ✓ |  |  |
+| 78 | ascii-art-diagram-converter | ✓ |  |  |
+| 79 | assertions | ✓ |  |  |
+| 80 | associative-array-creation | ✓ |  |  |
+| 81 | associative-array-iteration | ✓ |  |  |
+| 82 | associative-array-merging | ✓ |  |  |
+| 83 | atomic-updates | ✓ |  |  |
+| 84 | attractive-numbers | ✓ |  |  |
+| 85 | average-loop-length | ✓ |  |  |
+| 86 | averages-arithmetic-mean | ✓ |  |  |
+| 87 | averages-mean-time-of-day | ✓ |  |  |
+| 88 | averages-median-1 | ✓ |  |  |
+| 89 | averages-median-2 | ✓ |  |  |
+| 90 | averages-median-3 | ✓ |  |  |
+| 91 | averages-mode | ✓ |  |  |
+| 92 | averages-pythagorean-means | ✓ |  |  |
+| 93 | averages-root-mean-square | ✓ |  |  |
+| 94 | averages-simple-moving-average | ✓ |  |  |
+| 95 | avl-tree | ✓ |  |  |
+| 96 | b-zier-curves-intersections | ✓ |  |  |
+| 97 | babbage-problem | ✓ |  |  |
+| 98 | babylonian-spiral | ✓ |  |  |
+| 99 | balanced-brackets | ✓ |  |  |
+| 100 | balanced-ternary | ✓ |  |  |
+| 101 | barnsley-fern | ✓ |  |  |
+| 102 | base64-decode-data | ✓ |  |  |
+| 103 | bell-numbers | ✓ |  |  |
+| 104 | benfords-law | ✓ |  |  |
+| 105 | bernoulli-numbers | ✓ |  |  |
+| 106 | best-shuffle | ✓ |  |  |
+| 107 | bifid-cipher | ✓ |  |  |
+| 108 | bin-given-limits | ✓ |  |  |
+| 109 | binary-digits | ✓ |  |  |
+| 110 | binary-search | ✓ |  |  |
+| 111 | binary-strings | ✓ |  |  |
+| 112 | bioinformatics-base-count | ✓ |  |  |
+| 113 | bioinformatics-global-alignment |   |  |  |
+| 114 | bioinformatics-sequence-mutation | ✓ |  |  |
+| 115 | biorhythms |   |  |  |
+| 116 | bitcoin-address-validation |   |  |  |
+| 117 | bitmap-b-zier-curves-cubic |   |  |  |
+| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
+| 119 | bitmap-bresenhams-line-algorithm | ✓ |  |  |
+| 120 | bitmap-flood-fill | ✓ |  |  |
+| 121 | bitmap-histogram | ✓ |  |  |
+| 122 | bitmap-midpoint-circle-algorithm | ✓ |  |  |
+| 123 | bitmap-ppm-conversion-through-a-pipe | ✓ |  |  |
+| 124 | bitmap-read-a-ppm-file |   |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe | ✓ |  |  |
+| 126 | bitmap-write-a-ppm-file | ✓ |  |  |
+| 127 | bitmap | ✓ |  |  |
+| 128 | bitwise-io-1 | ✓ |  |  |
+| 129 | bitwise-io-2 |   |  |  |
+| 130 | bitwise-operations | ✓ |  |  |
+| 131 | blum-integer | ✓ |  |  |
+| 132 | boolean-values | ✓ |  |  |
+| 133 | box-the-compass |   |  |  |
+| 134 | boyer-moore-string-search |   |  |  |
+| 135 | brazilian-numbers |   |  |  |
+| 136 | break-oo-privacy |   |  |  |
+| 137 | brilliant-numbers |   |  |  |
+| 138 | brownian-tree |   |  |  |
+| 139 | bulls-and-cows-player |   |  |  |
+| 140 | bulls-and-cows |   |  |  |
+| 141 | burrows-wheeler-transform |   |  |  |
+| 142 | caesar-cipher-1 |   |  |  |
+| 143 | caesar-cipher-2 |   |  |  |
+| 144 | calculating-the-value-of-e |   |  |  |
+| 145 | calendar---for-real-programmers-1 |   |  |  |
+| 146 | calendar---for-real-programmers-2 |   |  |  |
+| 147 | calendar |   |  |  |
+| 148 | calkin-wilf-sequence |   |  |  |
+| 149 | call-a-foreign-language-function |   |  |  |
+| 150 | call-a-function-1 |   |  |  |
+| 151 | call-a-function-10 |   |  |  |
+| 152 | call-a-function-11 |   |  |  |
+| 153 | call-a-function-12 |   |  |  |
+| 154 | call-a-function-2 |   |  |  |
+| 155 | call-a-function-3 |   |  |  |
+| 156 | call-a-function-4 |   |  |  |
+| 157 | call-a-function-5 |   |  |  |
+| 158 | call-a-function-6 |   |  |  |
+| 159 | call-a-function-7 |   |  |  |
+| 160 | call-a-function-8 |   |  |  |
+| 161 | call-a-function-9 |   |  |  |
+| 162 | call-an-object-method-1 |   |  |  |
+| 163 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-3 |   |  |  |
+| 165 | call-an-object-method |   |  |  |
+| 166 | camel-case-and-snake-case |   |  |  |
+| 167 | canny-edge-detector |   |  |  |
+| 168 | canonicalize-cidr |   |  |  |
+| 169 | cantor-set |   |  |  |
+| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 175 | case-sensitivity-of-identifiers |   |  |  |
+| 176 | casting-out-nines |   |  |  |
+| 177 | catalan-numbers-1 |   |  |  |
+| 178 | catalan-numbers-2 |   |  |  |
+| 179 | catalan-numbers-pascals-triangle |   |  |  |
+| 180 | catamorphism |   |  |  |
+| 181 | catmull-clark-subdivision-surface |   |  |  |
+| 182 | chaocipher |   |  |  |
+| 183 | chaos-game |   |  |  |
+| 184 | character-codes-1 |   |  |  |
+| 185 | character-codes-2 |   |  |  |
+| 186 | character-codes-3 |   |  |  |
+| 187 | character-codes-4 |   |  |  |
+| 188 | character-codes-5 |   |  |  |
+| 189 | chat-server |   |  |  |
+| 190 | check-machin-like-formulas |   |  |  |
+| 191 | check-that-file-exists |   |  |  |
+| 192 | checkpoint-synchronization-1 |   |  |  |
+| 193 | checkpoint-synchronization-2 |   |  |  |
+| 194 | checkpoint-synchronization-3 |   |  |  |
+| 195 | checkpoint-synchronization-4 |   |  |  |
+| 196 | chernicks-carmichael-numbers |   |  |  |
+| 197 | cheryls-birthday |   |  |  |
+| 198 | chinese-remainder-theorem |   |  |  |
+| 199 | chinese-zodiac |   |  |  |
+| 200 | cholesky-decomposition-1 |   |  |  |
+| 201 | cholesky-decomposition |   |  |  |
+| 202 | chowla-numbers |   |  |  |
+| 203 | church-numerals-1 |   |  |  |
+| 204 | church-numerals-2 |   |  |  |
+| 205 | circles-of-given-radius-through-two-points |   |  |  |
+| 206 | circular-primes |   |  |  |
+| 207 | cistercian-numerals |   |  |  |
+| 208 | comma-quibbling |   |  |  |
+| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 211 | compound-data-type |   |  |  |
+| 212 | concurrent-computing-1 |   |  |  |
+| 213 | concurrent-computing-2 |   |  |  |
+| 214 | concurrent-computing-3 |   |  |  |
+| 215 | conditional-structures-1 |   |  |  |
+| 216 | conditional-structures-10 |   |  |  |
+| 217 | conditional-structures-2 |   |  |  |
+| 218 | conditional-structures-3 |   |  |  |
+| 219 | conditional-structures-4 |   |  |  |
+| 220 | conditional-structures-5 |   |  |  |
+| 221 | conditional-structures-6 |   |  |  |
+| 222 | conditional-structures-7 |   |  |  |
+| 223 | conditional-structures-8 |   |  |  |
+| 224 | conditional-structures-9 |   |  |  |
+| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 226 | constrained-genericity-1 |   |  |  |
+| 227 | constrained-genericity-2 |   |  |  |
+| 228 | constrained-genericity-3 |   |  |  |
+| 229 | constrained-genericity-4 |   |  |  |
+| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 232 | continued-fraction |   |  |  |
+| 233 | convert-decimal-number-to-rational |   |  |  |
+| 234 | convert-seconds-to-compound-duration |   |  |  |
+| 235 | convex-hull |   |  |  |
+| 236 | conways-game-of-life |   |  |  |
+| 237 | copy-a-string-1 |   |  |  |
+| 238 | copy-a-string-2 |   |  |  |
+| 239 | copy-stdin-to-stdout-1 |   |  |  |
+| 240 | copy-stdin-to-stdout-2 |   |  |  |
+| 241 | count-in-factors |   |  |  |
+| 242 | count-in-octal-1 |   |  |  |
+| 243 | count-in-octal-2 |   |  |  |
+| 244 | count-in-octal-3 |   |  |  |
+| 245 | count-in-octal-4 |   |  |  |
+| 246 | count-occurrences-of-a-substring |   |  |  |
+| 247 | count-the-coins-1 |   |  |  |
+| 248 | count-the-coins-2 |   |  |  |
+| 249 | cramers-rule |   |  |  |
+| 250 | crc-32-1 |   |  |  |
+| 251 | crc-32-2 |   |  |  |
+| 252 | create-a-file-on-magnetic-tape |   |  |  |
+| 253 | create-a-file |   |  |  |
+| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 255 | create-an-html-table |   |  |  |
+| 256 | create-an-object-at-a-given-address |   |  |  |
+| 257 | csv-data-manipulation |   |  |  |
+| 258 | csv-to-html-translation-1 |   |  |  |
+| 259 | csv-to-html-translation-2 |   |  |  |
+| 260 | csv-to-html-translation-3 |   |  |  |
+| 261 | csv-to-html-translation-4 |   |  |  |
+| 262 | csv-to-html-translation-5 |   |  |  |
+| 263 | cuban-primes |   |  |  |
+| 264 | cullen-and-woodall-numbers |   |  |  |
+| 265 | cumulative-standard-deviation |   |  |  |
+| 266 | currency |   |  |  |
+| 267 | currying |   |  |  |
+| 268 | curzon-numbers |   |  |  |
+| 269 | cusip |   |  |  |
+| 270 | cyclops-numbers |   |  |  |
+| 271 | damm-algorithm |   |  |  |
+| 272 | date-format |   |  |  |
+| 273 | date-manipulation |   |  |  |
+| 274 | day-of-the-week |   |  |  |
+| 275 | de-bruijn-sequences |   |  |  |
+| 276 | deal-cards-for-freecell |   |  |  |
+| 277 | death-star |   |  |  |
+| 278 | deceptive-numbers |   |  |  |
+| 279 | deconvolution-1d-2 |   |  |  |
+| 280 | deconvolution-1d-3 |   |  |  |
+| 281 | deconvolution-1d |   |  |  |
+| 282 | deepcopy-1 |   |  |  |
+| 283 | define-a-primitive-data-type |   |  |  |
+| 284 | md5 |   |  |  |
 
-_Last updated: 2025-07-25 07:57 +0700_
+_Last updated: 2025-07-25 10:01 +0700_

--- a/transpiler/x/dart/transpiler_test.go
+++ b/transpiler/x/dart/transpiler_test.go
@@ -51,7 +51,7 @@ func runGolden(t *testing.T, name string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	ast, err := dartt.Transpile(prog, env, false)
+	ast, err := dartt.Transpile(prog, env, false, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}

--- a/transpiler/x/dart/vm_valid_golden_test.go
+++ b/transpiler/x/dart/vm_valid_golden_test.go
@@ -47,7 +47,7 @@ func TestDartTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, errs[0]
 		}
 		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
-		ast, err := dartt.Transpile(prog, env, bench)
+		ast, err := dartt.Transpile(prog, env, bench, bench)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
 			return nil, err


### PR DESCRIPTION
## Summary
- add WrapMain flag to Dart transpiler and wrap statements in a benchmark block when requested
- output absolute memory usage in benchmark code
- write `.bench` files and update benchmark handling in Dart Rosetta tests
- update Dart ROSETTA checklist format
- regenerate benchmark for `100-doors-2` in Dart

## Testing
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=true go test ./transpiler/x/dart -run Rosetta -tags=slow -count=1 -v`
- `go test ./transpiler/x/dart -run UpdateRosetta -tags=slow -v`
- `go test ./transpiler/x/dart -run TestTranspile_PrintHello -tags=slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882f3e204088320a3a4d1956ebcd684