### PR TITLE
Improve Java transpiler

### DIFF
--- a/tests/rosetta/transpiler/Java/bitcoin-address-validation.bench
+++ b/tests/rosetta/transpiler/Java/bitcoin-address-validation.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 79428,
+  "duration_us": 34084,
   "memory_bytes": 258464,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/bitcoin-address-validation.java
+++ b/tests/rosetta/transpiler/Java/bitcoin-address-validation.java
@@ -70,18 +70,52 @@ a[j] = ((Number)(Math.floorMod(c, 256))).intValue();
         return true;
     }
     public static void main(String[] args) {
-        System.out.println(String.valueOf(validA58("1AGNa15ZQXAZUgFiqJ3i7Z2DPU2J6hW62i")));
-        System.out.println(String.valueOf(validA58("17NdbrSGoUotzeGCcMMCqnFkEvLymoou9j")));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(validA58("1AGNa15ZQXAZUgFiqJ3i7Z2DPU2J6hW62i")));
+            System.out.println(String.valueOf(validA58("17NdbrSGoUotzeGCcMMCqnFkEvLymoou9j")));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static int[] _sha256(int[] bs) {
         try {
-            byte[] b = new byte[bs.length];
-            for (int i = 0; i < bs.length; i++) b[i] = (byte)bs[i];
             java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
-            byte[] h = md.digest(b);
-            int[] out = new int[h.length];
-            for (int i = 0; i < h.length; i++) out[i] = h[i] & 0xFF;
+            byte[] bytes = new byte[bs.length];
+            for (int i = 0; i < bs.length; i++) bytes[i] = (byte)bs[i];
+            byte[] hash = md.digest(bytes);
+            int[] out = new int[hash.length];
+            for (int i = 0; i < hash.length; i++) out[i] = hash[i] & 0xff;
             return out;
         } catch (Exception e) { return new int[0]; }
     }

--- a/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-cubic.bench
+++ b/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-cubic.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 23719,
+  "memory_bytes": -2878472,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-cubic.error
+++ b/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-cubic.error
@@ -1,8 +1,0 @@
-compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Goldenbitmap-b-zier-curves-cubic3340706997/001/Main.java:46: error: array required, but Object found
-((Object)b.get("data"))[y][x] = p;
-                       ^
-/tmp/TestJavaTranspiler_Rosetta_Goldenbitmap-b-zier-curves-cubic3340706997/001/Main.java:57: error: array required, but Object found
-((Object)b.get("data"))[y][x] = p;
-                       ^
-2 errors

--- a/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-quadratic.bench
+++ b/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-quadratic.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 40602,
+  "memory_bytes": -2878472,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-quadratic.java
+++ b/tests/rosetta/transpiler/Java/bitmap-b-zier-curves-quadratic.java
@@ -1,5 +1,5 @@
 public class Main {
-    static int b3Seg = 30;
+    static int b2Seg = 20;
     static class Pixel {
         int r;
         int g;
@@ -100,11 +100,11 @@ public class Main {
         }
     }
 
-    static void bezier3(java.util.Map<String,Object> b, int x1, int y1, int x2, int y2, int x3, int y3, int x4, int y4, Pixel p) {
+    static void bezier2(java.util.Map<String,Object> b, int x1, int y1, int x2, int y2, int x3, int y3, Pixel p) {
         int[] px = new int[]{};
         int[] py = new int[]{};
         int i = 0;
-        while (i <= b3Seg) {
+        while (i <= b2Seg) {
             px = java.util.stream.IntStream.concat(java.util.Arrays.stream(px), java.util.stream.IntStream.of(0)).toArray();
             py = java.util.stream.IntStream.concat(java.util.Arrays.stream(py), java.util.stream.IntStream.of(0)).toArray();
             i = i + 1;
@@ -115,26 +115,21 @@ public class Main {
         double fy2 = ((Number)(y2)).doubleValue();
         double fx3 = ((Number)(x3)).doubleValue();
         double fy3 = ((Number)(y3)).doubleValue();
-        double fx4 = ((Number)(x4)).doubleValue();
-        double fy4 = ((Number)(y4)).doubleValue();
         i = 0;
-        while (i <= b3Seg) {
-            double d = (((Number)(i)).doubleValue()) / (((Number)(b3Seg)).doubleValue());
-            double a = 1.0 - d;
-            double bcoef = a * a;
-            double ccoef = d * d;
-            double a2 = a * bcoef;
-            double b2 = 3.0 * bcoef * d;
-            double c2 = 3.0 * a * ccoef;
-            double d2 = ccoef * d;
-px[i] = ((Number)((a2 * fx1 + b2 * fx2 + c2 * fx3 + d2 * fx4))).intValue();
-py[i] = ((Number)((a2 * fy1 + b2 * fy2 + c2 * fy3 + d2 * fy4))).intValue();
+        while (i <= b2Seg) {
+            double c = (((Number)(i)).doubleValue()) / (((Number)(b2Seg)).doubleValue());
+            double a = 1.0 - c;
+            double a2 = a * a;
+            double b2 = 2.0 * c * a;
+            double c2 = c * c;
+px[i] = ((Number)((a2 * fx1 + b2 * fx2 + c2 * fx3))).intValue();
+py[i] = ((Number)((a2 * fy1 + b2 * fy2 + c2 * fy3))).intValue();
             i = i + 1;
         }
         int x0 = px[0];
         int y0 = py[0];
         i = 1;
-        while (i <= b3Seg) {
+        while (i <= b2Seg) {
             int x = px[i];
             int y = py[i];
             line(b, x0, y0, x, y, p);
@@ -147,8 +142,8 @@ py[i] = ((Number)((a2 * fy1 + b2 * fy2 + c2 * fy3 + d2 * fy4))).intValue();
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            fillRgb(b, 16773055);
-            bezier3(b, 20, 200, 700, 50, -300, 50, 380, 150, pixelFromRgb(4165615));
+            fillRgb(b, 14614575);
+            bezier2(b, 20, 150, 500, -100, 300, 280, pixelFromRgb(4165615));
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
             System.out.println("{");

--- a/tests/rosetta/transpiler/Java/bitmap-bresenhams-line-algorithm.bench
+++ b/tests/rosetta/transpiler/Java/bitmap-bresenhams-line-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 22524,
+  "memory_bytes": 94560,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/bitmap-bresenhams-line-algorithm.java
+++ b/tests/rosetta/transpiler/Java/bitmap-bresenhams-line-algorithm.java
@@ -1,0 +1,99 @@
+public class Main {
+    static class Point {
+        int x;
+        int y;
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+        @Override public String toString() {
+            return String.format("{'x': %s, 'y': %s}", String.valueOf(x), String.valueOf(y));
+        }
+    }
+
+
+    static int absi(int x) {
+        if (x < 0) {
+            return -x;
+        }
+        return x;
+    }
+
+    static Point[] bresenham(int x0, int y0, int x1, int y1) {
+        int dx = absi(x1 - x0);
+        int dy = absi(y1 - y0);
+        int sx = -1;
+        if (x0 < x1) {
+            sx = 1;
+        }
+        int sy = -1;
+        if (y0 < y1) {
+            sy = 1;
+        }
+        int err = dx - dy;
+        Point[] pts = new Point[]{};
+        while (true) {
+            pts = java.util.stream.Stream.concat(java.util.Arrays.stream(pts), java.util.stream.Stream.of(new Point(x0, y0))).toArray(Point[]::new);
+            if (x0 == x1 && y0 == y1) {
+                break;
+            }
+            int e2 = 2 * err;
+            if (e2 > (-dy)) {
+                err = err - dy;
+                x0 = x0 + sx;
+            }
+            if (e2 < dx) {
+                err = err + dx;
+                y0 = y0 + sy;
+            }
+        }
+        return pts;
+    }
+
+    static void main() {
+        Point[] pts = bresenham(0, 0, 6, 4);
+        int i = 0;
+        while (i < pts.length) {
+            Point p = pts[i];
+            System.out.println("(" + String.valueOf(p.x) + "," + String.valueOf(p.y) + ")");
+            i = i + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-26 10:21 GMT+7
+Last updated: 2025-07-26 17:42 GMT+7
 
-## Rosetta Checklist (113/284)
+## Rosetta Checklist (120/332)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -21,272 +21,320 @@ Last updated: 2025-07-26 10:21 GMT+7
 | 13 | 99-bottles-of-beer-2 | ✓ | 63.0ms | 6.96MB |
 | 14 | 99-bottles-of-beer | ✓ | 14.0ms | 0B |
 | 15 | DNS-query | ✓ | 391.0µs | 0B |
-| 16 | a+b | ✓ | 1.0ms | 0B |
-| 17 | abbreviations-automatic | ✓ | 44.0ms | 2.96MB |
-| 18 | abbreviations-easy | ✓ | 23.0ms | 491.63KB |
-| 19 | abbreviations-simple | ✓ | 39.0ms | 737.39KB |
-| 20 | abc-problem | ✓ | 22.0ms | 737.38KB |
-| 21 | abelian-sandpile-model-identity | ✓ | 16.0ms | 491.65KB |
-| 22 | abelian-sandpile-model | ✓ | 10.0ms | 245.78KB |
-| 23 | abstract-type | ✓ | 25.0ms | 245.84KB |
-| 24 | abundant-deficient-and-perfect-number-classifications | ✓ | 205.0ms | 245.78KB |
-| 25 | abundant-odd-numbers | ✓ | 554.0ms | 95.51MB |
-| 26 | accumulator-factory | ✓ | 4.0ms | 0B |
-| 27 | achilles-numbers | ✓ | 54.0ms | 10.33MB |
-| 28 | ackermann-function-2 | ✓ | 5.0ms | 0B |
-| 29 | ackermann-function-3 | ✓ | 160.47s | 11.78MB |
-| 30 | ackermann-function | ✓ | 5.0ms | 0B |
-| 31 | active-directory-connect | ✓ | 5.0ms | 0B |
-| 32 | active-directory-search-for-a-user | ✓ | 20.0ms | 246.02KB |
-| 33 | active-object | ✓ | 710.0µs | 0B |
-| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 4.0ms | 0B |
-| 35 | additive-primes | ✓ | 14.0ms | 0B |
-| 36 | address-of-a-variable | ✓ | 11.0ms | 245.78KB |
-| 37 | adfgvx-cipher |   |  |  |
-| 38 | aks-test-for-primes | ✓ | 14.0ms | 245.79KB |
-| 39 | algebraic-data-types | ✓ | 15.0ms | 245.98KB |
-| 40 | align-columns | ✓ | 11.0ms | 491.66KB |
-| 41 | aliquot-sequence-classifications | ✓ | 19.0ms | 491.59KB |
-| 42 | almkvist-giullera-formula-for-pi | ✓ | 227.0ms | 63.45MB |
-| 43 | almost-prime | ✓ | 9.0ms | 0B |
-| 44 | amb | ✓ | 16.0ms | 245.88KB |
-| 45 | amicable-pairs | ✓ | 405.0ms | 80.72MB |
-| 46 | anagrams-deranged-anagrams | ✓ | 9.0ms | 245.78KB |
-| 47 | anagrams | ✓ | 21.0ms | 491.59KB |
-| 48 | angle-difference-between-two-bearings-1 | ✓ | 627.0µs | 0B |
-| 49 | angle-difference-between-two-bearings-2 | ✓ | 802.0µs | 0B |
-| 50 | angles-geometric-normalization-and-conversion | ✓ | 9.0ms | 245.78KB |
-| 51 | animate-a-pendulum | ✓ | 634.0µs | 0B |
-| 52 | animation | ✓ | 11.0ms | 0B |
-| 53 | anonymous-recursion-1 | ✓ | 7.0ms | 0B |
-| 54 | anonymous-recursion-2 | ✓ | 8.0ms | 0B |
-| 55 | anonymous-recursion | ✓ | 10.0ms | 0B |
-| 56 | anti-primes | ✓ | 44.0ms | 0B |
-| 57 | append-a-record-to-the-end-of-a-text-file | ✓ | 9.0ms | 0B |
-| 58 | apply-a-callback-to-an-array-1 | ✓ | 517.0µs | 0B |
-| 59 | apply-a-callback-to-an-array-2 | ✓ | 23.0ms | 0B |
-| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 1.0ms | 0B |
-| 61 | approximate-equality | ✓ | 15.0ms | 48.33KB |
-| 62 | arbitrary-precision-integers-included- | ✓ | 22.0ms | 65.13KB |
-| 63 | archimedean-spiral | ✓ | 23.0ms | 47.97KB |
-| 64 | arena-storage-pool | ✓ | 13.0ms | 46.47KB |
-| 65 | arithmetic-complex | ✓ | 13.0ms | 50.62KB |
-| 66 | arithmetic-derivative | ✓ | 23.0ms | 56.12KB |
-| 67 | arithmetic-evaluation | ✓ | 10.0ms | 38.70KB |
-| 68 | arithmetic-geometric-mean-calculate-pi | ✓ | 6.0ms | 10.35KB |
-| 69 | arithmetic-geometric-mean | ✓ | 6.0ms | 10.35KB |
-| 70 | arithmetic-integer-1 | ✓ | 23.0ms | 40.70KB |
-| 71 | arithmetic-integer-2 | ✓ | 10.0ms | 40.70KB |
-| 72 | arithmetic-numbers | ✓ |  |  |
-| 73 | arithmetic-rational | ✓ | 24.0ms | 39.38KB |
-| 74 | array-concatenation | ✓ | 14.0ms | 47.89KB |
-| 75 | array-length | ✓ | 11.0ms | 39.15KB |
-| 76 | arrays | ✓ | 16.0ms | 58.69KB |
-| 77 | ascending-primes | ✓ | 18.0ms | 55.77KB |
-| 78 | ascii-art-diagram-converter | ✓ | 6.0ms | 3.63KB |
-| 79 | assertions | ✓ | 5.0ms | 504B |
-| 80 | associative-array-creation | ✓ | 19.0ms | 94.27KB |
-| 81 | associative-array-iteration | ✓ | 11.0ms | 39.91KB |
-| 82 | associative-array-merging | ✓ | 6.0ms | 11.35KB |
-| 83 | atomic-updates | ✓ | 14.0ms | 55.44KB |
-| 84 | attractive-numbers | ✓ | 13.0ms | 39.11KB |
-| 85 | average-loop-length | ✓ | 77.0ms | 91.09KB |
-| 86 | averages-arithmetic-mean | ✓ | 12.0ms | 49.51KB |
-| 87 | averages-mean-time-of-day | ✓ | 17.0ms | 77.97KB |
-| 88 | averages-median-1 | ✓ | 6.0ms | 10.35KB |
-| 89 | averages-median-2 | ✓ | 13.0ms | 10.35KB |
-| 90 | averages-median-3 | ✓ | 7.0ms | 10.45KB |
-| 91 | averages-mode | ✓ | 16.0ms | 46.71KB |
-| 92 | averages-pythagorean-means | ✓ | 14.0ms | 49.09KB |
-| 93 | averages-root-mean-square | ✓ | 21.0ms | 448B |
-| 94 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
-| 95 | avl-tree |   |  |  |
-| 96 | b-zier-curves-intersections |   |  |  |
-| 97 | babbage-problem | ✓ | 28.0ms | 38.90KB |
-| 98 | babylonian-spiral | ✓ | 31.0ms | 40.02KB |
-| 99 | balanced-brackets | ✓ | 27.0ms | 54.56KB |
-| 100 | balanced-ternary | ✓ | 19.0ms | 56.83KB |
-| 101 | barnsley-fern | ✓ | 167.0ms | 81.71KB |
-| 102 | base64-decode-data | ✓ | 18.0ms | 5.48KB |
-| 103 | bell-numbers | ✓ | 53.0ms | 64.29KB |
-| 104 | benfords-law | ✓ | 91.0ms | 106.47KB |
-| 105 | bernoulli-numbers | ✓ | 335.0ms | 104.32KB |
-| 106 | best-shuffle | ✓ | 60.0ms | 101.66KB |
-| 107 | bifid-cipher | ✓ | 65.0ms | 100.41KB |
-| 108 | bin-given-limits | ✓ | 68.0ms | 122.30KB |
-| 109 | binary-digits | ✓ | 28.0ms | 32.82KB |
-| 110 | binary-search | ✓ | 48.0ms | 79.30KB |
-| 111 | binary-strings | ✓ | 37.0ms | 47.36KB |
-| 112 | bioinformatics-base-count | ✓ | 50.0ms | 81.38KB |
-| 113 | bioinformatics-global-alignment | ✓ | 770.0ms | 91.08KB |
-| 114 | bioinformatics-sequence-mutation | ✓ | 95.0ms | 125.98KB |
-| 115 | biorhythms | ✓ | 63.0ms | 126.57KB |
-| 116 | bitcoin-address-validation | ✓ | 79.0ms | 252.41KB |
-| 117 | bitmap-b-zier-curves-cubic |   |  |  |
-| 118 | bitmap-b-zier-curves-quadratic |   |  |  |
-| 119 | bitmap-bresenhams-line-algorithm |   |  |  |
-| 120 | bitmap-flood-fill |   |  |  |
-| 121 | bitmap-histogram |   |  |  |
-| 122 | bitmap-midpoint-circle-algorithm |   |  |  |
-| 123 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
-| 124 | bitmap-read-a-ppm-file |   |  |  |
-| 125 | bitmap-read-an-image-through-a-pipe |   |  |  |
-| 126 | bitmap-write-a-ppm-file |   |  |  |
-| 127 | bitmap |   |  |  |
-| 128 | bitwise-io-1 |   |  |  |
-| 129 | bitwise-io-2 |   |  |  |
-| 130 | bitwise-operations |   |  |  |
-| 131 | blum-integer |   |  |  |
-| 132 | boolean-values |   |  |  |
-| 133 | box-the-compass |   |  |  |
-| 134 | boyer-moore-string-search |   |  |  |
-| 135 | brazilian-numbers |   |  |  |
-| 136 | break-oo-privacy |   |  |  |
-| 137 | brilliant-numbers |   |  |  |
-| 138 | brownian-tree |   |  |  |
-| 139 | bulls-and-cows-player |   |  |  |
-| 140 | bulls-and-cows |   |  |  |
-| 141 | burrows-wheeler-transform |   |  |  |
-| 142 | caesar-cipher-1 |   |  |  |
-| 143 | caesar-cipher-2 |   |  |  |
-| 144 | calculating-the-value-of-e |   |  |  |
-| 145 | calendar---for-real-programmers-1 |   |  |  |
-| 146 | calendar---for-real-programmers-2 |   |  |  |
-| 147 | calendar |   |  |  |
-| 148 | calkin-wilf-sequence |   |  |  |
-| 149 | call-a-foreign-language-function |   |  |  |
-| 150 | call-a-function-1 |   |  |  |
-| 151 | call-a-function-10 |   |  |  |
-| 152 | call-a-function-11 |   |  |  |
-| 153 | call-a-function-12 |   |  |  |
-| 154 | call-a-function-2 |   |  |  |
-| 155 | call-a-function-3 |   |  |  |
-| 156 | call-a-function-4 |   |  |  |
-| 157 | call-a-function-5 |   |  |  |
-| 158 | call-a-function-6 |   |  |  |
-| 159 | call-a-function-7 |   |  |  |
-| 160 | call-a-function-8 |   |  |  |
-| 161 | call-a-function-9 |   |  |  |
-| 162 | call-an-object-method-1 |   |  |  |
-| 163 | call-an-object-method-2 |   |  |  |
-| 164 | call-an-object-method-3 |   |  |  |
-| 165 | call-an-object-method |   |  |  |
-| 166 | camel-case-and-snake-case |   |  |  |
-| 167 | canny-edge-detector |   |  |  |
-| 168 | canonicalize-cidr |   |  |  |
-| 169 | cantor-set |   |  |  |
-| 170 | carmichael-3-strong-pseudoprimes |   |  |  |
-| 171 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
-| 172 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
-| 173 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
-| 174 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
-| 175 | case-sensitivity-of-identifiers |   |  |  |
-| 176 | casting-out-nines |   |  |  |
-| 177 | catalan-numbers-1 |   |  |  |
-| 178 | catalan-numbers-2 |   |  |  |
-| 179 | catalan-numbers-pascals-triangle |   |  |  |
-| 180 | catamorphism |   |  |  |
-| 181 | catmull-clark-subdivision-surface |   |  |  |
-| 182 | chaocipher |   |  |  |
-| 183 | chaos-game |   |  |  |
-| 184 | character-codes-1 |   |  |  |
-| 185 | character-codes-2 |   |  |  |
-| 186 | character-codes-3 |   |  |  |
-| 187 | character-codes-4 |   |  |  |
-| 188 | character-codes-5 |   |  |  |
-| 189 | chat-server |   |  |  |
-| 190 | check-machin-like-formulas |   |  |  |
-| 191 | check-that-file-exists |   |  |  |
-| 192 | checkpoint-synchronization-1 |   |  |  |
-| 193 | checkpoint-synchronization-2 |   |  |  |
-| 194 | checkpoint-synchronization-3 |   |  |  |
-| 195 | checkpoint-synchronization-4 |   |  |  |
-| 196 | chernicks-carmichael-numbers |   |  |  |
-| 197 | cheryls-birthday |   |  |  |
-| 198 | chinese-remainder-theorem |   |  |  |
-| 199 | chinese-zodiac |   |  |  |
-| 200 | cholesky-decomposition-1 |   |  |  |
-| 201 | cholesky-decomposition |   |  |  |
-| 202 | chowla-numbers |   |  |  |
-| 203 | church-numerals-1 |   |  |  |
-| 204 | church-numerals-2 |   |  |  |
-| 205 | circles-of-given-radius-through-two-points |   |  |  |
-| 206 | circular-primes |   |  |  |
-| 207 | cistercian-numerals |   |  |  |
-| 208 | comma-quibbling |   |  |  |
-| 209 | compiler-virtual-machine-interpreter |   |  |  |
-| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
-| 211 | compound-data-type |   |  |  |
-| 212 | concurrent-computing-1 |   |  |  |
-| 213 | concurrent-computing-2 |   |  |  |
-| 214 | concurrent-computing-3 |   |  |  |
-| 215 | conditional-structures-1 |   |  |  |
-| 216 | conditional-structures-10 |   |  |  |
-| 217 | conditional-structures-2 |   |  |  |
-| 218 | conditional-structures-3 |   |  |  |
-| 219 | conditional-structures-4 |   |  |  |
-| 220 | conditional-structures-5 |   |  |  |
-| 221 | conditional-structures-6 |   |  |  |
-| 222 | conditional-structures-7 |   |  |  |
-| 223 | conditional-structures-8 |   |  |  |
-| 224 | conditional-structures-9 |   |  |  |
-| 225 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
-| 226 | constrained-genericity-1 |   |  |  |
-| 227 | constrained-genericity-2 |   |  |  |
-| 228 | constrained-genericity-3 |   |  |  |
-| 229 | constrained-genericity-4 |   |  |  |
-| 230 | constrained-random-points-on-a-circle-1 |   |  |  |
-| 231 | constrained-random-points-on-a-circle-2 |   |  |  |
-| 232 | continued-fraction |   |  |  |
-| 233 | convert-decimal-number-to-rational |   |  |  |
-| 234 | convert-seconds-to-compound-duration |   |  |  |
-| 235 | convex-hull |   |  |  |
-| 236 | conways-game-of-life |   |  |  |
-| 237 | copy-a-string-1 |   |  |  |
-| 238 | copy-a-string-2 |   |  |  |
-| 239 | copy-stdin-to-stdout-1 |   |  |  |
-| 240 | copy-stdin-to-stdout-2 |   |  |  |
-| 241 | count-in-factors |   |  |  |
-| 242 | count-in-octal-1 |   |  |  |
-| 243 | count-in-octal-2 |   |  |  |
-| 244 | count-in-octal-3 |   |  |  |
-| 245 | count-in-octal-4 |   |  |  |
-| 246 | count-occurrences-of-a-substring |   |  |  |
-| 247 | count-the-coins-1 |   |  |  |
-| 248 | count-the-coins-2 |   |  |  |
-| 249 | cramers-rule |   |  |  |
-| 250 | crc-32-1 |   |  |  |
-| 251 | crc-32-2 |   |  |  |
-| 252 | create-a-file-on-magnetic-tape |   |  |  |
-| 253 | create-a-file |   |  |  |
-| 254 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
-| 255 | create-an-html-table |   |  |  |
-| 256 | create-an-object-at-a-given-address |   |  |  |
-| 257 | csv-data-manipulation |   |  |  |
-| 258 | csv-to-html-translation-1 |   |  |  |
-| 259 | csv-to-html-translation-2 |   |  |  |
-| 260 | csv-to-html-translation-3 |   |  |  |
-| 261 | csv-to-html-translation-4 |   |  |  |
-| 262 | csv-to-html-translation-5 |   |  |  |
-| 263 | cuban-primes |   |  |  |
-| 264 | cullen-and-woodall-numbers |   |  |  |
-| 265 | cumulative-standard-deviation |   |  |  |
-| 266 | currency |   |  |  |
-| 267 | currying |   |  |  |
-| 268 | curzon-numbers |   |  |  |
-| 269 | cusip |   |  |  |
-| 270 | cyclops-numbers |   |  |  |
-| 271 | damm-algorithm |   |  |  |
-| 272 | date-format |   |  |  |
-| 273 | date-manipulation |   |  |  |
-| 274 | day-of-the-week |   |  |  |
-| 275 | de-bruijn-sequences |   |  |  |
-| 276 | deal-cards-for-freecell |   |  |  |
-| 277 | death-star |   |  |  |
-| 278 | deceptive-numbers |   |  |  |
-| 279 | deconvolution-1d-2 |   |  |  |
-| 280 | deconvolution-1d-3 |   |  |  |
-| 281 | deconvolution-1d |   |  |  |
-| 282 | deepcopy-1 |   |  |  |
-| 283 | define-a-primitive-data-type |   |  |  |
-| 284 | md5 |   |  |  |
+| 16 | Duffinian-numbers |   |  |  |
+| 17 | a+b | ✓ | 1.0ms | 0B |
+| 18 | abbreviations-automatic | ✓ | 44.0ms | 2.96MB |
+| 19 | abbreviations-easy | ✓ | 23.0ms | 491.63KB |
+| 20 | abbreviations-simple | ✓ | 39.0ms | 737.39KB |
+| 21 | abc-problem | ✓ | 22.0ms | 737.38KB |
+| 22 | abelian-sandpile-model-identity | ✓ | 16.0ms | 491.65KB |
+| 23 | abelian-sandpile-model | ✓ | 10.0ms | 245.78KB |
+| 24 | abstract-type | ✓ | 25.0ms | 245.84KB |
+| 25 | abundant-deficient-and-perfect-number-classifications | ✓ | 205.0ms | 245.78KB |
+| 26 | abundant-odd-numbers | ✓ | 554.0ms | 95.51MB |
+| 27 | accumulator-factory | ✓ | 4.0ms | 0B |
+| 28 | achilles-numbers | ✓ | 54.0ms | 10.33MB |
+| 29 | ackermann-function-2 | ✓ | 5.0ms | 0B |
+| 30 | ackermann-function-3 | ✓ | 160.47s | 11.78MB |
+| 31 | ackermann-function | ✓ | 5.0ms | 0B |
+| 32 | active-directory-connect | ✓ | 5.0ms | 0B |
+| 33 | active-directory-search-for-a-user | ✓ | 20.0ms | 246.02KB |
+| 34 | active-object | ✓ | 710.0µs | 0B |
+| 35 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 4.0ms | 0B |
+| 36 | additive-primes | ✓ | 14.0ms | 0B |
+| 37 | address-of-a-variable | ✓ | 11.0ms | 245.78KB |
+| 38 | adfgvx-cipher |   |  |  |
+| 39 | aks-test-for-primes | ✓ | 14.0ms | 245.79KB |
+| 40 | algebraic-data-types | ✓ | 15.0ms | 245.98KB |
+| 41 | align-columns | ✓ | 11.0ms | 491.66KB |
+| 42 | aliquot-sequence-classifications | ✓ | 19.0ms | 491.59KB |
+| 43 | almkvist-giullera-formula-for-pi | ✓ | 227.0ms | 63.45MB |
+| 44 | almost-prime | ✓ | 9.0ms | 0B |
+| 45 | amb | ✓ | 16.0ms | 245.88KB |
+| 46 | amicable-pairs | ✓ | 405.0ms | 80.72MB |
+| 47 | anagrams-deranged-anagrams | ✓ | 9.0ms | 245.78KB |
+| 48 | anagrams | ✓ | 21.0ms | 491.59KB |
+| 49 | angle-difference-between-two-bearings-1 | ✓ | 627.0µs | 0B |
+| 50 | angle-difference-between-two-bearings-2 | ✓ | 802.0µs | 0B |
+| 51 | angles-geometric-normalization-and-conversion | ✓ | 9.0ms | 245.78KB |
+| 52 | animate-a-pendulum | ✓ | 634.0µs | 0B |
+| 53 | animation | ✓ | 11.0ms | 0B |
+| 54 | anonymous-recursion-1 | ✓ | 7.0ms | 0B |
+| 55 | anonymous-recursion-2 | ✓ | 8.0ms | 0B |
+| 56 | anonymous-recursion | ✓ | 10.0ms | 0B |
+| 57 | anti-primes | ✓ | 44.0ms | 0B |
+| 58 | append-a-record-to-the-end-of-a-text-file | ✓ | 9.0ms | 0B |
+| 59 | apply-a-callback-to-an-array-1 | ✓ | 517.0µs | 0B |
+| 60 | apply-a-callback-to-an-array-2 | ✓ | 23.0ms | 0B |
+| 61 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 1.0ms | 0B |
+| 62 | approximate-equality | ✓ | 15.0ms | 48.33KB |
+| 63 | arbitrary-precision-integers-included- | ✓ | 22.0ms | 65.13KB |
+| 64 | archimedean-spiral | ✓ | 23.0ms | 47.97KB |
+| 65 | arena-storage-pool | ✓ | 13.0ms | 46.47KB |
+| 66 | arithmetic-complex | ✓ | 13.0ms | 50.62KB |
+| 67 | arithmetic-derivative | ✓ | 23.0ms | 56.12KB |
+| 68 | arithmetic-evaluation | ✓ | 10.0ms | 38.70KB |
+| 69 | arithmetic-geometric-mean-calculate-pi | ✓ | 6.0ms | 10.35KB |
+| 70 | arithmetic-geometric-mean | ✓ | 6.0ms | 10.35KB |
+| 71 | arithmetic-integer-1 | ✓ | 23.0ms | 40.70KB |
+| 72 | arithmetic-integer-2 | ✓ | 10.0ms | 40.70KB |
+| 73 | arithmetic-numbers | ✓ |  |  |
+| 74 | arithmetic-rational | ✓ | 24.0ms | 39.38KB |
+| 75 | array-concatenation | ✓ | 14.0ms | 47.89KB |
+| 76 | array-length | ✓ | 11.0ms | 39.15KB |
+| 77 | arrays | ✓ | 16.0ms | 58.69KB |
+| 78 | ascending-primes | ✓ | 18.0ms | 55.77KB |
+| 79 | ascii-art-diagram-converter | ✓ | 6.0ms | 3.63KB |
+| 80 | assertions | ✓ | 5.0ms | 504B |
+| 81 | associative-array-creation | ✓ | 19.0ms | 94.27KB |
+| 82 | associative-array-iteration | ✓ | 11.0ms | 39.91KB |
+| 83 | associative-array-merging | ✓ | 6.0ms | 11.35KB |
+| 84 | atomic-updates | ✓ | 14.0ms | 55.44KB |
+| 85 | attractive-numbers | ✓ | 13.0ms | 39.11KB |
+| 86 | average-loop-length | ✓ | 77.0ms | 91.09KB |
+| 87 | averages-arithmetic-mean | ✓ | 12.0ms | 49.51KB |
+| 88 | averages-mean-time-of-day | ✓ | 17.0ms | 77.97KB |
+| 89 | averages-median-1 | ✓ | 6.0ms | 10.35KB |
+| 90 | averages-median-2 | ✓ | 13.0ms | 10.35KB |
+| 91 | averages-median-3 | ✓ | 7.0ms | 10.45KB |
+| 92 | averages-mode | ✓ | 16.0ms | 46.71KB |
+| 93 | averages-pythagorean-means | ✓ | 14.0ms | 49.09KB |
+| 94 | averages-root-mean-square | ✓ | 21.0ms | 448B |
+| 95 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
+| 96 | avl-tree |   |  |  |
+| 97 | b-zier-curves-intersections |   |  |  |
+| 98 | babbage-problem | ✓ | 28.0ms | 38.90KB |
+| 99 | babylonian-spiral | ✓ | 31.0ms | 40.02KB |
+| 100 | balanced-brackets | ✓ | 27.0ms | 54.56KB |
+| 101 | balanced-ternary | ✓ | 19.0ms | 56.83KB |
+| 102 | barnsley-fern | ✓ | 167.0ms | 81.71KB |
+| 103 | base64-decode-data | ✓ | 18.0ms | 5.48KB |
+| 104 | bell-numbers | ✓ | 53.0ms | 64.29KB |
+| 105 | benfords-law | ✓ | 91.0ms | 106.47KB |
+| 106 | bernoulli-numbers | ✓ | 335.0ms | 104.32KB |
+| 107 | best-shuffle | ✓ | 60.0ms | 101.66KB |
+| 108 | bifid-cipher | ✓ | 65.0ms | 100.41KB |
+| 109 | bin-given-limits | ✓ | 68.0ms | 122.30KB |
+| 110 | binary-digits | ✓ | 28.0ms | 32.82KB |
+| 111 | binary-search | ✓ | 48.0ms | 79.30KB |
+| 112 | binary-strings | ✓ | 37.0ms | 47.36KB |
+| 113 | bioinformatics-base-count | ✓ | 50.0ms | 81.38KB |
+| 114 | bioinformatics-global-alignment | ✓ | 770.0ms | 91.08KB |
+| 115 | bioinformatics-sequence-mutation | ✓ | 95.0ms | 125.98KB |
+| 116 | biorhythms | ✓ | 63.0ms | 126.57KB |
+| 117 | bitcoin-address-validation | ✓ | 34.0ms | 252.41KB |
+| 118 | bitmap-b-zier-curves-cubic | ✓ | 23.0ms | -2878472B |
+| 119 | bitmap-b-zier-curves-quadratic | ✓ | 40.0ms | -2878472B |
+| 120 | bitmap-bresenhams-line-algorithm | ✓ | 22.0ms | 92.34KB |
+| 121 | bitmap-flood-fill |   |  |  |
+| 122 | bitmap-histogram | ✓ | 16.0ms | 54.98KB |
+| 123 | bitmap-midpoint-circle-algorithm | ✓ | 9.0ms | 5.04KB |
+| 124 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 125 | bitmap-read-a-ppm-file |   |  |  |
+| 126 | bitmap-read-an-image-through-a-pipe | ✓ | 24.0ms | 41.38KB |
+| 127 | bitmap-write-a-ppm-file | ✓ | 33.0ms | 121.02KB |
+| 128 | bitmap |   |  |  |
+| 129 | bitwise-io-1 |   |  |  |
+| 130 | bitwise-io-2 |   |  |  |
+| 131 | bitwise-operations |   |  |  |
+| 132 | blum-integer |   |  |  |
+| 133 | boolean-values |   |  |  |
+| 134 | box-the-compass |   |  |  |
+| 135 | boyer-moore-string-search |   |  |  |
+| 136 | brazilian-numbers |   |  |  |
+| 137 | break-oo-privacy |   |  |  |
+| 138 | brilliant-numbers |   |  |  |
+| 139 | brownian-tree |   |  |  |
+| 140 | bulls-and-cows-player |   |  |  |
+| 141 | bulls-and-cows |   |  |  |
+| 142 | burrows-wheeler-transform |   |  |  |
+| 143 | caesar-cipher-1 |   |  |  |
+| 144 | caesar-cipher-2 |   |  |  |
+| 145 | calculating-the-value-of-e |   |  |  |
+| 146 | calendar---for-real-programmers-1 |   |  |  |
+| 147 | calendar---for-real-programmers-2 |   |  |  |
+| 148 | calendar |   |  |  |
+| 149 | calkin-wilf-sequence |   |  |  |
+| 150 | call-a-foreign-language-function |   |  |  |
+| 151 | call-a-function-1 |   |  |  |
+| 152 | call-a-function-10 |   |  |  |
+| 153 | call-a-function-11 |   |  |  |
+| 154 | call-a-function-12 |   |  |  |
+| 155 | call-a-function-2 |   |  |  |
+| 156 | call-a-function-3 |   |  |  |
+| 157 | call-a-function-4 |   |  |  |
+| 158 | call-a-function-5 |   |  |  |
+| 159 | call-a-function-6 |   |  |  |
+| 160 | call-a-function-7 |   |  |  |
+| 161 | call-a-function-8 |   |  |  |
+| 162 | call-a-function-9 |   |  |  |
+| 163 | call-an-object-method-1 |   |  |  |
+| 164 | call-an-object-method-2 |   |  |  |
+| 165 | call-an-object-method-3 |   |  |  |
+| 166 | call-an-object-method |   |  |  |
+| 167 | camel-case-and-snake-case |   |  |  |
+| 168 | canny-edge-detector |   |  |  |
+| 169 | canonicalize-cidr |   |  |  |
+| 170 | cantor-set |   |  |  |
+| 171 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 175 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 176 | case-sensitivity-of-identifiers |   |  |  |
+| 177 | casting-out-nines |   |  |  |
+| 178 | catalan-numbers-1 |   |  |  |
+| 179 | catalan-numbers-2 |   |  |  |
+| 180 | catalan-numbers-pascals-triangle |   |  |  |
+| 181 | catamorphism |   |  |  |
+| 182 | catmull-clark-subdivision-surface |   |  |  |
+| 183 | chaocipher |   |  |  |
+| 184 | chaos-game |   |  |  |
+| 185 | character-codes-1 |   |  |  |
+| 186 | character-codes-2 |   |  |  |
+| 187 | character-codes-3 |   |  |  |
+| 188 | character-codes-4 |   |  |  |
+| 189 | character-codes-5 |   |  |  |
+| 190 | chat-server |   |  |  |
+| 191 | check-machin-like-formulas |   |  |  |
+| 192 | check-that-file-exists |   |  |  |
+| 193 | checkpoint-synchronization-1 |   |  |  |
+| 194 | checkpoint-synchronization-2 |   |  |  |
+| 195 | checkpoint-synchronization-3 |   |  |  |
+| 196 | checkpoint-synchronization-4 |   |  |  |
+| 197 | chernicks-carmichael-numbers |   |  |  |
+| 198 | cheryls-birthday |   |  |  |
+| 199 | chinese-remainder-theorem |   |  |  |
+| 200 | chinese-zodiac |   |  |  |
+| 201 | cholesky-decomposition-1 |   |  |  |
+| 202 | cholesky-decomposition |   |  |  |
+| 203 | chowla-numbers |   |  |  |
+| 204 | church-numerals-1 |   |  |  |
+| 205 | church-numerals-2 |   |  |  |
+| 206 | circles-of-given-radius-through-two-points |   |  |  |
+| 207 | circular-primes |   |  |  |
+| 208 | cistercian-numerals |   |  |  |
+| 209 | comma-quibbling |   |  |  |
+| 210 | compiler-virtual-machine-interpreter |   |  |  |
+| 211 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 212 | compound-data-type |   |  |  |
+| 213 | concurrent-computing-1 |   |  |  |
+| 214 | concurrent-computing-2 |   |  |  |
+| 215 | concurrent-computing-3 |   |  |  |
+| 216 | conditional-structures-1 |   |  |  |
+| 217 | conditional-structures-10 |   |  |  |
+| 218 | conditional-structures-2 |   |  |  |
+| 219 | conditional-structures-3 |   |  |  |
+| 220 | conditional-structures-4 |   |  |  |
+| 221 | conditional-structures-5 |   |  |  |
+| 222 | conditional-structures-6 |   |  |  |
+| 223 | conditional-structures-7 |   |  |  |
+| 224 | conditional-structures-8 |   |  |  |
+| 225 | conditional-structures-9 |   |  |  |
+| 226 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 227 | constrained-genericity-1 |   |  |  |
+| 228 | constrained-genericity-2 |   |  |  |
+| 229 | constrained-genericity-3 |   |  |  |
+| 230 | constrained-genericity-4 |   |  |  |
+| 231 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 232 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 233 | continued-fraction |   |  |  |
+| 234 | convert-decimal-number-to-rational |   |  |  |
+| 235 | convert-seconds-to-compound-duration |   |  |  |
+| 236 | convex-hull |   |  |  |
+| 237 | conways-game-of-life |   |  |  |
+| 238 | copy-a-string-1 |   |  |  |
+| 239 | copy-a-string-2 |   |  |  |
+| 240 | copy-stdin-to-stdout-1 |   |  |  |
+| 241 | copy-stdin-to-stdout-2 |   |  |  |
+| 242 | count-in-factors |   |  |  |
+| 243 | count-in-octal-1 |   |  |  |
+| 244 | count-in-octal-2 |   |  |  |
+| 245 | count-in-octal-3 |   |  |  |
+| 246 | count-in-octal-4 |   |  |  |
+| 247 | count-occurrences-of-a-substring |   |  |  |
+| 248 | count-the-coins-1 |   |  |  |
+| 249 | count-the-coins-2 |   |  |  |
+| 250 | cramers-rule |   |  |  |
+| 251 | crc-32-1 |   |  |  |
+| 252 | crc-32-2 |   |  |  |
+| 253 | create-a-file-on-magnetic-tape |   |  |  |
+| 254 | create-a-file |   |  |  |
+| 255 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 256 | create-an-html-table |   |  |  |
+| 257 | create-an-object-at-a-given-address |   |  |  |
+| 258 | csv-data-manipulation |   |  |  |
+| 259 | csv-to-html-translation-1 |   |  |  |
+| 260 | csv-to-html-translation-2 |   |  |  |
+| 261 | csv-to-html-translation-3 |   |  |  |
+| 262 | csv-to-html-translation-4 |   |  |  |
+| 263 | csv-to-html-translation-5 |   |  |  |
+| 264 | cuban-primes |   |  |  |
+| 265 | cullen-and-woodall-numbers |   |  |  |
+| 266 | cumulative-standard-deviation |   |  |  |
+| 267 | currency |   |  |  |
+| 268 | currying |   |  |  |
+| 269 | curzon-numbers |   |  |  |
+| 270 | cusip |   |  |  |
+| 271 | cyclops-numbers |   |  |  |
+| 272 | damm-algorithm |   |  |  |
+| 273 | date-format |   |  |  |
+| 274 | date-manipulation |   |  |  |
+| 275 | day-of-the-week |   |  |  |
+| 276 | de-bruijn-sequences |   |  |  |
+| 277 | deal-cards-for-freecell |   |  |  |
+| 278 | death-star |   |  |  |
+| 279 | deceptive-numbers |   |  |  |
+| 280 | deconvolution-1d-2 |   |  |  |
+| 281 | deconvolution-1d-3 |   |  |  |
+| 282 | deconvolution-1d |   |  |  |
+| 283 | deepcopy-1 |   |  |  |
+| 284 | define-a-primitive-data-type |   |  |  |
+| 285 | delegates |   |  |  |
+| 286 | demings-funnel |   |  |  |
+| 287 | department-numbers |   |  |  |
+| 288 | descending-primes |   |  |  |
+| 289 | detect-division-by-zero |   |  |  |
+| 290 | determine-if-a-string-has-all-the-same-characters |   |  |  |
+| 291 | determine-if-a-string-has-all-unique-characters |   |  |  |
+| 292 | determine-if-a-string-is-collapsible |   |  |  |
+| 293 | determine-if-a-string-is-numeric-1 |   |  |  |
+| 294 | determine-if-a-string-is-numeric-2 |   |  |  |
+| 295 | determine-if-a-string-is-squeezable |   |  |  |
+| 296 | determine-if-only-one-instance-is-running |   |  |  |
+| 297 | determine-if-two-triangles-overlap |   |  |  |
+| 298 | determine-sentence-type |   |  |  |
+| 299 | dice-game-probabilities-1 |   |  |  |
+| 300 | dice-game-probabilities-2 |   |  |  |
+| 301 | digital-root-multiplicative-digital-root |   |  |  |
+| 302 | dijkstras-algorithm |   |  |  |
+| 303 | dinesmans-multiple-dwelling-problem |   |  |  |
+| 304 | dining-philosophers-1 |   |  |  |
+| 305 | dining-philosophers-2 |   |  |  |
+| 306 | disarium-numbers |   |  |  |
+| 307 | discordian-date |   |  |  |
+| 308 | display-a-linear-combination |   |  |  |
+| 309 | display-an-outline-as-a-nested-table |   |  |  |
+| 310 | distance-and-bearing |   |  |  |
+| 311 | distributed-programming |   |  |  |
+| 312 | diversity-prediction-theorem |   |  |  |
+| 313 | documentation |   |  |  |
+| 314 | doomsday-rule |   |  |  |
+| 315 | dot-product |   |  |  |
+| 316 | doubly-linked-list-definition-1 |   |  |  |
+| 317 | doubly-linked-list-definition-2 |   |  |  |
+| 318 | doubly-linked-list-element-definition |   |  |  |
+| 319 | doubly-linked-list-traversal |   |  |  |
+| 320 | dragon-curve |   |  |  |
+| 321 | draw-a-clock |   |  |  |
+| 322 | draw-a-cuboid |   |  |  |
+| 323 | draw-a-pixel-1 |   |  |  |
+| 324 | draw-a-rotating-cube |   |  |  |
+| 325 | draw-a-sphere |   |  |  |
+| 326 | dutch-national-flag-problem |   |  |  |
+| 327 | dynamic-variable-names |   |  |  |
+| 328 | earliest-difference-between-prime-gaps |   |  |  |
+| 329 | eban-numbers |   |  |  |
+| 330 | echo-server |   |  |  |
+| 331 | ekg-sequence-convergence |   |  |  |
+| 332 | md5 |   |  |  |


### PR DESCRIPTION
## Summary
- add SHA256 runtime helper for Java code generation
- handle map assignments with nested indexing
- support 2-arg function types via Java `BiConsumer`/`BiFunction`
- fix return statement handling for `while true` loops
- regenerate Rosetta outputs for updated programs

## Testing
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=117 -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index=117 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=118 -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index=118 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=119 -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index=119 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=120 -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/java -run Rosetta -index=120 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=121 -count=1` *(fails)*
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=122 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=123 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=126 -count=1`
- `go test -tags slow ./transpiler/x/java -run Rosetta -index=127 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6884a990b8ac8320befabe5733e902ab