### PR TITLE
Fix F# transpiler map field access

### DIFF
--- a/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.bench
+++ b/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 517,
+  "memory_bytes": 55376,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.error
+++ b/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.error
@@ -1,9 +1,0 @@
-compile: exit status 1
-F# Compiler for F# 4.0 (Open Source Edition)
-Freely distributed under the Apache 2.0 Open Source License
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.fs(3,1): warning FS0221: The declarations in this file will be placed in an implicit module 'Bitmap-read-an-image-through-a-pipe' based on the file name 'bitmap-read-an-image-through-a-pipe.fs'. However this is not a valid F# identifier, so the contents will not be accessible from other files. Consider renaming the file or adding a 'module' or 'namespace' declaration at the top of the file.
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.fs(73,41): error FS0039: The field, constructor or member 'w' is not defined
-
-/workspace/mochi/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.fs(73,75): error FS0039: The field, constructor or member 'h' is not defined

--- a/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.fs
+++ b/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.fs
@@ -1,7 +1,37 @@
-// Generated 2025-07-26 04:38 +0700
+// Generated 2025-07-26 12:01 +0700
 
 exception Return
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _substring (s:string) (start:int) (finish:int) =
+    let len = String.length s
+    let mutable st = if start < 0 then len + start else start
+    let mutable en = if finish < 0 then len + finish else finish
+    if st < 0 then st <- 0
+    if st > len then st <- len
+    if en > len then en <- len
+    if st > en then st <- en
+    s.Substring(st, en - st)
+
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
 let rec parseIntStr (str: string) =
     let mutable __ret : int = Unchecked.defaultof<int>
     let mutable str = str
@@ -14,7 +44,7 @@ let rec parseIntStr (str: string) =
         let mutable n: int = 0
         let digits: Map<string, int> = Map.ofList [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6); ("7", 7); ("8", 8); ("9", 9)]
         while i < (String.length str) do
-            n <- (n * 10) + (int (digits.[(str.Substring(i, (i + 1) - i))] |> unbox<int>))
+            n <- int ((n * 10) + (int (digits.[(str.Substring(i, (i + 1) - i))] |> unbox<int>)))
             i <- i + 1
         if neg then
             n <- -n
@@ -23,7 +53,7 @@ let rec parseIntStr (str: string) =
         __ret
     with
         | Return -> __ret
-and splitWs (s: string) =
+let rec splitWs (s: string) =
     let mutable __ret : string array = Unchecked.defaultof<string array>
     let mutable s = s
     try
@@ -31,28 +61,28 @@ and splitWs (s: string) =
         let mutable cur: string = ""
         let mutable i: int = 0
         while i < (String.length s) do
-            let ch: string = s.Substring(i, (i + 1) - i)
+            let ch: string = _substring s i (i + 1)
             if (((ch = " ") || (ch = "\n")) || (ch = "\t")) || (ch = "\r") then
                 if (String.length cur) > 0 then
-                    parts <- Array.append parts [|cur|]
+                    parts <- unbox<string array> (Array.append parts [|cur|])
                     cur <- ""
             else
                 cur <- cur + ch
             i <- i + 1
         if (String.length cur) > 0 then
-            parts <- Array.append parts [|cur|]
-        __ret <- parts
+            parts <- unbox<string array> (Array.append parts [|cur|])
+        __ret <- unbox<string array> parts
         raise Return
         __ret
     with
         | Return -> __ret
-and parsePpm (data: string) =
+let rec parsePpm (data: string) =
     let mutable __ret : Map<string, obj> = Unchecked.defaultof<Map<string, obj>>
     let mutable data = data
     try
         let toks: string array = splitWs data
         if (int (Array.length toks)) < 4 then
-            __ret <- Map.ofList [("err", box true)]
+            __ret <- unbox<Map<string, obj>> (Map.ofList [("err", box true)])
             raise Return
         let magic: string = toks.[0]
         let w: int = parseIntStr (unbox<string> (toks.[1]))
@@ -61,13 +91,16 @@ and parsePpm (data: string) =
         let mutable px: int array = [||]
         let mutable i: int = 4
         while i < (int (Array.length toks)) do
-            px <- Array.append px [|parseIntStr (unbox<string> (toks.[i]))|]
+            px <- unbox<int array> (Array.append px [|parseIntStr (unbox<string> (toks.[i]))|])
             i <- i + 1
-        __ret <- Map.ofList [("magic", box magic); ("w", box w); ("h", box h); ("max", box maxv); ("px", box px)]
+        __ret <- unbox<Map<string, obj>> (Map.ofList [("magic", box magic); ("w", box w); ("h", box h); ("max", box maxv); ("px", box px)])
         raise Return
         __ret
     with
         | Return -> __ret
 let ppmData: string = "P3\n2 2\n1\n0 1 1 0 1 0 0 1 1 1 0 0\n"
 let img: Map<string, obj> = parsePpm ppmData
-printfn "%s" ((("width=" + (string (img.w))) + " height=") + (string (img.h)))
+printfn "%s" ((("width=" + (string (img.["w"]))) + " height=") + (string (img.["h"])))
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.out
+++ b/tests/rosetta/transpiler/FS/bitmap-read-an-image-through-a-pipe.out
@@ -1,0 +1,1 @@
+width=2 height=2

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (131/284)
+## Rosetta Golden Test Checklist (133/310)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -129,16 +129,16 @@ This file is auto-generated from rosetta tests.
 | 122 | bitmap-midpoint-circle-algorithm | ✓ | 861µs | 70.0 KB |
 | 123 | bitmap-ppm-conversion-through-a-pipe | ✓ | 1.385ms | 1.4 MB |
 | 124 | bitmap-read-a-ppm-file | ✓ | 356µs | 47.0 KB |
-| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
-| 126 | bitmap-write-a-ppm-file | ✓ |  |  |
+| 125 | bitmap-read-an-image-through-a-pipe | ✓ | 517µs | 54.1 KB |
+| 126 | bitmap-write-a-ppm-file | ✓ | 361µs | 55.8 KB |
 | 127 | bitmap |   |  |  |
-| 128 | bitwise-io-1 | ✓ |  |  |
+| 128 | bitwise-io-1 | ✓ | 706µs | 76.2 KB |
 | 129 | bitwise-io-2 |   |  |  |
-| 130 | bitwise-operations |   |  |  |
-| 131 | blum-integer | ✓ |  |  |
+| 130 | bitwise-operations | ✓ | 359µs | 51.1 KB |
+| 131 | blum-integer | ✓ | 343µs | 57.0 KB |
 | 132 | boolean-values |   |  |  |
-| 133 | box-the-compass | ✓ |  |  |
-| 134 | boyer-moore-string-search | ✓ |  |  |
+| 133 | box-the-compass | ✓ | 397µs | 43.0 KB |
+| 134 | boyer-moore-string-search | ✓ | 328µs | 49.7 KB |
 | 135 | brazilian-numbers | ✓ |  |  |
 | 136 | break-oo-privacy | ✓ |  |  |
 | 137 | brilliant-numbers |   |  |  |
@@ -288,6 +288,32 @@ This file is auto-generated from rosetta tests.
 | 281 | deconvolution-1d |   |  |  |
 | 282 | deepcopy-1 |   |  |  |
 | 283 | define-a-primitive-data-type |   |  |  |
-| 284 | md5 |   |  |  |
+| 284 | delegates |   |  |  |
+| 285 | demings-funnel |   |  |  |
+| 286 | department-numbers |   |  |  |
+| 287 | descending-primes |   |  |  |
+| 288 | detect-division-by-zero |   |  |  |
+| 289 | determine-if-a-string-has-all-the-same-characters |   |  |  |
+| 290 | determine-if-a-string-has-all-unique-characters |   |  |  |
+| 291 | determine-if-a-string-is-collapsible |   |  |  |
+| 292 | determine-if-a-string-is-numeric-1 |   |  |  |
+| 293 | determine-if-a-string-is-numeric-2 |   |  |  |
+| 294 | determine-if-a-string-is-squeezable |   |  |  |
+| 295 | determine-if-only-one-instance-is-running |   |  |  |
+| 296 | determine-if-two-triangles-overlap |   |  |  |
+| 297 | determine-sentence-type |   |  |  |
+| 298 | dice-game-probabilities-1 |   |  |  |
+| 299 | dice-game-probabilities-2 |   |  |  |
+| 300 | digital-root-multiplicative-digital-root |   |  |  |
+| 301 | dijkstras-algorithm |   |  |  |
+| 302 | dinesmans-multiple-dwelling-problem |   |  |  |
+| 303 | dining-philosophers-1 |   |  |  |
+| 304 | dining-philosophers-2 |   |  |  |
+| 305 | disarium-numbers |   |  |  |
+| 306 | discordian-date |   |  |  |
+| 307 | display-a-linear-combination |   |  |  |
+| 308 | display-an-outline-as-a-nested-table |   |  |  |
+| 309 | documentation |   |  |  |
+| 310 | md5 |   |  |  |
 
-Last updated: 2025-07-26 10:43 +0700
+Last updated: 2025-07-26 12:01 +0700


### PR DESCRIPTION
## Summary
- handle field access on map/object types in F# transpiler
- regenerate Rosetta results
- add golden output for `bitmap-read-an-image-through-a-pipe`

## Testing
- `MOCHI_ROSETTA_INDEX=125 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -run Rosetta -count=1 -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_6884614b3c5c832080a18cead1f135fe