### PR TITLE
Process Rosetta programs 132-162 for PHP transpiler

### DIFF
--- a/tests/rosetta/transpiler/php/boolean-values.bench
+++ b/tests/rosetta/transpiler/php/boolean-values.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 46,
+  "memory_bytes": 96,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/box-the-compass.bench
+++ b/tests/rosetta/transpiler/php/box-the-compass.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 127,
+  "memory_bytes": 288,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/boyer-moore-string-search.bench
+++ b/tests/rosetta/transpiler/php/boyer-moore-string-search.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 98,
+  "memory_bytes": 96,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/brazilian-numbers.bench
+++ b/tests/rosetta/transpiler/php/brazilian-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 161763631,
+  "memory_bytes": 96,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/break-oo-privacy.bench
+++ b/tests/rosetta/transpiler/php/break-oo-privacy.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 62,
+  "memory_bytes": 504,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/call-an-object-method-1.bench
+++ b/tests/rosetta/transpiler/php/call-an-object-method-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 1,
+  "memory_bytes": 128,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/call-an-object-method-1.out
+++ b/tests/rosetta/transpiler/php/call-an-object-method-1.out
@@ -1,0 +1,5 @@
+{
+  "duration_us": 1,
+  "memory_bytes": 128,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/call-an-object-method-1.php
+++ b/tests/rosetta/transpiler/php/call-an-object-method-1.php
@@ -1,0 +1,41 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  function Foo_ValueMethod($self, $x) {
+  global $myValue, $myPointer;
+};
+  function Foo_PointerMethod($self, $x) {
+  global $myValue, $myPointer;
+};
+  $myValue = [];
+  $myPointer = [];
+  Foo_ValueMethod($myValue, 0);
+  Foo_PointerMethod($myPointer, 0);
+  Foo_ValueMethod($myPointer, 0);
+  Foo_PointerMethod($myValue, 0);
+  Foo_ValueMethod($myValue, 0);
+  Foo_PointerMethod($myPointer, 0);
+$__end = _now();
+$__end_mem = memory_get_usage();
+$__duration = intdiv($__end - $__start, 1000);
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;;

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-25 21:15 +0700
+Last updated: 2025-07-25 22:09 +0700
 
-## Checklist (265/284)
+## Checklist (266/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 142µs | 136 B |
@@ -138,11 +138,11 @@ Last updated: 2025-07-25 21:15 +0700
 | 129 | bitwise-io-2 | ✓ | 240µs | 192 B |
 | 130 | bitwise-operations | ✓ | 138µs | 96 B |
 | 131 | blum-integer | ✓ | 181µs | 96 B |
-| 132 | boolean-values | ✓ |  |  |
-| 133 | box-the-compass | ✓ |  |  |
-| 134 | boyer-moore-string-search | ✓ |  |  |
-| 135 | brazilian-numbers | ✓ |  |  |
-| 136 | break-oo-privacy | ✓ |  |  |
+| 132 | boolean-values | ✓ | 46µs | 96 B |
+| 133 | box-the-compass | ✓ | 127µs | 288 B |
+| 134 | boyer-moore-string-search | ✓ | 98µs | 96 B |
+| 135 | brazilian-numbers | ✓ | 2m41.763631s | 96 B |
+| 136 | break-oo-privacy | ✓ | 62µs | 504 B |
 | 137 | brilliant-numbers |   |  |  |
 | 138 | brownian-tree | ✓ |  |  |
 | 139 | bulls-and-cows-player | ✓ |  |  |
@@ -168,7 +168,7 @@ Last updated: 2025-07-25 21:15 +0700
 | 159 | call-a-function-7 | ✓ |  |  |
 | 160 | call-a-function-8 | ✓ |  |  |
 | 161 | call-a-function-9 | ✓ |  |  |
-| 162 | call-an-object-method-1 |   |  |  |
+| 162 | call-an-object-method-1 | ✓ | 1µs | 128 B |
 | 163 | call-an-object-method-2 | ✓ |  |  |
 | 164 | call-an-object-method-3 |   |  |  |
 | 165 | call-an-object-method |   |  |  |


### PR DESCRIPTION
## Summary
- add struct method support in PHP transpiler
- generate PHP for programs 132-162 (except the long running 137)
- capture benchmark output for the new programs

## Testing
- `go vet ./transpiler/x/php`
- `MOCHI_ROSETTA_INDEX=162 UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/php -run Rosetta -tags=slow -count=1 -timeout 180s`


------
https://chatgpt.com/codex/tasks/task_e_68839e416bac832087863a21cb56e5f7