### PR TITLE
Add Mochi solution for Rosetta 'Draw a pixel' task

### DIFF
--- a/tests/rosetta/x/Mochi/draw-a-pixel-1.mochi
+++ b/tests/rosetta/x/Mochi/draw-a-pixel-1.mochi
@@ -1,0 +1,20 @@
+let width = 320
+let height = 240
+
+var img: list<list<string>> = []
+var y = 0
+while y < height {
+  var row: list<string> = []
+  var x = 0
+  while x < width {
+    row = append(row, "green")
+    x = x + 1
+  }
+  img = append(img, row)
+  y = y + 1
+}
+
+img[100][100] = "red"
+
+print("The color of the pixel at (  0,   0) is " + img[0][0] + ".")
+print("The color of the pixel at (100, 100) is " + img[100][100] + ".")

--- a/tests/rosetta/x/Mochi/draw-a-pixel-1.out
+++ b/tests/rosetta/x/Mochi/draw-a-pixel-1.out
@@ -1,0 +1,2 @@
+The color of the pixel at (  0,   0) is green.
+The color of the pixel at (100, 100) is red.


### PR DESCRIPTION
## Summary
- download Rosetta task #291 (Draw-a-pixel) using rosetta tools
- add Mochi translation for the Draw-a-pixel Go example
- include runtime/vm output for the program

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/draw-a-pixel-1.mochi`

------
https://chatgpt.com/codex/tasks/task_e_688461bcb6fc83209563c23e00681f53