### PR TITLE
Optimize VM append

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 10:06 UTC
+Last updated: 2025-07-25 11:03 UTC
 
 ## Rosetta Golden Test Checklist (53/284)
 | Index | Name | Status | Duration | Memory |
@@ -10,7 +10,7 @@ Last updated: 2025-07-25 10:06 UTC
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
 | 2 | 100-doors-3 | ✓ | 184µs | 7.7 KB |
 | 3 | 100-doors | ✓ | 6.231ms | 851.8 KB |
-| 4 | 100-prisoners | ✓ | 4.224632s | 275.7 KB |
+| 4 | 100-prisoners | ✓ | 802.494ms | 672.9 KB |
 | 5 | 15-puzzle-game | ✓ |  |  |
 | 6 | 15-puzzle-solver | ✓ | 917.949ms | 26.9 KB |
 | 7 | 2048 | ✓ | 5.393ms |  |

--- a/tests/rosetta/ir/100-prisoners.bench
+++ b/tests/rosetta/ir/100-prisoners.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 4224632,
-  "memory_bytes": 282304,
+  "duration_us": 802494,
+  "memory_bytes": 689024,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-prisoners.out
+++ b/tests/rosetta/ir/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 296 relative frequency = 29.599999999999998%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 307 relative frequency = 30.7%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 323 relative frequency = 32.300000000000004%
+  strategy = optimal  pardoned = 305 relative frequency = 30.5%


### PR DESCRIPTION
## Summary
- improve `OpAppend` to use Go's built-in slice growth
- regenerate Rosetta artifacts for program 4 after optimization

## Testing
- `MOCHI_ROSETTA_INDEX=4 MOCHI_BENCHMARK=1 go test ./runtime/vm -tags slow -run Rosetta_Golden -update -count=1`
- `MOCHI_ROSETTA_INDEX=4 go test ./runtime/vm -tags slow -run Rosetta_Golden -update -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68835a9aebb883208f28f70ced15e7aa