### PR TITLE
Enable Kotlin transpiler benchmarks

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/almost-prime.bench
+++ b/tests/rosetta/transpiler/Kotlin/almost-prime.bench
@@ -1,0 +1,1 @@
+{"duration_us":13540, "memory_bytes":125648, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/almost-prime.kt
+++ b/tests/rosetta/transpiler/Kotlin/almost-prime.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Int {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed.toInt())
+    } else {
+        kotlin.math.abs(System.nanoTime().toInt())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun kPrime(n: Int, k: Int): Boolean {
     var n: Int = n
     var nf: Int = 0
@@ -19,7 +45,7 @@ fun gen(k: Int, count: Int): MutableList<Int> {
     var r: MutableList<Int> = mutableListOf()
     var n: Int = 2
     while (r.size < count) {
-        if (kPrime(n, k) as Boolean) {
+        if ((kPrime(n, k)) as Boolean) {
             r = run { val _tmp = r.toMutableList(); _tmp.add(n); _tmp } as MutableList<Int>
         }
         n = n + 1
@@ -36,5 +62,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/rosetta/transpiler/Kotlin/amb.bench
+++ b/tests/rosetta/transpiler/Kotlin/amb.bench
@@ -1,0 +1,1 @@
+{"duration_us":31887, "memory_bytes":124088, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/amb.kt
+++ b/tests/rosetta/transpiler/Kotlin/amb.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun amb(wordsets: MutableList<MutableList<String>>, res: MutableList<String>, idx: Int): Boolean {
     if (idx == wordsets.size) {
         return true
@@ -11,7 +37,7 @@ fun amb(wordsets: MutableList<MutableList<String>>, res: MutableList<String>, id
         val w: String = wordsets[idx][i]
         if ((idx == 0) || (prev.substring(prev.length - 1, prev.length) == w.substring(0, 1))) {
             res[idx] = w
-            if (amb(wordsets, res, idx + 1) as Boolean) {
+            if ((amb(wordsets, res, idx + 1)) as Boolean) {
                 return true
             }
         }
@@ -28,7 +54,7 @@ fun user_main(): Unit {
         res = run { val _tmp = res.toMutableList(); _tmp.add(""); _tmp } as MutableList<String>
         i = i + 1
     }
-    if (amb(wordset as MutableList<MutableList<String>>, res, 0) as Boolean) {
+    if ((amb(wordset, res, 0)) as Boolean) {
         var out: String = "[" + res[0]
         var j: Int = 1
         while (j < res.size) {
@@ -43,5 +69,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-25 22:07 +0700
+Last updated: 2025-07-26 04:45 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-25 22:07 +0700
+Last updated: 2025-07-26 04:45 +0700
 
 Completed tasks: **54/284**
 
@@ -51,8 +51,8 @@ Completed tasks: **54/284**
 | 40 | align-columns |  |  |  |
 | 41 | aliquot-sequence-classifications |  |  |  |
 | 42 | almkvist-giullera-formula-for-pi |  |  |  |
-| 43 | almost-prime | ✓ |  |  |
-| 44 | amb | ✓ |  |  |
+| 43 | almost-prime | ✓ | 13.54ms | 122.7 KB |
+| 44 | amb | ✓ | 31.89ms | 121.2 KB |
 | 45 | amicable-pairs | ✓ |  |  |
 | 46 | anagrams-deranged-anagrams |  |  |  |
 | 47 | anagrams |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,15 @@
+## VM Golden Progress (2025-07-26 04:45 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 04:45 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 04:45 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 04:45 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-25 22:07 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -129,7 +129,7 @@ func init() {
 		"importBigInt": `import java.math.BigInteger`,
 		"_now": `var _nowSeed = 0L
 var _nowSeeded = false
-fun _now(): Int {
+fun _now(): Long {
     if (!_nowSeeded) {
         System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
             _nowSeed = it
@@ -138,9 +138,9 @@ fun _now(): Int {
     }
     return if (_nowSeeded) {
         _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
-        kotlin.math.abs(_nowSeed.toInt())
+        kotlin.math.abs(_nowSeed)
     } else {
-        kotlin.math.abs(System.nanoTime().toInt())
+        kotlin.math.abs(System.nanoTime())
     }
 }`,
 	}


### PR DESCRIPTION
## Summary
- generate Kotlin benchmark files for Rosetta programs 43 and 44
- fix `_now` helper to return `Long` so duration can't underflow
- update Kotlin ROSETTA checklist and docs

## Testing
- `ROSETTA_INDEX=44 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -tags slow -run TestRosettaKotlin -v`


------
https://chatgpt.com/codex/tasks/task_e_6883fb328c8c8320bd1a5a71fd03f82d