### PR TITLE
Fix VM main execution and update Rosetta outputs

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 09:46 UTC
+Last updated: 2025-07-25 10:34 UTC
 
 ## Rosetta Golden Test Checklist (53/284)
 | Index | Name | Status | Duration | Memory |
@@ -10,7 +10,7 @@ Last updated: 2025-07-25 09:46 UTC
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
 | 2 | 100-doors-3 | ✓ | 184µs | 7.7 KB |
 | 3 | 100-doors | ✓ | 6.231ms | 851.8 KB |
-| 4 | 100-prisoners | ✓ | 4.224632s | 275.7 KB |
+| 4 | 100-prisoners | ✓ | 2.081421s | 424.4 KB |
 | 5 | 15-puzzle-game | ✓ |  |  |
 | 6 | 15-puzzle-solver | ✓ | 917.949ms | 26.9 KB |
 | 7 | 2048 | ✓ | 5.393ms |  |

--- a/runtime/vm/rosetta_test.go
+++ b/runtime/vm/rosetta_test.go
@@ -3,23 +3,23 @@
 package vm_test
 
 import (
-        "bufio"
-        "bytes"
-        "encoding/json"
-        "flag"
-        "fmt"
-        "io"
-        "os"
-        "path/filepath"
-        "runtime"
-        "strconv"
-        "strings"
-        "testing"
-        "time"
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
 
-        "mochi/parser"
-        "mochi/runtime/vm"
-        "mochi/types"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
 )
 
 func repoRoot(t *testing.T) string {
@@ -97,13 +97,16 @@ func runRosettaCase(t *testing.T, name string) {
 		t.Fatalf("write ir: %v", err)
 	}
 
-    bench := os.Getenv("MOCHI_BENCHMARK") == "true" || os.Getenv("MOCHI_BENCHMARK") == "1"
-    var out bytes.Buffer
-    var in io.Reader = os.Stdin
-    if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
-            in = bytes.NewReader(data)
-    }
-    m := vm.NewWithIO(p, in, &out)
+	bench := os.Getenv("MOCHI_BENCHMARK") == "true" || os.Getenv("MOCHI_BENCHMARK") == "1"
+	// Use a fixed seed so calls to now() are deterministic. This also avoids
+	// the overhead of repeated system time queries when running benchmarks.
+	vm.SetNowSeed(1)
+	var out bytes.Buffer
+	var in io.Reader = os.Stdin
+	if data, err := os.ReadFile(strings.TrimSuffix(src, ".mochi") + ".in"); err == nil {
+		in = bytes.NewReader(data)
+	}
+	m := vm.NewWithIO(p, in, &out)
 	var start time.Time
 	var startMem uint64
 	if bench {

--- a/tests/rosetta/ir/100-prisoners.bench
+++ b/tests/rosetta/ir/100-prisoners.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 4224632,
-  "memory_bytes": 282304,
+  "duration_us": 2081421,
+  "memory_bytes": 434592,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-prisoners.out
+++ b/tests/rosetta/ir/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 296 relative frequency = 29.599999999999998%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 323 relative frequency = 32.300000000000004%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%


### PR DESCRIPTION
## Summary
- ensure rosetta tests use deterministic `now()` by seeding the VM
- speed up the `Append` instruction by preallocating slices
- refresh IR outputs for the `100-prisoners` task
- update benchmark and checklist entries
- improve `now()` builtin speed with lightweight RNG

## Testing
- `go test ./...`
- `MOCHI_ROSETTA_INDEX=4 MOCHI_BENCHMARK=1 go test ./runtime/vm -tags slow -run TestVM_Rosetta_Golden -v`


------
https://chatgpt.com/codex/tasks/task_e_688358317d688320ae15f6e91e6fa043