### PR TITLE
Fix F# Rosetta programs

### DIFF
--- a/tests/rosetta/transpiler/FS/biorhythms.bench
+++ b/tests/rosetta/transpiler/FS/biorhythms.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 600,
+  "memory_bytes": 76968,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/biorhythms.error
+++ b/tests/rosetta/transpiler/FS/biorhythms.error
@@ -1,5 +1,0 @@
-compile: exit status 1
-F# Compiler for F# 4.0 (Open Source Edition)
-Freely distributed under the Apache 2.0 Open Source License
-
-/workspace/mochi/tests/rosetta/transpiler/FS/biorhythms.fs(249,33): error FS0039: The value or constructor 'contains' is not defined

--- a/tests/rosetta/transpiler/FS/biorhythms.fs
+++ b/tests/rosetta/transpiler/FS/biorhythms.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 09:59 +0700
 
 exception Return
 
@@ -81,7 +81,7 @@ and parseIntStr (str: string) =
         let mutable n: int = 0
         let digits: Map<string, int> = Map.ofList [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6); ("7", 7); ("8", 8); ("9", 9)]
         while i < (String.length str) do
-            n <- (n * 10) + (int (digits.[(str.Substring(i, (i + 1) - i))] |> unbox<int>))
+            n <- unbox<int> ((n * 10) + (unbox<int> (digits.[(str.Substring(i, (i + 1) - i))] |> unbox<int>)))
             i <- i + 1
         if neg then
             n <- -n
@@ -143,7 +143,7 @@ and addDays (y: int) (m: int) (d: int) (n: int) =
             let mutable i: int = 0
             while i < n do
                 dd <- dd + 1
-                if dd > (int (daysInMonth yy mm)) then
+                if dd > (unbox<int> (daysInMonth yy mm)) then
                     dd <- 1
                     mm <- mm + 1
                     if mm > 12 then
@@ -159,7 +159,7 @@ and addDays (y: int) (m: int) (d: int) (n: int) =
                     if mm < 1 then
                         mm <- 12
                         yy <- yy - 1
-                    dd <- daysInMonth yy mm
+                    dd <- unbox<int> (daysInMonth yy mm)
                 i <- i - 1
         __ret <- [|yy; mm; dd|]
         raise Return
@@ -213,7 +213,7 @@ and biorhythms (birth: string) (target: string) =
         let ty: int = tparts.[0]
         let tm: int = tparts.[1]
         let td: int = tparts.[2]
-        let diff: int = absInt (int ((day ty tm td) - (day by bm bd)))
+        let diff: int = absInt (unbox<int> ((day ty tm td) - (day by bm bd)))
         printfn "%s" ((("Born " + birth) + ", Target ") + target)
         printfn "%s" ("Day " + (string diff))
         let cycles: string array = [|"Physical day "; "Emotional day"; "Mental day   "|]
@@ -226,7 +226,7 @@ and biorhythms (birth: string) (target: string) =
             let position: int = ((diff % length + length) % length)
             let quadrant: int = (position * 4) / length
             let mutable percent: float = sinApprox (((2.0 * PI) * (float position)) / (float length))
-            percent <- (float (floor (percent * 1000.0))) / 10.0
+            percent <- float ((float (floor (percent * 1000.0))) / 10.0)
             let mutable description: string = ""
             if percent > 95.0 then
                 description <- " peak"
@@ -246,7 +246,7 @@ and biorhythms (birth: string) (target: string) =
                         let trend = (quadrants.[quadrant]).[0]
                         let next = (quadrants.[quadrant]).[1]
                         let mutable pct: string = string percent
-                        if not (contains pct ".") then
+                        if not (pct.Contains(".")) then
                             pct <- pct + ".0"
                         description <- (((((((" " + pct) + "% (") + (unbox<string> trend)) + ", next ") + (unbox<string> next)) + " ") + transition) + ")"
             let mutable posStr: string = string position
@@ -265,7 +265,7 @@ and main () =
         let __mem_start = System.GC.GetTotalMemory(true)
         let pairs: string array array = [|[|"1943-03-09"; "1972-07-11"|]; [|"1809-01-12"; "1863-11-19"|]; [|"1809-02-12"; "1863-11-19"|]|]
         let mutable idx: int = 0
-        while idx < (int (Array.length pairs)) do
+        while idx < (unbox<int> (Array.length pairs)) do
             let p: string array = pairs.[idx]
             biorhythms (unbox<string> (p.[0])) (unbox<string> (p.[1]))
             idx <- idx + 1

--- a/tests/rosetta/transpiler/FS/biorhythms.out
+++ b/tests/rosetta/transpiler/FS/biorhythms.out
@@ -1,0 +1,17 @@
+Born 1943-03-09, Target 1972-07-11
+Day 10717
+Physical day 22 :  -26.6% (down but rising, next transition 1972-07-12)
+Emotional day21 :  valley
+Mental day   25 :  valley
+
+Born 1809-01-12, Target 1863-11-19
+Day 20034
+Physical day  1 :  26.9% (up and rising, next peak 1863-11-23)
+Emotional day14 :  critical transition
+Mental day    3 :  54.0% (up and rising, next peak 1863-11-24)
+
+Born 1809-02-12, Target 1863-11-19
+Day 20003
+Physical day 16 :  -94.3% (down and falling, next valley 1863-11-20)
+Emotional day11 :  62.3% (up but falling, next transition 1863-11-22)
+Mental day    5 :  81.4% (up and rising, next peak 1863-11-22)

--- a/tests/rosetta/transpiler/FS/bitcoin-address-validation.bench
+++ b/tests/rosetta/transpiler/FS/bitcoin-address-validation.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 549,
+  "memory_bytes": 88272,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitcoin-address-validation.error
+++ b/tests/rosetta/transpiler/FS/bitcoin-address-validation.error
@@ -1,9 +1,0 @@
-compile: exit status 1
-F# Compiler for F# 4.0 (Open Source Edition)
-Freely distributed under the Apache 2.0 Open Source License
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitcoin-address-validation.fs(3,1): warning FS0221: The declarations in this file will be placed in an implicit module 'Bitcoin-address-validation' based on the file name 'bitcoin-address-validation.fs'. However this is not a valid F# identifier, so the contents will not be accessible from other files. Consider renaming the file or adding a 'module' or 'namespace' declaration at the top of the file.
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitcoin-address-validation.fs(57,32): error FS0039: The value or constructor 'sha256' is not defined
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitcoin-address-validation.fs(58,18): error FS0039: The value or constructor 'sha256' is not defined

--- a/tests/rosetta/transpiler/FS/bitcoin-address-validation.fs
+++ b/tests/rosetta/transpiler/FS/bitcoin-address-validation.fs
@@ -1,6 +1,33 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 03:08 +0000
 
 exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _sha256 (bs:int array) : int array =
+    use sha = System.Security.Cryptography.SHA256.Create()
+    let bytes = Array.map byte bs
+    sha.ComputeHash(bytes) |> Array.map int
+
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+open System.Security.Cryptography
 
 let rec indexOf (s: string) (ch: string) =
     let mutable __ret : int = Unchecked.defaultof<int>
@@ -18,7 +45,7 @@ let rec indexOf (s: string) (ch: string) =
         __ret
     with
         | Return -> __ret
-and set58 (addr: string) =
+let rec set58 (addr: string) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable addr = addr
     try
@@ -26,7 +53,7 @@ and set58 (addr: string) =
         let mutable a: int array = [||]
         let mutable i: int = 0
         while i < 25 do
-            a <- Array.append a [|0|]
+            a <- unbox<int array> (Array.append a [|0|])
             i <- i + 1
         let mutable idx: int = 0
         while idx < (String.length addr) do
@@ -37,7 +64,7 @@ and set58 (addr: string) =
                 raise Return
             let mutable j: int = 24
             while j >= 0 do
-                c <- c + (int (58 * (int (a.[j]))))
+                c <- unbox<int> (c + (unbox<int> (58 * (unbox<int> (a.[j])))))
                 a.[j] <- ((c % 256 + 256) % 256)
                 c <- int (c / 256)
                 j <- j - 1
@@ -50,17 +77,17 @@ and set58 (addr: string) =
         __ret
     with
         | Return -> __ret
-and doubleSHA256 (bs: int array) =
+let rec doubleSHA256 (bs: int array) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable bs = bs
     try
-        let first: int array = sha256 bs
-        __ret <- sha256 first
+        let first: int array = _sha256 bs
+        __ret <- _sha256 first
         raise Return
         __ret
     with
         | Return -> __ret
-and computeChecksum (a: int array) =
+let rec computeChecksum (a: int array) =
     let mutable __ret : int array = Unchecked.defaultof<int array>
     let mutable a = a
     try
@@ -70,15 +97,15 @@ and computeChecksum (a: int array) =
         __ret
     with
         | Return -> __ret
-and validA58 (addr: string) =
+let rec validA58 (addr: string) =
     let mutable __ret : bool = Unchecked.defaultof<bool>
     let mutable addr = addr
     try
         let a: int array = set58 addr
-        if (int (Array.length a)) <> 25 then
+        if (unbox<int> (Array.length a)) <> 25 then
             __ret <- false
             raise Return
-        if (int (a.[0])) <> 0 then
+        if (unbox<int> (a.[0])) <> 0 then
             __ret <- false
             raise Return
         let sum: int array = computeChecksum a
@@ -95,3 +122,6 @@ and validA58 (addr: string) =
         | Return -> __ret
 printfn "%s" (string (validA58 "1AGNa15ZQXAZUgFiqJ3i7Z2DPU2J6hW62i"))
 printfn "%s" (string (validA58 "17NdbrSGoUotzeGCcMMCqnFkEvLymoou9j"))
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/bitcoin-address-validation.out
+++ b/tests/rosetta/transpiler/FS/bitcoin-address-validation.out
@@ -1,0 +1,2 @@
+False
+True

--- a/tests/rosetta/transpiler/FS/bitmap-bresenhams-line-algorithm.bench
+++ b/tests/rosetta/transpiler/FS/bitmap-bresenhams-line-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 401,
+  "memory_bytes": 54584,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitmap-flood-fill.bench
+++ b/tests/rosetta/transpiler/FS/bitmap-flood-fill.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 388,
+  "memory_bytes": 42720,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitmap-flood-fill.fs
+++ b/tests/rosetta/transpiler/FS/bitmap-flood-fill.fs
@@ -1,7 +1,27 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 03:08 +0000
 
 exception Return
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
 let mutable grid: string array array = [|[|"."; "."; "."; "."; "."|]; [|"."; "#"; "#"; "#"; "."|]; [|"."; "#"; "."; "#"; "."|]; [|"."; "#"; "#"; "#"; "."|]; [|"."; "."; "."; "."; "."|]|]
 let rec flood (x: int) (y: int) (repl: string) =
     let mutable __ret : unit = Unchecked.defaultof<unit>
@@ -18,7 +38,7 @@ let rec flood (x: int) (y: int) (repl: string) =
             let mutable px = px
             let mutable py = py
             try
-                if (((px < 0) || (py < 0)) || (py >= (int (Array.length grid)))) || (px >= (Seq.length (grid.[0]))) then
+                if (((px < 0) || (py < 0)) || (py >= (unbox<int> (Array.length grid)))) || (px >= (Seq.length (grid.[0]))) then
                     __ret <- ()
                     raise Return
                 if (unbox<string> ((grid.[py]).[px])) <> target then
@@ -42,3 +62,6 @@ for row in grid do
     for ch in row do
         line <- line + (unbox<string> ch)
     printfn "%s" line
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/bitmap-histogram.bench
+++ b/tests/rosetta/transpiler/FS/bitmap-histogram.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 382,
+  "memory_bytes": 53264,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitmap-histogram.fs
+++ b/tests/rosetta/transpiler/FS/bitmap-histogram.fs
@@ -1,7 +1,25 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 03:08 +0000
 
 exception Return
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
 let rec image () =
     let mutable __ret : int array array = Unchecked.defaultof<int array array>
     try
@@ -20,16 +38,16 @@ and histogram (g: int array array) (bins: int) =
         let mutable h: int array = [||]
         let mutable i: int = 0
         while i < bins do
-            h <- Array.append h [|0|]
+            h <- unbox<int array> (Array.append h [|0|])
             i <- i + 1
         let mutable y: int = 0
-        while y < (int (Array.length g)) do
+        while y < (unbox<int> (Array.length g)) do
             let mutable row: int array = g.[y]
             let mutable x: int = 0
-            while x < (int (Array.length row)) do
+            while x < (unbox<int> (Array.length row)) do
                 let mutable p: int = row.[x]
                 let mutable idx: int = int ((p * (bins - 1)) / 65535)
-                h.[idx] <- (int (h.[idx])) + 1
+                h.[idx] <- (unbox<int> (h.[idx])) + 1
                 x <- x + 1
             y <- y + 1
         __ret <- h
@@ -42,17 +60,17 @@ and medianThreshold (h: int array) =
     let mutable h = h
     try
         let mutable lb: int = 0
-        let mutable ub: int = (int (Array.length h)) - 1
+        let mutable ub: int = (unbox<int> (Array.length h)) - 1
         let mutable lSum: int = 0
         let mutable uSum: int = 0
         while lb <= ub do
-            if (lSum + (int (h.[lb]))) < (uSum + (int (h.[ub]))) then
-                lSum <- lSum + (int (h.[lb]))
+            if (lSum + (unbox<int> (h.[lb]))) < (uSum + (unbox<int> (h.[ub]))) then
+                lSum <- unbox<int> (lSum + (unbox<int> (h.[lb])))
                 lb <- lb + 1
             else
-                uSum <- uSum + (int (h.[ub]))
+                uSum <- unbox<int> (uSum + (unbox<int> (h.[ub])))
                 ub <- ub - 1
-        __ret <- int ((ub * 65535) / (int (Array.length h)))
+        __ret <- unbox<int> ((ub * 65535) / (unbox<int> (Array.length h)))
         raise Return
         __ret
     with
@@ -64,17 +82,17 @@ and threshold (g: int array array) (t: int) =
     try
         let mutable out: int array array = [||]
         let mutable y: int = 0
-        while y < (int (Array.length g)) do
+        while y < (unbox<int> (Array.length g)) do
             let mutable row: int array = g.[y]
             let mutable newRow: int array = [||]
             let mutable x: int = 0
-            while x < (int (Array.length row)) do
-                if (int (row.[x])) < t then
-                    newRow <- Array.append newRow [|0|]
+            while x < (unbox<int> (Array.length row)) do
+                if (unbox<int> (row.[x])) < t then
+                    newRow <- unbox<int array> (Array.append newRow [|0|])
                 else
-                    newRow <- Array.append newRow [|65535|]
+                    newRow <- unbox<int array> (Array.append newRow [|65535|])
                 x <- x + 1
-            out <- Array.append out [|newRow|]
+            out <- unbox<int array array> (Array.append out [|newRow|])
             y <- y + 1
         __ret <- out
         raise Return
@@ -86,12 +104,12 @@ and printImage (g: int array array) =
     let mutable g = g
     try
         let mutable y: int = 0
-        while y < (int (Array.length g)) do
+        while y < (unbox<int> (Array.length g)) do
             let mutable row: int array = g.[y]
             let mutable line: string = ""
             let mutable x: int = 0
-            while x < (int (Array.length row)) do
-                if (int (row.[x])) = 0 then
+            while x < (unbox<int> (Array.length row)) do
+                if (unbox<int> (row.[x])) = 0 then
                     line <- line + "0"
                 else
                     line <- line + "1"
@@ -104,6 +122,8 @@ and printImage (g: int array array) =
 and main () =
     let mutable __ret : unit = Unchecked.defaultof<unit>
     try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
         let img: int array array = image()
         let h: int array = histogram img 0
         printfn "%s" ("Histogram: " + (string h))
@@ -111,6 +131,10 @@ and main () =
         printfn "%s" ("Threshold: " + (string t))
         let bw: int array array = threshold img t
         printImage bw
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
         __ret
     with
         | Return -> __ret

--- a/tests/rosetta/transpiler/FS/bitmap-midpoint-circle-algorithm.bench
+++ b/tests/rosetta/transpiler/FS/bitmap-midpoint-circle-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 861,
+  "memory_bytes": 71696,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitmap-midpoint-circle-algorithm.fs
+++ b/tests/rosetta/transpiler/FS/bitmap-midpoint-circle-algorithm.fs
@@ -1,7 +1,27 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 03:08 +0000
 
 exception Return
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
 let rec initGrid (size: int) =
     let mutable __ret : string array array = Unchecked.defaultof<string array array>
     let mutable size = size
@@ -12,27 +32,27 @@ let rec initGrid (size: int) =
             let mutable row: string array = [||]
             let mutable x: int = 0
             while x < size do
-                row <- Array.append row [|" "|]
+                row <- unbox<string array> (Array.append row [|" "|])
                 x <- x + 1
-            g <- Array.append g [|row|]
+            g <- unbox<string array array> (Array.append g [|row|])
             y <- y + 1
         __ret <- g
         raise Return
         __ret
     with
         | Return -> __ret
-and set (g: string array array) (x: int) (y: int) =
+let rec set (g: string array array) (x: int) (y: int) =
     let mutable __ret : unit = Unchecked.defaultof<unit>
     let mutable g = g
     let mutable x = x
     let mutable y = y
     try
-        if (((x >= 0) && (x < (Seq.length (g.[0])))) && (y >= 0)) && (y < (int (Array.length g))) then
+        if (((x >= 0) && (x < (Seq.length (g.[0])))) && (y >= 0)) && (y < (unbox<int> (Array.length g))) then
             (g.[y]).[x] <- "#"
         __ret
     with
         | Return -> __ret
-and circle (r: int) =
+let rec circle (r: int) =
     let mutable __ret : string array array = Unchecked.defaultof<string array array>
     let mutable r = r
     try
@@ -61,7 +81,7 @@ and circle (r: int) =
         __ret
     with
         | Return -> __ret
-and trimRight (row: string array) =
+let rec trimRight (row: string array) =
     let mutable __ret : string = Unchecked.defaultof<string>
     let mutable row = row
     try
@@ -81,3 +101,6 @@ and trimRight (row: string array) =
 let mutable g: string array array = circle 10
 for row in g do
     printfn "%A" (trimRight (unbox<string array> row))
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -111,4 +111,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-07-26 05:05 +0700
+Last updated: 2025-07-26 03:08 +0000

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (127/284)
+## Rosetta Golden Test Checklist (129/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -119,14 +119,14 @@ This file is auto-generated from rosetta tests.
 | 112 | bioinformatics-base-count | ✓ | 210µs | 42.9 KB |
 | 113 | bioinformatics-global-alignment | ✓ |  |  |
 | 114 | bioinformatics-sequence-mutation | ✓ |  |  |
-| 115 | biorhythms |   |  |  |
-| 116 | bitcoin-address-validation |   |  |  |
+| 115 | biorhythms | ✓ | 600µs | 75.2 KB |
+| 116 | bitcoin-address-validation | ✓ | 549µs | 86.2 KB |
 | 117 | bitmap-b-zier-curves-cubic |   |  |  |
 | 118 | bitmap-b-zier-curves-quadratic |   |  |  |
-| 119 | bitmap-bresenhams-line-algorithm | ✓ |  |  |
-| 120 | bitmap-flood-fill | ✓ |  |  |
-| 121 | bitmap-histogram | ✓ |  |  |
-| 122 | bitmap-midpoint-circle-algorithm | ✓ |  |  |
+| 119 | bitmap-bresenhams-line-algorithm | ✓ | 401µs | 53.3 KB |
+| 120 | bitmap-flood-fill | ✓ | 388µs | 41.7 KB |
+| 121 | bitmap-histogram | ✓ | 382µs | 52.0 KB |
+| 122 | bitmap-midpoint-circle-algorithm | ✓ | 861µs | 70.0 KB |
 | 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
 | 124 | bitmap-read-a-ppm-file |   |  |  |
 | 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
@@ -290,4 +290,4 @@ This file is auto-generated from rosetta tests.
 | 283 | define-a-primitive-data-type |   |  |  |
 | 284 | md5 |   |  |  |
 
-Last updated: 2025-07-26 02:24 +0000
+Last updated: 2025-07-26 03:08 +0000

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,11 @@
+## Progress (2025-07-26 03:08 +0000)
+- fs transpiler: implement contains builtin
+- Generated F# for 103/104 programs (103 passing)
+
+## Progress (2025-07-26 09:59 +0700)
+- ex transpiler: handle padStart and while vars
+- Generated F# for 103/104 programs (103 passing)
+
 ## Progress (2025-07-26 05:05 +0700)
 - dart rosetta: add next batch
 - Generated F# for 103/104 programs (103 passing)


### PR DESCRIPTION
## Summary
- implement `contains` builtin in F# transpiler
- add `_sha256` helper and support for `sha256`
- regenerate F# Rosetta files for indexes 115, 116 and 119-122 with benchmark data

## Testing
- `MOCHI_ROSETTA_INDEX=115 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=116 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=117 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1` *(fails: bitmap-b-zier-curves-cubic)*
- `MOCHI_ROSETTA_INDEX=119 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=120 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=121 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`
- `MOCHI_ROSETTA_INDEX=122 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68843f71607083209f8dc46d79cc53e9