### PR TITLE
Fix build failure in tools package

### DIFF
--- a/tools/update_dart_rosetta.go
+++ b/tools/update_dart_rosetta.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- ensure `tools/update_dart_rosetta.go` is built only with `slow` tag
- this prevents multiple `main` definitions when running tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883863687c88320a851c01b5922c722