### PR TITLE
Improve Java transpiler benchmark mode

### DIFF
--- a/transpiler/x/java/rosetta_test.go
+++ b/transpiler/x/java/rosetta_test.go
@@ -79,7 +79,9 @@ func runRosettaTask(t *testing.T, name string) {
 	}
 	cmd = exec.Command("java", "-cp", tmp, className)
 	runEnv := []string{"MOCHI_ROOT=" + root}
-	if !bench {
+	if bench {
+		runEnv = append(runEnv, "MOCHI_BENCHMARK=1")
+	} else {
 		runEnv = append(runEnv, "MOCHI_NOW_SEED=1")
 	}
 	cmd.Env = append(os.Environ(), runEnv...)
@@ -94,6 +96,9 @@ func runRosettaTask(t *testing.T, name string) {
 	}
 	_ = os.Remove(errPath)
 	if bench {
+		if idx := bytes.LastIndexByte(got, '{'); idx >= 0 {
+			got = got[idx:]
+		}
 		if shouldUpdateRosetta() {
 			_ = os.WriteFile(benchPath, got, 0644)
 		}

--- a/transpiler/x/java/vm_valid_golden_test.go
+++ b/transpiler/x/java/vm_valid_golden_test.go
@@ -35,6 +35,8 @@ func TestJavaTranspiler_VMValid_Golden(t *testing.T) {
 		outPath := filepath.Join(outDir, base+".out")
 		errPath := filepath.Join(outDir, base+".error")
 
+		bench := os.Getenv("MOCHI_BENCHMARK") == "true"
+		javatr.SetBenchMain(bench)
 		prog, err := parser.Parse(src)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
@@ -65,7 +67,13 @@ func TestJavaTranspiler_VMValid_Golden(t *testing.T) {
 			return nil, err
 		}
 		cmd = exec.Command("java", "-cp", outDir, "Main")
-		cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
+		runEnv := []string{"MOCHI_ROOT=" + root}
+		if bench {
+			runEnv = append(runEnv, "MOCHI_BENCHMARK=1")
+		} else {
+			runEnv = append(runEnv, "MOCHI_NOW_SEED=1")
+		}
+		cmd.Env = append(os.Environ(), runEnv...)
 		if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 			cmd.Stdin = bytes.NewReader(data)
 		}


### PR DESCRIPTION
## Summary
- support `UnionType` and float casts in Java transpiler
- ensure append uses existing list type when available
- allow running Rosetta tests in benchmark mode
- update Java VM golden tests for benchmark mode

## Testing
- `ROSETTA_MAX=4 go test ./transpiler/x/java -run Rosetta -tags slow -count=1`
- `MOCHI_BENCHMARK=true MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/java -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882f3fbacf0832093af61060a83428b