### PR TITLE
Run first Rosetta programs in Clojure

### DIFF
--- a/tests/rosetta/transpiler/Clojure/100-doors-2.bench
+++ b/tests/rosetta/transpiler/Clojure/100-doors-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 17246,
-  "memory_bytes": 19501672,
+  "duration_us": 42868,
+  "memory_bytes": 19341528,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Clojure/100-doors-2.out
+++ b/tests/rosetta/transpiler/Clojure/100-doors-2.out
@@ -6,14 +6,14 @@ Door 5 Closed
 Door 6 Closed
 Door 7 Closed
 Door 8 Closed
-Door 9 Closed
+Door 9 Open
 Door 10 Closed
 Door 11 Closed
 Door 12 Closed
-Door 13 Open
+Door 13 Closed
 Door 14 Closed
 Door 15 Closed
-Door 16 Closed
+Door 16 Open
 Door 17 Closed
 Door 18 Closed
 Door 19 Closed
@@ -22,7 +22,7 @@ Door 21 Closed
 Door 22 Closed
 Door 23 Closed
 Door 24 Closed
-Door 25 Closed
+Door 25 Open
 Door 26 Closed
 Door 27 Closed
 Door 28 Closed
@@ -33,7 +33,7 @@ Door 32 Closed
 Door 33 Closed
 Door 34 Closed
 Door 35 Closed
-Door 36 Closed
+Door 36 Open
 Door 37 Closed
 Door 38 Closed
 Door 39 Closed
@@ -43,10 +43,10 @@ Door 42 Closed
 Door 43 Closed
 Door 44 Closed
 Door 45 Closed
-Door 46 Open
+Door 46 Closed
 Door 47 Closed
 Door 48 Closed
-Door 49 Closed
+Door 49 Open
 Door 50 Closed
 Door 51 Closed
 Door 52 Closed
@@ -61,7 +61,7 @@ Door 60 Closed
 Door 61 Closed
 Door 62 Closed
 Door 63 Closed
-Door 64 Closed
+Door 64 Open
 Door 65 Closed
 Door 66 Closed
 Door 67 Closed
@@ -78,7 +78,7 @@ Door 77 Closed
 Door 78 Closed
 Door 79 Closed
 Door 80 Closed
-Door 81 Closed
+Door 81 Open
 Door 82 Closed
 Door 83 Closed
 Door 84 Closed
@@ -97,4 +97,4 @@ Door 96 Closed
 Door 97 Closed
 Door 98 Closed
 Door 99 Closed
-Door 100 Closed
+Door 100 Open

--- a/tests/rosetta/transpiler/Clojure/100-doors-3.bench
+++ b/tests/rosetta/transpiler/Clojure/100-doors-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 40460,
+  "memory_bytes": 19245760,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/100-doors-3.clj
+++ b/tests/rosetta/transpiler/Clojure/100-doors-3.clj
@@ -2,10 +2,23 @@
 
 (require 'clojure.set)
 
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
 (def result "")
 
 (defn -main []
-  (doseq [i (range 1 101)] (do (def j 1) (while (< (* j j) i) (def j (+ j 1))) (if (= (* j j) i) (def result (str result "O")) (def result (str result "-")))))
-  (println result))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (doseq [i (range 1 101)] (do (def j 1) (while (< (* j j) i) (def j (+ j 1))) (if (= (* j j) i) (def result (str result "O")) (def result (str result "-")))))
+      (println result)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/100-doors.bench
+++ b/tests/rosetta/transpiler/Clojure/100-doors.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 43762,
+  "memory_bytes": 20308768,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/100-doors.clj
+++ b/tests/rosetta/transpiler/Clojure/100-doors.clj
@@ -2,11 +2,24 @@
 
 (require 'clojure.set)
 
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
 (def doors [])
 
 (defn -main []
-  (dotimes [i 100] (def doors (conj doors false)))
-  (doseq [pass (range 1 101)] (do (def idx (- pass 1)) (while (< idx 100) (do (def doors (assoc doors idx (not (nth doors idx)))) (def idx (+ idx pass))))))
-  (dotimes [row 10] (do (def line "") (dotimes [col 10] (do (def idx (+ (* row 10) col)) (if (nth doors idx) (def line (str line "1")) (def line (str line "0"))) (when (< col 9) (def line (str line " "))))) (println line))))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (dotimes [i 100] (def doors (conj doors false)))
+      (doseq [pass (range 1 101)] (do (def idx (- pass 1)) (while (< idx 100) (do (def doors (assoc doors idx (not (nth doors idx)))) (def idx (+ idx pass))))))
+      (dotimes [row 10] (do (def line "") (dotimes [col 10] (do (def idx (+ (* row 10) col)) (if (nth doors idx) (def line (str line "1")) (def line (str line "0"))) (when (< col 9) (def line (str line " "))))) (println line)))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/100-prisoners.bench
+++ b/tests/rosetta/transpiler/Clojure/100-prisoners.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 2882578,
+  "memory_bytes": 22824384,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/100-prisoners.clj
+++ b/tests/rosetta/transpiler/Clojure/100-prisoners.clj
@@ -2,24 +2,31 @@
 
 (require 'clojure.set)
 
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare shuffle doTrials main)
+
 (defn shuffle [xs]
-  (def arr xs)
-  (def i 99)
-  (while (> i 0) (do (def j (mod (System/currentTimeMillis) (+ i 1))) (def tmp (nth arr i)) (def arr (assoc arr i (nth arr j))) (def arr (assoc arr j tmp)) (def i (- i 1))))
-  arr)
+  (try (do (def arr xs) (def i 99) (while (> i 0) (do (def j (mod (swap! nowSeed (fn [s] (mod (+ (* s 1664525) 1013904223) 2147483647))) (+ i 1))) (def tmp (nth arr i)) (def arr (assoc arr i (nth arr j))) (def arr (assoc arr j tmp)) (def i (- i 1)))) (throw (ex-info "return" {:v arr}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn doTrials [trials np strategy]
-  (def pardoned 0)
-  (def t 0)
-  (while (< t trials) (do (def drawers []) (def i 0) (while (< i 100) (do (def drawers (conj drawers i)) (def i (+ i 1)))) (def drawers (shuffle drawers)) (def p 0) (def success true) (loop [while_flag_1 true] (when (and while_flag_1 (< p np)) (do (def found false) (if (= strategy "optimal") (do (def prev p) (def d 0) (loop [while_flag_2 true] (when (and while_flag_2 (< d 50)) (do (def this (nth drawers prev)) (cond (= this p) (do (def found true) (recur false)) :else (do (def prev this) (def d (+ d 1)) (recur while_flag_2))))))) (do (def opened []) (def k 0) (while (< k 100) (do (def opened (conj opened false)) (def k (+ k 1)))) (def d 0) (loop [while_flag_3 true] (when (and while_flag_3 (< d 50)) (do (def n (mod (System/currentTimeMillis) 100)) (while (nth opened n) (def n (mod (System/currentTimeMillis) 100))) (def opened (assoc opened n true)) (cond (= (nth drawers n) p) (do (def found true) (recur false)) :else (do (def d (+ d 1)) (recur while_flag_3)))))))) (cond (not found) (do (def success false) (recur false)) :else (do (def p (+ p 1)) (recur while_flag_1)))))) (when success (def pardoned (+ pardoned 1))) (def t (+ t 1))))
-  (def rf (* (/ (double pardoned) (double trials)) 100))
-  (println (str (str (str (str (str (str "  strategy = " strategy) "  pardoned = ") (str pardoned)) " relative frequency = ") (str rf)) "%")))
+  (do (def pardoned 0) (def t 0) (while (< t trials) (do (def drawers []) (def i 0) (while (< i 100) (do (def drawers (conj drawers i)) (def i (+ i 1)))) (def drawers (shuffle drawers)) (def p 0) (def success true) (loop [while_flag_1 true] (when (and while_flag_1 (< p np)) (do (def found false) (if (= strategy "optimal") (do (def prev p) (def d 0) (loop [while_flag_2 true] (when (and while_flag_2 (< d 50)) (do (def this (nth drawers prev)) (cond (= this p) (do (def found true) (recur false)) :else (do (def prev this) (def d (+ d 1)) (recur while_flag_2))))))) (do (def opened []) (def k 0) (while (< k 100) (do (def opened (conj opened false)) (def k (+ k 1)))) (def d 0) (loop [while_flag_3 true] (when (and while_flag_3 (< d 50)) (do (def n (mod (swap! nowSeed (fn [s] (mod (+ (* s 1664525) 1013904223) 2147483647))) 100)) (while (nth opened n) (def n (mod (swap! nowSeed (fn [s] (mod (+ (* s 1664525) 1013904223) 2147483647))) 100))) (def opened (assoc opened n true)) (cond (= (nth drawers n) p) (do (def found true) (recur false)) :else (do (def d (+ d 1)) (recur while_flag_3)))))))) (cond (not found) (do (def success false) (recur false)) :else (do (def p (+ p 1)) (recur while_flag_1)))))) (when success (def pardoned (+ pardoned 1))) (def t (+ t 1)))) (def rf (* (/ (double pardoned) (double trials)) 100)) (println (str (str (str (str (str (str "  strategy = " strategy) "  pardoned = ") (str pardoned)) " relative frequency = ") (str rf)) "%"))))
 
 (defn main []
-  (def trials 1000)
-  (doseq [np [10 100]] (do (println (str (str (str (str "Results from " (str trials)) " trials with ") (str np)) " prisoners:\n")) (doseq [strat ["random" "optimal"]] (doTrials trials np strat)))))
+  (do (def trials 1000) (doseq [np [10 100]] (do (println (str (str (str (str "Results from " (str trials)) " trials with ") (str np)) " prisoners:\n")) (doseq [strat ["random" "optimal"]] (doTrials trials np strat))))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/100-prisoners.out
+++ b/tests/rosetta/transpiler/Clojure/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 2 relative frequency = 0.2%
-  strategy = optimal  pardoned = 299 relative frequency = 29.9%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0.0%
-  strategy = optimal  pardoned = 124 relative frequency = 12.4%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -2,11 +2,12 @@
 
 This directory contains experimental source translators for generating Clojure code. Each program in `tests/vm/valid` is transpiled and executed with `clojure`.
 
-Compiled programs: 101/103
+Compiled programs: 101/104
 
 - [x] append_builtin
 - [x] avg_builtin
 - [x] basic_compare
+- [ ] bench_block
 - [x] binary_precedence
 - [x] bool_chain
 - [x] break_continue
@@ -107,4 +108,4 @@ Compiled programs: 101/103
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-25 00:22 +0700
+Last updated: 2025-07-25 10:48 +0700

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,14 +1,14 @@
 # Clojure Rosetta Transpiler
 
-Completed: 15/284
-Last updated: 2025-07-25 10:15 +0700
+Completed: 16/284
+Last updated: 2025-07-25 10:49 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 |   | 17.246ms | 18.6 MB |
-| 2 | 100-doors-3 | ✓ |  |  |
-| 3 | 100-doors | ✓ |  |  |
-| 4 | 100-prisoners | ✓ |  |  |
+| 1 | 100-doors-2 | ✓ | 42.868ms | 18.4 MB |
+| 2 | 100-doors-3 | ✓ | 40.46ms | 18.4 MB |
+| 3 | 100-doors | ✓ | 43.762ms | 19.4 MB |
+| 4 | 100-prisoners | ✓ | 2.882578s | 21.8 MB |
 | 5 | 15-puzzle-game |   |  |  |
 | 6 | 15-puzzle-solver | ✓ |  |  |
 | 7 | 2048 | ✓ |  |  |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -2192,6 +2192,10 @@ func transpileWhileStmt(w *parser.WhileStmt) (Node, error) {
 	condFound := false
 	for _, n := range bodyNodes {
 		if c, b, ok := condRecur(n); ok {
+			if condFound {
+				other = append(other, n)
+				continue
+			}
 			condFound = true
 			condElems = append(condElems, c, b)
 		} else {


### PR DESCRIPTION
## Summary
- enable 100‑doors-2, 100‑doors-3 and 100‑doors examples for the Clojure transpiler
- record benchmark data for these programs
- fix Clojure transpiler loop handling

## Testing
- `go test ./transpiler/x/clj -run Rosetta -index=1 -tags=slow -update`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run Rosetta -index=1 -tags=slow`
- `go test ./transpiler/x/clj -run Rosetta -index=2 -tags=slow -update`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run Rosetta -index=2 -tags=slow`
- `go test ./transpiler/x/clj -run Rosetta -index=3 -tags=slow -update`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run Rosetta -index=3 -tags=slow`
- `go test ./transpiler/x/clj -run Rosetta -index=4 -tags=slow -update`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run Rosetta -index=4 -tags=slow`


------
https://chatgpt.com/codex/tasks/task_e_6882fb85623c832097086a7c809f2add