### PR TITLE
Add Discordian date Mochi example

### DIFF
--- a/tests/rosetta/x/Mochi/discordian-date.mochi
+++ b/tests/rosetta/x/Mochi/discordian-date.mochi
@@ -1,0 +1,68 @@
+let dayNames = ["Sweetmorn", "Boomtime", "Pungenday", "Prickle-Prickle", "Setting Orange"]
+let seasons = ["Chaos", "Discord", "Confusion", "Bureaucracy", "The Aftermath"]
+let holydays = [["Mungday", "Chaoflux"], ["Mojoday", "Discoflux"], ["Syaday", "Confuflux"], ["Zaraday", "Bureflux"], ["Maladay", "Afflux"]]
+
+fun isLeap(y: int): bool {
+  if y % 400 == 0 { return true }
+  if y % 100 == 0 { return false }
+  return y % 4 == 0
+}
+
+let daysBefore = [0,31,59,90,120,151,181,212,243,273,304,334]
+
+fun dayOfYear(y: int, m: int, d: int): int {
+  var doy = daysBefore[m-1] + d
+  if m > 2 && isLeap(y) { doy = doy + 1 }
+  return doy
+}
+
+fun ordinal(n: int): string {
+  var suff = "th"
+  let mod100 = n % 100
+  if mod100 < 11 || mod100 > 13 {
+    let r = n % 10
+    if r == 1 { suff = "st" }
+    else if r == 2 { suff = "nd" }
+    else if r == 3 { suff = "rd" }
+  }
+  return str(n) + suff
+}
+
+fun discordian(y: int, m: int, d: int): string {
+  if isLeap(y) && m == 2 && d == 29 {
+    return "St. Tib's Day, YOLD " + str(y + 1166)
+  }
+  var doy = dayOfYear(y, m, d)
+  if isLeap(y) && doy > 60 { doy = doy - 1 }
+  var idx = doy - 1
+  let season = idx / 73
+  let day = idx % 73
+  var res = dayNames[idx % 5] + ", the " + ordinal(day + 1) + " day of " + seasons[season] + " in the YOLD " + str(y + 1166)
+  if day == 4 { res = res + ". Celebrate " + holydays[season][0] + "!" }
+  if day == 49 { res = res + ". Celebrate " + holydays[season][1] + "!" }
+  return res
+}
+
+fun main() {
+  let dates = [
+    [2010,7,22],
+    [2012,2,28],
+    [2012,2,29],
+    [2012,3,1],
+    [2012,12,31],
+    [2013,1,1],
+    [2100,12,31],
+    [2015,10,19],
+    [2010,1,5],
+    [2011,5,3],
+    [2000,3,13],
+  ]
+  var i = 0
+  while i < len(dates) {
+    let dt = dates[i]
+    print(discordian(dt[0], dt[1], dt[2]))
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/discordian-date.out
+++ b/tests/rosetta/x/Mochi/discordian-date.out
@@ -1,0 +1,11 @@
+Pungenday, the 57th day of Confusion in the YOLD 3176
+Prickle-Prickle, the 59th day of Chaos in the YOLD 3178
+St. Tib's Day, YOLD 3178
+Setting Orange, the 60th day of Chaos in the YOLD 3178
+Setting Orange, the 73rd day of The Aftermath in the YOLD 3178
+Sweetmorn, the 1st day of Chaos in the YOLD 3179
+Setting Orange, the 73rd day of The Aftermath in the YOLD 3266
+Boomtime, the 73rd day of Bureaucracy in the YOLD 3181
+Setting Orange, the 5th day of Chaos in the YOLD 3176. Celebrate Mungday!
+Pungenday, the 50th day of Discord in the YOLD 3177. Celebrate Discoflux!
+Boomtime, the 72nd day of Chaos in the YOLD 3166


### PR DESCRIPTION
## Summary
- add Mochi translation for the Discordian date task
- include example output

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/discordian-date.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68845613d6e88320af29c4df46121a5a