### PR TITLE
Add benchmark results for indexes 28-36

### DIFF
--- a/tests/rosetta/transpiler/Go/ackermann-function-2.bench
+++ b/tests/rosetta/transpiler/Go/ackermann-function-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 89,
+  "memory_bytes": 1080,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/ackermann-function-3.bench
+++ b/tests/rosetta/transpiler/Go/ackermann-function-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 100310793,
+  "memory_bytes": 656032,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/ackermann-function.bench
+++ b/tests/rosetta/transpiler/Go/ackermann-function.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 165,
+  "memory_bytes": 1080,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/active-directory-connect.bench
+++ b/tests/rosetta/transpiler/Go/active-directory-connect.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 84,
+  "memory_bytes": 1000,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/active-directory-search-for-a-user.bench
+++ b/tests/rosetta/transpiler/Go/active-directory-search-for-a-user.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 57,
+  "memory_bytes": 1128,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/active-object.bench
+++ b/tests/rosetta/transpiler/Go/active-object.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 253,
+  "memory_bytes": 1000,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/add-a-variable-to-a-class-instance-at-runtime.bench
+++ b/tests/rosetta/transpiler/Go/add-a-variable-to-a-class-instance-at-runtime.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 112,
+  "memory_bytes": 5208,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/additive-primes.bench
+++ b/tests/rosetta/transpiler/Go/additive-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 113,
+  "memory_bytes": 4752,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/address-of-a-variable.bench
+++ b/tests/rosetta/transpiler/Go/address-of-a-variable.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 82,
+  "memory_bytes": 1016,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Go/aks-test-for-primes.bench
+++ b/tests/rosetta/transpiler/Go/aks-test-for-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 85,
+  "memory_bytes": 3432,
+  "name": "main"
+}


### PR DESCRIPTION
## Summary
- add benchmark results for Rosetta programs 28-36

## Testing
- `go test ./transpiler/x/go -tags slow -run Rosetta_Golden -v` *(individual indexes)*

------
https://chatgpt.com/codex/tasks/task_e_688354d45e848320b1906973f20e3447