### PR TITLE
Add delete-a-file Rosetta translation

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-26 03:26 UTC
+Last updated: 2025-07-26 04:02 UTC
 
-## Rosetta Golden Test Checklist (201/284)
+## Rosetta Golden Test Checklist (202/285)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
@@ -291,3 +291,4 @@ Last updated: 2025-07-26 03:26 UTC
 | 282 | deepcopy-1 |   |  |  |
 | 283 | define-a-primitive-data-type |   |  |  |
 | 284 | md5 |   |  |  |
+| 285 | delete-a-file | ✓ |  |  |

--- a/tests/rosetta/ir/delete-a-file.ir
+++ b/tests/rosetta/ir/delete-a-file.ir
@@ -1,0 +1,83 @@
+func main (regs=1)
+  // main()
+  Call         r0, main, 
+  Return       r0
+
+  // fun remove(fs: map<string,bool>, path: string) {
+func remove (regs=9)
+  // if path in fs {
+  In           r2, r1, r0
+  JumpIfFalse  r2, L0
+  // delete fs[path]
+  Index        r4, r0, r1
+  // print("removed " + path)
+  Const        r5, "removed "
+  Add          r6, r5, r1
+  Print        r6
+  // if path in fs {
+  Jump         L1
+L0:
+  // print(path + ": not found")
+  Const        r7, ": not found"
+  Add          r8, r1, r7
+  Print        r8
+L1:
+  Return       r0
+
+  // fun removeAll(fs: map<string,bool>, path: string) {
+func removeAll (regs=9)
+  // if path in fs {
+  In           r2, r1, r0
+  JumpIfFalse  r2, L0
+  // delete fs[path]
+  Index        r4, r0, r1
+  // print("removed recursively " + path)
+  Const        r5, "removed recursively "
+  Add          r6, r5, r1
+  Print        r6
+  // if path in fs {
+  Jump         L1
+L0:
+  // print(path + ": not found")
+  Const        r7, ": not found"
+  Add          r8, r1, r7
+  Print        r8
+L1:
+  Return       r0
+
+  // fun main() {
+func main (regs=24)
+  // var fs: map<string,bool> = {
+  Const        r0, {"/docs": true, "/input.txt": false, "docs": true, "input.txt": false}
+  Move         r1, r0
+  // remove(fs, "input.txt")
+  Move         r2, r1
+  Const        r4, "input.txt"
+  Move         r3, r4
+  Call2        r5, remove, r2, r3
+  // remove(fs, "/input.txt")
+  Move         r6, r1
+  Const        r8, "/input.txt"
+  Move         r7, r8
+  Call2        r9, remove, r6, r7
+  // remove(fs, "docs")
+  Move         r10, r1
+  Const        r12, "docs"
+  Move         r11, r12
+  Call2        r13, remove, r10, r11
+  // remove(fs, "/docs")
+  Move         r14, r1
+  Const        r16, "/docs"
+  Move         r15, r16
+  Call2        r17, remove, r14, r15
+  // removeAll(fs, "docs")
+  Move         r18, r1
+  Const        r12, "docs"
+  Move         r19, r12
+  Call2        r20, removeAll, r18, r19
+  // removeAll(fs, "/docs")
+  Move         r21, r1
+  Const        r16, "/docs"
+  Move         r22, r16
+  Call2        r23, removeAll, r21, r22
+  Return       r0

--- a/tests/rosetta/ir/delete-a-file.out
+++ b/tests/rosetta/ir/delete-a-file.out
@@ -1,0 +1,6 @@
+removed input.txt
+removed /input.txt
+removed docs
+removed /docs
+removed recursively docs
+removed recursively /docs

--- a/tests/rosetta/x/Mochi/delete-a-file.mochi
+++ b/tests/rosetta/x/Mochi/delete-a-file.mochi
@@ -1,0 +1,38 @@
+// Mochi translation of Rosetta "Delete a file" task
+// Simulates file deletion in a simple in-memory filesystem
+
+fun remove(fs: map<string,bool>, path: string) {
+  if path in fs {
+    delete fs[path]
+    print("removed " + path)
+  } else {
+    print(path + ": not found")
+  }
+}
+
+fun removeAll(fs: map<string,bool>, path: string) {
+  if path in fs {
+    delete fs[path]
+    print("removed recursively " + path)
+  } else {
+    print(path + ": not found")
+  }
+}
+
+fun main() {
+  var fs: map<string,bool> = {
+    "input.txt": false,
+    "/input.txt": false,
+    "docs": true,
+    "/docs": true,
+  }
+
+  remove(fs, "input.txt")
+  remove(fs, "/input.txt")
+  remove(fs, "docs")
+  remove(fs, "/docs")
+  removeAll(fs, "docs")
+  removeAll(fs, "/docs")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/delete-a-file.out
+++ b/tests/rosetta/x/Mochi/delete-a-file.out
@@ -1,0 +1,6 @@
+removed input.txt
+removed /input.txt
+removed docs
+removed /docs
+removed recursively docs
+removed recursively /docs

--- a/tests/rosetta/x/Mochi/index.txt
+++ b/tests/rosetta/x/Mochi/index.txt
@@ -282,3 +282,4 @@
 282 deepcopy-1.mochi
 283 define-a-primitive-data-type.mochi
 284 md5.mochi
+285 delete-a-file.mochi


### PR DESCRIPTION
## Summary
- use `DownloadTaskByNumber` to fetch task 252 (Delete-a-file)
- add Mochi translation for Delete-a-file
- store output and IR for the new program
- update Rosetta task index and checklist

## Testing
- `MOCHI_ROSETTA_ONLY=delete-a-file go test ./runtime/vm -run Rosetta -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_68845206f0dc83208256490294252dd6