### PR TITLE
Update Java transpiler for map support

### DIFF
--- a/tests/rosetta/transpiler/Java/ackermann-function.bench
+++ b/tests/rosetta/transpiler/Java/ackermann-function.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 5757,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/ackermann-function.java
+++ b/tests/rosetta/transpiler/Java/ackermann-function.java
@@ -17,6 +17,39 @@ public class Main {
         System.out.println("A(3, 4) = " + String.valueOf(ackermann(3, 4)));
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/active-directory-connect.bench
+++ b/tests/rosetta/transpiler/Java/active-directory-connect.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 5696,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/active-directory-connect.java
+++ b/tests/rosetta/transpiler/Java/active-directory-connect.java
@@ -39,6 +39,39 @@ public class Main {
         }
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.bench
+++ b/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 20760,
+  "memory_bytes": 251928,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.error
+++ b/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.error
@@ -1,8 +1,0 @@
-compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Goldenactive-directory-search-for-a-user2735668891/001/Main.java:4: error: incompatible types: Object cannot be converted to String[]
-        return (Object)(directory.get(username));
-               ^
-/tmp/TestJavaTranspiler_Rosetta_Goldenactive-directory-search-for-a-user2735668891/001/Main.java:8: error: incompatible types: LinkedHashMap<String,Object> cannot be converted to Map<String,String>
-        java.util.Map<String,String> client = new java.util.LinkedHashMap<String, Object>(java.util.Map.of("Base", "dc=example,dc=com", "Host", "ldap.example.com", "Port", 389, "GroupFilter", "(memberUid=%s)"));
-                                              ^
-2 errors

--- a/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.java
+++ b/tests/rosetta/transpiler/Java/active-directory-search-for-a-user.java
@@ -1,30 +1,63 @@
 public class Main {
 
-    static String[] search_user(java.util.Map<String,Object> directory, String username) {
-        return (Object)(directory.get(username));
+    static String[] search_user(java.util.Map<String,String[]> directory, String username) {
+        return ((String[])directory.get(username));
     }
 
     static void main() {
-        java.util.Map<String,String> client = new java.util.LinkedHashMap<String, Object>(java.util.Map.of("Base", "dc=example,dc=com", "Host", "ldap.example.com", "Port", 389, "GroupFilter", "(memberUid=%s)"));
-        java.util.Map<String,Object> directory = new java.util.LinkedHashMap<String, Object>(java.util.Map.of("username", new String[]{"admins", "users"}, "john", new String[]{"users"}));
+        java.util.Map<String,String> client = new java.util.LinkedHashMap<String, String>() {{ put("Base", "dc=example,dc=com"); put("Host", "ldap.example.com"); put("Port", String.valueOf(389)); put("GroupFilter", "(memberUid=%s)"); }};
+        java.util.Map<String,String[]> directory = new java.util.LinkedHashMap<String, String[]>() {{ put("username", new String[]{"admins", "users"}); put("john", new String[]{"users"}); }};
         String[] groups = search_user(directory, "username");
         if (groups.length > 0) {
             String out = "Groups: [";
             int i = 0;
             while (i < groups.length) {
-                out = out + "\"" + groups[i] + "\"";
+                out = String.valueOf(String.valueOf(out + "\"" + groups[i]) + "\"");
                 if (i < groups.length - 1) {
-                    out = out + ", ";
+                    out = String.valueOf(out + ", ");
                 }
                 i = i + 1;
             }
-            out = out + "]";
+            out = String.valueOf(out + "]");
             System.out.println(out);
         } else {
             System.out.println("User not found");
         }
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/active-object.bench
+++ b/tests/rosetta/transpiler/Java/active-object.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 710,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/active-object.java
+++ b/tests/rosetta/transpiler/Java/active-object.java
@@ -20,22 +20,55 @@ public class Main {
         return sum;
     }
     public static void main(String[] args) {
-        while (i <= 200) {
-            double t2 = (((Number)(i)).doubleValue()) * dt;
-            double k2 = sinApprox(t2 * PI);
-            s = s + (k1 + k2) * 0.5 * (t2 - t1);
-            t1 = t2;
-            k1 = k2;
-            i = i + 1;
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            while (i <= 200) {
+                double t2 = (((Number)(i)).doubleValue()) * dt;
+                double k2 = sinApprox(t2 * PI);
+                s = s + (k1 + k2) * 0.5 * (t2 - t1);
+                t1 = t2;
+                k1 = k2;
+                i = i + 1;
+            }
+            while (i2 <= 50) {
+                double t2 = 2.0 + (((Number)(i2)).doubleValue()) * dt;
+                double k2 = 0.0;
+                s = s + (k1 + k2) * 0.5 * (t2 - t1);
+                t1 = t2;
+                k1 = k2;
+                i2 = i2 + 1;
+            }
+            System.out.println(s);
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
         }
-        while (i2 <= 50) {
-            double t2 = 2.0 + (((Number)(i2)).doubleValue()) * dt;
-            double k2 = 0.0;
-            s = s + (k1 + k2) * 0.5 * (t2 - t1);
-            t1 = t2;
-            k1 = k2;
-            i2 = i2 + 1;
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
         }
-        System.out.println(s);
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.bench
+++ b/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4275,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.error
+++ b/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.error
@@ -1,1 +1,0 @@
-transpile: unsupported binary op: in

--- a/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.java
+++ b/tests/rosetta/transpiler/Java/add-a-variable-to-a-class-instance-at-runtime.java
@@ -1,0 +1,79 @@
+public class Main {
+    static class SomeStruct {
+        java.util.Map<String,String> runtimeFields;
+        SomeStruct(java.util.Map<String,String> runtimeFields) {
+            this.runtimeFields = runtimeFields;
+        }
+        @Override public String toString() {
+            return String.format("{'runtimeFields': %s}", String.valueOf(runtimeFields));
+        }
+    }
+
+
+    static java.util.Scanner _scanner = new java.util.Scanner(System.in);
+
+    static void main() {
+        SomeStruct ss = new SomeStruct(new java.util.LinkedHashMap<String, String>());
+        System.out.println("Create two fields at runtime: \n");
+        int i = 1;
+        while (i <= 2) {
+            System.out.println(String.valueOf("  Field #" + String.valueOf(i)) + ":\n");
+            System.out.println("       Enter name  : ");
+            String name = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            System.out.println("       Enter value : ");
+            String value = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            java.util.Map<String,String> fields = ss.runtimeFields;
+fields.put(name, value);
+ss.runtimeFields = fields;
+            System.out.println("\n");
+            i = i + 1;
+        }
+        while (true) {
+            System.out.println("Which field do you want to inspect ? ");
+            String name = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            if (ss.runtimeFields.containsKey(name)) {
+                Object value = (Object)(((Object)((java.util.Map)ss.runtimeFields).get(name)));
+                System.out.println(String.valueOf("Its value is '" + value) + "'");
+                return;
+            } else {
+                System.out.println("There is no field of that name, try again\n");
+            }
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/additive-primes.bench
+++ b/tests/rosetta/transpiler/Java/additive-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 14337,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/additive-primes.java
+++ b/tests/rosetta/transpiler/Java/additive-primes.java
@@ -53,7 +53,7 @@ public class Main {
         while (i < 500) {
             if (isPrime(i) && isPrime(sumDigits(i))) {
                 count = count + 1;
-                line = line + pad(i) + "  ";
+                line = String.valueOf(String.valueOf(line + String.valueOf(pad(i))) + "  ");
                 lineCount = lineCount + 1;
                 if (lineCount == 10) {
                     System.out.println(line.substring(0, line.length() - 2));
@@ -73,6 +73,39 @@ public class Main {
         System.out.println(String.valueOf(count) + " additive primes found.");
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/address-of-a-variable.bench
+++ b/tests/rosetta/transpiler/Java/address-of-a-variable.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 11671,
+  "memory_bytes": 251680,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/address-of-a-variable.java
+++ b/tests/rosetta/transpiler/Java/address-of-a-variable.java
@@ -2,7 +2,40 @@ public class Main {
     static double myVar = 3.14;
 
     public static void main(String[] args) {
-        System.out.println("value as float:" + " " + myVar);
-        System.out.println("address: <not available>");
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println("value as float:" + " " + myVar);
+            System.out.println("address: <not available>");
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/104) - updated 2025-07-25 07:49 UTC
+## VM Golden Test Checklist (103/104) - updated 2025-07-25 09:47 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-25 14:49 GMT+7
+Last updated: 2025-07-25 16:47 GMT+7
 
-## Rosetta Checklist (42/284)
+## Rosetta Checklist (44/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -35,13 +35,13 @@ Last updated: 2025-07-25 14:49 GMT+7
 | 27 | achilles-numbers | ✓ | 54.0ms | 10.33MB |
 | 28 | ackermann-function-2 | ✓ | 5.0ms | 0B |
 | 29 | ackermann-function-3 | ✓ | 160.47s | 11.78MB |
-| 30 | ackermann-function | ✓ |  |  |
-| 31 | active-directory-connect | ✓ |  |  |
-| 32 | active-directory-search-for-a-user |   |  |  |
-| 33 | active-object | ✓ |  |  |
-| 34 | add-a-variable-to-a-class-instance-at-runtime |   |  |  |
-| 35 | additive-primes | ✓ |  |  |
-| 36 | address-of-a-variable | ✓ |  |  |
+| 30 | ackermann-function | ✓ | 5.0ms | 0B |
+| 31 | active-directory-connect | ✓ | 5.0ms | 0B |
+| 32 | active-directory-search-for-a-user | ✓ | 20.0ms | 246.02KB |
+| 33 | active-object | ✓ | 710.0µs | 0B |
+| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 4.0ms | 0B |
+| 35 | additive-primes | ✓ | 14.0ms | 0B |
+| 36 | address-of-a-variable | ✓ | 11.0ms | 245.78KB |
 | 37 | adfgvx-cipher |   |  |  |
 | 38 | aks-test-for-primes | ✓ |  |  |
 | 39 | algebraic-data-types | ✓ |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,36 @@
-## Progress (2025-07-25 14:32 +0700)
+## Progress (2025-07-25 09:47 UTC)
+- rosetta: update index 35 (e892c009c0)
+
+- rosetta: support map fields in structs (55a74ae43a)
+
+- rosetta: update index 33 (8232275d7f)
+
+- rosetta: update index 33 (8232275d7f)
+
+- rosetta: update index 33 (8232275d7f)
+
+- remove old error file (b2c4c5935c)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 31 (01ba73c49d)
+
+- rosetta: update Java output for index 30 (a70ada40d6)
+
+- java transpiler: add bigint support (e46c95c50b)
+
 - transpiler/java: update rosetta outputs and add features (aefc0b2d3e)
 
 - transpiler/java: update rosetta outputs and add features (aefc0b2d3e)


### PR DESCRIPTION
## Summary
- generate Rosetta Java outputs for indexes 30-36
- improve Java transpiler map logic
- handle struct map fields and value casting
- update Rosetta checklist

## Testing
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 30 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 31 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 32 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 33 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 34 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 35 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 36 -count=1`
- `MOCHI_BENCHMARK=1 UPDATE=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 37 -count=1` *(fails)*


------
https://chatgpt.com/codex/tasks/task_e_68835018a0b08320b24ef940856c3815