### PR TITLE
Update Java transpiler for Babylonian Spiral

### DIFF
--- a/tests/rosetta/transpiler/Java/babbage-problem.bench
+++ b/tests/rosetta/transpiler/Java/babbage-problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 12970,
+  "duration_us": 28766,
   "memory_bytes": 39832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/babylonian-spiral.bench
+++ b/tests/rosetta/transpiler/Java/babylonian-spiral.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 31541,
+  "memory_bytes": 40976,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/babylonian-spiral.error
+++ b/tests/rosetta/transpiler/Java/babylonian-spiral.error
@@ -1,7 +1,0 @@
-compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Goldenbabylonian-spiral1281693363/001/Main.java:22: error: int cannot be dereferenced
-        while ((h.length > 0 && ((int)h[0].getOrDefault("s", 0)).equals(s))) {
-                                                                ^
-Note: /tmp/TestJavaTranspiler_Rosetta_Goldenbabylonian-spiral1281693363/001/Main.java uses unchecked or unsafe operations.
-Note: Recompile with -Xlint:unchecked for details.
-1 error

--- a/tests/rosetta/transpiler/Java/babylonian-spiral.java
+++ b/tests/rosetta/transpiler/Java/babylonian-spiral.java
@@ -19,7 +19,7 @@ h[i] = tmp;
         }
         int s = (int)(((int)h[0].getOrDefault("s", 0)));
         int[][] v = new int[][]{};
-        while ((h.length > 0 && ((int)h[0].getOrDefault("s", 0)).equals(s))) {
+        while (h.length > 0 && ((int)h[0].getOrDefault("s", 0)) == s) {
             java.util.Map<String,Integer> it = h[0];
             h = java.util.Arrays.copyOfRange(h, 1, h.length);
             v = appendObj(v, new int[]{((int)it.getOrDefault("a", 0)), ((int)it.getOrDefault("b", 0))});

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/104) - updated 2025-07-25 12:28 UTC
+## VM Golden Test Checklist (103/104) - updated 2025-07-25 17:20 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-26 00:07 GMT+7
+Last updated: 2025-07-26 00:20 GMT+7
 
-## Rosetta Checklist (94/284)
+## Rosetta Checklist (95/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -102,8 +102,8 @@ Last updated: 2025-07-26 00:07 GMT+7
 | 94 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
 | 95 | avl-tree |   |  |  |
 | 96 | b-zier-curves-intersections |   |  |  |
-| 97 | babbage-problem | ✓ | 12.0ms | 38.90KB |
-| 98 | babylonian-spiral |   |  |  |
+| 97 | babbage-problem | ✓ | 28.0ms | 38.90KB |
+| 98 | babylonian-spiral | ✓ | 31.0ms | 40.02KB |
 | 99 | balanced-brackets |   |  |  |
 | 100 | balanced-ternary |   |  |  |
 | 101 | barnsley-fern |   |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,12 @@
-## Progress (2025-07-25 19:02 +0700)
+## Progress (2025-07-26 00:11 +0700)
+- transpiler/java: handle generic arrays (c574f72cc9)
+
+- transpiler/java: handle generic arrays (c574f72cc9)
+
+- transpiler/java: handle generic arrays (c574f72cc9)
+
+- transpiler/java: handle generic arrays (c574f72cc9)
+
 - pascal transpiler: handle else-if and list concatenation (6bb4e4bd23)
 
 - pascal transpiler: handle else-if and list concatenation (6bb4e4bd23)

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -1319,7 +1319,7 @@ func (b *BinaryExpr) emit(w io.Writer) {
 		emitCastExpr(w, b.Right, "String")
 		return
 	}
-	if (b.Op == "==" || b.Op == "!=") && (isStringExpr(b.Left) || isStringExpr(b.Right)) {
+	if (b.Op == "==" || b.Op == "!=") && isStringExpr(b.Left) && isStringExpr(b.Right) {
 		if b.Op == "!=" {
 			fmt.Fprint(w, "!")
 		}


### PR DESCRIPTION
## Summary
- fix Java transpiler equality check so int comparisons don't use `equals`
- regenerate Babylonian Spiral output and benchmark files
- update Rosetta progress tables for indices 97-98

## Testing
- `go test -tags slow ./transpiler/x/java -run Rosetta -index 98 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index 97 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6883baeba5ac832091a75c620352bb7e