### PR TITLE
Add release notes for v0.10.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 📦 CHANGELOG.md
 
+## [0.10.41] – 2025-07-26T12:01:29+07:00
+
+### Added
+
+* Mochi solutions for many new Rosetta tasks including Dijkstra's algorithm and dining philosophers
+* Slice builtin and forward references in the VM with else-if and bigrat cast support
+* Transpiler updates across Go, F#, Scala, Swift, TypeScript, Java and C++ with new builtins and benchmark features
+* Benchmarks and golden outputs refreshed across languages
+
+### Changed
+
+* Improved index handling and casting logic in multiple backends
+* Documentation and progress logs updated for various transpilers
+
+### Fixed
+
+* Numerous compiler issues such as foreach handling in Go and int64 casts in F#
 ## [0.10.40] – 2025-07-25T10:01:54+07:00
 
 ### Added

--- a/releases/v0.10.41.md
+++ b/releases/v0.10.41.md
@@ -1,0 +1,19 @@
+# Jul 2025 (v0.10.41)
+
+Released on Sat Jul 26 12:01:29 2025 +0700.
+
+Mochi v0.10.41 expands Rosetta coverage and updates many transpilers with new builtins, benchmark features and fixes.
+
+## Compilers
+
+- Numerous new Mochi solutions including Dijkstra's algorithm, dining philosophers and digital root
+- Slice builtin, forward references and else-if support added to the VM with bigrat casts and improved main handling
+- Go transpiler gains object methods, inner function types, empty list casts and pow/repeat helpers
+- F#, Scala and Swift improve casting and indexing with new substr, _int and BigRat features plus wider Rosetta indices
+- TypeScript, Java, C++ and others updated with SHA256, 64-bit integers, generic arrays and bench mode refinements
+- Benchmarks and golden outputs refreshed across languages
+
+## Documentation
+
+- Rosetta progress tables and README timestamps updated
+- Obsolete files removed with new docs for various transpilers


### PR DESCRIPTION
## Summary
- document new features in CHANGELOG
- add release notes for v0.10.41

## Testing
- `go test ./... --run TestFoo`

------
https://chatgpt.com/codex/tasks/task_e_688462121d548320b851ee3df6cae021