### PR TITLE
Process Rosetta index 28 for Kotlin

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/ackermann-function-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/ackermann-function-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":5904, "memory_bytes":137088, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/ackermann-function-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/ackermann-function-2.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Int {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed.toInt())
+    } else {
+        kotlin.math.abs(System.nanoTime().toInt())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun pow(base: Int, exp: Int): Int {
     var result: Int = 1
     var i: Int = 0
@@ -22,9 +48,9 @@ fun ackermann2(m: Int, n: Int): Int {
         return (8 * pow(2, n)) - 3
     }
     if (n == 0) {
-        return ackermann2(m - 1, 1) as Int
+        return ackermann2(m - 1, 1)
     }
-    return ackermann2(m - 1, ackermann2(m, n - 1) as Int) as Int
+    return ackermann2(m - 1, ackermann2(m, n - 1))
 }
 
 fun user_main(): Unit {
@@ -35,5 +61,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-25 19:33 +0700
+Last updated: 2025-07-25 20:01 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-25 19:33 +0700
+Last updated: 2025-07-25 20:01 +0700
 
 Completed tasks: **54/284**
 
@@ -36,7 +36,7 @@ Completed tasks: **54/284**
 | 25 | abundant-odd-numbers | ✓ |  | 826.2 KB |
 | 26 | accumulator-factory | ✓ |  | 109.3 KB |
 | 27 | achilles-numbers |  |  |  |
-| 28 | ackermann-function-2 | ✓ |  |  |
+| 28 | ackermann-function-2 | ✓ | 5.90ms | 133.9 KB |
 | 29 | ackermann-function-3 | ✓ |  |  |
 | 30 | ackermann-function | ✓ |  |  |
 | 31 | active-directory-connect | ✓ |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,27 @@
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-25 20:01 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-25 19:33 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -1899,7 +1899,8 @@ func kotlinTypeFromType(t types.Type) string {
 	case types.Int64Type, *types.Int64Type:
 		return "Long"
 	case types.BigIntType, *types.BigIntType:
-		return "Int"
+		useHelper("importBigInt")
+		return "BigInteger"
 	case types.BoolType, *types.BoolType:
 		return "Boolean"
 	case types.StringType, *types.StringType:


### PR DESCRIPTION
## Summary
- update Kotlin transpiler to recognize `bigint` types
- run Kotlin transpiler on Rosetta index 28 with benchmarking enabled
- update docs automatically

## Testing
- `ROSETTA_INDEX=29 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1 -v` *(fails: program failed)*


------
https://chatgpt.com/codex/tasks/task_e_6883804f138c83209878bd9e956284d9