### PR TITLE
Improve Kotlin transpiler for rosetta cases

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/2048.kt
+++ b/tests/rosetta/transpiler/Kotlin/2048.kt
@@ -93,7 +93,7 @@ fun draw(b: Board, score: Int): Unit {
             if (v == 0) {
                 line = line + "    |"
             } else {
-                line = (line + (pad(v)).toString()) + "|"
+                line = (line + pad(v)) + "|"
             }
             x = x + 1
         }
@@ -149,9 +149,9 @@ fun moveLeft(b: Board, score: Int): MoveResult {
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
-        val r: SlideResult = slideLeft(grid[y] as MutableList<Int>)
-        val new = r.row
-        score = score + (r.gain as Int)
+        val r: SlideResult = slideLeft(grid[y])
+        val new: MutableList<Int> = r.row
+        score = score + r.gain
         var x: Int = 0
         while (x < SIZE) {
             if (grid[y][x] != new[x]) {
@@ -171,11 +171,11 @@ fun moveRight(b: Board, score: Int): MoveResult {
     var moved: Boolean = false
     var y: Int = 0
     while (y < SIZE) {
-        var rev: MutableList<Int> = reverseRow(grid[y] as MutableList<Int>)
+        var rev: MutableList<Int> = reverseRow(grid[y])
         val r: SlideResult = slideLeft(rev)
-        rev = r.row as MutableList<Int>
-        score = score + (r.gain as Int)
-        rev = reverseRow(rev) as MutableList<Int>
+        rev = r.row
+        score = score + r.gain
+        rev = reverseRow(rev)
         var x: Int = 0
         while (x < SIZE) {
             if (grid[y][x] != rev[x]) {
@@ -203,7 +203,7 @@ fun setCol(b: Board, x: Int, col: MutableList<Int>): Unit {
     var rows: MutableList<MutableList<Int>> = b.cells
     var y: Int = 0
     while (y < SIZE) {
-        var row = rows[y]
+        var row: MutableList<Int> = rows[y]
         row[x] = col[y]
         rows[y] = row
         y = y + 1
@@ -219,8 +219,8 @@ fun moveUp(b: Board, score: Int): MoveResult {
     while (x < SIZE) {
         var col: MutableList<Int> = getCol(b, x)
         val r: SlideResult = slideLeft(col)
-        val new = r.row
-        score = score + (r.gain as Int)
+        val new: MutableList<Int> = r.row
+        score = score + r.gain
         var y: Int = 0
         while (y < SIZE) {
             if (grid[y][x] != new[y]) {
@@ -240,11 +240,11 @@ fun moveDown(b: Board, score: Int): MoveResult {
     var moved: Boolean = false
     var x: Int = 0
     while (x < SIZE) {
-        var col: MutableList<Int> = reverseRow(getCol(b, x) as MutableList<Int>)
+        var col: MutableList<Int> = reverseRow(getCol(b, x))
         val r: SlideResult = slideLeft(col)
-        col = r.row as MutableList<Int>
-        score = score + (r.gain as Int)
-        col = reverseRow(col) as MutableList<Int>
+        col = r.row
+        score = score + r.gain
+        col = reverseRow(col)
         var y: Int = 0
         while (y < SIZE) {
             if (grid[y][x] != col[y]) {
@@ -306,47 +306,47 @@ fun main() {
         var moved: Boolean = false
         if ((cmd == "a") || (cmd == "A")) {
             val m: MoveResult = moveLeft(board, score)
-            board = m.board as Board
-            score = m.score as Int
-            moved = m.moved as Boolean
+            board = m.board
+            score = m.score
+            moved = m.moved
         }
         if ((cmd == "d") || (cmd == "D")) {
             val m: MoveResult = moveRight(board, score)
-            board = m.board as Board
-            score = m.score as Int
-            moved = m.moved as Boolean
+            board = m.board
+            score = m.score
+            moved = m.moved
         }
         if ((cmd == "w") || (cmd == "W")) {
             val m: MoveResult = moveUp(board, score)
-            board = m.board as Board
-            score = m.score as Int
-            moved = m.moved as Boolean
+            board = m.board
+            score = m.score
+            moved = m.moved
         }
         if ((cmd == "s") || (cmd == "S")) {
             val m: MoveResult = moveDown(board, score)
-            board = m.board as Board
-            score = m.score as Int
-            moved = m.moved as Boolean
+            board = m.board
+            score = m.score
+            moved = m.moved
         }
         if ((cmd == "q") || (cmd == "Q")) {
             break
         }
         if (moved as Boolean) {
             val r2: SpawnResult = spawnTile(board)
-            board = r2.board as Board
-            full = r2.full as Boolean
-            if (full && (!(hasMoves(board) as Boolean) as Boolean)) {
+            board = r2.board
+            full = r2.full
+            if (full && (!hasMoves(board) as Boolean)) {
                 draw(board, score)
                 println("Game Over")
                 break
             }
         }
         draw(board, score)
-        if (has2048(board) as Boolean) {
+        if ((has2048(board)) as Boolean) {
             println("You win!")
             break
         }
-        if (!(hasMoves(board) as Boolean)) {
+        if (!hasMoves(board)) {
             println("Game Over")
             break
         }

--- a/tests/rosetta/transpiler/Kotlin/21-game.kt
+++ b/tests/rosetta/transpiler/Kotlin/21-game.kt
@@ -27,7 +27,7 @@ fun parseIntStr(str: String): Int {
     var n: Int = 0
     val digits: MutableMap<String, Int> = mutableMapOf<String, Int>("0" to (0), "1" to (1), "2" to (2), "3" to (3), "4" to (4), "5" to (5), "6" to (6), "7" to (7), "8" to (8), "9" to (9))
     while (i < str.length) {
-        n = (n * 10) + ((digits)[str.substring(i, i + 1)]!! as Int) as Int
+        n = (n * 10) + (digits)[str.substring(i, i + 1)] as Int
         i = i + 1
     }
     if (neg as Boolean) {

--- a/tests/rosetta/transpiler/Kotlin/24-game-solve.kt
+++ b/tests/rosetta/transpiler/Kotlin/24-game-solve.kt
@@ -118,18 +118,19 @@ fun solve(xs: MutableList<Expr>): Boolean {
             }
             val a: Expr = xs[i]
             val b: Expr = xs[j]
+            var node: Bin = Bin(op = OP_ADD, left = a, right = b)
             for (op in mutableListOf(OP_ADD, OP_SUB, OP_MUL, OP_DIV)) {
-                var node: Bin = Bin(op = op, left = a, right = b)
-                if (solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>) as Boolean) {
+                node = Bin(op = op, left = a, right = b)
+                if ((solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>)) as Boolean) {
                     return true
                 }
             }
-            var node: Bin = Bin(op = OP_SUB, left = b, right = a)
-            if (solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>) as Boolean) {
+            node = Bin(op = OP_SUB, left = b, right = a)
+            if ((solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>)) as Boolean) {
                 return true
             }
             node = Bin(op = OP_DIV, left = b, right = a)
-            if (solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>) as Boolean) {
+            if ((solve(run { val _tmp = rest.toMutableList(); _tmp.add(node); _tmp } as MutableList<Expr>)) as Boolean) {
                 return true
             }
             j = j + 1
@@ -151,7 +152,7 @@ fun user_main(): Unit {
             i = i + 1
         }
         println(":  ")
-        if (!(solve(cards) as Boolean)) {
+        if (!solve(cards)) {
             println("No solution")
         }
         iter = iter + 1

--- a/tests/rosetta/transpiler/Kotlin/24-game.kt
+++ b/tests/rosetta/transpiler/Kotlin/24-game.kt
@@ -18,17 +18,17 @@ fun _now(): Int {
 fun input(): String = readLine() ?: ""
 
 fun randDigit(): Int {
-    return (_now() % 9) + 1 as Int
+    return (_now() % 9) + 1
 }
 
 fun user_main(): Unit {
-    var digits: MutableList<Any> = mutableListOf()
+    var digits: MutableList<Any?> = mutableListOf()
     for (i in 0 until 4) {
-        digits = run { val _tmp = digits.toMutableList(); _tmp.add(randDigit()); _tmp } as MutableList<Any>
+        digits = run { val _tmp = digits.toMutableList(); _tmp.add(randDigit()); _tmp } as MutableList<Any?>
     }
     var numstr: String = ""
     for (i in 0 until 4) {
-        numstr = numstr + digits[i].toString()
+        numstr = numstr + (digits[i]).toString()
     }
     println(("Your numbers: " + numstr) + "\n")
     println("Enter RPN: ")
@@ -37,7 +37,7 @@ fun user_main(): Unit {
         println("invalid. expression length must be 7. (4 numbers, 3 operators, no spaces)")
         return
     }
-    var stack: MutableList<Any> = mutableListOf()
+    var stack: MutableList<Any?> = mutableListOf()
     var i: Int = 0
     var valid: Boolean = true
     while (i < expr.length) {
@@ -48,7 +48,7 @@ fun user_main(): Unit {
                 return
             }
             var j: Int = 0
-            while (digits[j] != ((ch as Int as Number).toDouble() - ("0" as Int as Number).toDouble())) {
+            while (digits[j] != (ch.toInt() - "0".toInt())) {
                 j = j + 1
                 if (j == digits.size) {
                     println("wrong numbers.")
@@ -56,15 +56,15 @@ fun user_main(): Unit {
                 }
             }
             digits = (digits.subList(0, j) + digits.subList(j + 1, digits.size)).toMutableList()
-            stack = run { val _tmp = stack.toMutableList(); _tmp.add((ch as Int as Number).toDouble() - ("0" as Int as Number).toDouble().toDouble()); _tmp } as MutableList<Any>
+            stack = run { val _tmp = stack.toMutableList(); _tmp.add((ch.toInt() - "0".toInt()).toDouble()); _tmp } as MutableList<Any?>
         } else {
             if (stack.size < 2) {
                 println("invalid expression syntax.")
                 valid = false
                 break
             }
-            var b = stack[stack.size - 1]
-            var a = stack[stack.size - 2]
+            var b: Any? = stack[stack.size - 1]
+            var a: Any? = stack[stack.size - 2]
             if (ch == "+") {
                 stack[stack.size - 2] = (a as Number).toDouble() + (b as Number).toDouble()
             } else {
@@ -89,8 +89,8 @@ fun user_main(): Unit {
         i = i + 1
     }
     if (valid as Boolean) {
-        if ((kotlin.math.abs((stack[0] as Number).toDouble() - 24.0) as Number).toDouble() > 0.000001) {
-            println(("incorrect. " + stack[0].toString()) + " != 24")
+        if (kotlin.math.abs((stack[0] as Number).toDouble() - 24.0) > 0.000001) {
+            println(("incorrect. " + (stack[0]).toString()) + " != 24")
         } else {
             println("correct.")
         }

--- a/tests/rosetta/transpiler/Kotlin/4-rings-or-4-squares-puzzle.kt
+++ b/tests/rosetta/transpiler/Kotlin/4-rings-or-4-squares-puzzle.kt
@@ -1,12 +1,12 @@
-val r1: MutableMap<String, Any> = getCombs(1, 7, true)
-val r2: MutableMap<String, Any> = getCombs(3, 9, true)
-val r3: MutableMap<String, Any> = getCombs(0, 9, false)
+val r1: MutableMap<String, Any?> = getCombs(1, 7, true)
+val r2: MutableMap<String, Any?> = getCombs(3, 9, true)
+val r3: MutableMap<String, Any?> = getCombs(0, 9, false)
 fun validComb(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int): Boolean {
     val square1: Int = a + b
     val square2: Int = (b + c) + d
     val square3: Int = (d + e) + f
     val square4: Int = f + g
-    return (((square1 == square2) && (square2 == square3) as Boolean)) && (square3 == square4) as Boolean
+    return ((((square1 == square2) && (square2 == square3) as Boolean)) && (square3 == square4)) as Boolean
 }
 
 fun isUnique(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int): Boolean {
@@ -16,17 +16,17 @@ fun isUnique(a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int): Boolean {
         var j: Int = i + 1
         while (j < nums.size) {
             if (nums[i] == nums[j]) {
-                return false as Boolean
+                return false
             }
             j = j + 1
         }
         i = i + 1
     }
-    return true as Boolean
+    return true
 }
 
-fun getCombs(low: Int, high: Int, unique: Boolean): MutableMap<String, Any> {
-    var valid: MutableList<Any> = mutableListOf()
+fun getCombs(low: Int, high: Int, unique: Boolean): MutableMap<String, Any?> {
+    var valid: MutableList<Any?> = mutableListOf()
     var count: Int = 0
     for (b in low until high + 1) {
         for (c in low until high + 1) {
@@ -48,8 +48,8 @@ fun getCombs(low: Int, high: Int, unique: Boolean): MutableMap<String, Any> {
                         if ((f + g) != s) {
                             continue
                         }
-                        if ((!unique as Boolean) || (isUnique(a, b, c, d, e, f, g) as Boolean)) {
-                            valid = run { val _tmp = valid.toMutableList(); _tmp.add(mutableListOf(a, b, c, d, e, f, g)); _tmp } as MutableList<Any>
+                        if ((!unique as Boolean) || isUnique(a, b, c, d, e, f, g)) {
+                            valid = run { val _tmp = valid.toMutableList(); _tmp.add(mutableListOf(a, b, c, d, e, f, g)); _tmp } as MutableList<Any?>
                             count = count + 1
                         }
                     }
@@ -57,13 +57,13 @@ fun getCombs(low: Int, high: Int, unique: Boolean): MutableMap<String, Any> {
             }
         }
     }
-    return mutableMapOf<String, Any>("count" to (count), "list" to (valid)) as MutableMap<String, Any>
+    return mutableMapOf<String, Any?>("count" to (count), "list" to (valid))
 }
 
 fun main() {
-    println((r1)["count"]!!.toString() + " unique solutions in 1 to 7")
-    println((r1)["list"]!!)
-    println((r2)["count"]!!.toString() + " unique solutions in 3 to 9")
-    println((r2)["list"]!!)
-    println((r3)["count"]!!.toString() + " non-unique solutions in 0 to 9")
+    println(((r1)["count"] as Any?).toString() + " unique solutions in 1 to 7")
+    println((r1)["list"] as Any?)
+    println(((r2)["count"] as Any?).toString() + " unique solutions in 3 to 9")
+    println((r2)["list"] as Any?)
+    println(((r3)["count"] as Any?).toString() + " non-unique solutions in 0 to 9")
 }

--- a/tests/rosetta/transpiler/Kotlin/9-billion-names-of-god-the-integer.kt
+++ b/tests/rosetta/transpiler/Kotlin/9-billion-names-of-god-the-integer.kt
@@ -6,12 +6,12 @@ fun bigTrim(a: MutableList<Int>): MutableList<Int> {
         a = a.subList(0, n - 1)
         n = n - 1
     }
-    return a as MutableList<Int>
+    return a
 }
 
 fun bigFromInt(x: Int): MutableList<Int> {
     if (x == 0) {
-        return mutableListOf(0) as MutableList<Int>
+        return mutableListOf(0)
     }
     var digits: MutableList<Int> = mutableListOf()
     var n: Int = x
@@ -19,20 +19,20 @@ fun bigFromInt(x: Int): MutableList<Int> {
         digits = run { val _tmp = digits.toMutableList(); _tmp.add(n % 10); _tmp } as MutableList<Int>
         n = n / 10
     }
-    return digits as MutableList<Int>
+    return digits
 }
 
 fun bigAdd(a: MutableList<Int>, b: MutableList<Int>): MutableList<Int> {
     var res: MutableList<Int> = mutableListOf()
     var carry: Int = 0
     var i: Int = 0
-    while ((((i < (a.size as Number).toDouble()) || (i < (b.size as Number).toDouble()) as Boolean)) || (carry > 0)) {
+    while ((((i < a.size) || (i < b.size) as Boolean)) || (carry > 0)) {
         var av: Int = 0
-        if (i < (a.size as Number).toDouble()) {
+        if (i < a.size) {
             av = a[i]
         }
         var bv: Int = 0
-        if (i < (b.size as Number).toDouble()) {
+        if (i < b.size) {
             bv = b[i]
         }
         var s: Int = (av + bv) + carry
@@ -40,17 +40,17 @@ fun bigAdd(a: MutableList<Int>, b: MutableList<Int>): MutableList<Int> {
         carry = s / 10
         i = i + 1
     }
-    return bigTrim(res) as MutableList<Int>
+    return bigTrim(res)
 }
 
 fun bigSub(a: MutableList<Int>, b: MutableList<Int>): MutableList<Int> {
     var res: MutableList<Int> = mutableListOf()
     var borrow: Int = 0
     var i: Int = 0
-    while (i < (a.size as Number).toDouble()) {
+    while (i < a.size) {
         var av: Int = a[i]
         var bv: Int = 0
-        if (i < (b.size as Number).toDouble()) {
+        if (i < b.size) {
             bv = b[i]
         }
         var diff: Int = (av - bv) - borrow
@@ -63,24 +63,24 @@ fun bigSub(a: MutableList<Int>, b: MutableList<Int>): MutableList<Int> {
         res = run { val _tmp = res.toMutableList(); _tmp.add(diff); _tmp } as MutableList<Int>
         i = i + 1
     }
-    return bigTrim(res) as MutableList<Int>
+    return bigTrim(res)
 }
 
 fun bigToString(a: MutableList<Int>): String {
     var s: String = ""
-    var i: Int = (a.size as Int) - 1
+    var i: Int = a.size - 1
     while (i >= 0) {
-        s = s + a[i].toString()
+        s = s + (a[i]).toString()
         i = i - 1
     }
-    return s as String
+    return s
 }
 
 fun minInt(a: Int, b: Int): Int {
     if (a < b) {
-        return a as Int
+        return a
     } else {
-        return b as Int
+        return b
     }
 }
 
@@ -91,14 +91,14 @@ fun cumu(n: Int): MutableList<MutableList<Int>> {
         var row: MutableList<MutableList<Int>> = mutableListOf(bigFromInt(0))
         var x: Int = 1
         while (x <= y) {
-            val _val: MutableList<Int> = (cache[y - x])[minInt(x, y - x)] as MutableList<Int>
-            row = run { val _tmp = row.toMutableList(); _tmp.add(bigAdd(row[(row.size as Int) - 1], _val)); _tmp } as MutableList<MutableList<Int>>
+            val _val: MutableList<Int> = cache[y - x][minInt(x, y - x)]
+            row = run { val _tmp = row.toMutableList(); _tmp.add(bigAdd(row[row.size - 1], _val)); _tmp } as MutableList<MutableList<Int>>
             x = x + 1
         }
         cache = run { val _tmp = cache.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<MutableList<Int>>>
         y = y + 1
     }
-    return cache[n] as MutableList<MutableList<Int>>
+    return cache[n]
 }
 
 fun row(n: Int): MutableList<String> {
@@ -106,11 +106,11 @@ fun row(n: Int): MutableList<String> {
     var out: MutableList<String> = mutableListOf()
     var i: Int = 0
     while (i < n) {
-        val diff: MutableList<Int> = bigSub(e[i + 1] as MutableList<Int>, e[i] as MutableList<Int>)
+        val diff: MutableList<Int> = bigSub(e[i + 1], e[i])
         out = run { val _tmp = out.toMutableList(); _tmp.add(bigToString(diff)); _tmp } as MutableList<String>
         i = i + 1
     }
-    return out as MutableList<String>
+    return out
 }
 
 fun main() {
@@ -119,7 +119,7 @@ fun main() {
         val r: MutableList<String> = row(x)
         var line: String = ""
         var i: Int = 0
-        while (i < (r.size as Number).toDouble()) {
+        while (i < r.size) {
             line = ((line + " ") + r[i]) + " "
             i = i + 1
         }
@@ -129,7 +129,7 @@ fun main() {
     println("")
     println("sums:")
     for (num in mutableListOf(23, 123, 1234)) {
-        val r = cumu(num)
-        println((num.toString() + " ") + (bigToString((r as MutableList<Any?>)[(r.size as Int) - 1]!! as MutableList<Int>)).toString())
+        val r: MutableList<MutableList<Int>> = cumu(num)
+        println((num.toString() + " ") + bigToString((r[r.size - 1]) as MutableList<Int>))
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/99-bottles-of-beer-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/99-bottles-of-beer-2.kt
@@ -17,7 +17,7 @@ fun fields(s: String): MutableList<String> {
     if (cur.length > 0) {
         words = run { val _tmp = words.toMutableList(); _tmp.add(cur); _tmp } as MutableList<String>
     }
-    return words as MutableList<String>
+    return words
 }
 
 fun join(xs: MutableList<String>, sep: String): String {
@@ -30,48 +30,48 @@ fun join(xs: MutableList<String>, sep: String): String {
         res = res + xs[i]
         i = i + 1
     }
-    return res as String
+    return res
 }
 
 fun numberName(n: Int): String {
     val small: MutableList<String> = mutableListOf("no", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen")
     val tens: MutableList<String> = mutableListOf("ones", "ten", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety")
     if (n < 0) {
-        return "" as String
+        return ""
     }
     if (n < 20) {
-        return small[n] as String
+        return small[n]
     }
     if (n < 100) {
-        var t: String = (tens)[n / 10 as Int] as String
+        var t: String = tens[(n / 10).toInt()]
         var s: Int = n % 10
         if (s > 0) {
             t = (t + " ") + small[s]
         }
-        return t as String
+        return t
     }
-    return "" as String
+    return ""
 }
 
 fun pluralizeFirst(s: String, n: Int): String {
     if (n == 1) {
-        return s as String
+        return s
     }
     val w: MutableList<String> = fields(s)
     if (w.size > 0) {
         w[0] = w[0] + "s"
     }
-    return join(w, " ") as String
+    return join(w, " ")
 }
 
 fun randInt(seed: Int, n: Int): Int {
     val next: Int = ((seed * 1664525) + 1013904223) % 2147483647
-    return next % n as Int
+    return next % n
 }
 
 fun slur(p: String, d: Int): String {
     if (p.length <= 2) {
-        return p as String
+        return p
     }
     var a: MutableList<String> = mutableListOf()
     var i: Int = 1
@@ -99,16 +99,16 @@ fun slur(p: String, d: Int): String {
     }
     s = s + (p.substring(p.length - 1, p.length)).toString()
     val w: MutableList<String> = fields(s)
-    return join(w, " ") as String
+    return join(w, " ")
 }
 
 fun user_main(): Unit {
     var i: Int = 99
     while (i > 0) {
-        println(((((slur(numberName(i) as String, i)).toString() + " ") + (pluralizeFirst(slur("bottle of", i) as String, i)).toString()) + " ") + (slur("beer on the wall", i)).toString())
-        println(((((slur(numberName(i) as String, i)).toString() + " ") + (pluralizeFirst(slur("bottle of", i) as String, i)).toString()) + " ") + (slur("beer", i)).toString())
-        println(((((slur("take one", i)).toString() + " ") + (slur("down", i)).toString()) + " ") + (slur("pass it around", i)).toString())
-        println(((((slur(numberName(i - 1) as String, i)).toString() + " ") + (pluralizeFirst(slur("bottle of", i) as String, i - 1)).toString()) + " ") + (slur("beer on the wall", i)).toString())
+        println((((slur(numberName(i), i) + " ") + pluralizeFirst(slur("bottle of", i), i)) + " ") + slur("beer on the wall", i))
+        println((((slur(numberName(i), i) + " ") + pluralizeFirst(slur("bottle of", i), i)) + " ") + slur("beer", i))
+        println((((slur("take one", i) + " ") + slur("down", i)) + " ") + slur("pass it around", i))
+        println((((slur(numberName(i - 1), i) + " ") + pluralizeFirst(slur("bottle of", i), i - 1)) + " ") + slur("beer on the wall", i))
         i = i - 1
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/99-bottles-of-beer.kt
+++ b/tests/rosetta/transpiler/Kotlin/99-bottles-of-beer.kt
@@ -1,20 +1,20 @@
 fun bottles(n: Int): String {
     if (n == 0) {
-        return "No more bottles" as String
+        return "No more bottles"
     }
     if (n == 1) {
-        return "1 bottle" as String
+        return "1 bottle"
     }
-    return n.toString() + " bottles" as String
+    return n.toString() + " bottles"
 }
 
 fun user_main(): Unit {
     var i: Int = 99
     while (i > 0) {
-        println((bottles(i)).toString() + " of beer on the wall")
-        println((bottles(i)).toString() + " of beer")
+        println(bottles(i) + " of beer on the wall")
+        println(bottles(i) + " of beer")
         println("Take one down, pass it around")
-        println((bottles(i - 1)).toString() + " of beer on the wall")
+        println(bottles(i - 1) + " of beer on the wall")
         i = i - 1
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/DNS-query.kt
+++ b/tests/rosetta/transpiler/Kotlin/DNS-query.kt
@@ -1,6 +1,6 @@
-val res: MutableList<Any> = mutableListOf<Any?>(mutableListOf("210.155.141.200"), null) as MutableList<Any>
-val addrs = res[0]
-val err = res[1]
+val res: MutableList<Any?> = mutableListOf<Any?>(mutableListOf("210.155.141.200"), null) as MutableList<Any?>
+val addrs: Any? = res[0]
+val err: Any? = res[1]
 fun main() {
     if (err == null) {
         println(addrs.toString())

--- a/tests/rosetta/transpiler/Kotlin/a+b.kt
+++ b/tests/rosetta/transpiler/Kotlin/a+b.kt
@@ -1,8 +1,8 @@
 fun input(): String = readLine() ?: ""
 
 fun user_main(): Unit {
-    val a: Int = input().toInt()
-    val b: Int = input().toInt()
+    val a: Int = (input()).toInt()
+    val b: Int = (input()).toInt()
     println(a + b)
 }
 

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-25 12:54 +0700
+Last updated: 2025-07-25 19:02 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-25 12:54 +0700
+Last updated: 2025-07-25 19:02 +0700
 
 Completed tasks: **54/284**
 

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,48 @@
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 19:02 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-25 12:54 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -763,7 +763,7 @@ func (b *BinaryExpr) emit(w io.Writer) {
 			}
 		} else if numOp {
 			t := guessType(e)
-			if t == "Any" {
+			if t == "Any" || t == "Any?" {
 				ot := guessType(other)
 				if ot == "Int" {
 					cast(e, "Int")
@@ -2662,6 +2662,8 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 				var tt types.Type
 				if s.Let.Type != nil {
 					tt = types.ResolveTypeRef(s.Let.Type, env)
+				} else if t := types.CheckExprType(s.Let.Value, env); t != nil {
+					tt = t
 				} else {
 					switch typ {
 					case "Int":
@@ -2776,6 +2778,8 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 				var tt types.Type
 				if s.Var.Type != nil {
 					tt = types.ResolveTypeRef(s.Var.Type, env)
+				} else if t := types.CheckExprType(s.Var.Value, env); t != nil {
+					tt = t
 				} else {
 					switch typ {
 					case "Int":
@@ -3937,7 +3941,7 @@ func convertPostfix(env *types.Env, p *parser.PostfixExpr) (Expr, error) {
 			case "go_net":
 				if field == "LookupHost" {
 					list := &TypedListLit{ElemType: "Any?", Elems: []Expr{&ListLit{Elems: []Expr{&StringLit{Value: "210.155.141.200"}}}, &VarRef{Name: "null"}}}
-					return &CastExpr{Value: list, Type: "MutableList<Any>"}, nil
+					return &CastExpr{Value: list, Type: "MutableList<Any?>"}, nil
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- enhance variable type inference in Kotlin transpiler
- handle Any? operands in arithmetic expressions
- fix LookupHost stub type
- regenerate Kotlin sources and rosetta progress

## Testing
- `ROSETTA_INDEX=7 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/kt -run Rosetta -count=1`
- `ROSETTA_INDEX=10 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/kt -run Rosetta -count=1`
- `ROSETTA_INDEX=15 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/kt -run Rosetta -count=1`
- `ROSETTA_INDEX=16 MOCHI_BENCHMARK=1 go test -tags=slow ./transpiler/x/kt -run Rosetta -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6883740cd8008320b3becbf2a187dc7f