### PR TITLE
Add doubly-linked list element example

### DIFF
--- a/tests/rosetta/x/Mochi/doubly-linked-list-element-definition.mochi
+++ b/tests/rosetta/x/Mochi/doubly-linked-list-element-definition.mochi
@@ -1,0 +1,28 @@
+// Mochi translation of Rosetta "Doubly-linked-list Element definition" task
+// Defines a Node type with next and prev pointers and iteration helpers
+
+type Node {
+  value: any
+  prev: any
+  next: any
+}
+
+fun iterForward(n: any): list<any> {
+  var vals: list<any> = []
+  var cur = n
+  while cur != null {
+    vals = append(vals, cur.value)
+    cur = cur.next
+  }
+  return vals
+}
+
+fun iterBackward(n: any): list<any> {
+  var vals: list<any> = []
+  var cur = n
+  while cur != null {
+    vals = append(vals, cur.value)
+    cur = cur.prev
+  }
+  return vals
+}


### PR DESCRIPTION
## Summary
- add a Mochi translation of the "Doubly-linked-list Element definition" Rosetta task
- include empty output file

## Testing
- `MOCHI_ROSETTA_ONLY=doubly-linked-list-element-definition go test ./runtime/vm -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688461b42df08320adbfb187f7f05534