### PR TITLE
Add Mochi solution for numeric string test

### DIFF
--- a/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-1.mochi
+++ b/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-1.mochi
@@ -1,0 +1,46 @@
+// Mochi translation of Rosetta "Determine if a string is numeric" task (variant 1)
+// Implements a simple parser similar to the Go example using strconv.ParseFloat.
+
+fun isNumeric(s: string): bool {
+  if s == "NaN" { return true }
+  var i = 0
+  if len(s) == 0 { return false }
+  if s[0] == "+" || s[0] == "-" {
+    if len(s) == 1 { return false }
+    i = 1
+  }
+  var digits = false
+  var dot = false
+  while i < len(s) {
+    let ch = s[i]
+    if ch >= "0" && ch <= "9" {
+      digits = true
+      i = i + 1
+    } else if ch == "." && dot == false {
+      dot = true
+      i = i + 1
+    } else if (ch == "e" || ch == "E") && digits {
+      i = i + 1
+      if i < len(s) && (s[i] == "+" || s[i] == "-") { i = i + 1 }
+      var ed = false
+      while i < len(s) && s[i] >= "0" && s[i] <= "9" {
+        ed = true
+        i = i + 1
+      }
+      return ed && i == len(s)
+    } else {
+      return false
+    }
+  }
+  return digits
+}
+
+fun main() {
+  print("Are these strings numeric?")
+  let strs = ["1", "3.14", "-100", "1e2", "NaN", "rose"]
+  for s in strs {
+    print("  " + s + " -> " + str(isNumeric(s)))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-1.out
+++ b/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-1.out
@@ -1,0 +1,7 @@
+Are these strings numeric?
+  1 -> true
+  3.14 -> true
+  -100 -> true
+  1e2 -> true
+  NaN -> true
+  rose -> false

--- a/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-2.mochi
+++ b/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-2.mochi
@@ -1,0 +1,21 @@
+// Mochi translation of Rosetta "Determine if a string is numeric" task (variant 2)
+// Checks if a string contains only decimal digits.
+
+fun isInt(s: string): bool {
+  if len(s) == 0 { return false }
+  for ch in s { if ch < "0" || ch > "9" { return false } }
+  return true
+}
+
+fun main() {
+  print("Are these strings integers?")
+  let v = "1"
+  var b = false
+  // emulate strconv.Atoi check
+  if isInt(v) { b = true }
+  print("  " + v + " -> " + str(b))
+  let i = "one"
+  print("  " + i + " -> " + str(isInt(i)))
+}
+
+main()

--- a/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-2.out
+++ b/tests/rosetta/x/Mochi/determine-if-a-string-is-numeric-2.out
@@ -1,0 +1,3 @@
+Are these strings integers?
+  1 -> true
+  one -> false


### PR DESCRIPTION
## Summary
- add Mochi versions of "Determine if a string is numeric" Rosetta task
- include expected outputs for both variants

## Testing
- `MOCHI_ROSETTA_ONLY=determine-if-a-string-is-numeric-1 go test ./runtime/vm -run Rosetta -tags slow -count=1`
- `MOCHI_ROSETTA_ONLY=determine-if-a-string-is-numeric-2 go test ./runtime/vm -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688455a4177c8320ba02567d20486b7b