### PR TITLE
Add Mochi solution for Documentation Rosetta task

### DIFF
--- a/tests/rosetta/x/Mochi/documentation.mochi
+++ b/tests/rosetta/x/Mochi/documentation.mochi
@@ -1,0 +1,25 @@
+// Mochi translation of Rosetta "Documentation" task
+// Based on Go version in tests/rosetta/x/Go/documentation.go
+
+// Example serves as an example but does nothing useful.
+//
+// A package comment precedes the package clause and explains the purpose
+// of the package.
+
+// Exported variables.
+var X: int = 0  // lookie
+var Y: int = 0
+var Z: int = 0  // popular names
+
+/* XP does nothing.
+
+Here's a block comment. */
+fun XP() { // here we go!
+  // comments inside
+}
+
+// Non-exported.
+fun nonXP() {}
+
+// Doc not extracted.
+var MEMEME: int = 0


### PR DESCRIPTION
## Summary
- add Mochi translation of the "Documentation" task from Rosetta Code
- include empty expected output for the new program

## Testing
- `MOCHI_ROSETTA_ONLY=documentation go test ./runtime/vm -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688456604c0c832084a31105ab82ea1c