### PR TITLE
Update Java transpiler for Rosetta tasks

### DIFF
--- a/tests/rosetta/transpiler/Java/atomic-updates.bench
+++ b/tests/rosetta/transpiler/Java/atomic-updates.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 14215,
+  "memory_bytes": 56768,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/atomic-updates.java
+++ b/tests/rosetta/transpiler/Java/atomic-updates.java
@@ -1,0 +1,123 @@
+public class Main {
+
+    static int[] randOrder(int seed, int n) {
+        int next = Math.floorMod((seed * 1664525 + 1013904223), 2147483647);
+        return new int[]{next, Math.floorMod(next, n)};
+    }
+
+    static int[] randChaos(int seed, int n) {
+        int next = Math.floorMod((seed * 1103515245 + 12345), 2147483647);
+        return new int[]{next, Math.floorMod(next, n)};
+    }
+
+    static void main() {
+        int nBuckets = 10;
+        int initialSum = 1000;
+        int[] buckets = new int[]{};
+        for (int i = 0; i < nBuckets; i++) {
+            buckets = java.util.stream.IntStream.concat(java.util.Arrays.stream(buckets), java.util.stream.IntStream.of(0)).toArray();
+        }
+        int i = nBuckets;
+        int dist = initialSum;
+        while (i > 0) {
+            int v = dist / i;
+            i = i - 1;
+buckets[i] = v;
+            dist = dist - v;
+        }
+        int tc0 = 0;
+        int tc1 = 0;
+        int total = 0;
+        int nTicks = 0;
+        int seedOrder = 1;
+        int seedChaos = 2;
+        System.out.println("sum  ---updates---    mean  buckets");
+        int t = 0;
+        while (t < 5) {
+            int[] r = randOrder(seedOrder, nBuckets);
+            seedOrder = r[0];
+            int b1 = r[1];
+            int b2 = Math.floorMod((b1 + 1), nBuckets);
+            int v1 = buckets[b1];
+            int v2 = buckets[b2];
+            if (v1 > v2) {
+                int a = ((Number)(((v1 - v2) / 2))).intValue();
+                if (a > buckets[b1]) {
+                    a = buckets[b1];
+                }
+buckets[b1] = buckets[b1] - a;
+buckets[b2] = buckets[b2] + a;
+            } else {
+                int a = ((Number)(((v2 - v1) / 2))).intValue();
+                if (a > buckets[b2]) {
+                    a = buckets[b2];
+                }
+buckets[b2] = buckets[b2] - a;
+buckets[b1] = buckets[b1] + a;
+            }
+            tc0 = tc0 + 1;
+            r = randChaos(seedChaos, nBuckets);
+            seedChaos = r[0];
+            b1 = r[1];
+            b2 = Math.floorMod((b1 + 1), nBuckets);
+            r = randChaos(seedChaos, buckets[b1] + 1);
+            seedChaos = r[0];
+            int amt = r[1];
+            if (amt > buckets[b1]) {
+                amt = buckets[b1];
+            }
+buckets[b1] = buckets[b1] - amt;
+buckets[b2] = buckets[b2] + amt;
+            tc1 = tc1 + 1;
+            int sum = 0;
+            int idx = 0;
+            while (idx < nBuckets) {
+                sum = sum + buckets[idx];
+                idx = idx + 1;
+            }
+            total = total + tc0 + tc1;
+            nTicks = nTicks + 1;
+            System.out.println(String.valueOf(String.valueOf(String.valueOf(String.valueOf(String.valueOf(String.valueOf(String.valueOf(String.valueOf(sum) + " ") + String.valueOf(tc0)) + " ") + String.valueOf(tc1)) + " ") + String.valueOf(total / nTicks)) + "  ") + String.valueOf(buckets));
+            tc0 = 0;
+            tc1 = 0;
+            t = t + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/attractive-numbers.bench
+++ b/tests/rosetta/transpiler/Java/attractive-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 13462,
+  "memory_bytes": 40048,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/attractive-numbers.java
+++ b/tests/rosetta/transpiler/Java/attractive-numbers.java
@@ -1,0 +1,124 @@
+public class Main {
+
+    static boolean isPrime(int n) {
+        if (n < 2) {
+            return false;
+        }
+        if (((Number)(Math.floorMod(n, 2))).intValue() == 0) {
+            return n == 2;
+        }
+        if (((Number)(Math.floorMod(n, 3))).intValue() == 0) {
+            return n == 3;
+        }
+        int d = 5;
+        while (d * d <= n) {
+            if (((Number)(Math.floorMod(n, d))).intValue() == 0) {
+                return false;
+            }
+            d = d + 2;
+            if (((Number)(Math.floorMod(n, d))).intValue() == 0) {
+                return false;
+            }
+            d = d + 4;
+        }
+        return true;
+    }
+
+    static int countPrimeFactors(int n) {
+        if (n == 1) {
+            return 0;
+        }
+        if (isPrime(n)) {
+            return 1;
+        }
+        int count = 0;
+        int f = 2;
+        while (true) {
+            if (((Number)(Math.floorMod(n, f))).intValue() == 0) {
+                count = count + 1;
+                n = n / f;
+                if (n == 1) {
+                    return count;
+                }
+                if (isPrime(n)) {
+                    f = n;
+                }
+            } else             if (f >= 3) {
+                f = f + 2;
+            } else {
+                f = 3;
+            }
+        }
+    }
+
+    static String pad4(int n) {
+        String s = String.valueOf(n);
+        while (s.length() < 4) {
+            s = String.valueOf(" " + s);
+        }
+        return s;
+    }
+
+    static void main() {
+        int max = 120;
+        System.out.println(String.valueOf("The attractive numbers up to and including " + String.valueOf(max)) + " are:");
+        int count = 0;
+        String line = "";
+        int lineCount = 0;
+        int i = 1;
+        while (i <= max) {
+            int c = countPrimeFactors(i);
+            if (isPrime(c)) {
+                line = String.valueOf(line + String.valueOf(pad4(i)));
+                count = count + 1;
+                lineCount = lineCount + 1;
+                if (lineCount == 20) {
+                    System.out.println(line);
+                    line = "";
+                    lineCount = 0;
+                }
+            }
+            i = i + 1;
+        }
+        if (lineCount > 0) {
+            System.out.println(line);
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/average-loop-length.bench
+++ b/tests/rosetta/transpiler/Java/average-loop-length.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 77005,
+  "memory_bytes": 93272,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/average-loop-length.java
+++ b/tests/rosetta/transpiler/Java/average-loop-length.java
@@ -1,0 +1,156 @@
+public class Main {
+
+    static double absf(double x) {
+        if (x < 0.0) {
+            return -x;
+        }
+        return x;
+    }
+
+    static double floorf(double x) {
+        int y = ((Number)(x)).intValue();
+        return ((Number)(y)).doubleValue();
+    }
+
+    static int indexOf(String s, String ch) {
+        int i = 0;
+        while (i < s.length()) {
+            if ((s.substring(i, i + 1).equals(ch))) {
+                return i;
+            }
+            i = i + 1;
+        }
+        return -1;
+    }
+
+    static String fmtF(double x) {
+        double y = floorf(x * 10000.0 + 0.5) / 10000.0;
+        String s = String.valueOf(y);
+        int dot = indexOf(s, ".");
+        if (dot == 0 - 1) {
+            s = String.valueOf(s + ".0000");
+        } else {
+            int decs = s.length() - dot - 1;
+            if (decs > 4) {
+                s = s.substring(0, dot + 5);
+            } else {
+                while (decs < 4) {
+                    s = String.valueOf(s + "0");
+                    decs = decs + 1;
+                }
+            }
+        }
+        return s;
+    }
+
+    static String padInt(int n, int width) {
+        String s = String.valueOf(n);
+        while (s.length() < width) {
+            s = String.valueOf(" " + s);
+        }
+        return s;
+    }
+
+    static String padFloat(double x, int width) {
+        String s = String.valueOf(fmtF(x));
+        while (s.length() < width) {
+            s = String.valueOf(" " + s);
+        }
+        return s;
+    }
+
+    static double avgLen(int n) {
+        int tests = 10000;
+        int sum = 0;
+        int seed = 1;
+        int t = 0;
+        while (t < tests) {
+            boolean[] visited = new boolean[]{};
+            int i = 0;
+            while (i < n) {
+                visited = appendBool(visited, false);
+                i = i + 1;
+            }
+            int x = 0;
+            while (!(Boolean)visited[x]) {
+visited[x] = true;
+                sum = sum + 1;
+                seed = Math.floorMod((seed * 1664525 + 1013904223), 2147483647);
+                x = Math.floorMod(seed, n);
+            }
+            t = t + 1;
+        }
+        return (((Number)(sum)).doubleValue()) / tests;
+    }
+
+    static double ana(int n) {
+        double nn = ((Number)(n)).doubleValue();
+        double term = 1.0;
+        double sum = 1.0;
+        double i = nn - 1.0;
+        while (i >= 1.0) {
+            term = term * (i / nn);
+            sum = sum + term;
+            i = i - 1.0;
+        }
+        return sum;
+    }
+
+    static void main() {
+        int nmax = 20;
+        System.out.println(" N    average    analytical    (error)");
+        System.out.println("===  =========  ============  =========");
+        int n = 1;
+        while (n <= nmax) {
+            double a = avgLen(n);
+            double b = ana(n);
+            double err = absf(a - b) / b * 100.0;
+            String line = String.valueOf(String.valueOf(String.valueOf(String.valueOf(String.valueOf(padInt(n, 3)) + "  " + padFloat(a, 9)) + "  " + padFloat(b, 12)) + "  (" + padFloat(err, 6)) + "%)");
+            System.out.println(line);
+            n = n + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static boolean[] appendBool(boolean[] arr, boolean v) {
+        boolean[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-arithmetic-mean.bench
+++ b/tests/rosetta/transpiler/Java/averages-arithmetic-mean.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 12600,
+  "memory_bytes": 50696,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-arithmetic-mean.java
+++ b/tests/rosetta/transpiler/Java/averages-arithmetic-mean.java
@@ -1,0 +1,66 @@
+public class Main {
+
+    static java.util.Map<String,Object> mean(double[] v) {
+        if (v.length == 0) {
+            return new java.util.LinkedHashMap<String, Object>(java.util.Map.ofEntries(java.util.Map.entry("ok", false)));
+        }
+        double sum = 0.0;
+        int i = 0;
+        while (i < v.length) {
+            sum = sum + v[i];
+            i = i + 1;
+        }
+        return new java.util.LinkedHashMap<String, Object>(java.util.Map.ofEntries(java.util.Map.entry("ok", true), java.util.Map.entry("mean", sum / (((Number)(v.length)).doubleValue()))));
+    }
+
+    static void main() {
+        double[][] sets = new double[][]{new double[]{}, new double[]{3.0, 1.0, 4.0, 1.0, 5.0, 9.0}, new double[]{100000000000000000000.0, 3.0, 1.0, 4.0, 1.0, 5.0, 9.0, -100000000000000000000.0}, new double[]{10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.11}, new double[]{10.0, 20.0, 30.0, 40.0, 50.0, -100.0, 4.7, -1100.0}};
+        for (double[] v : sets) {
+            System.out.println("Vector: " + String.valueOf(v));
+            java.util.Map<String,Object> r = mean(v);
+            if (((boolean)r.getOrDefault("ok", false))) {
+                System.out.println(String.valueOf(String.valueOf("Mean of " + String.valueOf(v.length)) + " numbers is ") + String.valueOf(((double)r.getOrDefault("mean", 0.0))));
+            } else {
+                System.out.println("Mean undefined");
+            }
+            System.out.println("");
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-mean-time-of-day.bench
+++ b/tests/rosetta/transpiler/Java/averages-mean-time-of-day.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 17601,
+  "memory_bytes": 79840,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-mean-time-of-day.java
+++ b/tests/rosetta/transpiler/Java/averages-mean-time-of-day.java
@@ -1,0 +1,155 @@
+public class Main {
+    static double PI = 3.141592653589793;
+
+    static double sinApprox(double x) {
+        double term = x;
+        double sum = x;
+        int n = 1;
+        while (n <= 8) {
+            double denom = ((Number)(((2 * n) * (2 * n + 1)))).doubleValue();
+            term = -term * x * x / denom;
+            sum = sum + term;
+            n = n + 1;
+        }
+        return sum;
+    }
+
+    static double cosApprox(double x) {
+        double term = 1.0;
+        double sum = 1.0;
+        int n = 1;
+        while (n <= 8) {
+            double denom = ((Number)(((2 * n - 1) * (2 * n)))).doubleValue();
+            term = -term * x * x / denom;
+            sum = sum + term;
+            n = n + 1;
+        }
+        return sum;
+    }
+
+    static double atanApprox(double x) {
+        if (x > 1.0) {
+            return PI / 2.0 - x / (x * x + 0.28);
+        }
+        if (x < (-1.0)) {
+            return -PI / 2.0 - x / (x * x + 0.28);
+        }
+        return x / (1.0 + 0.28 * x * x);
+    }
+
+    static double atan2Approx(double y, double x) {
+        if (x > 0.0) {
+            return atanApprox(y / x);
+        }
+        if (x < 0.0) {
+            if (y >= 0.0) {
+                return atanApprox(y / x) + PI;
+            }
+            return atanApprox(y / x) - PI;
+        }
+        if (y > 0.0) {
+            return PI / 2.0;
+        }
+        if (y < 0.0) {
+            return -PI / 2.0;
+        }
+        return 0.0;
+    }
+
+    static int digit(String ch) {
+        String digits = "0123456789";
+        int i = 0;
+        while (i < digits.length()) {
+            if ((digits.substring(i, i + 1).equals(ch))) {
+                return i;
+            }
+            i = i + 1;
+        }
+        return 0;
+    }
+
+    static int parseTwo(String s, int idx) {
+        return digit(s.substring(idx, idx + 1)) * 10 + digit(s.substring(idx + 1, idx + 2));
+    }
+
+    static double parseSec(String s) {
+        int h = parseTwo(s, 0);
+        int m = parseTwo(s, 3);
+        int sec = parseTwo(s, 6);
+        int tmp = (h * 60 + m) * 60 + sec;
+        return ((Number)(tmp)).doubleValue();
+    }
+
+    static String pad(int n) {
+        if (n < 10) {
+            return "0" + String.valueOf(n);
+        }
+        return String.valueOf(n);
+    }
+
+    static String meanTime(String[] times) {
+        double ssum = 0.0;
+        double csum = 0.0;
+        int i = 0;
+        while (i < times.length) {
+            double sec = parseSec(times[i]);
+            double ang = sec * 2.0 * PI / 86400.0;
+            ssum = ssum + sinApprox(ang);
+            csum = csum + cosApprox(ang);
+            i = i + 1;
+        }
+        double theta = atan2Approx(ssum, csum);
+        double frac = theta / (2.0 * PI);
+        while (frac < 0.0) {
+            frac = frac + 1.0;
+        }
+        double total = frac * 86400.0;
+        int si = ((Number)(total)).intValue();
+        int h = ((Number)((si / 3600))).intValue();
+        int m = ((Number)((((Number)((Math.floorMod(si, 3600)))).intValue() / 60))).intValue();
+        int s = ((Number)((Math.floorMod(si, 60)))).intValue();
+        return String.valueOf(String.valueOf(pad(h)) + ":" + pad(m)) + ":" + pad(s);
+    }
+
+    static void main() {
+        String[] inputs = new String[]{"23:00:17", "23:40:20", "00:12:45", "00:17:19"};
+        System.out.println(meanTime(inputs));
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-median-1.bench
+++ b/tests/rosetta/transpiler/Java/averages-median-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 6962,
+  "memory_bytes": 10600,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-median-1.java
+++ b/tests/rosetta/transpiler/Java/averages-median-1.java
@@ -1,0 +1,69 @@
+public class Main {
+
+    static double[] sortFloat(double[] xs) {
+        double[] arr = xs;
+        int n = arr.length;
+        int i = 0;
+        while (i < n) {
+            int j = 0;
+            while (j < n - 1) {
+                if (arr[j] > arr[j + 1]) {
+                    double tmp = arr[j];
+arr[j] = arr[j + 1];
+arr[j + 1] = tmp;
+                }
+                j = j + 1;
+            }
+            i = i + 1;
+        }
+        return arr;
+    }
+
+    static double median(double[] a) {
+        double[] arr = sortFloat(a);
+        int half = ((Number)((arr.length / 2))).intValue();
+        double m = arr[half];
+        if (((Number)(Math.floorMod(arr.length, 2))).intValue() == 0) {
+            m = (m + arr[half - 1]) / 2.0;
+        }
+        return m;
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0})));
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0, 5.0})));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-median-2.bench
+++ b/tests/rosetta/transpiler/Java/averages-median-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 13193,
+  "memory_bytes": 10600,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-median-2.java
+++ b/tests/rosetta/transpiler/Java/averages-median-2.java
@@ -1,0 +1,69 @@
+public class Main {
+
+    static double sel(double[] list, int k) {
+        int i = 0;
+        while (i <= k) {
+            int minIndex = i;
+            int j = i + 1;
+            while (j < list.length) {
+                if (list[j] < list[minIndex]) {
+                    minIndex = j;
+                }
+                j = j + 1;
+            }
+            double tmp = list[i];
+list[i] = list[minIndex];
+list[minIndex] = tmp;
+            i = i + 1;
+        }
+        return list[k];
+    }
+
+    static double median(double[] a) {
+        double[] arr = a;
+        int half = ((Number)((arr.length / 2))).intValue();
+        double med = sel(arr, half);
+        if (((Number)(Math.floorMod(arr.length, 2))).intValue() == 0) {
+            return (med + arr[half - 1]) / 2.0;
+        }
+        return med;
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0})));
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0, 5.0})));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-median-3.bench
+++ b/tests/rosetta/transpiler/Java/averages-median-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 7628,
+  "memory_bytes": 10704,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-median-3.java
+++ b/tests/rosetta/transpiler/Java/averages-median-3.java
@@ -1,0 +1,87 @@
+public class Main {
+
+    static double qsel(double[] a, int k) {
+        double[] arr = a;
+        while (arr.length > 1) {
+            int px = Math.floorMod(_now(), arr.length);
+            double pv = arr[px];
+            int last = arr.length - 1;
+            double tmp = arr[px];
+arr[px] = arr[last];
+arr[last] = tmp;
+            px = 0;
+            int i = 0;
+            while (i < last) {
+                double v = arr[i];
+                if (v < pv) {
+                    double tmp2 = arr[px];
+arr[px] = arr[i];
+arr[i] = tmp2;
+                    px = px + 1;
+                }
+                i = i + 1;
+            }
+            if (px == k) {
+                return pv;
+            }
+            if (k < px) {
+                arr = java.util.Arrays.copyOfRange(arr, 0, px);
+            } else {
+                double tmp2 = arr[px];
+arr[px] = pv;
+arr[last] = tmp2;
+                arr = java.util.Arrays.copyOfRange(arr, (px + 1), arr.length);
+                k = k - (px + 1);
+            }
+        }
+        return arr[0];
+    }
+
+    static double median(double[] list) {
+        double[] arr = list;
+        int half = ((Number)((arr.length / 2))).intValue();
+        double med = qsel(arr, half);
+        if (((Number)(Math.floorMod(arr.length, 2))).intValue() == 0) {
+            return (med + qsel(arr, half - 1)) / 2.0;
+        }
+        return med;
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0})));
+            System.out.println(String.valueOf(median(new double[]{3.0, 1.0, 4.0, 1.0, 5.0})));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-mode.bench
+++ b/tests/rosetta/transpiler/Java/averages-mode.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 16012,
+  "memory_bytes": 47832,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-mode.java
+++ b/tests/rosetta/transpiler/Java/averages-mode.java
@@ -1,0 +1,107 @@
+public class Main {
+    static int[] arr1 = new int[]{2, 7, 1, 8, 2};
+    static java.util.Map<Integer,Integer> counts1 = new java.util.LinkedHashMap<Integer, Integer>();
+    static int[] keys1 = new int[]{};
+    static int i = 0;
+    static int max1 = 0;
+    static int[] modes1 = new int[]{};
+    static int[] arr2 = new int[]{2, 7, 1, 8, 2, 8};
+    static java.util.Map<Integer,Integer> counts2 = new java.util.LinkedHashMap<Integer, Integer>();
+    static int[] keys2 = new int[]{};
+    static int max2 = 0;
+    static int[] modes2 = new int[]{};
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            while (i < arr1.length) {
+                int v = arr1[i];
+                if (counts1.containsKey(v)) {
+counts1.put(v, (int)(((int)counts1.getOrDefault(v, 0))) + 1);
+                } else {
+counts1.put(v, 1);
+                    keys1 = java.util.stream.IntStream.concat(java.util.Arrays.stream(keys1), java.util.stream.IntStream.of(v)).toArray();
+                }
+                i = i + 1;
+            }
+            i = 0;
+            while (i < keys1.length) {
+                int k = keys1[i];
+                int c = (int)(((int)counts1.getOrDefault(k, 0)));
+                if (c > max1) {
+                    max1 = c;
+                }
+                i = i + 1;
+            }
+            i = 0;
+            while (i < keys1.length) {
+                int k = keys1[i];
+                if ((int)(((int)counts1.getOrDefault(k, 0))) == max1) {
+                    modes1 = java.util.stream.IntStream.concat(java.util.Arrays.stream(modes1), java.util.stream.IntStream.of(k)).toArray();
+                }
+                i = i + 1;
+            }
+            System.out.println(String.valueOf(modes1));
+            i = 0;
+            while (i < arr2.length) {
+                int v = arr2[i];
+                if (counts2.containsKey(v)) {
+counts2.put(v, (int)(((int)counts2.getOrDefault(v, 0))) + 1);
+                } else {
+counts2.put(v, 1);
+                    keys2 = java.util.stream.IntStream.concat(java.util.Arrays.stream(keys2), java.util.stream.IntStream.of(v)).toArray();
+                }
+                i = i + 1;
+            }
+            i = 0;
+            while (i < keys2.length) {
+                int k = keys2[i];
+                int c = (int)(((int)counts2.getOrDefault(k, 0)));
+                if (c > max2) {
+                    max2 = c;
+                }
+                i = i + 1;
+            }
+            i = 0;
+            while (i < keys2.length) {
+                int k = keys2[i];
+                if ((int)(((int)counts2.getOrDefault(k, 0))) == max2) {
+                    modes2 = java.util.stream.IntStream.concat(java.util.Arrays.stream(modes2), java.util.stream.IntStream.of(k)).toArray();
+                }
+                i = i + 1;
+            }
+            System.out.println(String.valueOf(modes2));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/averages-pythagorean-means.bench
+++ b/tests/rosetta/transpiler/Java/averages-pythagorean-means.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 14993,
+  "memory_bytes": 50264,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/averages-pythagorean-means.java
+++ b/tests/rosetta/transpiler/Java/averages-pythagorean-means.java
@@ -1,0 +1,85 @@
+public class Main {
+
+    static double powf(double base, int exp) {
+        double result = 1.0;
+        int i = 0;
+        while (i < exp) {
+            result = result * base;
+            i = i + 1;
+        }
+        return result;
+    }
+
+    static double nthRoot(double x, int n) {
+        double low = 0.0;
+        double high = x;
+        int i = 0;
+        while (i < 60) {
+            double mid = (low + high) / 2.0;
+            if (powf(mid, n) > x) {
+                high = mid;
+            } else {
+                low = mid;
+            }
+            i = i + 1;
+        }
+        return low;
+    }
+
+    static void main() {
+        double sum = 0.0;
+        double sumRecip = 0.0;
+        double prod = 1.0;
+        int n = 1;
+        while (n <= 10) {
+            double f = ((Number)(n)).doubleValue();
+            sum = sum + f;
+            sumRecip = sumRecip + 1.0 / f;
+            prod = prod * f;
+            n = n + 1;
+        }
+        double count = 10.0;
+        double a = sum / count;
+        double g = nthRoot(prod, 10);
+        double h = count / sumRecip;
+        System.out.println(String.valueOf(String.valueOf(String.valueOf(String.valueOf("A: " + String.valueOf(a)) + " G: ") + String.valueOf(g)) + " H: ") + String.valueOf(h));
+        System.out.println("A >= G >= H: " + String.valueOf(a >= g && g >= h));
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-25 19:28 GMT+7
+Last updated: 2025-07-25 19:48 GMT+7
 
-## Rosetta Checklist (81/284)
+## Rosetta Checklist (91/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -88,16 +88,16 @@ Last updated: 2025-07-25 19:28 GMT+7
 | 80 | associative-array-creation | ✓ | 19.0ms | 94.27KB |
 | 81 | associative-array-iteration | ✓ | 11.0ms | 39.91KB |
 | 82 | associative-array-merging | ✓ | 6.0ms | 11.35KB |
-| 83 | atomic-updates |   |  |  |
-| 84 | attractive-numbers |   |  |  |
-| 85 | average-loop-length |   |  |  |
-| 86 | averages-arithmetic-mean |   |  |  |
-| 87 | averages-mean-time-of-day |   |  |  |
-| 88 | averages-median-1 |   |  |  |
-| 89 | averages-median-2 |   |  |  |
-| 90 | averages-median-3 |   |  |  |
-| 91 | averages-mode |   |  |  |
-| 92 | averages-pythagorean-means |   |  |  |
+| 83 | atomic-updates | ✓ | 14.0ms | 55.44KB |
+| 84 | attractive-numbers | ✓ | 13.0ms | 39.11KB |
+| 85 | average-loop-length | ✓ | 77.0ms | 91.09KB |
+| 86 | averages-arithmetic-mean | ✓ | 12.0ms | 49.51KB |
+| 87 | averages-mean-time-of-day | ✓ | 17.0ms | 77.97KB |
+| 88 | averages-median-1 | ✓ | 6.0ms | 10.35KB |
+| 89 | averages-median-2 | ✓ | 13.0ms | 10.35KB |
+| 90 | averages-median-3 | ✓ | 7.0ms | 10.45KB |
+| 91 | averages-mode | ✓ | 16.0ms | 46.71KB |
+| 92 | averages-pythagorean-means | ✓ | 14.0ms | 49.09KB |
 | 93 | averages-root-mean-square |   |  |  |
 | 94 | averages-simple-moving-average |   |  |  |
 | 95 | avl-tree |   |  |  |


### PR DESCRIPTION
## Summary
- improve Java transpiler to use `Math.floorMod` for integer modulo
- drop unreachable returns after `while(true)` loops
- handle map return types for functions
- update generated Rosetta output up to index 92

## Testing
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 83`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 84`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 85`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 86`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 87`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 88`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 89`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 90`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 91`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index 92`


------
https://chatgpt.com/codex/tasks/task_e_68837943a63c8320a1e03e671c95ab67