### PR TITLE
Add benchmark mode for Prolog transpiler

### DIFF
--- a/transpiler/x/pl/transpiler_test.go
+++ b/transpiler/x/pl/transpiler_test.go
@@ -1579,6 +1579,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	updateReadme()
 	updateTasks()
+	pl.UpdateRosettaReadme()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
## Summary
- support bench mode in Prolog transpiler
- write benchmark results when `MOCHI_BENCHMARK` is set
- generate Rosetta checklist table with durations and memory stats

## Testing
- `go test -tags slow ./transpiler/x/pl -run TestPrologTranspiler_Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6882f41113308320bd3a796dff57f0a8