### PR TITLE
Fix closure capture of globals

### DIFF
--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -2788,6 +2788,9 @@ func (fc *funcCompiler) compileStmt(s *parser.Statement) error {
 	case s.Fun != nil:
 		captureNames := make([]string, 0, len(fc.vars))
 		for name := range fc.vars {
+			if _, ok := fc.comp.globals[name]; ok {
+				continue
+			}
 			captureNames = append(captureNames, name)
 		}
 		sort.Strings(captureNames)
@@ -3564,6 +3567,9 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 	if p.FunExpr != nil {
 		captureNames := make([]string, 0, len(fc.vars))
 		for name := range fc.vars {
+			if _, ok := fc.comp.globals[name]; ok {
+				continue
+			}
 			captureNames = append(captureNames, name)
 		}
 		sort.Strings(captureNames)


### PR DESCRIPTION
## Summary
- avoid capturing global variables when compiling nested functions

## Testing
- `go run /tmp/proginfo.go`
- `go run /tmp/simple3.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6884488808b88320a436a78887d803b1