### PR TITLE
Fix Pascal transpiler for record returns

### DIFF
--- a/tests/rosetta/transpiler/Pascal/4-rings-or-4-squares-puzzle.bench
+++ b/tests/rosetta/transpiler/Pascal/4-rings-or-4-squares-puzzle.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 44,
+  "memory_bytes": 207136,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Pascal/4-rings-or-4-squares-puzzle.pas
+++ b/tests/rosetta/transpiler/Pascal/4-rings-or-4-squares-puzzle.pas
@@ -3,6 +3,37 @@ program Main;
 uses SysUtils, fgl;
 type IntArray = array of integer;
 type IntArrayArray = array of IntArray;
+var _nowSeed: int64 = 0;
+var _nowSeeded: boolean = false;
+procedure init_now();
+var s: string; v: int64;
+begin
+  s := GetEnvironmentVariable('MOCHI_NOW_SEED');
+  if s <> '' then begin
+    Val(s, v);
+    _nowSeed := v;
+    _nowSeeded := true;
+  end;
+end;
+function _now(): integer;
+begin
+  if _nowSeeded then begin
+    _nowSeed := (_nowSeed * 1664525 + 1013904223) mod 2147483647;
+    _now := _nowSeed;
+  end else begin
+    _now := Integer(GetTickCount64()*1000);
+  end;
+end;
+function _bench_now(): int64;
+begin
+  _bench_now := GetTickCount64()*1000;
+end;
+function _mem(): int64;
+var h: TFPCHeapStatus;
+begin
+  h := GetFPCHeapStatus;
+  _mem := h.CurrHeapUsed;
+end;
 procedure show_list(xs: array of integer);
 var i: integer;
 begin
@@ -27,6 +58,10 @@ type Anon1 = record
   list: array of IntArray;
 end;
 var
+  bench_start_0: integer;
+  bench_dur_0: integer;
+  bench_mem_0: int64;
+  bench_memdiff_0: int64;
   validComb_square1: integer;
   validComb_square2: integer;
   validComb_square3: integer;
@@ -112,12 +147,23 @@ end;
   exit(makeAnon1(getCombs_count, getCombs_valid));
 end;
 begin
+  init_now();
+  bench_mem_0 := _mem();
+  bench_start_0 := _bench_now();
   r1 := getCombs(1, 7, true);
-  r2 := getCombs(3, 9, true);
-  r3 := getCombs(0, 9, false);
   writeln(IntToStr(r1.count) + ' unique solutions in 1 to 7');
   show_list_list(r1.list);
+  r2 := getCombs(3, 9, true);
   writeln(IntToStr(r2.count) + ' unique solutions in 3 to 9');
   show_list_list(r2.list);
+  r3 := getCombs(0, 9, false);
   writeln(IntToStr(r3.count) + ' non-unique solutions in 0 to 9');
+  Sleep(1);
+  bench_memdiff_0 := _mem() - bench_mem_0;
+  bench_dur_0 := (_bench_now() - bench_start_0) div 1000;
+  writeln('{');
+  writeln(('  "duration_us": ' + IntToStr(bench_dur_0)) + ',');
+  writeln(('  "memory_bytes": ' + IntToStr(bench_memdiff_0)) + ',');
+  writeln(('  "name": "' + 'main') + '"');
+  writeln('}');
 end.


### PR DESCRIPTION
## Summary
- update `inferType` to resolve array aliases when indexing
- mark programs using `array of IntArray` so `show_list_list` is emitted
- handle map return types correctly when wrapped in benchmark blocks
- include benchmark result for `4-rings-or-4-squares-puzzle`

## Testing
- `ROSETTA_INDEX=11 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/pas -run Rosetta -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6883ba4ea2708320882cc388157be436