### PR TITLE
Improve Kotlin transpiler int64 handling

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.error
+++ b/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.error
@@ -2,9 +2,6 @@ OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were depre
 /workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:32:25: error: type mismatch: inferred type is Int but BigInteger was expected
     var y: BigInteger = (x + 1) / 2
                         ^
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:35:13: error: type mismatch: inferred type is Int but BigInteger was expected
-        y = (x + (n / x)) / 2
-            ^
 /workspace/mochi/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt:150:20: error: the integer literal does not conform to the expected type Int
     val big: Int = 15355717786080
                    ^

--- a/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt
+++ b/tests/rosetta/transpiler/Kotlin/aliquot-sequence-classifications.kt
@@ -30,9 +30,9 @@ fun intSqrt(n: Int): Int {
     }
     var x: Int = n
     var y: BigInteger = (x + 1) / 2
-    while ((y as Number).toDouble() < x) {
+    while (y.compareTo(x.toBigInteger()) < 0) {
         x = y as Int
-        y = (x + (n / x)) / 2
+        y = ((x + (n / x)) / 2).toBigInteger()
     }
     return x
 }
@@ -80,8 +80,8 @@ fun classifySequence(k: Int): MutableMap<String, Any?> {
                             aliquot = "Aspiring"
                         } else {
                             if ((contains(seq.subList(1, maxOf(1, n - 2)), last)) as Boolean) {
-                                val idx: Int = indexOf(seq, last)
-                                aliquot = ("Cyclic[" + ((n - 1) - idx).toString()) + "]"
+                                val idx: Any? = indexOf(seq, last)
+                                aliquot = ("Cyclic[" + ((n - 1) - (idx as Int)).toString()) + "]"
                             } else {
                                 if ((n == 16) || (last > THRESHOLD)) {
                                     aliquot = "Non-Terminating"

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -2346,6 +2346,8 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 						if lit.Value > 2147483647 || lit.Value < -2147483648 {
 							typ = "Long"
 						}
+					} else if guessType(val) == "Long" {
+						typ = "Long"
 					}
 				}
 				if typ == "Any" {
@@ -2369,9 +2371,17 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 				} else if t := types.CheckExprType(st.Let.Value, env); t != nil {
 					tt = t
 				} else {
-					tt = types.AnyType{}
+					if typ == "Long" {
+						tt = types.Int64Type{}
+					} else {
+						tt = types.AnyType{}
+					}
 				}
-				env.SetVar(st.Let.Name, tt, false)
+				if typ == "Long" {
+					env.SetVar(st.Let.Name, types.Int64Type{}, false)
+				} else {
+					env.SetVar(st.Let.Name, tt, false)
+				}
 			}
 		case st.Var != nil:
 			var val Expr
@@ -2419,9 +2429,17 @@ func Transpile(env *types.Env, prog *parser.Program) (*Program, error) {
 				} else if t := types.CheckExprType(st.Var.Value, env); t != nil {
 					tt = t
 				} else {
-					tt = types.AnyType{}
+					if typ == "Long" {
+						tt = types.Int64Type{}
+					} else {
+						tt = types.AnyType{}
+					}
 				}
-				env.SetVar(st.Var.Name, tt, true)
+				if typ == "Long" {
+					env.SetVar(st.Var.Name, types.Int64Type{}, true)
+				} else {
+					env.SetVar(st.Var.Name, tt, true)
+				}
 			}
 		case st.Assign != nil && len(st.Assign.Index) == 0 && len(st.Assign.Field) == 0:
 			e, err := convertExpr(env, st.Assign.Value)
@@ -2725,7 +2743,11 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						}
 					}
 				}
-				env.SetVar(s.Let.Name, tt, false)
+				if typ == "Long" {
+					env.SetVar(s.Let.Name, types.Int64Type{}, false)
+				} else {
+					env.SetVar(s.Let.Name, tt, false)
+				}
 			}
 		case s.Var != nil:
 			v, err := convertExpr(env, s.Var.Value)
@@ -2759,6 +2781,8 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						if lit.Value > 2147483647 || lit.Value < -2147483648 {
 							typ = "Long"
 						}
+					} else if guessType(v) == "Long" {
+						typ = "Long"
 					}
 				}
 				if typ == "Any" {
@@ -2839,7 +2863,11 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						}
 					}
 				}
-				env.SetVar(s.Var.Name, tt, true)
+				if typ == "Long" {
+					env.SetVar(s.Var.Name, types.Int64Type{}, true)
+				} else {
+					env.SetVar(s.Var.Name, tt, true)
+				}
 			}
 		case s.Assign != nil && len(s.Assign.Index) == 0 && len(s.Assign.Field) == 0:
 			v, err := convertExpr(env, s.Assign.Value)


### PR DESCRIPTION
## Summary
- improve Kotlin transpiler handling of large integer literals
- regenerate aliquot sequence example and update error output

## Testing
- `ROSETTA_INDEX=41 go test -run TestRosettaKotlin -tags slow -count=1` *(fails: kotlinc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6883f9813ff0832087ec66acf7b242f3