### PR TITLE
Update Kotlin transpiler and add benchmark outputs

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/animation.bench
+++ b/tests/rosetta/transpiler/Kotlin/animation.bench
@@ -1,0 +1,1 @@
+{"duration_us":17191, "memory_bytes":141456, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/animation.error
+++ b/tests/rosetta/transpiler/Kotlin/animation.error
@@ -1,4 +1,0 @@
-OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/animation.kt:44:54: error: unresolved reference: add
-                line = line + msg.substring(idx, idx.add(1.toBigInteger()))
-                                                     ^

--- a/tests/rosetta/transpiler/Kotlin/animation.kt
+++ b/tests/rosetta/transpiler/Kotlin/animation.kt
@@ -41,7 +41,7 @@ fun main() {
             var i: Int = 0
             while (i < msg.length) {
                 val idx: Int = (shift + i) % msg.length
-                line = line + msg.substring(idx, idx.add(1.toBigInteger()))
+                line = line + msg.substring(idx, idx + 1)
                 i = i + 1
             }
             println(line)

--- a/tests/rosetta/transpiler/Kotlin/animation.out
+++ b/tests/rosetta/transpiler/Kotlin/animation.out
@@ -1,0 +1,65 @@
+Hello World! 
+ello World! H
+llo World! He
+lo World! Hel
+o World! Hell
+ World! Hello
+World! Hello 
+orld! Hello W
+rld! Hello Wo
+ld! Hello Wor
+d! Hello Worl
+! Hello World
+ Hello World!
+Hello World! 
+ Hello World!
+! Hello World
+d! Hello Worl
+ld! Hello Wor
+rld! Hello Wo
+orld! Hello W
+World! Hello 
+ World! Hello
+o World! Hell
+lo World! Hel
+llo World! He
+ello World! H
+Hello World! 
+ello World! H
+llo World! He
+lo World! Hel
+o World! Hell
+ World! Hello
+World! Hello 
+orld! Hello W
+rld! Hello Wo
+ld! Hello Wor
+d! Hello Worl
+! Hello World
+ Hello World!
+Hello World! 
+ Hello World!
+! Hello World
+d! Hello Worl
+ld! Hello Wor
+rld! Hello Wo
+orld! Hello W
+World! Hello 
+ World! Hello
+o World! Hell
+lo World! Hel
+llo World! He
+ello World! H
+Hello World! 
+ello World! H
+llo World! He
+lo World! Hel
+o World! Hell
+ World! Hello
+World! Hello 
+orld! Hello W
+rld! Hello Wo
+ld! Hello Wor
+d! Hello Worl
+! Hello World
+ Hello World!

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.bench
@@ -1,0 +1,1 @@
+{"duration_us":18997, "memory_bytes":133312, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.error
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.error
@@ -1,4 +1,0 @@
-OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.kt:37:29: error: type mismatch: inferred type is Int but BigInteger was expected
-        val t: BigInteger = a + b
-                            ^

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.kt
@@ -34,9 +34,9 @@ fun fib(n: Int): Int {
     var b: Int = 1
     var i: Int = 1
     while (i < n) {
-        val t: BigInteger = a + b
+        val t: Int = a + b
         a = b
-        b = t as Int
+        b = t
         i = i + 1
     }
     return b

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.out
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-1.out
@@ -1,0 +1,9 @@
+fib 0 = 0
+fib 1 = 1
+fib 2 = 1
+fib 3 = 2
+fib 4 = 3
+fib 5 = 5
+fib 10 = 55
+fib 40 = 102334155
+fib undefined for negative numbers

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":19314, "memory_bytes":133256, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.error
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.error
@@ -1,4 +1,0 @@
-OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
-/workspace/mochi/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.kt:37:29: error: type mismatch: inferred type is Int but BigInteger was expected
-        val t: BigInteger = a + b
-                            ^

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.kt
@@ -34,9 +34,9 @@ fun fib(n: Int): Int {
     var b: Int = 1
     var i: Int = 1
     while (i < n) {
-        val t: BigInteger = a + b
+        val t: Int = a + b
         a = b
-        b = t as Int
+        b = t
         i = i + 1
     }
     return b

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.out
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion-2.out
@@ -1,0 +1,12 @@
+fib(-1) returned error: negative n is forbidden
+fib(0) = 0
+fib(1) = 1
+fib(2) = 1
+fib(3) = 2
+fib(4) = 3
+fib(5) = 5
+fib(6) = 8
+fib(7) = 13
+fib(8) = 21
+fib(9) = 34
+fib(10) = 55

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion.bench
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion.bench
@@ -1,0 +1,1 @@
+{"duration_us":7399, "memory_bytes":144120, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/anonymous-recursion.kt
+++ b/tests/rosetta/transpiler/Kotlin/anonymous-recursion.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun fib(n: Int): Int {
     if (n < 2) {
         return n
@@ -18,5 +44,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/rosetta/transpiler/Kotlin/anti-primes.bench
+++ b/tests/rosetta/transpiler/Kotlin/anti-primes.bench
@@ -1,0 +1,1 @@
+{"duration_us":49294, "memory_bytes":141048, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/anti-primes.kt
+++ b/tests/rosetta/transpiler/Kotlin/anti-primes.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun countDivisors(n: Int): Int {
     if (n < 2) {
         return 1
@@ -33,5 +59,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/rosetta/transpiler/Kotlin/append-a-record-to-the-end-of-a-text-file.bench
+++ b/tests/rosetta/transpiler/Kotlin/append-a-record-to-the-end-of-a-text-file.bench
@@ -1,0 +1,1 @@
+{"duration_us":21996, "memory_bytes":133400, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/append-a-record-to-the-end-of-a-text-file.kt
+++ b/tests/rosetta/transpiler/Kotlin/append-a-record-to-the-end-of-a-text-file.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun writeTwo(): MutableList<String> {
     return mutableListOf("jsmith:x:1001:1000:Joe Smith,Room 1007,(234)555-8917,(234)555-0077,jsmith@rosettacode.org:/home/jsmith:/bin/bash", "jdoe:x:1002:1000:Jane Doe,Room 1004,(234)555-8914,(234)555-0044,jdoe@rosettacode.org:/home/jsmith:/bin/bash")
 }
@@ -17,5 +43,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-1.bench
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-1.bench
@@ -1,0 +1,1 @@
+{"duration_us":19754, "memory_bytes":133456, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-1.kt
@@ -1,5 +1,43 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun main() {
-    for (i in mutableListOf(1, 2, 3, 4, 5)) {
-        println((i * i).toString())
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (i in mutableListOf(1, 2, 3, 4, 5)) {
+            println((i * i).toString())
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":21427, "memory_bytes":131328, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-callback-to-an-array-2.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun each(xs: MutableList<Int>, f: (Int) -> Any): Unit {
     for (x in xs) {
         f(x)
@@ -19,5 +45,17 @@ fun user_main(): Unit {
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/tests/rosetta/transpiler/Kotlin/apply-a-digital-filter-direct-form-ii-transposed-.bench
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-digital-filter-direct-form-ii-transposed-.bench
@@ -1,0 +1,1 @@
+{"duration_us":9072, "memory_bytes":134368, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/apply-a-digital-filter-direct-form-ii-transposed-.kt
+++ b/tests/rosetta/transpiler/Kotlin/apply-a-digital-filter-direct-form-ii-transposed-.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 val a: MutableList<Double> = mutableListOf(1.0, 0.0 - 0.00000000000000027756, 0.33333333, 0.0 - 0.0000000000000000185)
 val b: MutableList<Double> = mutableListOf(0.16666667, 0.5, 0.5, 0.16666667)
 val sig: MutableList<Double> = mutableListOf(0.0 - 0.917843918645, 0.141984778794, 1.20536903482, 0.190286794412, 0.0 - 0.662370894973, 0.0 - 1.00700480494, 0.0 - 0.404707073677, 0.800482325044, 0.743500089861, 1.01090520172, 0.741527555207, 0.277841675195, 0.400833448236, 0.0 - 0.2085993586, 0.0 - 0.172842103641, 0.0 - 0.134316096293, 0.0259303398477, 0.490105989562, 0.549391221511, 0.9047198589)
@@ -26,8 +52,20 @@ fun applyFilter(input: MutableList<Double>, a: MutableList<Double>, b: MutableLi
 }
 
 fun main() {
-    while (k < res.size) {
-        println(res[k])
-        k = k + 1
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        while (k < res.size) {
+            println(res[k])
+            k = k + 1
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
     }
 }

--- a/tests/rosetta/transpiler/Kotlin/approximate-equality.bench
+++ b/tests/rosetta/transpiler/Kotlin/approximate-equality.bench
@@ -1,0 +1,1 @@
+{"duration_us":19539, "memory_bytes":122792, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/approximate-equality.kt
+++ b/tests/rosetta/transpiler/Kotlin/approximate-equality.kt
@@ -1,3 +1,29 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
 fun abs(x: Double): Double {
     if (x < 0.0) {
         return 0.0 - x
@@ -14,9 +40,9 @@ fun maxf(a: Double, b: Double): Double {
 
 fun isClose(a: Double, b: Double): Boolean {
     val relTol: Double = 0.000000001
-    val t = kotlin.math.abs(a - b)
-    val u: Double = relTol * maxf(kotlin.math.abs(a) as Double, kotlin.math.abs(b) as Double)
-    return (t as Number).toDouble() <= u
+    val t: Double = kotlin.math.abs(a - b)
+    val u: Double = relTol * maxf(kotlin.math.abs(a), kotlin.math.abs(b))
+    return t <= u
 }
 
 fun sqrtApprox(x: Double): Double {
@@ -33,13 +59,25 @@ fun user_main(): Unit {
     val root2: Double = sqrtApprox(2.0)
     val pairs: MutableList<MutableList<Double>> = mutableListOf(mutableListOf(100000000000000.02, 100000000000000.02), mutableListOf(100.01, 100.011), mutableListOf(10000000000000.002 / 10000.0, 1000000000.0000001), mutableListOf(0.001, 0.0010000001), mutableListOf(0.000000000000000000000101, 0.0), mutableListOf(root2 * root2, 2.0), mutableListOf((0.0 - root2) * root2, 0.0 - 2.0), mutableListOf(100000000000000000.0, 100000000000000000.0), mutableListOf(3.141592653589793, 3.141592653589793))
     for (pair in pairs) {
-        val a = pair[0]
-        val b = pair[1]
-        val s: String = if (isClose(a as Double, b as Double) != null) "≈" else "≉"
+        val a: Double = pair[0]
+        val b: Double = pair[1]
+        val s: String = if (isClose(a, b) != null) "≈" else "≉"
         println((((a.toString() + " ") + s) + " ") + b.toString())
     }
 }
 
 fun main() {
-    user_main()
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
 }

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-26 05:05 +0700
+Last updated: 2025-07-26 17:18 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-26 05:05 +0700
+Last updated: 2025-07-26 17:18 +0700
 
-Completed tasks: **57/284**
+Completed tasks: **60/332**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -24,272 +24,320 @@ Completed tasks: **57/284**
 | 13 | 99-bottles-of-beer-2 | ✓ |  | 97.2 KB |
 | 14 | 99-bottles-of-beer | ✓ | 11.87ms | 133.8 KB |
 | 15 | DNS-query | ✓ |  | 134.1 KB |
-| 16 | a+b | ✓ |  | 102.6 KB |
-| 17 | abbreviations-automatic | ✓ | 24.27ms | 131.6 KB |
-| 18 | abbreviations-easy | ✓ |  | 123.0 KB |
-| 19 | abbreviations-simple | ✓ |  | 119.5 KB |
-| 20 | abc-problem | ✓ | 13.57ms | 121.4 KB |
-| 21 | abelian-sandpile-model-identity | ✓ |  | 133.0 KB |
-| 22 | abelian-sandpile-model | ✓ |  | 123.5 KB |
-| 23 | abstract-type | ✓ | 5.54ms | 130.4 KB |
-| 24 | abundant-deficient-and-perfect-number-classifications | ✓ |  | 133.6 KB |
-| 25 | abundant-odd-numbers | ✓ |  | 826.2 KB |
-| 26 | accumulator-factory | ✓ | 12.46ms | 109.0 KB |
-| 27 | achilles-numbers |  |  |  |
-| 28 | ackermann-function-2 | ✓ | 3.06ms | 133.9 KB |
-| 29 | ackermann-function-3 | ✓ |  |  |
-| 30 | ackermann-function | ✓ |  | 133.9 KB |
-| 31 | active-directory-connect | ✓ | 9.17ms | 122.7 KB |
-| 32 | active-directory-search-for-a-user | ✓ |  | 120.8 KB |
-| 33 | active-object | ✓ |  | 124.4 KB |
-| 34 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 14.70ms | 101.4 KB |
-| 35 | additive-primes | ✓ |  | 131.2 KB |
-| 36 | address-of-a-variable | ✓ | 19.16ms | 105.8 KB |
-| 37 | adfgvx-cipher |  |  |  |
-| 38 | aks-test-for-primes | ✓ | 5.39ms | 130.5 KB |
-| 39 | algebraic-data-types | ✓ |  | 121.9 KB |
-| 40 | align-columns |  |  |  |
-| 41 | aliquot-sequence-classifications |  |  |  |
-| 42 | almkvist-giullera-formula-for-pi |  |  |  |
-| 43 | almost-prime | ✓ | 13.54ms | 122.7 KB |
-| 44 | amb | ✓ | 31.89ms | 121.2 KB |
-| 45 | amicable-pairs | ✓ | 1.96s | 821.3 KB |
-| 46 | anagrams-deranged-anagrams | ✓ | 22.78ms | 129.9 KB |
-| 47 | anagrams | ✓ | 25.65ms | 128.6 KB |
-| 48 | angle-difference-between-two-bearings-1 | ✓ | 11.23ms | 131.0 KB |
-| 49 | angle-difference-between-two-bearings-2 | ✓ | 10.72ms | 131.0 KB |
-| 50 | angles-geometric-normalization-and-conversion | ✓ | 26.45ms | 120.1 KB |
-| 51 | animate-a-pendulum | ✓ | 7.51ms | 141.0 KB |
-| 52 | animation |  |  |  |
-| 53 | anonymous-recursion-1 |  |  |  |
-| 54 | anonymous-recursion-2 |  |  |  |
-| 55 | anonymous-recursion | ✓ |  |  |
-| 56 | anti-primes | ✓ |  |  |
-| 57 | append-a-record-to-the-end-of-a-text-file | ✓ |  |  |
-| 58 | apply-a-callback-to-an-array-1 | ✓ |  |  |
-| 59 | apply-a-callback-to-an-array-2 | ✓ |  |  |
-| 60 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ |  |  |
-| 61 | approximate-equality | ✓ |  |  |
-| 62 | arbitrary-precision-integers-included- | ✓ |  |  |
-| 63 | archimedean-spiral | ✓ |  |  |
-| 64 | arena-storage-pool |  |  |  |
-| 65 | arithmetic-complex | ✓ |  |  |
-| 66 | arithmetic-derivative |  |  |  |
-| 67 | arithmetic-evaluation |  |  |  |
-| 68 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
-| 69 | arithmetic-geometric-mean |  |  |  |
-| 70 | arithmetic-integer-1 |  |  |  |
-| 71 | arithmetic-integer-2 |  |  |  |
-| 72 | arithmetic-numbers |  |  |  |
-| 73 | arithmetic-rational |  |  |  |
-| 74 | array-concatenation |  |  |  |
-| 75 | array-length |  |  |  |
-| 76 | arrays |  |  |  |
-| 77 | ascending-primes |  |  |  |
-| 78 | ascii-art-diagram-converter |  |  |  |
-| 79 | assertions |  |  |  |
-| 80 | associative-array-creation |  |  |  |
-| 81 | associative-array-iteration |  |  |  |
-| 82 | associative-array-merging |  |  |  |
-| 83 | atomic-updates |  |  |  |
-| 84 | attractive-numbers |  |  |  |
-| 85 | average-loop-length |  |  |  |
-| 86 | averages-arithmetic-mean |  |  |  |
-| 87 | averages-mean-time-of-day |  |  |  |
-| 88 | averages-median-1 |  |  |  |
-| 89 | averages-median-2 |  |  |  |
-| 90 | averages-median-3 |  |  |  |
-| 91 | averages-mode |  |  |  |
-| 92 | averages-pythagorean-means |  |  |  |
-| 93 | averages-root-mean-square |  |  |  |
-| 94 | averages-simple-moving-average |  |  |  |
-| 95 | avl-tree |  |  |  |
-| 96 | b-zier-curves-intersections |  |  |  |
-| 97 | babbage-problem |  |  |  |
-| 98 | babylonian-spiral |  |  |  |
-| 99 | balanced-brackets |  |  |  |
-| 100 | balanced-ternary |  |  |  |
-| 101 | barnsley-fern |  |  |  |
-| 102 | base64-decode-data |  |  |  |
-| 103 | bell-numbers |  |  |  |
-| 104 | benfords-law |  |  |  |
-| 105 | bernoulli-numbers |  |  |  |
-| 106 | best-shuffle |  |  |  |
-| 107 | bifid-cipher |  |  |  |
-| 108 | bin-given-limits |  |  |  |
-| 109 | binary-digits |  |  |  |
-| 110 | binary-search |  |  |  |
-| 111 | binary-strings |  |  |  |
-| 112 | bioinformatics-base-count |  |  |  |
-| 113 | bioinformatics-global-alignment |  |  |  |
-| 114 | bioinformatics-sequence-mutation |  |  |  |
-| 115 | biorhythms |  |  |  |
-| 116 | bitcoin-address-validation |  |  |  |
-| 117 | bitmap-b-zier-curves-cubic |  |  |  |
-| 118 | bitmap-b-zier-curves-quadratic |  |  |  |
-| 119 | bitmap-bresenhams-line-algorithm |  |  |  |
-| 120 | bitmap-flood-fill |  |  |  |
-| 121 | bitmap-histogram |  |  |  |
-| 122 | bitmap-midpoint-circle-algorithm |  |  |  |
-| 123 | bitmap-ppm-conversion-through-a-pipe |  |  |  |
-| 124 | bitmap-read-a-ppm-file |  |  |  |
-| 125 | bitmap-read-an-image-through-a-pipe |  |  |  |
-| 126 | bitmap-write-a-ppm-file |  |  |  |
-| 127 | bitmap |  |  |  |
-| 128 | bitwise-io-1 |  |  |  |
-| 129 | bitwise-io-2 |  |  |  |
-| 130 | bitwise-operations |  |  |  |
-| 131 | blum-integer |  |  |  |
-| 132 | boolean-values |  |  |  |
-| 133 | box-the-compass |  |  |  |
-| 134 | boyer-moore-string-search |  |  |  |
-| 135 | brazilian-numbers |  |  |  |
-| 136 | break-oo-privacy |  |  |  |
-| 137 | brilliant-numbers |  |  |  |
-| 138 | brownian-tree |  |  |  |
-| 139 | bulls-and-cows-player |  |  |  |
-| 140 | bulls-and-cows |  |  |  |
-| 141 | burrows-wheeler-transform |  |  |  |
-| 142 | caesar-cipher-1 |  |  |  |
-| 143 | caesar-cipher-2 |  |  |  |
-| 144 | calculating-the-value-of-e |  |  |  |
-| 145 | calendar---for-real-programmers-1 |  |  |  |
-| 146 | calendar---for-real-programmers-2 |  |  |  |
-| 147 | calendar |  |  |  |
-| 148 | calkin-wilf-sequence |  |  |  |
-| 149 | call-a-foreign-language-function |  |  |  |
-| 150 | call-a-function-1 |  |  |  |
-| 151 | call-a-function-10 |  |  |  |
-| 152 | call-a-function-11 |  |  |  |
-| 153 | call-a-function-12 |  |  |  |
-| 154 | call-a-function-2 |  |  |  |
-| 155 | call-a-function-3 |  |  |  |
-| 156 | call-a-function-4 |  |  |  |
-| 157 | call-a-function-5 |  |  |  |
-| 158 | call-a-function-6 |  |  |  |
-| 159 | call-a-function-7 |  |  |  |
-| 160 | call-a-function-8 |  |  |  |
-| 161 | call-a-function-9 |  |  |  |
-| 162 | call-an-object-method-1 |  |  |  |
-| 163 | call-an-object-method-2 |  |  |  |
-| 164 | call-an-object-method-3 |  |  |  |
-| 165 | call-an-object-method |  |  |  |
-| 166 | camel-case-and-snake-case |  |  |  |
-| 167 | canny-edge-detector |  |  |  |
-| 168 | canonicalize-cidr |  |  |  |
-| 169 | cantor-set |  |  |  |
-| 170 | carmichael-3-strong-pseudoprimes |  |  |  |
-| 171 | cartesian-product-of-two-or-more-lists-1 |  |  |  |
-| 172 | cartesian-product-of-two-or-more-lists-2 |  |  |  |
-| 173 | cartesian-product-of-two-or-more-lists-3 |  |  |  |
-| 174 | cartesian-product-of-two-or-more-lists-4 |  |  |  |
-| 175 | case-sensitivity-of-identifiers |  |  |  |
-| 176 | casting-out-nines |  |  |  |
-| 177 | catalan-numbers-1 |  |  |  |
-| 178 | catalan-numbers-2 |  |  |  |
-| 179 | catalan-numbers-pascals-triangle |  |  |  |
-| 180 | catamorphism |  |  |  |
-| 181 | catmull-clark-subdivision-surface |  |  |  |
-| 182 | chaocipher |  |  |  |
-| 183 | chaos-game |  |  |  |
-| 184 | character-codes-1 |  |  |  |
-| 185 | character-codes-2 |  |  |  |
-| 186 | character-codes-3 |  |  |  |
-| 187 | character-codes-4 |  |  |  |
-| 188 | character-codes-5 |  |  |  |
-| 189 | chat-server |  |  |  |
-| 190 | check-machin-like-formulas |  |  |  |
-| 191 | check-that-file-exists |  |  |  |
-| 192 | checkpoint-synchronization-1 |  |  |  |
-| 193 | checkpoint-synchronization-2 |  |  |  |
-| 194 | checkpoint-synchronization-3 |  |  |  |
-| 195 | checkpoint-synchronization-4 |  |  |  |
-| 196 | chernicks-carmichael-numbers |  |  |  |
-| 197 | cheryls-birthday |  |  |  |
-| 198 | chinese-remainder-theorem |  |  |  |
-| 199 | chinese-zodiac |  |  |  |
-| 200 | cholesky-decomposition-1 |  |  |  |
-| 201 | cholesky-decomposition |  |  |  |
-| 202 | chowla-numbers |  |  |  |
-| 203 | church-numerals-1 |  |  |  |
-| 204 | church-numerals-2 |  |  |  |
-| 205 | circles-of-given-radius-through-two-points |  |  |  |
-| 206 | circular-primes |  |  |  |
-| 207 | cistercian-numerals |  |  |  |
-| 208 | comma-quibbling |  |  |  |
-| 209 | compiler-virtual-machine-interpreter |  |  |  |
-| 210 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |  |  |  |
-| 211 | compound-data-type |  |  |  |
-| 212 | concurrent-computing-1 |  |  |  |
-| 213 | concurrent-computing-2 |  |  |  |
-| 214 | concurrent-computing-3 |  |  |  |
-| 215 | conditional-structures-1 |  |  |  |
-| 216 | conditional-structures-10 |  |  |  |
-| 217 | conditional-structures-2 |  |  |  |
-| 218 | conditional-structures-3 |  |  |  |
-| 219 | conditional-structures-4 |  |  |  |
-| 220 | conditional-structures-5 |  |  |  |
-| 221 | conditional-structures-6 |  |  |  |
-| 222 | conditional-structures-7 |  |  |  |
-| 223 | conditional-structures-8 |  |  |  |
-| 224 | conditional-structures-9 |  |  |  |
-| 225 | consecutive-primes-with-ascending-or-descending-differences |  |  |  |
-| 226 | constrained-genericity-1 |  |  |  |
-| 227 | constrained-genericity-2 |  |  |  |
-| 228 | constrained-genericity-3 |  |  |  |
-| 229 | constrained-genericity-4 |  |  |  |
-| 230 | constrained-random-points-on-a-circle-1 |  |  |  |
-| 231 | constrained-random-points-on-a-circle-2 |  |  |  |
-| 232 | continued-fraction |  |  |  |
-| 233 | convert-decimal-number-to-rational |  |  |  |
-| 234 | convert-seconds-to-compound-duration |  |  |  |
-| 235 | convex-hull |  |  |  |
-| 236 | conways-game-of-life |  |  |  |
-| 237 | copy-a-string-1 |  |  |  |
-| 238 | copy-a-string-2 |  |  |  |
-| 239 | copy-stdin-to-stdout-1 |  |  |  |
-| 240 | copy-stdin-to-stdout-2 |  |  |  |
-| 241 | count-in-factors |  |  |  |
-| 242 | count-in-octal-1 |  |  |  |
-| 243 | count-in-octal-2 |  |  |  |
-| 244 | count-in-octal-3 |  |  |  |
-| 245 | count-in-octal-4 |  |  |  |
-| 246 | count-occurrences-of-a-substring |  |  |  |
-| 247 | count-the-coins-1 |  |  |  |
-| 248 | count-the-coins-2 |  |  |  |
-| 249 | cramers-rule |  |  |  |
-| 250 | crc-32-1 |  |  |  |
-| 251 | crc-32-2 |  |  |  |
-| 252 | create-a-file-on-magnetic-tape |  |  |  |
-| 253 | create-a-file |  |  |  |
-| 254 | create-a-two-dimensional-array-at-runtime-1 |  |  |  |
-| 255 | create-an-html-table |  |  |  |
-| 256 | create-an-object-at-a-given-address |  |  |  |
-| 257 | csv-data-manipulation |  |  |  |
-| 258 | csv-to-html-translation-1 |  |  |  |
-| 259 | csv-to-html-translation-2 |  |  |  |
-| 260 | csv-to-html-translation-3 |  |  |  |
-| 261 | csv-to-html-translation-4 |  |  |  |
-| 262 | csv-to-html-translation-5 |  |  |  |
-| 263 | cuban-primes |  |  |  |
-| 264 | cullen-and-woodall-numbers |  |  |  |
-| 265 | cumulative-standard-deviation |  |  |  |
-| 266 | currency |  |  |  |
-| 267 | currying |  |  |  |
-| 268 | curzon-numbers |  |  |  |
-| 269 | cusip |  |  |  |
-| 270 | cyclops-numbers |  |  |  |
-| 271 | damm-algorithm |  |  |  |
-| 272 | date-format |  |  |  |
-| 273 | date-manipulation |  |  |  |
-| 274 | day-of-the-week |  |  |  |
-| 275 | de-bruijn-sequences |  |  |  |
-| 276 | deal-cards-for-freecell |  |  |  |
-| 277 | death-star |  |  |  |
-| 278 | deceptive-numbers |  |  |  |
-| 279 | deconvolution-1d-2 |  |  |  |
-| 280 | deconvolution-1d-3 |  |  |  |
-| 281 | deconvolution-1d |  |  |  |
-| 282 | deepcopy-1 |  |  |  |
-| 283 | define-a-primitive-data-type |  |  |  |
-| 284 | md5 |  |  |  |
+| 16 | Duffinian-numbers |  |  |  |
+| 17 | a+b | ✓ |  | 102.6 KB |
+| 18 | abbreviations-automatic | ✓ | 24.27ms | 131.6 KB |
+| 19 | abbreviations-easy | ✓ |  | 123.0 KB |
+| 20 | abbreviations-simple | ✓ |  | 119.5 KB |
+| 21 | abc-problem | ✓ | 13.57ms | 121.4 KB |
+| 22 | abelian-sandpile-model-identity | ✓ |  | 133.0 KB |
+| 23 | abelian-sandpile-model | ✓ |  | 123.5 KB |
+| 24 | abstract-type | ✓ | 5.54ms | 130.4 KB |
+| 25 | abundant-deficient-and-perfect-number-classifications | ✓ |  | 133.6 KB |
+| 26 | abundant-odd-numbers | ✓ |  | 826.2 KB |
+| 27 | accumulator-factory | ✓ | 12.46ms | 109.0 KB |
+| 28 | achilles-numbers |  |  |  |
+| 29 | ackermann-function-2 | ✓ | 3.06ms | 133.9 KB |
+| 30 | ackermann-function-3 | ✓ |  |  |
+| 31 | ackermann-function | ✓ |  | 133.9 KB |
+| 32 | active-directory-connect | ✓ | 9.17ms | 122.7 KB |
+| 33 | active-directory-search-for-a-user | ✓ |  | 120.8 KB |
+| 34 | active-object | ✓ |  | 124.4 KB |
+| 35 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 14.70ms | 101.4 KB |
+| 36 | additive-primes | ✓ |  | 131.2 KB |
+| 37 | address-of-a-variable | ✓ | 19.16ms | 105.8 KB |
+| 38 | adfgvx-cipher |  |  |  |
+| 39 | aks-test-for-primes | ✓ | 5.39ms | 130.5 KB |
+| 40 | algebraic-data-types | ✓ |  | 121.9 KB |
+| 41 | align-columns |  |  |  |
+| 42 | aliquot-sequence-classifications |  |  |  |
+| 43 | almkvist-giullera-formula-for-pi |  |  |  |
+| 44 | almost-prime | ✓ | 13.54ms | 122.7 KB |
+| 45 | amb | ✓ | 31.89ms | 121.2 KB |
+| 46 | amicable-pairs | ✓ | 1.96s | 821.3 KB |
+| 47 | anagrams-deranged-anagrams | ✓ | 22.78ms | 129.9 KB |
+| 48 | anagrams | ✓ | 25.65ms | 128.6 KB |
+| 49 | angle-difference-between-two-bearings-1 | ✓ | 11.23ms | 131.0 KB |
+| 50 | angle-difference-between-two-bearings-2 | ✓ | 10.72ms | 131.0 KB |
+| 51 | angles-geometric-normalization-and-conversion | ✓ | 26.45ms | 120.1 KB |
+| 52 | animate-a-pendulum | ✓ | 7.51ms | 141.0 KB |
+| 53 | animation | ✓ | 17.19ms | 138.1 KB |
+| 54 | anonymous-recursion-1 | ✓ | 19.00ms | 130.2 KB |
+| 55 | anonymous-recursion-2 | ✓ | 19.31ms | 130.1 KB |
+| 56 | anonymous-recursion | ✓ | 7.40ms | 140.7 KB |
+| 57 | anti-primes | ✓ | 49.29ms | 137.7 KB |
+| 58 | append-a-record-to-the-end-of-a-text-file | ✓ | 22.00ms | 130.3 KB |
+| 59 | apply-a-callback-to-an-array-1 | ✓ | 19.75ms | 130.3 KB |
+| 60 | apply-a-callback-to-an-array-2 | ✓ | 21.43ms | 128.2 KB |
+| 61 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 9.07ms | 131.2 KB |
+| 62 | approximate-equality | ✓ | 19.54ms | 119.9 KB |
+| 63 | arbitrary-precision-integers-included- | ✓ |  |  |
+| 64 | archimedean-spiral | ✓ |  |  |
+| 65 | arena-storage-pool |  |  |  |
+| 66 | arithmetic-complex | ✓ |  |  |
+| 67 | arithmetic-derivative |  |  |  |
+| 68 | arithmetic-evaluation |  |  |  |
+| 69 | arithmetic-geometric-mean-calculate-pi | ✓ |  |  |
+| 70 | arithmetic-geometric-mean |  |  |  |
+| 71 | arithmetic-integer-1 |  |  |  |
+| 72 | arithmetic-integer-2 |  |  |  |
+| 73 | arithmetic-numbers |  |  |  |
+| 74 | arithmetic-rational |  |  |  |
+| 75 | array-concatenation |  |  |  |
+| 76 | array-length |  |  |  |
+| 77 | arrays |  |  |  |
+| 78 | ascending-primes |  |  |  |
+| 79 | ascii-art-diagram-converter |  |  |  |
+| 80 | assertions |  |  |  |
+| 81 | associative-array-creation |  |  |  |
+| 82 | associative-array-iteration |  |  |  |
+| 83 | associative-array-merging |  |  |  |
+| 84 | atomic-updates |  |  |  |
+| 85 | attractive-numbers |  |  |  |
+| 86 | average-loop-length |  |  |  |
+| 87 | averages-arithmetic-mean |  |  |  |
+| 88 | averages-mean-time-of-day |  |  |  |
+| 89 | averages-median-1 |  |  |  |
+| 90 | averages-median-2 |  |  |  |
+| 91 | averages-median-3 |  |  |  |
+| 92 | averages-mode |  |  |  |
+| 93 | averages-pythagorean-means |  |  |  |
+| 94 | averages-root-mean-square |  |  |  |
+| 95 | averages-simple-moving-average |  |  |  |
+| 96 | avl-tree |  |  |  |
+| 97 | b-zier-curves-intersections |  |  |  |
+| 98 | babbage-problem |  |  |  |
+| 99 | babylonian-spiral |  |  |  |
+| 100 | balanced-brackets |  |  |  |
+| 101 | balanced-ternary |  |  |  |
+| 102 | barnsley-fern |  |  |  |
+| 103 | base64-decode-data |  |  |  |
+| 104 | bell-numbers |  |  |  |
+| 105 | benfords-law |  |  |  |
+| 106 | bernoulli-numbers |  |  |  |
+| 107 | best-shuffle |  |  |  |
+| 108 | bifid-cipher |  |  |  |
+| 109 | bin-given-limits |  |  |  |
+| 110 | binary-digits |  |  |  |
+| 111 | binary-search |  |  |  |
+| 112 | binary-strings |  |  |  |
+| 113 | bioinformatics-base-count |  |  |  |
+| 114 | bioinformatics-global-alignment |  |  |  |
+| 115 | bioinformatics-sequence-mutation |  |  |  |
+| 116 | biorhythms |  |  |  |
+| 117 | bitcoin-address-validation |  |  |  |
+| 118 | bitmap-b-zier-curves-cubic |  |  |  |
+| 119 | bitmap-b-zier-curves-quadratic |  |  |  |
+| 120 | bitmap-bresenhams-line-algorithm |  |  |  |
+| 121 | bitmap-flood-fill |  |  |  |
+| 122 | bitmap-histogram |  |  |  |
+| 123 | bitmap-midpoint-circle-algorithm |  |  |  |
+| 124 | bitmap-ppm-conversion-through-a-pipe |  |  |  |
+| 125 | bitmap-read-a-ppm-file |  |  |  |
+| 126 | bitmap-read-an-image-through-a-pipe |  |  |  |
+| 127 | bitmap-write-a-ppm-file |  |  |  |
+| 128 | bitmap |  |  |  |
+| 129 | bitwise-io-1 |  |  |  |
+| 130 | bitwise-io-2 |  |  |  |
+| 131 | bitwise-operations |  |  |  |
+| 132 | blum-integer |  |  |  |
+| 133 | boolean-values |  |  |  |
+| 134 | box-the-compass |  |  |  |
+| 135 | boyer-moore-string-search |  |  |  |
+| 136 | brazilian-numbers |  |  |  |
+| 137 | break-oo-privacy |  |  |  |
+| 138 | brilliant-numbers |  |  |  |
+| 139 | brownian-tree |  |  |  |
+| 140 | bulls-and-cows-player |  |  |  |
+| 141 | bulls-and-cows |  |  |  |
+| 142 | burrows-wheeler-transform |  |  |  |
+| 143 | caesar-cipher-1 |  |  |  |
+| 144 | caesar-cipher-2 |  |  |  |
+| 145 | calculating-the-value-of-e |  |  |  |
+| 146 | calendar---for-real-programmers-1 |  |  |  |
+| 147 | calendar---for-real-programmers-2 |  |  |  |
+| 148 | calendar |  |  |  |
+| 149 | calkin-wilf-sequence |  |  |  |
+| 150 | call-a-foreign-language-function |  |  |  |
+| 151 | call-a-function-1 |  |  |  |
+| 152 | call-a-function-10 |  |  |  |
+| 153 | call-a-function-11 |  |  |  |
+| 154 | call-a-function-12 |  |  |  |
+| 155 | call-a-function-2 |  |  |  |
+| 156 | call-a-function-3 |  |  |  |
+| 157 | call-a-function-4 |  |  |  |
+| 158 | call-a-function-5 |  |  |  |
+| 159 | call-a-function-6 |  |  |  |
+| 160 | call-a-function-7 |  |  |  |
+| 161 | call-a-function-8 |  |  |  |
+| 162 | call-a-function-9 |  |  |  |
+| 163 | call-an-object-method-1 |  |  |  |
+| 164 | call-an-object-method-2 |  |  |  |
+| 165 | call-an-object-method-3 |  |  |  |
+| 166 | call-an-object-method |  |  |  |
+| 167 | camel-case-and-snake-case |  |  |  |
+| 168 | canny-edge-detector |  |  |  |
+| 169 | canonicalize-cidr |  |  |  |
+| 170 | cantor-set |  |  |  |
+| 171 | carmichael-3-strong-pseudoprimes |  |  |  |
+| 172 | cartesian-product-of-two-or-more-lists-1 |  |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-2 |  |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-3 |  |  |  |
+| 175 | cartesian-product-of-two-or-more-lists-4 |  |  |  |
+| 176 | case-sensitivity-of-identifiers |  |  |  |
+| 177 | casting-out-nines |  |  |  |
+| 178 | catalan-numbers-1 |  |  |  |
+| 179 | catalan-numbers-2 |  |  |  |
+| 180 | catalan-numbers-pascals-triangle |  |  |  |
+| 181 | catamorphism |  |  |  |
+| 182 | catmull-clark-subdivision-surface |  |  |  |
+| 183 | chaocipher |  |  |  |
+| 184 | chaos-game |  |  |  |
+| 185 | character-codes-1 |  |  |  |
+| 186 | character-codes-2 |  |  |  |
+| 187 | character-codes-3 |  |  |  |
+| 188 | character-codes-4 |  |  |  |
+| 189 | character-codes-5 |  |  |  |
+| 190 | chat-server |  |  |  |
+| 191 | check-machin-like-formulas |  |  |  |
+| 192 | check-that-file-exists |  |  |  |
+| 193 | checkpoint-synchronization-1 |  |  |  |
+| 194 | checkpoint-synchronization-2 |  |  |  |
+| 195 | checkpoint-synchronization-3 |  |  |  |
+| 196 | checkpoint-synchronization-4 |  |  |  |
+| 197 | chernicks-carmichael-numbers |  |  |  |
+| 198 | cheryls-birthday |  |  |  |
+| 199 | chinese-remainder-theorem |  |  |  |
+| 200 | chinese-zodiac |  |  |  |
+| 201 | cholesky-decomposition-1 |  |  |  |
+| 202 | cholesky-decomposition |  |  |  |
+| 203 | chowla-numbers |  |  |  |
+| 204 | church-numerals-1 |  |  |  |
+| 205 | church-numerals-2 |  |  |  |
+| 206 | circles-of-given-radius-through-two-points |  |  |  |
+| 207 | circular-primes |  |  |  |
+| 208 | cistercian-numerals |  |  |  |
+| 209 | comma-quibbling |  |  |  |
+| 210 | compiler-virtual-machine-interpreter |  |  |  |
+| 211 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |  |  |  |
+| 212 | compound-data-type |  |  |  |
+| 213 | concurrent-computing-1 |  |  |  |
+| 214 | concurrent-computing-2 |  |  |  |
+| 215 | concurrent-computing-3 |  |  |  |
+| 216 | conditional-structures-1 |  |  |  |
+| 217 | conditional-structures-10 |  |  |  |
+| 218 | conditional-structures-2 |  |  |  |
+| 219 | conditional-structures-3 |  |  |  |
+| 220 | conditional-structures-4 |  |  |  |
+| 221 | conditional-structures-5 |  |  |  |
+| 222 | conditional-structures-6 |  |  |  |
+| 223 | conditional-structures-7 |  |  |  |
+| 224 | conditional-structures-8 |  |  |  |
+| 225 | conditional-structures-9 |  |  |  |
+| 226 | consecutive-primes-with-ascending-or-descending-differences |  |  |  |
+| 227 | constrained-genericity-1 |  |  |  |
+| 228 | constrained-genericity-2 |  |  |  |
+| 229 | constrained-genericity-3 |  |  |  |
+| 230 | constrained-genericity-4 |  |  |  |
+| 231 | constrained-random-points-on-a-circle-1 |  |  |  |
+| 232 | constrained-random-points-on-a-circle-2 |  |  |  |
+| 233 | continued-fraction |  |  |  |
+| 234 | convert-decimal-number-to-rational |  |  |  |
+| 235 | convert-seconds-to-compound-duration |  |  |  |
+| 236 | convex-hull |  |  |  |
+| 237 | conways-game-of-life |  |  |  |
+| 238 | copy-a-string-1 |  |  |  |
+| 239 | copy-a-string-2 |  |  |  |
+| 240 | copy-stdin-to-stdout-1 |  |  |  |
+| 241 | copy-stdin-to-stdout-2 |  |  |  |
+| 242 | count-in-factors |  |  |  |
+| 243 | count-in-octal-1 |  |  |  |
+| 244 | count-in-octal-2 |  |  |  |
+| 245 | count-in-octal-3 |  |  |  |
+| 246 | count-in-octal-4 |  |  |  |
+| 247 | count-occurrences-of-a-substring |  |  |  |
+| 248 | count-the-coins-1 |  |  |  |
+| 249 | count-the-coins-2 |  |  |  |
+| 250 | cramers-rule |  |  |  |
+| 251 | crc-32-1 |  |  |  |
+| 252 | crc-32-2 |  |  |  |
+| 253 | create-a-file-on-magnetic-tape |  |  |  |
+| 254 | create-a-file |  |  |  |
+| 255 | create-a-two-dimensional-array-at-runtime-1 |  |  |  |
+| 256 | create-an-html-table |  |  |  |
+| 257 | create-an-object-at-a-given-address |  |  |  |
+| 258 | csv-data-manipulation |  |  |  |
+| 259 | csv-to-html-translation-1 |  |  |  |
+| 260 | csv-to-html-translation-2 |  |  |  |
+| 261 | csv-to-html-translation-3 |  |  |  |
+| 262 | csv-to-html-translation-4 |  |  |  |
+| 263 | csv-to-html-translation-5 |  |  |  |
+| 264 | cuban-primes |  |  |  |
+| 265 | cullen-and-woodall-numbers |  |  |  |
+| 266 | cumulative-standard-deviation |  |  |  |
+| 267 | currency |  |  |  |
+| 268 | currying |  |  |  |
+| 269 | curzon-numbers |  |  |  |
+| 270 | cusip |  |  |  |
+| 271 | cyclops-numbers |  |  |  |
+| 272 | damm-algorithm |  |  |  |
+| 273 | date-format |  |  |  |
+| 274 | date-manipulation |  |  |  |
+| 275 | day-of-the-week |  |  |  |
+| 276 | de-bruijn-sequences |  |  |  |
+| 277 | deal-cards-for-freecell |  |  |  |
+| 278 | death-star |  |  |  |
+| 279 | deceptive-numbers |  |  |  |
+| 280 | deconvolution-1d-2 |  |  |  |
+| 281 | deconvolution-1d-3 |  |  |  |
+| 282 | deconvolution-1d |  |  |  |
+| 283 | deepcopy-1 |  |  |  |
+| 284 | define-a-primitive-data-type |  |  |  |
+| 285 | delegates |  |  |  |
+| 286 | demings-funnel |  |  |  |
+| 287 | department-numbers |  |  |  |
+| 288 | descending-primes |  |  |  |
+| 289 | detect-division-by-zero |  |  |  |
+| 290 | determine-if-a-string-has-all-the-same-characters |  |  |  |
+| 291 | determine-if-a-string-has-all-unique-characters |  |  |  |
+| 292 | determine-if-a-string-is-collapsible |  |  |  |
+| 293 | determine-if-a-string-is-numeric-1 |  |  |  |
+| 294 | determine-if-a-string-is-numeric-2 |  |  |  |
+| 295 | determine-if-a-string-is-squeezable |  |  |  |
+| 296 | determine-if-only-one-instance-is-running |  |  |  |
+| 297 | determine-if-two-triangles-overlap |  |  |  |
+| 298 | determine-sentence-type |  |  |  |
+| 299 | dice-game-probabilities-1 |  |  |  |
+| 300 | dice-game-probabilities-2 |  |  |  |
+| 301 | digital-root-multiplicative-digital-root |  |  |  |
+| 302 | dijkstras-algorithm |  |  |  |
+| 303 | dinesmans-multiple-dwelling-problem |  |  |  |
+| 304 | dining-philosophers-1 |  |  |  |
+| 305 | dining-philosophers-2 |  |  |  |
+| 306 | disarium-numbers |  |  |  |
+| 307 | discordian-date |  |  |  |
+| 308 | display-a-linear-combination |  |  |  |
+| 309 | display-an-outline-as-a-nested-table |  |  |  |
+| 310 | distance-and-bearing |  |  |  |
+| 311 | distributed-programming |  |  |  |
+| 312 | diversity-prediction-theorem |  |  |  |
+| 313 | documentation |  |  |  |
+| 314 | doomsday-rule |  |  |  |
+| 315 | dot-product |  |  |  |
+| 316 | doubly-linked-list-definition-1 |  |  |  |
+| 317 | doubly-linked-list-definition-2 |  |  |  |
+| 318 | doubly-linked-list-element-definition |  |  |  |
+| 319 | doubly-linked-list-traversal |  |  |  |
+| 320 | dragon-curve |  |  |  |
+| 321 | draw-a-clock |  |  |  |
+| 322 | draw-a-cuboid |  |  |  |
+| 323 | draw-a-pixel-1 |  |  |  |
+| 324 | draw-a-rotating-cube |  |  |  |
+| 325 | draw-a-sphere |  |  |  |
+| 326 | dutch-national-flag-problem |  |  |  |
+| 327 | dynamic-variable-names |  |  |  |
+| 328 | earliest-difference-between-prime-gaps |  |  |  |
+| 329 | eban-numbers |  |  |  |
+| 330 | echo-server |  |  |  |
+| 331 | ekg-sequence-convergence |  |  |  |
+| 332 | md5 |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,114 @@
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-26 17:18 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-26 05:05 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -155,7 +155,15 @@ fun _now(): Long {
 	extraHelpers = nil
 	helpersUsed = map[string]bool{}
 	localFuncs = map[string]bool{}
-	funcRets = map[string]string{}
+	funcRets = map[string]string{
+		"kotlin.math.abs": "Double",
+	}
+}
+
+// HasFuncRet reports if a return type mapping exists for name.
+func HasFuncRet(name string) bool {
+	_, ok := funcRets[name]
+	return ok
 }
 
 // Program represents a simple Kotlin program consisting of statements executed in main.
@@ -2691,7 +2699,7 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						}
 					}
 				}
-				if typ == "" {
+				if typ == "" || typ == "Any" || typ == "Any?" {
 					typ = guessType(v)
 					if typ == "" {
 						if ix, ok := v.(*IndexExpr); ok && ix.Type != "" {
@@ -2724,7 +2732,27 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 				if s.Let.Type != nil {
 					tt = types.ResolveTypeRef(s.Let.Type, env)
 				} else if t := types.CheckExprType(s.Let.Value, env); t != nil {
-					tt = t
+					if typ != "" && types.ContainsAny(t) {
+						switch typ {
+						case "Int":
+							tt = types.IntType{}
+						case "Double":
+							tt = types.FloatType{}
+						case "Boolean":
+							tt = types.BoolType{}
+						case "String":
+							tt = types.StringType{}
+						default:
+							tt = t
+						}
+					} else {
+						tt = t
+						if typ == "Int" {
+							if _, ok := tt.(types.BigIntType); ok {
+								tt = types.IntType{}
+							}
+						}
+					}
 				} else {
 					switch typ {
 					case "Int":
@@ -2810,7 +2838,7 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 						}
 					}
 				}
-				if typ == "" {
+				if typ == "" || typ == "Any" || typ == "Any?" {
 					typ = guessType(v)
 					if typ == "" {
 						if ix, ok := v.(*IndexExpr); ok && ix.Type != "" {
@@ -2846,7 +2874,27 @@ func convertStmts(env *types.Env, list []*parser.Statement) ([]Stmt, error) {
 				if s.Var.Type != nil {
 					tt = types.ResolveTypeRef(s.Var.Type, env)
 				} else if t := types.CheckExprType(s.Var.Value, env); t != nil {
-					tt = t
+					if typ != "" && types.ContainsAny(t) {
+						switch typ {
+						case "Int":
+							tt = types.IntType{}
+						case "Double":
+							tt = types.FloatType{}
+						case "Boolean":
+							tt = types.BoolType{}
+						case "String":
+							tt = types.StringType{}
+						default:
+							tt = t
+						}
+					} else {
+						tt = t
+						if typ == "Int" {
+							if _, ok := tt.(types.BigIntType); ok {
+								tt = types.IntType{}
+							}
+						}
+					}
 				} else {
 					switch typ {
 					case "Int":


### PR DESCRIPTION
## Summary
- improve Kotlin transpiler type inference for arithmetic expressions
- regenerate Kotlin sources for Rosetta tasks 53-62
- add benchmark results for tasks 53-62
- update transpiler documentation

## Testing
- `ROSETTA_INDEX=53 go test ./transpiler/x/kt -tags slow -run TestRosettaKotlin -count=1 -timeout 0 -v`
- `for i in $(seq 54 62); do ROSETTA_INDEX=$i go test ./transpiler/x/kt -tags slow -run TestRosettaKotlin -count=1 -timeout 0 -v; done`
- `for i in $(seq 53 62); do MOCHI_BENCHMARK=true ROSETTA_INDEX=$i go test ./transpiler/x/kt -tags slow -run TestRosettaKotlin -count=1 -timeout 0; done`


------
https://chatgpt.com/codex/tasks/task_e_6884abb2d69c83209bf955816ef9ea68