### PR TITLE
Fix OCaml transpiler mutation handling

### DIFF
--- a/tests/rosetta/transpiler/OCaml/abelian-sandpile-model-identity.bench
+++ b/tests/rosetta/transpiler/OCaml/abelian-sandpile-model-identity.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 617,
+  "memory_bytes": 44176,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/abelian-sandpile-model.bench
+++ b/tests/rosetta/transpiler/OCaml/abelian-sandpile-model.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 874,
+  "memory_bytes": 119536,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/abstract-type.bench
+++ b/tests/rosetta/transpiler/OCaml/abstract-type.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 26,
+  "memory_bytes": 600,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/abundant-deficient-and-perfect-number-classifications.bench
+++ b/tests/rosetta/transpiler/OCaml/abundant-deficient-and-perfect-number-classifications.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 3909676,
+  "memory_bytes": 512,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/abundant-odd-numbers.bench
+++ b/tests/rosetta/transpiler/OCaml/abundant-odd-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 4232706,
+  "memory_bytes": 320761168,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/accumulator-factory.bench
+++ b/tests/rosetta/transpiler/OCaml/accumulator-factory.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 151,
+  "memory_bytes": 752,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/achilles-numbers.bench
+++ b/tests/rosetta/transpiler/OCaml/achilles-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 310570,
+  "memory_bytes": 69708232,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/OCaml/ackermann-function-2.bench
+++ b/tests/rosetta/transpiler/OCaml/ackermann-function-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 41,
+  "duration_us": 152,
   "memory_bytes": 368,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/OCaml/ackermann-function-3.bench
+++ b/tests/rosetta/transpiler/OCaml/ackermann-function-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 56,
+  "duration_us": 135,
   "memory_bytes": 1648,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/OCaml/ackermann-function.bench
+++ b/tests/rosetta/transpiler/OCaml/ackermann-function.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 291,
+  "duration_us": 519,
   "memory_bytes": 368,
   "name": "main"
 }

--- a/transpiler/x/ocaml/ROSETTA.md
+++ b/transpiler/x/ocaml/ROSETTA.md
@@ -26,16 +26,16 @@ Completed programs: 52/284
 | 18 | abbreviations-easy | ✓ | 3.0ms | 250.42KB |
 | 19 | abbreviations-simple | ✓ | 5.0ms | 499.24KB |
 | 20 | abc-problem | ✓ | 1.0ms | 193.75KB |
-| 21 | abelian-sandpile-model-identity | ✓ |  |  |
-| 22 | abelian-sandpile-model | ✓ |  |  |
-| 23 | abstract-type | ✓ |  |  |
-| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
-| 25 | abundant-odd-numbers | ✓ |  |  |
-| 26 | accumulator-factory | ✓ |  |  |
-| 27 | achilles-numbers | ✓ |  |  |
-| 28 | ackermann-function-2 | ✓ | 41.0µs | 368B |
-| 29 | ackermann-function-3 | ✓ | 56.0µs | 1.61KB |
-| 30 | ackermann-function | ✓ | 291.0µs | 368B |
+| 21 | abelian-sandpile-model-identity | ✓ | 617.0µs | 43.14KB |
+| 22 | abelian-sandpile-model | ✓ | 874.0µs | 116.73KB |
+| 23 | abstract-type | ✓ | 26.0µs | 600B |
+| 24 | abundant-deficient-and-perfect-number-classifications | ✓ | 3.91s | 512B |
+| 25 | abundant-odd-numbers | ✓ | 4.23s | 305.90MB |
+| 26 | accumulator-factory | ✓ | 151.0µs | 752B |
+| 27 | achilles-numbers | ✓ | 310.0ms | 66.48MB |
+| 28 | ackermann-function-2 | ✓ | 152.0µs | 368B |
+| 29 | ackermann-function-3 | ✓ | 135.0µs | 1.61KB |
+| 30 | ackermann-function | ✓ | 519.0µs | 368B |
 | 31 | active-directory-connect | ✓ | 19.0µs | 248B |
 | 32 | active-directory-search-for-a-user | ✓ | 25.0µs | 560B |
 | 33 | active-object | ✓ | 746.0µs | 256.98KB |
@@ -290,4 +290,4 @@ Completed programs: 52/284
 | 282 | deepcopy-1 |   |  |  |
 | 283 | define-a-primitive-data-type |   |  |  |
 | 284 | md5 |   |  |  |
-Last updated 2025-07-25 20:48 +0700
+Last updated 2025-07-25 21:12 +0700


### PR DESCRIPTION
## Summary
- improve OCaml transpiler to keep mutated parameters by reference
- regenerate OCaml code for Rosetta programs 21–30
- add benchmark results for updated programs

## Testing
- `ROSETTA_INDEX=21 MOCHI_BENCHMARK=1 go test ./transpiler/x/ocaml -run TestOCamlTranspiler_Rosetta_Golden -tags='rosetta slow' -count=1 -timeout=120s`
- `for i in $(seq 22 30); do ROSETTA_INDEX=$i MOCHI_BENCHMARK=1 go test ./transpiler/x/ocaml -run TestOCamlTranspiler_Rosetta_Golden -tags='rosetta slow' -count=1; done`

------
https://chatgpt.com/codex/tasks/task_e_688390efe4f88320bca12051cfedf608