### PR TITLE
Fix top-level main call handling

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 10:06 UTC
+Last updated: 2025-07-25 11:09 UTC
 
 ## Rosetta Golden Test Checklist (53/284)
 | Index | Name | Status | Duration | Memory |
@@ -10,7 +10,7 @@ Last updated: 2025-07-25 10:06 UTC
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
 | 2 | 100-doors-3 | ✓ | 184µs | 7.7 KB |
 | 3 | 100-doors | ✓ | 6.231ms | 851.8 KB |
-| 4 | 100-prisoners | ✓ | 4.224632s | 275.7 KB |
+| 4 | 100-prisoners | ✓ | 741.752ms | 70.0 KB |
 | 5 | 15-puzzle-game | ✓ |  |  |
 | 6 | 15-puzzle-solver | ✓ | 917.949ms | 26.9 KB |
 | 7 | 2048 | ✓ | 5.393ms |  |

--- a/tests/rosetta/ir/100-prisoners.bench
+++ b/tests/rosetta/ir/100-prisoners.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 4224632,
-  "memory_bytes": 282304,
+  "duration_us": 741752,
+  "memory_bytes": 71696,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-prisoners.ir
+++ b/tests/rosetta/ir/100-prisoners.ir
@@ -63,7 +63,7 @@ L2:
   LessInt      r11, r9, r10
   JumpIfFalse  r11, L1
   // drawers = append(drawers, i)
-  Append       r12, r8, r9
+  AppendFast   r12, r8, r9
   Move         r8, r12
   // i = i + 1
   Const        r13, 1
@@ -137,7 +137,7 @@ L9:
   JumpIfFalse  r35, L8
   // opened = append(opened, false)
   Const        r21, false
-  Append       r36, r33, r21
+  AppendFast   r36, r33, r21
   Move         r33, r36
   // k = k + 1
   Const        r13, 1

--- a/tests/rosetta/ir/100-prisoners.out
+++ b/tests/rosetta/ir/100-prisoners.out
@@ -1,8 +1,8 @@
 Results from 1000 trials with 10 prisoners:
 
-  strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 296 relative frequency = 29.599999999999998%
+  strategy = random  pardoned = 1 relative frequency = 0.1%
+  strategy = optimal  pardoned = 295 relative frequency = 29.5%
 Results from 1000 trials with 100 prisoners:
 
   strategy = random  pardoned = 0 relative frequency = 0%
-  strategy = optimal  pardoned = 323 relative frequency = 32.300000000000004%
+  strategy = optimal  pardoned = 303 relative frequency = 30.3%


### PR DESCRIPTION
## Summary
- don't skip `main()` invocation when compiling program entry
- regenerate IR and outputs for 100-prisoners

## Testing
- `MOCHI_ROSETTA_INDEX=4 MOCHI_NOW_SEED=1 go test ./runtime/vm -tags=slow -run Rosetta_Golden -count=1 -v`
- `MOCHI_ROSETTA_INDEX=4 MOCHI_NOW_SEED=1 MOCHI_BENCHMARK=1 go test ./runtime/vm -tags=slow -run Rosetta_Golden -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68835a928f8883209ff43d36eed75d2a