### PR TITLE
Update Java transpiler map handling

### DIFF
--- a/tests/rosetta/transpiler/Java/babbage-problem.bench
+++ b/tests/rosetta/transpiler/Java/babbage-problem.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 12970,
+  "memory_bytes": 39832,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/babbage-problem.java
+++ b/tests/rosetta/transpiler/Java/babbage-problem.java
@@ -1,0 +1,51 @@
+public class Main {
+    static int target = 269696;
+    static int modulus = 1000000;
+    static int n = 1;
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            while (true) {
+                int square = n * n;
+                int ending = Math.floorMod(square, modulus);
+                if (ending == target) {
+                    System.out.println(String.valueOf(String.valueOf("The smallest number whose square ends with " + String.valueOf(target)) + " is ") + String.valueOf(n));
+                    break;
+                }
+                n = n + 1;
+            }
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/babbage-problem.out
+++ b/tests/rosetta/transpiler/Java/babbage-problem.out
@@ -1,0 +1,1 @@
+The smallest number whose square ends with 269696 is 25264

--- a/tests/rosetta/transpiler/Java/babylonian-spiral.error
+++ b/tests/rosetta/transpiler/Java/babylonian-spiral.error
@@ -1,0 +1,12 @@
+compile: exit status 1
+/tmp/TestJavaTranspiler_Rosetta_Goldenbabylonian-spiral275556754/001/Main.java:6: error: bad operand types for binary operator '>'
+        while (i > 0 && (boolean)(((Object)h[i - 1].get("s"))) > ((Number)(((Object)h[i].get("s")))).intValue()) {
+                                                               ^
+  first type:  boolean
+  second type: int
+/tmp/TestJavaTranspiler_Rosetta_Goldenbabylonian-spiral275556754/001/Main.java:72: error: generic array creation
+        java.util.Map<String,Integer>[] heap = new java.util.Map<String,Integer>[]{};
+                                               ^
+Note: /tmp/TestJavaTranspiler_Rosetta_Goldenbabylonian-spiral275556754/001/Main.java uses unchecked or unsafe operations.
+Note: Recompile with -Xlint:unchecked for details.
+2 errors

--- a/tests/rosetta/transpiler/Java/babylonian-spiral.java
+++ b/tests/rosetta/transpiler/Java/babylonian-spiral.java
@@ -1,0 +1,121 @@
+public class Main {
+
+    static java.util.Map<String,Integer>[] push(java.util.Map<String,Integer>[] h, java.util.Map<String,Integer> it) {
+        h = appendObj(h, it);
+        int i = h.length - 1;
+        while (i > 0 && (boolean)(((Object)h[i - 1].get("s"))) > ((Number)(((Object)h[i].get("s")))).intValue()) {
+            java.util.Map<String,Integer> tmp = h[i - 1];
+h[i - 1] = h[i];
+h[i] = tmp;
+            i = i - 1;
+        }
+        return h;
+    }
+
+    static java.util.Map<String,Object> step(java.util.Map<String,Integer>[] h, int nv, int[] dir) {
+        while (h.length == 0 || nv * nv <= ((Number)(((Object)h[0].get("s")))).intValue()) {
+            h = push(h, new java.util.LinkedHashMap<String, Integer>(java.util.Map.ofEntries(java.util.Map.entry("s", nv * nv), java.util.Map.entry("a", nv), java.util.Map.entry("b", 0))));
+            nv = nv + 1;
+        }
+        Object s = (Object)(((Object)h[0].get("s")));
+        int[][] v = new int[][]{};
+        while ((h.length > 0 && (boolean)(((Object)h[0].get("s"))).equals(s))) {
+            java.util.Map<String,Integer> it = h[0];
+            h = java.util.Arrays.copyOfRange(h, 1, h.length);
+            v = appendObj(v, new int[]{((int)it.getOrDefault("a", 0)), ((int)it.getOrDefault("b", 0))});
+            if ((int)(((int)it.getOrDefault("a", 0))) > (int)(((int)it.getOrDefault("b", 0)))) {
+                h = push(h, new java.util.LinkedHashMap<String, Integer>(java.util.Map.ofEntries(java.util.Map.entry("s", (int)(((int)it.getOrDefault("a", 0))) * (int)(((int)it.getOrDefault("a", 0))) + ((int)(((int)it.getOrDefault("b", 0))) + 1) * ((int)(((int)it.getOrDefault("b", 0))) + 1)), java.util.Map.entry("a", ((int)it.getOrDefault("a", 0))), java.util.Map.entry("b", (int)(((int)it.getOrDefault("b", 0))) + 1))));
+            }
+        }
+        int[][] list = new int[][]{};
+        for (int[] p : v) {
+            list = appendObj(list, p);
+        }
+        int[][] temp = list;
+        for (int[] p : temp) {
+            if (p[0] != p[1]) {
+                list = appendObj(list, new int[]{p[1], p[0]});
+            }
+        }
+        temp = list;
+        for (int[] p : temp) {
+            if (p[1] != 0) {
+                list = appendObj(list, new int[]{p[0], -p[1]});
+            }
+        }
+        temp = list;
+        for (int[] p : temp) {
+            if (p[0] != 0) {
+                list = appendObj(list, new int[]{-p[0], p[1]});
+            }
+        }
+        int bestDot = -999999999;
+        int[] best = dir;
+        for (int[] p : list) {
+            int cross = p[0] * dir[1] - p[1] * dir[0];
+            if (cross >= 0) {
+                int dot = p[0] * dir[0] + p[1] * dir[1];
+                if (dot > bestDot) {
+                    bestDot = dot;
+                    best = p;
+                }
+            }
+        }
+        return new java.util.LinkedHashMap<String, Object>(java.util.Map.ofEntries(java.util.Map.entry("d", best), java.util.Map.entry("heap", h), java.util.Map.entry("n", nv)));
+    }
+
+    static int[][] positions(int n) {
+        int[][] pos = new int[][]{};
+        int x = 0;
+        int y = 0;
+        int[] dir = new int[]{0, 1};
+        java.util.Map<String,Integer>[] heap = new java.util.Map<String,Integer>[]{};
+        int nv = 1;
+        int i = 0;
+        while (i < n) {
+            pos = appendObj(pos, new int[]{x, y});
+            java.util.Map<String,Object> st = step(heap, nv, dir);
+            dir = (int[])(((int[])st.get("d")));
+            heap = (java.util.Map<String,Integer>[])(((java.util.Map<String,Integer>[])st.get("heap")));
+            nv = (int)(((int)st.getOrDefault("n", 0)));
+            x = x + dir[0];
+            y = y + dir[1];
+            i = i + 1;
+        }
+        return pos;
+    }
+
+    static String pad(String s, int w) {
+        String r = s;
+        while (r.length() < w) {
+            r = String.valueOf(r + " ");
+        }
+        return r;
+    }
+
+    static void main() {
+        int[][] pts = positions(40);
+        System.out.println("The first 40 Babylonian spiral points are:");
+        String line = "";
+        int i = 0;
+        while (i < pts.length) {
+            int[] p = pts[i];
+            String s = String.valueOf(pad(String.valueOf(String.valueOf(String.valueOf(String.valueOf("(" + String.valueOf(p[0])) + ", ") + String.valueOf(p[1])) + ")"), 10));
+            line = String.valueOf(line + s);
+            if (((Number)(Math.floorMod((i + 1), 10))).intValue() == 0) {
+                System.out.println(line);
+                line = "";
+            }
+            i = i + 1;
+        }
+    }
+    public static void main(String[] args) {
+        main();
+    }
+
+    static <T> T[] appendObj(T[] arr, T v) {
+        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-25 20:26 GMT+7
+Last updated: 2025-07-25 22:04 GMT+7
 
-## Rosetta Checklist (93/284)
+## Rosetta Checklist (94/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -102,7 +102,7 @@ Last updated: 2025-07-25 20:26 GMT+7
 | 94 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
 | 95 | avl-tree |   |  |  |
 | 96 | b-zier-curves-intersections |   |  |  |
-| 97 | babbage-problem |   |  |  |
+| 97 | babbage-problem | ✓ | 12.0ms | 38.90KB |
 | 98 | babylonian-spiral |   |  |  |
 | 99 | balanced-brackets |   |  |  |
 | 100 | balanced-ternary |   |  |  |


### PR DESCRIPTION
## Summary
- fix parsing of generic map types in Java transpiler
- handle appending elements with generic types
- regenerate Rosetta output for `babbage-problem`
- add failing output for `babylonian-spiral`

## Testing
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -tags=slow -run Rosetta -index=97`
- `UPDATE=1 go test ./transpiler/x/java -tags=slow -run Rosetta -index=98` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_688399c5c31883208912a15eebbde87b