### PR TITLE
Add Mochi version for Doomsday rule task

### DIFF
--- a/tests/rosetta/x/Mochi/doomsday-rule.mochi
+++ b/tests/rosetta/x/Mochi/doomsday-rule.mochi
@@ -1,0 +1,71 @@
+// Mochi translation of the Go "Doomsday rule" example
+
+let days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+let firstDaysCommon = [3,7,7,4,2,6,4,1,5,3,7,5]
+let firstDaysLeap   = [4,1,7,4,2,6,4,1,5,3,7,5]
+
+fun anchorDay(y: int): int {
+  return (2 + 5*(y % 4) + 4*(y % 100) + 6*(y % 400)) % 7
+}
+
+fun isLeapYear(y: int): bool {
+  return y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)
+}
+
+fun parseIntStr(str: string): int {
+  var i = 0
+  var neg = false
+  if len(str) > 0 && str[0:1] == "-" {
+    neg = true
+    i = 1
+  }
+  var n = 0
+  let digits = {
+    "0": 0,
+    "1": 1,
+    "2": 2,
+    "3": 3,
+    "4": 4,
+    "5": 5,
+    "6": 6,
+    "7": 7,
+    "8": 8,
+    "9": 9,
+  }
+  while i < len(str) {
+    n = n * 10 + digits[str[i:i+1]]
+    i = i + 1
+  }
+  if neg { n = -n }
+  return n
+}
+
+fun main() {
+  let dates = [
+    "1800-01-06",
+    "1875-03-29",
+    "1915-12-07",
+    "1970-12-23",
+    "2043-05-14",
+    "2077-02-12",
+    "2101-04-02",
+  ]
+  print("Days of week given by Doomsday rule:")
+  var i = 0
+  while i < len(dates) {
+    let date = dates[i]
+    let y = parseIntStr(date[0:4])
+    let m = parseIntStr(date[5:7]) - 1
+    let d = parseIntStr(date[8:10])
+    let a = anchorDay(y)
+    var f = firstDaysCommon[m]
+    if isLeapYear(y) { f = firstDaysLeap[m] }
+    var w = d - f
+    if w < 0 { w = 7 + w }
+    let dow = (a + w) % 7
+    print(date + " -> " + days[dow])
+    i = i + 1
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/doomsday-rule.out
+++ b/tests/rosetta/x/Mochi/doomsday-rule.out
@@ -1,0 +1,8 @@
+Days of week given by Doomsday rule:
+1800-01-06 -> Monday
+1875-03-29 -> Monday
+1915-12-07 -> Tuesday
+1970-12-23 -> Wednesday
+2043-05-14 -> Thursday
+2077-02-12 -> Friday
+2101-04-02 -> Saturday


### PR DESCRIPTION
## Summary
- add Mochi translation for the Doomsday rule Rosetta task
- include expected output from running under the Mochi VM

## Testing
- `go run ./cmd/mochi/main.go run tests/rosetta/x/Mochi/doomsday-rule.mochi`

------
https://chatgpt.com/codex/tasks/task_e_688461ac90588320b5fdd111bfc468f2