### PR TITLE
Add Eban numbers Rosetta task

### DIFF
--- a/tests/rosetta/x/Go/eban-numbers.go
+++ b/tests/rosetta/x/Go/eban-numbers.go
@@ -6,60 +6,60 @@ package main
 import "fmt"
 
 type Range struct {
-    start, end uint64
-    print      bool
+	start, end uint64
+	print      bool
 }
 
 func main() {
-    rgs := []Range{
-        {2, 1000, true},
-        {1000, 4000, true},
-        {2, 1e4, false},
-        {2, 1e5, false},
-        {2, 1e6, false},
-        {2, 1e7, false},
-        {2, 1e8, false},
-        {2, 1e9, false},
-    }
-    for _, rg := range rgs {
-        if rg.start == 2 {
-            fmt.Printf("eban numbers up to and including %d:\n", rg.end)
-        } else {
-            fmt.Printf("eban numbers between %d and %d (inclusive):\n", rg.start, rg.end)
-        }
-        count := 0
-        for i := rg.start; i <= rg.end; i += 2 {
-            b := i / 1000000000
-            r := i % 1000000000
-            m := r / 1000000
-            r = i % 1000000
-            t := r / 1000
-            r %= 1000
-            if m >= 30 && m <= 66 {
-                m %= 10
-            }
-            if t >= 30 && t <= 66 {
-                t %= 10
-            }
-            if r >= 30 && r <= 66 {
-                r %= 10
-            }
-            if b == 0 || b == 2 || b == 4 || b == 6 {
-                if m == 0 || m == 2 || m == 4 || m == 6 {
-                    if t == 0 || t == 2 || t == 4 || t == 6 {
-                        if r == 0 || r == 2 || r == 4 || r == 6 {
-                            if rg.print {
-                                fmt.Printf("%d ", i)
-                            }
-                            count++
-                        }
-                    }
-                }
-            }
-        }
-        if rg.print {
-            fmt.Println()
-        }
-        fmt.Println("count =", count, "\n")
-    }
+	rgs := []Range{
+		{2, 1000, true},
+		{1000, 4000, true},
+		{2, 1e4, false},
+		{2, 1e5, false},
+		{2, 1e6, false},
+		{2, 1e7, false},
+		{2, 1e8, false},
+		{2, 1e9, false},
+	}
+	for _, rg := range rgs {
+		if rg.start == 2 {
+			fmt.Printf("eban numbers up to and including %d:\n", rg.end)
+		} else {
+			fmt.Printf("eban numbers between %d and %d (inclusive):\n", rg.start, rg.end)
+		}
+		count := 0
+		for i := rg.start; i <= rg.end; i += 2 {
+			b := i / 1000000000
+			r := i % 1000000000
+			m := r / 1000000
+			r = i % 1000000
+			t := r / 1000
+			r %= 1000
+			if m >= 30 && m <= 66 {
+				m %= 10
+			}
+			if t >= 30 && t <= 66 {
+				t %= 10
+			}
+			if r >= 30 && r <= 66 {
+				r %= 10
+			}
+			if b == 0 || b == 2 || b == 4 || b == 6 {
+				if m == 0 || m == 2 || m == 4 || m == 6 {
+					if t == 0 || t == 2 || t == 4 || t == 6 {
+						if r == 0 || r == 2 || r == 4 || r == 6 {
+							if rg.print {
+								fmt.Printf("%d ", i)
+							}
+							count++
+						}
+					}
+				}
+			}
+		}
+		if rg.print {
+			fmt.Println()
+		}
+		fmt.Println("count =", count, "\n")
+	}
 }

--- a/tests/rosetta/x/Mochi/eban-numbers.mochi
+++ b/tests/rosetta/x/Mochi/eban-numbers.mochi
@@ -1,0 +1,73 @@
+let vals = [0,2,4,6,30,32,34,36,40,42,44,46,50,52,54,56,60,62,64,66]
+let billions = [0,2,4,6]
+
+fun ebanNumbers(start: int, stop: int): list<int> {
+  var nums: list<int> = []
+  for b in billions {
+    for m in vals {
+      for t in vals {
+        for r in vals {
+          let n = b*1000000000 + m*1000000 + t*1000 + r
+          if (n >= start) && (n <= stop) {
+            nums = append(nums, n)
+          }
+        }
+      }
+    }
+  }
+  return nums
+}
+
+fun countEban(start: int, stop: int): int {
+  var count = 0
+  for b in billions {
+    for m in vals {
+      for t in vals {
+        for r in vals {
+          let n = b*1000000000 + m*1000000 + t*1000 + r
+          if (n >= start) && (n <= stop) {
+            count = count + 1
+          }
+        }
+      }
+    }
+  }
+  return count
+}
+
+fun main() {
+  let ranges = [
+    [2, 1000, true],
+    [1000, 4000, true],
+    [2, 10000, false],
+    [2, 100000, false],
+    [2, 1000000, false],
+    [2, 10000000, false],
+    [2, 100000000, false],
+    [2, 1000000000, false],
+  ]
+  for rg in ranges {
+    let start = rg[0] as int
+    let stop = rg[1] as int
+    let show = rg[2] as bool
+    if start == 2 {
+      print("eban numbers up to and including " + str(stop) + ":")
+    } else {
+      print("eban numbers between " + str(start) + " and " + str(stop) + " (inclusive):")
+    }
+    if show {
+      let nums = ebanNumbers(start, stop)
+      var line = ""
+      var i = 0
+      while i < len(nums) {
+        line = line + str(nums[i]) + " "
+        i = i + 1
+      }
+      if len(line) > 0 { print(substring(line, 0, len(line)-1)) }
+    }
+    let c = countEban(start, stop)
+    print("count = " + str(c) + "\n")
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/eban-numbers.out
+++ b/tests/rosetta/x/Mochi/eban-numbers.out
@@ -1,0 +1,26 @@
+eban numbers up to and including 1000:
+2 4 6 30 32 34 36 40 42 44 46 50 52 54 56 60 62 64 66
+count = 19
+
+eban numbers between 1000 and 4000 (inclusive):
+2000 2002 2004 2006 2030 2032 2034 2036 2040 2042 2044 2046 2050 2052 2054 2056 2060 2062 2064 2066 4000
+count = 21
+
+eban numbers up to and including 10000:
+count = 79
+
+eban numbers up to and including 100000:
+count = 399
+
+eban numbers up to and including 1000000:
+count = 399
+
+eban numbers up to and including 10000000:
+count = 1599
+
+eban numbers up to and including 100000000:
+count = 7999
+
+eban numbers up to and including 1000000000:
+count = 7999
+


### PR DESCRIPTION
## Summary
- add Go reference for the Eban numbers task
- implement `eban-numbers` in Mochi using combinatorial generation
- include expected output from running with `runtime/vm`

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/eban-numbers.mochi > /tmp/eban.out`

------
https://chatgpt.com/codex/tasks/task_e_688461c72264832085ad2189515d78a3