### PR TITLE
Fix failing Go tests

### DIFF
--- a/tools/rosetta/cmd/download_by_number.go
+++ b/tools/rosetta/cmd/download_by_number.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (


### PR DESCRIPTION
## Summary
- ensure `rosetta/cmd` is only built with the `slow` tag

## Testing
- `go test ./... --vet=off -v`

------
https://chatgpt.com/codex/tasks/task_e_68845b0db28c83208e1e34e3da395c6d