### PR TITLE
Update clj transpiler

### DIFF
--- a/tests/rosetta/transpiler/Clojure/9-billion-names-of-god-the-integer.bench
+++ b/tests/rosetta/transpiler/Clojure/9-billion-names-of-god-the-integer.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 7099292,
+  "memory_bytes": 48821384,
+  "name": "main"
+}

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
 Completed: 14/284
-Last updated: 2025-07-25 12:41 +0700
+Last updated: 2025-07-25 19:37 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -16,9 +16,9 @@ Last updated: 2025-07-25 12:41 +0700
 | 9 | 24-game-solve | ✓ | 128.127ms | 23.3 MB |
 | 10 | 24-game |   |  |  |
 | 11 | 4-rings-or-4-squares-puzzle |   |  |  |
-| 12 | 9-billion-names-of-god-the-integer | ✓ |  |  |
+| 12 | 9-billion-names-of-god-the-integer | ✓ | 7.099292s | 46.6 MB |
 | 13 | 99-bottles-of-beer-2 |   |  |  |
-| 14 | 99-bottles-of-beer |   |  |  |
+| 14 | 99-bottles-of-beer |   | 27.567ms | 18.0 MB |
 | 15 | DNS-query |   |  |  |
 | 16 | a+b |   |  |  |
 | 17 | abbreviations-automatic |   |  |  |
@@ -27,7 +27,7 @@ Last updated: 2025-07-25 12:41 +0700
 | 20 | abc-problem |   |  |  |
 | 21 | abelian-sandpile-model-identity | ✓ |  |  |
 | 22 | abelian-sandpile-model |   |  |  |
-| 23 | abstract-type | ✓ |  |  |
+| 23 | abstract-type | ✓ | 21.155ms | 19.2 MB |
 | 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
 | 25 | abundant-odd-numbers |   |  |  |
 | 26 | accumulator-factory |   |  |  |


### PR DESCRIPTION
## Summary
- transpiler/clj: detect nested return statements
- identify string-producing forms in `isStringNode`
- regenerate Rosetta bench output for "9-billion-names-of-god-the-integer"

## Testing
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run TestRosettaClojure -tags=slow -index=12`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -run TestRosettaClojure -tags=slow -index=14 -v`


------
https://chatgpt.com/codex/tasks/task_e_688376451bbc8320bdef673f574e4ae0