### PR TITLE
Add doubly linked list traversal example

### DIFF
--- a/tests/rosetta/x/Mochi/doubly-linked-list-traversal.mochi
+++ b/tests/rosetta/x/Mochi/doubly-linked-list-traversal.mochi
@@ -1,0 +1,45 @@
+// Mochi implementation of Rosetta "Doubly-linked list/Traversal" task
+// Simplified translation of Go version.
+
+var nodes: map<int, map<string, any>> = {}
+var head: int = 0 - 1
+var tail: int = 0 - 1
+
+fun listString(): string {
+  if head == 0 - 1 { return "<nil>" }
+  var r = "[" + nodes[head]["value"]
+  var id = nodes[head]["next"] as int
+  while id != 0 - 1 {
+    r = r + " " + nodes[id]["value"]
+    id = nodes[id]["next"] as int
+  }
+  r = r + "]"
+  return r
+}
+
+print(listString())
+
+# insert A
+nodes[0] = {"value":"A", "next": 0 - 1, "prev": 0 - 1}
+head = 0
+tail = 0
+
+# insert B at tail
+nodes[1] = {"value":"B", "next": 0 - 1, "prev": 0}
+nodes[0]["next"] = 1
+tail = 1
+print(listString())
+
+# insert C after A
+nodes[2] = {"value":"C", "next": 1, "prev": 0}
+nodes[1]["prev"] = 2
+nodes[0]["next"] = 2
+print(listString())
+
+var out = "From tail:"
+var id = tail
+while id != 0 - 1 {
+  out = out + " " + nodes[id]["value"]
+  id = nodes[id]["prev"] as int
+}
+print(out)

--- a/tests/rosetta/x/Mochi/doubly-linked-list-traversal.out
+++ b/tests/rosetta/x/Mochi/doubly-linked-list-traversal.out
@@ -1,0 +1,4 @@
+<nil>
+[A B]
+[A C B]
+From tail: B C A


### PR DESCRIPTION
## Summary
- download Rosetta task 287 (Go code already present)
- implement the same program in Mochi
- add golden output for the new program

## Testing
- `MOCHI_ROSETTA_ONLY=doubly-linked-list-traversal go test ./runtime/vm -run Rosetta -tags slow`

------
https://chatgpt.com/codex/tasks/task_e_688461b4f5848320a01ec0e9370a5084