### PR TITLE
Add Rosetta task: Determine only one instance running

### DIFF
--- a/tests/rosetta/x/Mochi/determine-if-only-one-instance-is-running.mochi
+++ b/tests/rosetta/x/Mochi/determine-if-only-one-instance-is-running.mochi
@@ -1,0 +1,21 @@
+// Mochi translation of Rosetta "Determine if only one instance is running" task
+// Simplified using an in-memory lock file because the Mochi runtime lacks full
+// filesystem access.
+
+var lockExists = false
+
+fun startOnce() {
+  if lockExists {
+    print("an instance is already running")
+  } else {
+    lockExists = true
+    print("single instance started")
+  }
+}
+
+fun main() {
+  startOnce()
+  startOnce()
+}
+
+main()

--- a/tests/rosetta/x/Mochi/determine-if-only-one-instance-is-running.out
+++ b/tests/rosetta/x/Mochi/determine-if-only-one-instance-is-running.out
@@ -1,0 +1,2 @@
+single instance started
+an instance is already running


### PR DESCRIPTION
## Summary
- add Mochi solution for `Determine-if-only-one-instance-is-running`
- include golden output for runtime/vm

## Testing
- `MOCHI_ROSETTA_ONLY=determine-if-only-one-instance-is-running go test ./runtime/vm -run RosettaTasks -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_688455b7aa6c8320b83333de91495398