### PR TITLE
Add benchmark mode to Rust transpiler

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -857,7 +857,7 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return buf.Bytes(), nil
 	case "rust":
-		p, err := rs.Transpile(prog, env)
+		p, err := rs.Transpile(prog, env, false)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/rosetta/transpiler/Rust/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Rust/100-doors-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 110,
+  "memory_bytes": 3313664,
+  "name": "main"
+}

--- a/transpiler/x/rs/rosetta_test.go
+++ b/transpiler/x/rs/rosetta_test.go
@@ -5,6 +5,7 @@ package rs_test
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -62,7 +63,7 @@ func updateIndex(dir string) error {
 	return os.WriteFile(filepath.Join(dir, "index.txt"), buf.Bytes(), 0o644)
 }
 
-func runRosetta(t *testing.T, src, outDir string) ([]byte, error) {
+func runRosetta(t *testing.T, src, outDir string, bench bool) ([]byte, error) {
 	base := strings.TrimSuffix(filepath.Base(src), ".mochi")
 	codePath := filepath.Join(outDir, base+".rs")
 	errPath := filepath.Join(outDir, base+".error")
@@ -77,7 +78,7 @@ func runRosetta(t *testing.T, src, outDir string) ([]byte, error) {
 		_ = os.WriteFile(errPath, []byte(errs[0].Error()), 0o644)
 		return nil, fmt.Errorf("type: %v", errs[0])
 	}
-	gprog, err := rs.Transpile(prog, env)
+	gprog, err := rs.Transpile(prog, env, bench)
 	if err != nil {
 		_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 		return nil, fmt.Errorf("transpile: %w", err)
@@ -99,7 +100,11 @@ func runRosetta(t *testing.T, src, outDir string) ([]byte, error) {
 		return nil, fmt.Errorf("rustc: %w", err)
 	}
 	cmd := exec.Command(bin)
-	cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
+	if !bench {
+		cmd.Env = append(os.Environ(), "MOCHI_NOW_SEED=1")
+	} else {
+		cmd.Env = os.Environ()
+	}
 	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
 		cmd.Stdin = bytes.NewReader(data)
 	}
@@ -110,6 +115,17 @@ func runRosetta(t *testing.T, src, outDir string) ([]byte, error) {
 		return nil, fmt.Errorf("run: %w", err)
 	}
 	_ = os.Remove(errPath)
+	benchPath := filepath.Join(outDir, base+".bench")
+	outPath := filepath.Join(outDir, base+".out")
+	if bench {
+		outBytes := got
+		if idx := bytes.LastIndexByte(outBytes, '{'); idx >= 0 {
+			outBytes = outBytes[idx:]
+		}
+		_ = os.WriteFile(benchPath, outBytes, 0o644)
+		return outBytes, nil
+	}
+	_ = os.WriteFile(outPath, got, 0o644)
 	return got, nil
 }
 
@@ -139,17 +155,21 @@ func TestTranspiler_Rosetta(t *testing.T) {
 	if len(names) == 0 {
 		t.Fatalf("no rosetta programs found")
 	}
+	bench := os.Getenv("MOCHI_BENCHMARK") != ""
 	var passed, failed int
 	var firstFail string
 	for _, name := range names {
 		src := filepath.Join(srcDir, name)
 		base := strings.TrimSuffix(name, ".mochi")
 		ok := t.Run(base, func(t *testing.T) {
-			got, err := runRosetta(t, src, outDir)
+			got, err := runRosetta(t, src, outDir, bench)
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
 			outFile := filepath.Join(outDir, base+".out")
+			if bench {
+				return
+			}
 			if shouldUpdate() {
 				_ = os.WriteFile(outFile, append(got, '\n'), 0o644)
 				return
@@ -187,31 +207,74 @@ func updateRosetta() {
 	total := len(names)
 	compiled := 0
 	var lines []string
+	lines = append(lines, "| Index | Name | Status | Duration | Memory |")
+	lines = append(lines, "|------:|------|:-----:|---------:|-------:|")
 	for i, f := range names {
 		name := strings.TrimSuffix(f, ".mochi")
-		mark := "[ ]"
-		if _, err := os.Stat(filepath.Join(outDir, name+".out")); err == nil {
-			if _, err2 := os.Stat(filepath.Join(outDir, name+".error")); os.IsNotExist(err2) {
-				compiled++
-				mark = "[x]"
+		status := " "
+		if _, err := os.Stat(filepath.Join(outDir, name+".error")); err == nil {
+			// leave unchecked
+		} else if _, err := os.Stat(filepath.Join(outDir, name+".rs")); err == nil {
+			compiled++
+			status = "✓"
+		}
+		dur := ""
+		mem := ""
+		benchFile := filepath.Join(outDir, name+".bench")
+		if data, err := os.ReadFile(benchFile); err == nil {
+			var js struct {
+				Duration int64 `json:"duration_us"`
+				Memory   int64 `json:"memory_bytes"`
+			}
+			if json.Unmarshal(bytes.TrimSpace(data), &js) == nil {
+				if js.Duration > 0 {
+					dur = humanDuration(js.Duration)
+				}
+				if js.Memory > 0 {
+					mem = humanSize(js.Memory)
+				}
+			}
+		} else if data, err := os.ReadFile(filepath.Join(outDir, name+".out")); err == nil {
+			var js struct {
+				Duration int64 `json:"duration_us"`
+				Memory   int64 `json:"memory_bytes"`
+			}
+			data = bytes.TrimSpace(data)
+			if idx := bytes.LastIndexByte(data, '{'); idx >= 0 {
+				if json.Unmarshal(data[idx:], &js) == nil && js.Duration > 0 {
+					dur = humanDuration(js.Duration)
+					mem = humanSize(js.Memory)
+				}
 			}
 		}
-		lines = append(lines, fmt.Sprintf("%3d. %s %s (%d)", i+1, mark, name, i+1))
+		lines = append(lines, fmt.Sprintf("| %d | %s | %s | %s | %s |", i+1, name, status, dur, mem))
 	}
-	tsRaw, _ := exec.Command("git", "log", "-1", "--format=%cI").Output()
-	ts := strings.TrimSpace(string(tsRaw))
-	if t, err := time.Parse(time.RFC3339, ts); err == nil {
-		if loc, lerr := time.LoadLocation("Asia/Bangkok"); lerr == nil {
-			ts = t.In(loc).Format("2006-01-02 15:04 -0700")
-		} else {
-			ts = t.Format("2006-01-02 15:04 MST")
-		}
-	}
+	ts := time.Now().UTC().Format("2006-01-02 15:04 MST")
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "# Rosetta Rust Transpiler Output (%d/%d)\n", compiled, total)
-	fmt.Fprintf(&buf, "Last updated: %s\n\n", ts)
-	buf.WriteString("## Program checklist\n\n")
+	buf.WriteString("# Rosetta Rust Transpiler Progress\n\n")
+	buf.WriteString("This checklist is auto-generated.\n")
+	buf.WriteString("Generated Rust code from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/transpiler/Rust`.\n")
+	buf.WriteString("Last updated: " + ts + "\n\n")
+	fmt.Fprintf(&buf, "## Rosetta Golden Test Checklist (%d/%d)\n", compiled, total)
 	buf.WriteString(strings.Join(lines, "\n"))
 	buf.WriteString("\n")
 	_ = os.WriteFile(readmePath, buf.Bytes(), 0o644)
+}
+
+func humanDuration(us int64) string {
+	d := time.Duration(us) * time.Microsecond
+	return d.String()
+}
+
+func humanSize(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }

--- a/transpiler/x/rs/transpiler_test.go
+++ b/transpiler/x/rs/transpiler_test.go
@@ -50,7 +50,7 @@ func TestTranspile_PrintHello(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	progAST, err := rs.Transpile(prog, env)
+	progAST, err := rs.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestTranspile_LetAndPrint(t *testing.T) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	progAST, err := rs.Transpile(prog, env)
+	progAST, err := rs.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}
@@ -151,7 +151,7 @@ func runExample(t *testing.T, base string) {
 	if errs := types.Check(prog, env); len(errs) > 0 {
 		t.Fatalf("type: %v", errs[0])
 	}
-	progAST, err := rs.Transpile(prog, env)
+	progAST, err := rs.Transpile(prog, env, false)
 	if err != nil {
 		t.Fatalf("transpile: %v", err)
 	}

--- a/transpiler/x/rs/vm_valid_golden_test.go
+++ b/transpiler/x/rs/vm_valid_golden_test.go
@@ -42,7 +42,7 @@ func TestRSTranspiler_VMValid_Golden(t *testing.T) {
 			_ = os.WriteFile(errPath, []byte("type: "+errs[0].Error()), 0o644)
 			return nil, errs[0]
 		}
-		progAST, err := rs.Transpile(prog, env)
+		progAST, err := rs.Transpile(prog, env, false)
 		if err != nil {
 			_ = os.WriteFile(errPath, []byte("transpile: "+err.Error()), 0o644)
 			return nil, err


### PR DESCRIPTION
## Summary
- support wrapping main in benchmark block for Rust transpiler
- record memory usage and real timing
- run rosetta tests with optional benchmark mode
- update command driver for new transpiler signature
- add golden benchmark result for program 1

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/rs -run TestTranspiler_Rosetta -tags slow`
- `MOCHI_ROSETTA_INDEX=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/rs -run TestTranspiler_Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6882f41e1e1c8320840beb04f7e9cb57