### PR TITLE
Fix Pascal benchmark RNG

### DIFF
--- a/tests/rosetta/transpiler/Pascal/24-game.bench
+++ b/tests/rosetta/transpiler/Pascal/24-game.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 1,
+  "memory_bytes": 64,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/24-game.pas
+++ b/tests/rosetta/transpiler/Pascal/24-game.pas
@@ -22,6 +22,16 @@ begin
     _now := Integer(GetTickCount64()*1000);
   end;
 end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
 function _input(): string;
 var s: string;
 begin
@@ -29,6 +39,10 @@ begin
   _input := s;
 end;
 var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
   main_digits: array of integer;
   i: integer;
   main_numstr: string;
@@ -122,5 +136,15 @@ end;
 end;
 begin
   init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
   main();
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
 end.

--- a/transpiler/x/pas/ROSETTA.md
+++ b/transpiler/x/pas/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pascal`.
 
-## Rosetta Checklist (17/284) - updated 2025-07-25 14:52 UTC
+## Rosetta Checklist (16/284) - updated 2025-07-25 17:06 UTC
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 571.223ms | 128 B |
@@ -14,8 +14,8 @@ Generated Pascal code for Rosetta tasks lives under `tests/rosetta/transpiler/Pa
 | 7 | 2048 | ✓ | 731.363ms | 1.3 KB |
 | 8 | 21-game | ✓ |  |  |
 | 9 | 24-game-solve | ✓ |  |  |
-| 10 | 24-game | ✓ |  |  |
-| 11 | 4-rings-or-4-squares-puzzle | ✓ |  |  |
+| 10 | 24-game | ✓ | 1µs | 64 B |
+| 11 | 4-rings-or-4-squares-puzzle |   |  |  |
 | 12 | 9-billion-names-of-god-the-integer |   |  |  |
 | 13 | 99-bottles-of-beer-2 | ✓ |  |  |
 | 14 | 99-bottles-of-beer | ✓ |  |  |


### PR DESCRIPTION
## Summary
- add `_bench_now` helper in Pascal transpiler
- use `_bench_now` for benchmark timing so RNG seed is preserved
- update generated Pascal code and benchmark output for `24-game`
- refresh Rosetta checklist

## Testing
- `ROSETTA_INDEX=10 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -count=1`
- `ROSETTA_INDEX=11 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -count=1` *(fails: compile error)*


------
https://chatgpt.com/codex/tasks/task_e_6883b0b51d48832091136f4d94b5a28e