### PR TITLE
Fix global variable handling in Elixir transpiler

### DIFF
--- a/transpiler/x/ex/transpiler.go
+++ b/transpiler/x/ex/transpiler.go
@@ -1549,6 +1549,7 @@ func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 	res := &Program{}
 	builtinAliases = make(map[string]string)
 	globalVars = make(map[string]struct{})
+	funcSeen := false
 	for _, st := range prog.Statements {
 		if st.Import != nil && st.Import.Lang != nil {
 			alias := st.Import.As
@@ -1578,10 +1579,15 @@ func Transpile(prog *parser.Program, env *types.Env) (*Program, error) {
 				}
 			}
 		}
-		if st.Let != nil {
-			globalVars[st.Let.Name] = struct{}{}
-		} else if st.Var != nil {
-			globalVars[st.Var.Name] = struct{}{}
+		if !funcSeen {
+			if st.Fun != nil {
+				funcSeen = true
+			}
+			if st.Let != nil {
+				globalVars[st.Let.Name] = struct{}{}
+			} else if st.Var != nil {
+				globalVars[st.Var.Name] = struct{}{}
+			}
 		}
 	}
 	for _, st := range prog.Statements {


### PR DESCRIPTION
## Summary
- fix global variable detection so only declarations before the first function are treated as module globals

## Testing
- `go test -tags slow ./transpiler/x/ex -run Rosetta -count=1 -v MOCHI_ROSETTA_INDEX=21` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68831e39169c8320ae194dd9ee2ea982