### PR TITLE
Run VM Rosetta programs with input support

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,27 +2,27 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 06:09 UTC
+Last updated: 2025-07-25 06:27 UTC
 
 ## Rosetta Golden Test Checklist (51/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 582µs | 11.7 KB |
-| 2 | 100-doors-3 | ✓ | 409µs | 7.8 KB |
-| 3 | 100-doors | ✓ | 18.974ms | 1.1 MB |
-| 4 | 100-prisoners | ✓ | 5.27737s | 1.3 MB |
+| 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
+| 2 | 100-doors-3 | ✓ | 184µs | 7.7 KB |
+| 3 | 100-doors | ✓ | 6.231ms | 851.8 KB |
+| 4 | 100-prisoners | ✓ | 4.224632s | 275.7 KB |
 | 5 | 15-puzzle-game | ✓ |  |  |
-| 6 | 15-puzzle-solver | ✓ | 1.637648s | 27.5 KB |
-| 7 | 2048 | ✓ |  |  |
-| 8 | 21-game | ✓ |  |  |
-| 9 | 24-game-solve | ✓ | 2.162ms |  |
-| 10 | 24-game | ✓ | 119µs | 17.0 KB |
-| 11 | 4-rings-or-4-squares-puzzle | ✓ | 273.989ms | 4.9 MB |
-| 12 | 9-billion-names-of-god-the-integer | ✓ | 11.35998s | 112.4 MB |
-| 13 | 99-bottles-of-beer-2 | ✓ | 60.961ms |  |
-| 14 | 99-bottles-of-beer | ✓ | 1.628ms | 434.1 KB |
-| 15 | DNS-query | ✓ | 740.178ms |  |
-| 16 | a+b | ✓ | 20µs | 792 B |
+| 6 | 15-puzzle-solver | ✓ | 917.949ms | 26.9 KB |
+| 7 | 2048 | ✓ | 5.393ms |  |
+| 8 | 21-game | ✓ | 386µs | 10.0 KB |
+| 9 | 24-game-solve | ✓ | 9.164ms |  |
+| 10 | 24-game | ✓ | 506µs | 17.0 KB |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ | 511.101ms | 5.2 MB |
+| 12 | 9-billion-names-of-god-the-integer | ✓ | 14.291954s | 151.1 MB |
+| 13 | 99-bottles-of-beer-2 | ✓ | 48.933ms | 721.5 KB |
+| 14 | 99-bottles-of-beer | ✓ | 1.041ms | 434.1 KB |
+| 15 | DNS-query | ✓ | 1.129634s | 30.4 KB |
+| 16 | a+b | ✓ | 184µs | 792 B |
 | 17 | abbreviations-automatic | ✓ | 14.043ms | 154.7 KB |
 | 18 | abbreviations-easy | ✓ | 4.772ms |  |
 | 19 | abbreviations-simple | ✓ | 5.16ms |  |

--- a/runtime/vm/rosetta_test.go
+++ b/runtime/vm/rosetta_test.go
@@ -3,22 +3,23 @@
 package vm_test
 
 import (
-	"bufio"
-	"bytes"
-	"encoding/json"
-	"flag"
-	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
+        "bufio"
+        "bytes"
+        "encoding/json"
+        "flag"
+        "fmt"
+        "io"
+        "os"
+        "path/filepath"
+        "runtime"
+        "strconv"
+        "strings"
+        "testing"
+        "time"
 
-	"mochi/parser"
-	"mochi/runtime/vm"
-	"mochi/types"
+        "mochi/parser"
+        "mochi/runtime/vm"
+        "mochi/types"
 )
 
 func repoRoot(t *testing.T) string {
@@ -96,9 +97,13 @@ func runRosettaCase(t *testing.T, name string) {
 		t.Fatalf("write ir: %v", err)
 	}
 
-	bench := os.Getenv("MOCHI_BENCHMARK") == "true" || os.Getenv("MOCHI_BENCHMARK") == "1"
-	var out bytes.Buffer
-	m := vm.New(p, &out)
+    bench := os.Getenv("MOCHI_BENCHMARK") == "true" || os.Getenv("MOCHI_BENCHMARK") == "1"
+    var out bytes.Buffer
+    var in io.Reader = os.Stdin
+    if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+            in = bytes.NewReader(data)
+    }
+    m := vm.NewWithIO(p, in, &out)
 	var start time.Time
 	var startMem uint64
 	if bench {

--- a/tests/rosetta/ir/2048.bench
+++ b/tests/rosetta/ir/2048.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 5393,
+  "memory_bytes": -1916760,
+  "name": "main"
+}

--- a/tests/rosetta/ir/21-game.bench
+++ b/tests/rosetta/ir/21-game.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 386,
+  "memory_bytes": 10200,
+  "name": "main"
+}

--- a/tests/rosetta/ir/24-game-solve.bench
+++ b/tests/rosetta/ir/24-game-solve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 2162,
-  "memory_bytes": -119624,
+  "duration_us": 9164,
+  "memory_bytes": -244120,
   "name": "main"
 }

--- a/tests/rosetta/ir/24-game.bench
+++ b/tests/rosetta/ir/24-game.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 119,
-  "memory_bytes": 17400,
+  "duration_us": 506,
+  "memory_bytes": 17416,
   "name": "main"
 }

--- a/tests/rosetta/ir/4-rings-or-4-squares-puzzle.bench
+++ b/tests/rosetta/ir/4-rings-or-4-squares-puzzle.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 273989,
-  "memory_bytes": 5101512,
+  "duration_us": 511101,
+  "memory_bytes": 5487888,
   "name": "main"
 }

--- a/tests/rosetta/ir/9-billion-names-of-god-the-integer.bench
+++ b/tests/rosetta/ir/9-billion-names-of-god-the-integer.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 11359980,
-  "memory_bytes": 117894992,
+  "duration_us": 14291954,
+  "memory_bytes": 158387656,
   "name": "main"
 }

--- a/tests/rosetta/ir/99-bottles-of-beer-2.bench
+++ b/tests/rosetta/ir/99-bottles-of-beer-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 60961,
-  "memory_bytes": -2109960,
+  "duration_us": 48933,
+  "memory_bytes": 738768,
   "name": "main"
 }

--- a/tests/rosetta/ir/99-bottles-of-beer.bench
+++ b/tests/rosetta/ir/99-bottles-of-beer.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1628,
+  "duration_us": 1041,
   "memory_bytes": 444552,
   "name": "main"
 }

--- a/tests/rosetta/ir/DNS-query.bench
+++ b/tests/rosetta/ir/DNS-query.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 740178,
-  "memory_bytes": -2402904,
+  "duration_us": 1129634,
+  "memory_bytes": 31160,
   "name": "main"
 }

--- a/tests/rosetta/ir/a+b.bench
+++ b/tests/rosetta/ir/a+b.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 20,
+  "duration_us": 184,
   "memory_bytes": 792,
   "name": "main"
 }


### PR DESCRIPTION
## Summary
- allow vm Rosetta tests to read `.in` files
- regenerate IR/bench results for programs 7–16
- update VM Rosetta progress table

## Testing
- `MOCHI_ROSETTA_INDEX=16 MOCHI_BENCHMARK=1 go test ./runtime/vm -run Rosetta_Golden -tags slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_688320305ab48320abcc27c879d083ab