### PR TITLE
Add slice builtin to VM and fix rosetta 209

### DIFF
--- a/runtime/vm/README.md
+++ b/runtime/vm/README.md
@@ -24,7 +24,7 @@ The VM supports a small but useful subset of Mochi:
 * Function definitions
 * Function calls with any number of arguments
 * Anonymous function expressions
-* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min`, `max`, `substring`, `substr`, `upper` and `lower`
+* Built‑ins `len`, `print` (up to two arguments), `append`, `concat`, `first`, `str`, `json`, `now`, `input`, `count`, `exists`, `avg`, `min`, `max`, `slice`, `substring`, `substr`, `upper` and `lower`
 * Dataset loading with `load` (optionally casting rows to a type) and saving with `save`
 * HTTP requests using the `fetch` expression
 * Loops internally use specialised integer instructions for indexing to improve performance

--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-26 03:53 UTC
+Last updated: 2025-07-26 04:17 UTC
 
-## Rosetta Golden Test Checklist (202/284)
+## Rosetta Golden Test Checklist (203/284)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
@@ -215,7 +215,7 @@ Last updated: 2025-07-26 03:53 UTC
 | 206 | circular-primes | ✓ | 6.883ms | 1.6 MB |
 | 207 | cistercian-numerals | ✓ |  |  |
 | 208 | comma-quibbling | ✓ | 50µs | 21.5 KB |
-| 209 | compiler-virtual-machine-interpreter |   |  |  |
+| 209 | compiler-virtual-machine-interpreter | ✓ | 1.774ms |  |
 | 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
 | 211 | compound-data-type |   |  |  |
 | 212 | concurrent-computing-1 |   |  |  |

--- a/tests/rosetta/ir/compiler-virtual-machine-interpreter.bench
+++ b/tests/rosetta/ir/compiler-virtual-machine-interpreter.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 1774,
+  "memory_bytes": -1649952,
+  "name": "main"
+}

--- a/tests/rosetta/ir/compiler-virtual-machine-interpreter.ir
+++ b/tests/rosetta/ir/compiler-virtual-machine-interpreter.ir
@@ -433,7 +433,7 @@ L3:
   Return       r113
 
   // fun runVM(prog: map<string, any>) {
-func runVM (regs=108)
+func runVM (regs=127)
   // var data: list<int> = []
   Const        r1, []
   Move         r2, r1
@@ -475,222 +475,269 @@ L0:
   Const        r19, "strings"
   Index        r20, r0, r19
   Move         r21, r20
+  // var line = ""
+  Const        r22, ""
+  Move         r23, r22
 L4:
   // while pc < len(code) {
-  Len          r22, r15
-  LessInt      r23, r12, r22
-  JumpIfFalse  r23, L2
+  Len          r24, r15
+  LessInt      r25, r12, r24
+  JumpIfFalse  r25, L2
   // let inst = code[pc]
-  Index        r24, r15, r12
-  Move         r25, r24
+  Index        r26, r15, r12
+  Move         r27, r26
   // let op = inst["op"]
-  Const        r26, "op"
-  Index        r27, r25, r26
-  Move         r28, r27
+  Const        r28, "op"
+  Index        r29, r27, r28
+  Move         r30, r29
   // let arg = inst["arg"]
-  Const        r29, "arg"
-  Index        r30, r25, r29
-  Move         r31, r30
+  Const        r31, "arg"
+  Index        r32, r27, r31
+  Move         r33, r32
   // if op == "push" {
-  Const        r32, "push"
-  Equal        r33, r28, r32
-  JumpIfFalse  r33, L3
+  Const        r34, "push"
+  Equal        r35, r30, r34
+  JumpIfFalse  r35, L3
   // stack = append(stack, arg)
-  Append       r34, r11, r31
-  Move         r11, r34
+  Append       r36, r11, r33
+  Move         r11, r36
   // pc = pc + 1
   Const        r9, 1
-  AddInt       r35, r12, r9
-  Move         r12, r35
+  AddInt       r37, r12, r9
+  Move         r12, r37
   // continue
   Jump         L4
 L3:
   // if op == "store" {
-  Const        r36, "store"
-  Equal        r37, r28, r36
-  JumpIfFalse  r37, L5
+  Const        r38, "store"
+  Equal        r39, r30, r38
+  JumpIfFalse  r39, L5
   // data[arg] = stack[len(stack)-1]
-  Len          r38, r11
+  Len          r40, r11
   Const        r9, 1
-  SubInt       r39, r38, r9
-  Index        r40, r11, r39
-  SetIndex     r2, r31, r40
+  SubInt       r41, r40, r9
+  Index        r42, r11, r41
+  SetIndex     r2, r33, r42
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r41
+  Const        r3, 0
+  Len          r43, r11
+  Const        r9, 1
+  SubInt       r44, r43, r9
+  Slice        r45, r11, r3, r44
+  Move         r11, r45
   // pc = pc + 1
   Const        r9, 1
-  AddInt       r42, r12, r9
-  Move         r12, r42
+  AddInt       r46, r12, r9
+  Move         r12, r46
   // continue
   Jump         L4
 L5:
   // if op == "fetch" {
-  Const        r43, "fetch"
-  Equal        r44, r28, r43
-  JumpIfFalse  r44, L6
+  Const        r47, "fetch"
+  Equal        r48, r30, r47
+  JumpIfFalse  r48, L6
   // stack = append(stack, data[arg])
-  Index        r45, r2, r31
-  Append       r46, r11, r45
-  Move         r11, r46
+  Index        r49, r2, r33
+  Append       r50, r11, r49
+  Move         r11, r50
   // pc = pc + 1
   Const        r9, 1
-  AddInt       r47, r12, r9
-  Move         r12, r47
+  AddInt       r51, r12, r9
+  Move         r12, r51
   // continue
   Jump         L4
 L6:
   // if op == "add" {
-  Const        r48, "add"
-  Equal        r49, r28, r48
-  JumpIfFalse  r49, L7
+  Const        r52, "add"
+  Equal        r53, r30, r52
+  JumpIfFalse  r53, L7
   // stack[len(stack)-2] = stack[len(stack)-2] + stack[len(stack)-1]
-  Len          r50, r11
-  Const        r51, 2
-  SubInt       r52, r50, r51
-  Index        r53, r11, r52
   Len          r54, r11
-  Const        r9, 1
-  SubInt       r55, r54, r9
-  Index        r56, r11, r55
-  Add          r57, r53, r56
+  Const        r55, 2
+  SubInt       r56, r54, r55
+  Index        r57, r11, r56
   Len          r58, r11
-  Const        r51, 2
-  SubInt       r59, r58, r51
-  SetIndex     r11, r59, r57
+  Const        r9, 1
+  SubInt       r59, r58, r9
+  Index        r60, r11, r59
+  Add          r61, r57, r60
+  Len          r62, r11
+  Const        r55, 2
+  SubInt       r63, r62, r55
+  SetIndex     r11, r63, r61
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r60
+  Const        r3, 0
+  Len          r64, r11
+  Const        r9, 1
+  SubInt       r65, r64, r9
+  Slice        r66, r11, r3, r65
+  Move         r11, r66
   // pc = pc + 1
   Const        r9, 1
-  AddInt       r61, r12, r9
-  Move         r12, r61
+  AddInt       r67, r12, r9
+  Move         r12, r67
   // continue
   Jump         L4
 L7:
   // if op == "lt" {
-  Const        r62, "lt"
-  Equal        r63, r28, r62
-  JumpIfFalse  r63, L8
+  Const        r68, "lt"
+  Equal        r69, r30, r68
+  JumpIfFalse  r69, L8
   // var v = 0
   Const        r3, 0
-  Move         r64, r3
+  Move         r70, r3
   // if stack[len(stack)-2] < stack[len(stack)-1] { v = 1 }
-  Len          r65, r11
-  Const        r51, 2
-  SubInt       r66, r65, r51
-  Index        r67, r11, r66
-  Len          r68, r11
+  Len          r71, r11
+  Const        r55, 2
+  SubInt       r72, r71, r55
+  Index        r73, r11, r72
+  Len          r74, r11
   Const        r9, 1
-  SubInt       r69, r68, r9
-  Index        r70, r11, r69
-  Less         r71, r67, r70
-  JumpIfFalse  r71, L9
+  SubInt       r75, r74, r9
+  Index        r76, r11, r75
+  Less         r77, r73, r76
+  JumpIfFalse  r77, L9
   Const        r9, 1
-  Move         r64, r9
+  Move         r70, r9
 L9:
   // stack[len(stack)-2] = v
-  Len          r72, r11
-  Const        r51, 2
-  SubInt       r73, r72, r51
-  SetIndex     r11, r73, r64
+  Len          r78, r11
+  Const        r55, 2
+  SubInt       r79, r78, r55
+  SetIndex     r11, r79, r70
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r74
+  Const        r3, 0
+  Len          r80, r11
+  Const        r9, 1
+  SubInt       r81, r80, r9
+  Slice        r82, r11, r3, r81
+  Move         r11, r82
   // pc = pc + 1
   Const        r9, 1
-  AddInt       r75, r12, r9
-  Move         r12, r75
+  AddInt       r83, r12, r9
+  Move         r12, r83
   // continue
   Jump         L4
 L8:
   // if op == "jz" {
-  Const        r76, "jz"
-  Equal        r77, r28, r76
-  JumpIfFalse  r77, L10
+  Const        r84, "jz"
+  Equal        r85, r30, r84
+  JumpIfFalse  r85, L10
   // let v = stack[len(stack)-1]
-  Len          r78, r11
+  Len          r86, r11
   Const        r9, 1
-  SubInt       r79, r78, r9
-  Index        r80, r11, r79
-  Move         r81, r80
+  SubInt       r87, r86, r9
+  Index        r88, r11, r87
+  Move         r89, r88
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r82
+  Const        r3, 0
+  Len          r90, r11
+  Const        r9, 1
+  SubInt       r91, r90, r9
+  Slice        r92, r11, r3, r91
+  Move         r11, r92
   // if v == 0 {
   Const        r3, 0
-  Equal        r83, r81, r3
-  JumpIfFalse  r83, L11
+  Equal        r93, r89, r3
+  JumpIfFalse  r93, L11
   // pc = addrMap[arg]
-  Index        r84, r18, r31
-  Move         r12, r84
+  Index        r94, r18, r33
+  Move         r12, r94
   // if v == 0 {
   Jump         L4
 L11:
   // pc = pc + 1
   Const        r9, 1
-  Add          r85, r12, r9
-  Move         r12, r85
+  Add          r95, r12, r9
+  Move         r12, r95
   // continue
   Jump         L4
 L10:
   // if op == "jmp" {
-  Const        r86, "jmp"
-  Equal        r87, r28, r86
-  JumpIfFalse  r87, L12
+  Const        r96, "jmp"
+  Equal        r97, r30, r96
+  JumpIfFalse  r97, L12
   // pc = addrMap[arg]
-  Index        r88, r18, r31
-  Move         r12, r88
+  Index        r98, r18, r33
+  Move         r12, r98
   // continue
   Jump         L4
 L12:
   // if op == "prts" {
-  Const        r89, "prts"
-  Equal        r90, r28, r89
-  JumpIfFalse  r90, L13
-  // print(pool[stack[len(stack)-1]])
-  Len          r91, r11
+  Const        r99, "prts"
+  Equal        r100, r30, r99
+  JumpIfFalse  r100, L13
+  // let s = pool[stack[len(stack)-1]]
+  Len          r101, r11
   Const        r9, 1
-  SubInt       r92, r91, r9
-  Index        r93, r11, r92
-  Index        r94, r21, r93
-  Print        r94
+  SubInt       r102, r101, r9
+  Index        r103, r11, r102
+  Index        r104, r21, r103
+  Move         r105, r104
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r95
+  Const        r3, 0
+  Len          r106, r11
+  Const        r9, 1
+  SubInt       r107, r106, r9
+  Slice        r108, r11, r3, r107
+  Move         r11, r108
+  // if s != "\n" {
+  Const        r109, "\n"
+  NotEqual     r110, r105, r109
+  JumpIfFalse  r110, L14
+  // line = line + s
+  Add          r111, r23, r105
+  Move         r23, r111
+L14:
   // pc = pc + 1
   Const        r9, 1
-  Add          r96, r12, r9
-  Move         r12, r96
+  Add          r112, r12, r9
+  Move         r12, r112
   // continue
   Jump         L4
 L13:
   // if op == "prti" {
-  Const        r97, "prti"
-  Equal        r98, r28, r97
-  JumpIfFalse  r98, L14
-  // print(str(stack[len(stack)-1]))
-  Len          r99, r11
+  Const        r113, "prti"
+  Equal        r114, r30, r113
+  JumpIfFalse  r114, L15
+  // line = line + str(stack[len(stack)-1])
+  Len          r115, r11
   Const        r9, 1
-  SubInt       r100, r99, r9
-  Index        r101, r11, r100
-  Str          r102, r101
-  Print        r102
+  SubInt       r116, r115, r9
+  Index        r117, r11, r116
+  Str          r118, r117
+  Add          r119, r23, r118
+  Move         r23, r119
+  // print(line)
+  Print        r23
+  // line = ""
+  Const        r22, ""
+  Move         r23, r22
   // stack = slice(stack, 0, len(stack)-1)
-  Move         r11, r103
+  Const        r3, 0
+  Len          r120, r11
+  Const        r9, 1
+  SubInt       r121, r120, r9
+  Slice        r122, r11, r3, r121
+  Move         r11, r122
   // pc = pc + 1
   Const        r9, 1
-  Add          r104, r12, r9
-  Move         r12, r104
+  Add          r123, r12, r9
+  Move         r12, r123
   // continue
   Jump         L4
-L14:
+L15:
   // if op == "halt" {
-  Const        r105, "halt"
-  Equal        r106, r28, r105
-  JumpIfFalse  r106, L15
+  Const        r124, "halt"
+  Equal        r125, r30, r124
+  JumpIfFalse  r125, L16
   // break
   Jump         L2
-L15:
+L16:
   // pc = pc + 1
   Const        r9, 1
-  Add          r107, r12, r9
-  Move         r12, r107
+  Add          r126, r12, r9
+  Move         r12, r126
   // while pc < len(code) {
   Jump         L4
 L2:

--- a/tests/rosetta/ir/compiler-virtual-machine-interpreter.out
+++ b/tests/rosetta/ir/compiler-virtual-machine-interpreter.out
@@ -1,0 +1,9 @@
+count is: 1
+count is: 2
+count is: 3
+count is: 4
+count is: 5
+count is: 6
+count is: 7
+count is: 8
+count is: 9

--- a/tests/rosetta/x/Mochi/compiler-virtual-machine-interpreter.mochi
+++ b/tests/rosetta/x/Mochi/compiler-virtual-machine-interpreter.mochi
@@ -112,6 +112,7 @@ fun runVM(prog: map<string, any>) {
   let code = prog["code"]
   let addrMap = prog["addrMap"]
   let pool = prog["strings"]
+  var line = ""
   while pc < len(code) {
     let inst = code[pc]
     let op = inst["op"]
@@ -161,13 +162,18 @@ fun runVM(prog: map<string, any>) {
       continue
     }
     if op == "prts" {
-      print(pool[stack[len(stack)-1]])
+      let s = pool[stack[len(stack)-1]]
       stack = slice(stack, 0, len(stack)-1)
+      if s != "\n" {
+        line = line + s
+      }
       pc = pc + 1
       continue
     }
     if op == "prti" {
-      print(str(stack[len(stack)-1]))
+      line = line + str(stack[len(stack)-1])
+      print(line)
+      line = ""
       stack = slice(stack, 0, len(stack)-1)
       pc = pc + 1
       continue


### PR DESCRIPTION
## Summary
- implement `slice` builtin in the VM compiler and constant folder
- document new builtin in runtime/vm README
- adjust `compiler-virtual-machine-interpreter` rosetta program to use newline logic
- regenerate IR, output and benchmark for index 209
- update rosetta progress checklist

## Testing
- `MOCHI_ROSETTA_INDEX=209 go test ./runtime/vm -run Rosetta_Golden -tags slow -count=1`
- `MOCHI_ROSETTA_INDEX=209 MOCHI_BENCHMARK=1 go test ./runtime/vm -run Rosetta_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688452fc89e08320858a163164be4b97