### PR TITLE
Add Mochi example for Draw-a-clock

### DIFF
--- a/tests/rosetta/x/Mochi/draw-a-clock.mochi
+++ b/tests/rosetta/x/Mochi/draw-a-clock.mochi
@@ -1,0 +1,57 @@
+// Binary clock drawing in Mochi
+// Mirrors the simple Python example from Rosetta
+
+fun pow2(exp: int): int {
+  var r = 1
+  var i = 0
+  while i < exp {
+    r = r * 2
+    i = i + 1
+  }
+  return r
+}
+
+fun bin(n: int, digits: int): string {
+  var s = ""
+  var i = digits - 1
+  while i >= 0 {
+    let p = pow2(i)
+    if n >= p {
+      s = s + "x"
+      n = n - p
+    } else {
+      s = s + " "
+    }
+    if i > 0 { s = s + "|" }
+    i = i - 1
+  }
+  return s
+}
+
+let t = now() / 1000000000
+let sec = t % 60
+let mins = t / 60
+let min = mins % 60
+let hour = (mins / 60) % 24
+
+print(bin(hour, 8))
+print("")
+print(bin(min, 8))
+print("")
+
+var xs = ""
+var i = 0
+while i < sec {
+  xs = xs + "x"
+  i = i + 1
+}
+var out = ""
+var j = 0
+while j < len(xs) {
+  out = out + substring(xs, j, j+1)
+  if (j + 1) % 5 == 0 && j + 1 < len(xs) {
+    out = out + "|"
+  }
+  j = j + 1
+}
+print(out)

--- a/tests/rosetta/x/Mochi/draw-a-clock.out
+++ b/tests/rosetta/x/Mochi/draw-a-clock.out
@@ -1,0 +1,5 @@
+ | | | | |x| |x
+
+ | | | |x| |x|x
+
+xxxxx|xxxxx|xxxxx|xxxxx


### PR DESCRIPTION
## Summary
- add Mochi implementation of the Rosetta task "Draw-a-clock"

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/draw-a-clock.mochi`

------
https://chatgpt.com/codex/tasks/task_e_688461b6dfa483208e32c91a82ddc8a6