### PR TITLE
Add benchmark flag support for Smalltalk transpiler tests

### DIFF
--- a/transpiler/x/st/rosetta_test.go
+++ b/transpiler/x/st/rosetta_test.go
@@ -93,7 +93,7 @@ func TestSmalltalkRosetta(t *testing.T) {
 				return
 			}
 			var buf bytes.Buffer
-			if err := st.Emit(&buf, ast, false); err != nil {
+			if err := st.Emit(&buf, ast, bench); err != nil {
 				_ = os.WriteFile(errPath, []byte(err.Error()), 0o644)
 				t.Skip("emit error")
 				return


### PR DESCRIPTION
## Summary
- support benchmark mode in Smalltalk transpiler golden tests

## Testing
- `MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/st -run TestSmalltalkRosetta -tags slow -count=1`
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=1 go test ./transpiler/x/st -run TestSmalltalkRosetta -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_6882f7bda4748320b05367b637d8ad79