### PR TITLE
Update animate-a-pendulum benchmark

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 09:46 UTC
+Last updated: 2025-07-25 10:06 UTC
 
 ## Rosetta Golden Test Checklist (53/284)
 | Index | Name | Status | Duration | Memory |
@@ -57,7 +57,7 @@ Last updated: 2025-07-25 09:46 UTC
 | 48 | angle-difference-between-two-bearings-1 | ✓ | 504µs | 19.2 KB |
 | 49 | angle-difference-between-two-bearings-2 | ✓ | 551µs | 26.6 KB |
 | 50 | angles-geometric-normalization-and-conversion | ✓ | 593µs | 136 B |
-| 51 | animate-a-pendulum | ✓ | 1.023ms | 73.8 KB |
+| 51 | animate-a-pendulum | ✓ | 138µs | 73.8 KB |
 | 52 | animation | ✓ | 930µs | 18.1 KB |
 | 53 | anonymous-recursion-1 | ✓ | 349µs | 15.6 KB |
 | 54 | anonymous-recursion-2 |   |  |  |

--- a/tests/rosetta/ir/animate-a-pendulum.bench
+++ b/tests/rosetta/ir/animate-a-pendulum.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1023,
+  "duration_us": 138,
   "memory_bytes": 75608,
   "name": "main"
 }

--- a/tests/rosetta/x/Mochi/animate-a-pendulum.out
+++ b/tests/rosetta/x/Mochi/animate-a-pendulum.out
@@ -8,3 +8,8 @@
 1
 0
 -1
+{
+  "duration_us": 176,
+  "memory_bytes": 75608,
+  "name": "main"
+}


### PR DESCRIPTION
## Summary
- regenerate IR benchmark for `animate-a-pendulum`
- update runtime/vm progress table
- include benchmark numbers in golden output

## Testing
- `MOCHI_ROSETTA_ONLY=animate-a-pendulum MOCHI_BENCHMARK=1 go test ./runtime/vm -run Rosetta -tags slow -count=1 -update`


------
https://chatgpt.com/codex/tasks/task_e_688355cad5fc8320a43706c0538b1b5c