### PR TITLE
Update VM rosetta benchmarks

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,22 +2,22 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-25 13:33 UTC
+Last updated: 2025-07-25 15:17 UTC
 
 ## Rosetta Golden Test Checklist (117/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
-| 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
-| 2 | 100-doors-3 | ✓ | 184µs | 7.7 KB |
-| 3 | 100-doors | ✓ | 6.231ms | 851.8 KB |
-| 4 | 100-prisoners | ✓ | 3.400683s | 1.5 MB |
+| 1 | 100-doors-2 | ✓ | 330µs | 11.7 KB |
+| 2 | 100-doors-3 | ✓ | 569µs | 7.8 KB |
+| 3 | 100-doors | ✓ | 12.668ms | 849.4 KB |
+| 4 | 100-prisoners | ✓ | 4.393344s | 50.2 KB |
 | 5 | 15-puzzle-game | ✓ |  |  |
-| 6 | 15-puzzle-solver | ✓ | 917.949ms | 26.9 KB |
-| 7 | 2048 | ✓ | 5.393ms |  |
-| 8 | 21-game | ✓ | 386µs | 10.0 KB |
-| 9 | 24-game-solve | ✓ | 9.164ms |  |
-| 10 | 24-game | ✓ | 506µs | 17.0 KB |
-| 11 | 4-rings-or-4-squares-puzzle | ✓ | 511.101ms | 5.2 MB |
+| 6 | 15-puzzle-solver | ✓ | 1.625296s | 27.1 KB |
+| 7 | 2048 | ✓ | 1.929ms | 759.3 KB |
+| 8 | 21-game | ✓ | 441µs | 10.1 KB |
+| 9 | 24-game-solve | ✓ | 2.272ms | 1.1 MB |
+| 10 | 24-game | ✓ | 646µs | 17.0 KB |
+| 11 | 4-rings-or-4-squares-puzzle | ✓ | 476.28ms | 4.7 MB |
 | 12 | 9-billion-names-of-god-the-integer | ✓ | 14.291954s | 151.1 MB |
 | 13 | 99-bottles-of-beer-2 | ✓ | 48.933ms | 721.5 KB |
 | 14 | 99-bottles-of-beer | ✓ | 1.041ms | 434.1 KB |

--- a/tests/rosetta/ir/100-doors-2.bench
+++ b/tests/rosetta/ir/100-doors-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 116,
+  "duration_us": 330,
   "memory_bytes": 11944,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-doors-3.bench
+++ b/tests/rosetta/ir/100-doors-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 184,
-  "memory_bytes": 7880,
+  "duration_us": 569,
+  "memory_bytes": 7992,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-doors.bench
+++ b/tests/rosetta/ir/100-doors.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 6231,
-  "memory_bytes": 872200,
+  "duration_us": 12668,
+  "memory_bytes": 869816,
   "name": "main"
 }

--- a/tests/rosetta/ir/100-prisoners.bench
+++ b/tests/rosetta/ir/100-prisoners.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 4224632,
-  "memory_bytes": 282304,
+  "duration_us": 4393344,
+  "memory_bytes": 51424,
   "name": "main"
 }

--- a/tests/rosetta/ir/15-puzzle-solver.bench
+++ b/tests/rosetta/ir/15-puzzle-solver.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 917949,
-  "memory_bytes": 27496,
+  "duration_us": 1625296,
+  "memory_bytes": 27752,
   "name": "main"
 }

--- a/tests/rosetta/ir/2048.bench
+++ b/tests/rosetta/ir/2048.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 5393,
-  "memory_bytes": -1916760,
+  "duration_us": 1929,
+  "memory_bytes": 777536,
   "name": "main"
 }

--- a/tests/rosetta/ir/21-game.bench
+++ b/tests/rosetta/ir/21-game.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 386,
-  "memory_bytes": 10200,
+  "duration_us": 441,
+  "memory_bytes": 10296,
   "name": "main"
 }

--- a/tests/rosetta/ir/24-game-solve.bench
+++ b/tests/rosetta/ir/24-game-solve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 9164,
-  "memory_bytes": -244120,
+  "duration_us": 2272,
+  "memory_bytes": 1115608,
   "name": "main"
 }

--- a/tests/rosetta/ir/24-game.bench
+++ b/tests/rosetta/ir/24-game.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 506,
+  "duration_us": 646,
   "memory_bytes": 17416,
   "name": "main"
 }

--- a/tests/rosetta/ir/4-rings-or-4-squares-puzzle.bench
+++ b/tests/rosetta/ir/4-rings-or-4-squares-puzzle.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 511101,
-  "memory_bytes": 5487888,
+  "duration_us": 476280,
+  "memory_bytes": 4906192,
   "name": "main"
 }


### PR DESCRIPTION
## Summary
- refresh VM rosetta benchmarks for first 10 tasks
- skip interactive puzzle game (index 5)

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=11 go test ./runtime/vm -tags=slow -run TestVM_Rosetta_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_68839b17641c8320aff1ff20f10e2c5d