### PR TITLE
Add benchmark mode for Elixir transpiler

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -762,11 +762,12 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return p.Emit(), nil
 	case "ex", "elixir":
-		p, err := ex.Transpile(prog, env)
+		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
+		p, err := ex.Transpile(prog, env, bench)
 		if err != nil {
 			return nil, err
 		}
-		return ex.Emit(p), nil
+		return ex.Emit(p, bench), nil
 	case "fortran", "ftn":
 		p, err := fortran.Transpile(prog, env)
 		if err != nil {

--- a/tests/rosetta/transpiler/Elixir/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Elixir/100-doors-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 8840,
+  "memory_bytes": 18800,
+  "name": "main"
+}

--- a/transpiler/x/ex/ROSETTA.md
+++ b/transpiler/x/ex/ROSETTA.md
@@ -3,10 +3,10 @@
 Generated Elixir code from Mochi Rosetta programs lives in `tests/rosetta/transpiler/Elixir`.
 
 ## Rosetta Test Checklist (19/284)
-_Last updated: 2025-07-25 01:57 +0000_
+_Last updated: 2025-07-25 10:01 +0700_
 | Index | Name | Status | Duration | Memory |
 | ---: | --- | :---: | ---: | ---: |
-| 1 | 100-doors-2 | ✓ | 7.11ms | 1.9 KB |
+| 1 | 100-doors-2 | ✓ | 8.84ms | 18.4 KB |
 | 2 | 100-doors-3 | ✓ |  |  |
 | 3 | 100-doors | ✓ |  |  |
 | 4 | 100-prisoners | ✓ |  |  |

--- a/transpiler/x/ex/transpiler.go
+++ b/transpiler/x/ex/transpiler.go
@@ -1544,7 +1544,7 @@ func Emit(p *Program, benchMain bool) []byte {
 }
 
 // Transpile converts a Mochi program into an Elixir AST.
-func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
+func Transpile(prog *parser.Program, env *types.Env, benchMain bool) (*Program, error) {
 	res := &Program{}
 	builtinAliases = make(map[string]string)
 	globalVars = make(map[string]struct{})
@@ -1596,6 +1596,9 @@ func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 		if stmt != nil {
 			res.Stmts = append(res.Stmts, stmt)
 		}
+	}
+	if benchMain {
+		res.Stmts = []Stmt{&BenchStmt{Name: "main", Body: res.Stmts}}
 	}
 	_ = env
 	return res, nil

--- a/transpiler/x/ex/transpiler_test.go
+++ b/transpiler/x/ex/transpiler_test.go
@@ -66,7 +66,7 @@ func TestElixirTranspiler_VMValid_Golden(t *testing.T) {
 				_ = os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
 				t.Fatalf("type: %v", errs[0])
 			}
-			gprog, err := ex.Transpile(prog, env)
+			gprog, err := ex.Transpile(prog, env, false)
 			if err != nil {
 				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 				t.Fatalf("transpile: %v", err)

--- a/transpiler/x/ex/vm_valid_golden_test.go
+++ b/transpiler/x/ex/vm_valid_golden_test.go
@@ -48,7 +48,7 @@ func TestExTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, errs[0]
 		}
 		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
-		ast, err := ex.Transpile(prog, env)
+		ast, err := ex.Transpile(prog, env, bench)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
 			return nil, err

--- a/transpiler/x/zig/stub.go
+++ b/transpiler/x/zig/stub.go
@@ -10,6 +10,8 @@ import (
 // Program is a placeholder used when the real implementation is excluded by build tags.
 type Program struct{}
 
+var benchMain bool
+
 // SetBenchMain is a no-op in the stub build.
 func SetBenchMain(v bool) { benchMain = v }
 


### PR DESCRIPTION
## Summary
- allow wrapping generated Elixir program in a benchmark block via new `benchMain` flag
- store benchmark results when MOCHI_BENCHMARK=true
- update transpiler and CLI usages for new flag
- keep rosetta progress updated

## Testing
- `go vet ./...`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=true go test ./transpiler/x/ex -run Rosetta -tags slow -count=1`
- `go test ./transpiler/x/ex -run ^$ -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882f3e4ae708320bf93b6be52d8a5c0