### PR TITLE
Fix build break by updating cs transpiler call

### DIFF
--- a/cmd/mochix/main.go
+++ b/cmd/mochix/main.go
@@ -750,7 +750,7 @@ func transpileProgram(lang string, env *types.Env, prog *parser.Program, root, s
 		}
 		return p.Emit(), nil
 	case "cs", "csharp":
-		p, err := cstranspiler.Transpile(prog, env, false)
+		p, err := cstranspiler.Transpile(prog, env)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- fix invocation of C# transpiler in `cmd/mochix`

## Testing
- `make buildx`

------
https://chatgpt.com/codex/tasks/task_e_688302e9ae30832092634f5c1e320484