### PR TITLE
Run Pascal Rosetta programs 4-8

### DIFF
--- a/tests/rosetta/transpiler/Pascal/100-prisoners.bench
+++ b/tests/rosetta/transpiler/Pascal/100-prisoners.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": -734139,
+  "memory_bytes": 576,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/15-puzzle-game.bench
+++ b/tests/rosetta/transpiler/Pascal/15-puzzle-game.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": -671044,
+  "memory_bytes": 192,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/15-puzzle-game.pas
+++ b/tests/rosetta/transpiler/Pascal/15-puzzle-game.pas
@@ -152,7 +152,7 @@ begin
   if playOneMove_s = '' then begin
   continue;
 end;
-  playOneMove_c := copy(playOneMove_s, 0+1, (1 - (0)));
+  playOneMove_c := copy(playOneMove_s, 0+1, (1 - 0));
   playOneMove_m := 0;
   if (playOneMove_c = 'U') or (playOneMove_c = 'u') then begin
   playOneMove_m := 0;

--- a/tests/rosetta/transpiler/Pascal/15-puzzle-solver.bench
+++ b/tests/rosetta/transpiler/Pascal/15-puzzle-solver.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 571223,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/2048.bench
+++ b/tests/rosetta/transpiler/Pascal/2048.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 731363,
+  "memory_bytes": 1344,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/21-game.bench
+++ b/tests/rosetta/transpiler/Pascal/21-game.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": -693671,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/21-game.out
+++ b/tests/rosetta/transpiler/Pascal/21-game.out
@@ -1,16 +1,12 @@
 Enter q to quit at any time
 
-The computer will choose first
+You will choose first
 
 
 Running total is now 0
 
 
 ROUND 1:
-
-
-The computer chooses 3
-Running total is now 3
 
 
 Your choice 1 to 3 : 

--- a/tests/rosetta/transpiler/Pascal/21-game.pas
+++ b/tests/rosetta/transpiler/Pascal/21-game.pas
@@ -22,6 +22,12 @@ begin
     _now := Integer(GetTickCount64()*1000);
   end;
 end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
 function _input(): string;
 var s: string;
 begin
@@ -41,6 +47,10 @@ type Anon1 = record
   f9: integer;
 end;
 var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
   parseIntStr_i: integer;
   parseIntStr_neg: boolean;
   parseIntStr_n: integer;
@@ -141,5 +151,15 @@ end;
 end;
 begin
   init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _now();
   main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
 end.

--- a/tests/rosetta/transpiler/Pascal/24-game-solve.error
+++ b/tests/rosetta/transpiler/Pascal/24-game-solve.error
@@ -1,0 +1,57 @@
+Free Pascal Compiler version 3.2.2+dfsg-32 [2024/01/05] for x86_64
+Copyright (c) 1993-2021 by Florian Klaempfl and others
+Target OS: Linux for x86-64
+Compiling /workspace/mochi/tests/rosetta/transpiler/Pascal/24-game-solve.pas
+24-game-solve.pas(4,27) Error: Identifier not found "Expr"
+24-game-solve.pas(4,31) Error: Error in type definition
+24-game-solve.pas(78,17) Error: Identifier not found "exprEval"
+24-game-solve.pas(79,17) Error: Identifier not found "exprEval"
+24-game-solve.pas(81,33) Error: Illegal qualifier
+24-game-solve.pas(81,50) Error: Illegal qualifier
+24-game-solve.pas(81,71) Error: Illegal qualifier
+24-game-solve.pas(81,90) Error: Illegal qualifier
+24-game-solve.pas(81,107) Error: Illegal qualifier
+24-game-solve.pas(81,126) Error: Illegal qualifier
+24-game-solve.pas(84,33) Error: Illegal qualifier
+24-game-solve.pas(84,50) Error: Illegal qualifier
+24-game-solve.pas(84,71) Error: Illegal qualifier
+24-game-solve.pas(84,90) Error: Illegal qualifier
+24-game-solve.pas(84,107) Error: Illegal qualifier
+24-game-solve.pas(84,126) Error: Illegal qualifier
+24-game-solve.pas(87,32) Error: Illegal qualifier
+24-game-solve.pas(87,49) Error: Illegal qualifier
+24-game-solve.pas(87,65) Error: Illegal qualifier
+24-game-solve.pas(87,84) Error: Illegal qualifier
+24-game-solve.pas(89,32) Error: Illegal qualifier
+24-game-solve.pas(89,49) Error: Illegal qualifier
+24-game-solve.pas(89,67) Error: Illegal qualifier
+24-game-solve.pas(89,86) Error: Illegal qualifier
+24-game-solve.pas(93,19) Error: Identifier not found "exprString"
+24-game-solve.pas(94,19) Error: Identifier not found "exprString"
+24-game-solve.pas(109,15) Error: Operator is not overloaded: "Char" + "LongInt"
+24-game-solve.pas(113,8) Error: Identifier not found "makeNum"
+24-game-solve.pas(117,8) Error: Generics without specialization cannot be used as a type for a variable
+24-game-solve.pas(117,19) Error: Identifier not found "Num"
+24-game-solve.pas(117,23) Error: Identifier not found "v"
+24-game-solve.pas(117,27) Error: Identifier not found "v"
+24-game-solve.pas(117,42) Error: Identifier not found "l"
+24-game-solve.pas(117,45) Error: Identifier not found "r"
+24-game-solve.pas(121,8) Error: Generics without specialization cannot be used as a type for a variable
+24-game-solve.pas(121,19) Error: Identifier not found "Num"
+24-game-solve.pas(121,23) Error: Identifier not found "v"
+24-game-solve.pas(121,36) Error: Identifier not found "v"
+24-game-solve.pas(121,58) Error: Identifier not found "l"
+24-game-solve.pas(121,61) Error: Identifier not found "r"
+24-game-solve.pas(126,28) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "Expr"
+24-game-solve.pas(128,27) Error: Incompatible type for arg no. 1: Got "<erroneous type>", expected "Expr"
+24-game-solve.pas(141,49) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of <erroneous type>" expected "{Dynamic} Array Of Expr"
+24-game-solve.pas(147,17) Error: Identifier not found "makeBin"
+24-game-solve.pas(149,17) Error: Identifier not found "makeBin"
+24-game-solve.pas(150,43) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of LongInt" expected "{Dynamic} Array Of Expr"
+24-game-solve.pas(150,32) Error: Incompatible types: got "LongInt" expected "Expr"
+24-game-solve.pas(150,44) Error: Incompatible type for arg no. 1: Got "{Dynamic} Array Of Expr", expected "ExprArray"
+24-game-solve.pas(154,17) Error: Identifier not found "makeBin"
+24-game-solve.pas(155,43) Error: Incompatible types: got "{Array Of Const/Constant Open} Array of LongInt" expected "{Dynamic} Array Of Expr"
+24-game-solve.pas(155,43) Fatal: There were 50 errors compiling module, stopping
+Fatal: Compilation aborted
+Error: /usr/bin/ppcx64 returned an error exitcode

--- a/tests/rosetta/transpiler/Pascal/24-game-solve.pas
+++ b/tests/rosetta/transpiler/Pascal/24-game-solve.pas
@@ -1,0 +1,207 @@
+{$mode objfpc}
+program Main;
+uses SysUtils;
+type ExprArray = array of Expr;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
+type Rational = record
+  num: integer;
+  denom: integer;
+end;
+type Expr = record
+end;
+var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
+  OP_ADD: integer;
+  OP_SUB: integer;
+  OP_MUL: integer;
+  OP_DIV: integer;
+  binEval_lv: integer;
+  binEval_rv: integer;
+  binString_ls: integer;
+  binString_rs: integer;
+  binString_opstr: string;
+  n_cards: integer;
+  goal: integer;
+  digit_range: integer;
+  solve_f: Rational;
+  solve_i: integer;
+  solve_j: integer;
+  solve_rest: array of Expr;
+  solve_k: integer;
+  solve_a: Expr;
+  solve_b: Expr;
+  solve_node: integer;
+  op: integer;
+  main_iter: integer;
+  main_cards: array of Expr;
+  main_i: integer;
+  main_n: integer;
+function makeExpr(): Expr;
+begin
+end;
+function makeRational(num: integer; denom: integer): Rational;
+begin
+  Result.num := num;
+  Result.denom := denom;
+end;
+function binEval(op: integer; l: Expr; r: Expr): Rational;
+begin
+  binEval_lv := exprEval(l);
+  binEval_rv := exprEval(r);
+  if op = OP_ADD then begin
+  exit(makeRational((binEval_lv.num * binEval_rv.denom) + (binEval_lv.denom * binEval_rv.num), binEval_lv.denom * binEval_rv.denom));
+end;
+  if op = OP_SUB then begin
+  exit(makeRational((binEval_lv.num * binEval_rv.denom) - (binEval_lv.denom * binEval_rv.num), binEval_lv.denom * binEval_rv.denom));
+end;
+  if op = OP_MUL then begin
+  exit(makeRational(binEval_lv.num * binEval_rv.num, binEval_lv.denom * binEval_rv.denom));
+end;
+  exit(makeRational(binEval_lv.num * binEval_rv.denom, binEval_lv.denom * binEval_rv.num));
+end;
+function binString(op: integer; l: Expr; r: Expr): string;
+begin
+  binString_ls := exprString(l);
+  binString_rs := exprString(r);
+  binString_opstr := '';
+  if op = OP_ADD then begin
+  binString_opstr := ' + ';
+end else begin
+  if op = OP_SUB then begin
+  binString_opstr := ' - ';
+end else begin
+  if op = OP_MUL then begin
+  binString_opstr := ' * ';
+end else begin
+  binString_opstr := ' / ';
+end;
+end;
+end;
+  exit(((('(' + binString_ls) + binString_opstr) + binString_rs) + ')');
+end;
+function newNum(n: integer): Expr;
+begin
+  exit(makeNum(makeRational(n, 1)));
+end;
+function exprEval(x: Expr): Rational;
+begin
+  exit(IfThen(x = Num(v), v, binEval(op, l, r)));
+end;
+function exprString(x: Expr): string;
+begin
+  exit(IfThen(x = Num(v), IntToStr(v.num), binString(op, l, r)));
+end;
+function solve(xs: ExprArray): boolean;
+begin
+  if Length(xs) = 1 then begin
+  solve_f := exprEval(xs[0]);
+  if (solve_f.denom <> 0) and (solve_f.num = (solve_f.denom * goal)) then begin
+  writeln(exprString(xs[0]));
+  exit(true);
+end;
+  exit(false);
+end;
+  solve_i := 0;
+  while solve_i < Length(xs) do begin
+  solve_j := solve_i + 1;
+  while solve_j < Length(xs) do begin
+  solve_rest := [];
+  solve_k := 0;
+  while solve_k < Length(xs) do begin
+  if (solve_k <> solve_i) and (solve_k <> solve_j) then begin
+  solve_rest := concat(solve_rest, [xs[solve_k]]);
+end;
+  solve_k := solve_k + 1;
+end;
+  solve_a := xs[solve_i];
+  solve_b := xs[solve_j];
+  solve_node := makeBin(OP_ADD, solve_a, solve_b);
+  for op in [OP_ADD, OP_SUB, OP_MUL, OP_DIV] do begin
+  solve_node := makeBin(op, solve_a, solve_b);
+  if solve(concat(solve_rest, [solve_node])) then begin
+  exit(true);
+end;
+end;
+  solve_node := makeBin(OP_SUB, solve_b, solve_a);
+  if solve(concat(solve_rest, [solve_node])) then begin
+  exit(true);
+end;
+  solve_node := makeBin(OP_DIV, solve_b, solve_a);
+  if solve(concat(solve_rest, [solve_node])) then begin
+  exit(true);
+end;
+  solve_j := solve_j + 1;
+end;
+  solve_i := solve_i + 1;
+end;
+  exit(false);
+end;
+procedure main();
+begin
+  main_iter := 0;
+  while main_iter < 10 do begin
+  main_cards := [];
+  main_i := 0;
+  while main_i < n_cards do begin
+  main_n := (_now() mod (digit_range - 1)) + 1;
+  main_cards := concat(main_cards, [newNum(main_n)]);
+  writeln(' ' + IntToStr(main_n));
+  main_i := main_i + 1;
+end;
+  writeln(':  ');
+  if not solve(main_cards) then begin
+  writeln('No solution');
+end;
+  main_iter := main_iter + 1;
+end;
+end;
+begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _now();
+  OP_ADD := 1;
+  OP_SUB := 2;
+  OP_MUL := 3;
+  OP_DIV := 4;
+  n_cards := 4;
+  goal := 24;
+  digit_range := 9;
+  main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
+end.

--- a/transpiler/x/pas/README.md
+++ b/transpiler/x/pas/README.md
@@ -108,4 +108,4 @@ Generated sources for the golden tests live under `tests/transpiler/x/pas`.
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-25 19:48 +0700
+Last updated: 2025-07-25 20:14 +0700

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,16 +2,16 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (15/284) - updated 2025-07-25 13:01 UTC
+## Rosetta Checklist (15/284) - updated 2025-07-25 13:21 UTC
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 571.223ms | 128 B |
 | 2 | 100-doors-3 | ✓ | 571.223ms |  |
 | 3 | 100-doors | ✓ | 571.223ms | 288 B |
-| 4 | 100-prisoners | ✓ |  |  |
-| 5 | 15-puzzle-game | ✓ |  |  |
-| 6 | 15-puzzle-solver | ✓ |  |  |
-| 7 | 2048 | ✓ |  |  |
+| 4 | 100-prisoners | ✓ |  | 576 B |
+| 5 | 15-puzzle-game | ✓ |  | 192 B |
+| 6 | 15-puzzle-solver | ✓ | 571.223ms |  |
+| 7 | 2048 | ✓ | 731.363ms | 1.3 KB |
 | 8 | 21-game | ✓ |  |  |
 | 9 | 24-game-solve |   |  |  |
 | 10 | 24-game | ✓ |  |  |

--- a/transpiler/x/pas/TASKS.md
+++ b/transpiler/x/pas/TASKS.md
@@ -1,3 +1,45 @@
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
+## Progress (2025-07-25 20:14 +0700)
+- pascal: update transpiler and rosetta outputs (progress 88/104)
+
 ## Progress (2025-07-25 19:48 +0700)
 - pascal transpiler: handle functions in bench mode and update generics (progress 88/104)
 


### PR DESCRIPTION
## Summary
- run Pascal Rosetta programs from index 4 up to 8
- update generated Pascal sources and golden outputs
- add benchmark results for the passing programs
- include failing 24‐game-solve program

## Testing
- `MOCHI_BENCHMARK=1 ROSETTA_INDEX=8 go test ./transpiler/x/pas -run TestPascalTranspiler_Rosetta -tags slow -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68838330a94c83208f8c9889c0add6c7