### PR TITLE
Update Rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Clojure/abbreviations-easy.bench
+++ b/tests/rosetta/transpiler/Clojure/abbreviations-easy.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 48779,
+  "memory_bytes": 23224824,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/abbreviations-easy.clj
+++ b/tests/rosetta/transpiler/Clojure/abbreviations-easy.clj
@@ -25,6 +25,17 @@
   (do (def table (str (str (str (str (str (str "Add ALTer  BAckup Bottom  CAppend Change SCHANGE  CInsert CLAst COMPress Copy " "COUnt COVerlay CURsor DELete CDelete Down DUPlicate Xedit EXPand EXTract Find ") "NFind NFINDUp NFUp CFind FINdup FUp FOrward GET Help HEXType Input POWerinput ") " Join SPlit SPLTJOIN  LOAD  Locate CLocate  LOWercase UPPercase  LPrefix MACRO ") "MErge MODify MOve MSG Next Overlay PARSE PREServe PURge PUT PUTD  Query  QUIT ") "READ  RECover REFRESH RENum REPeat  Replace CReplace  RESet  RESTore  RGTLEFT ") "RIght LEft  SAVE  SET SHift SI  SORT  SOS  STAck STATus  TOP TRAnsfer TypeUp ")) (def commands (fields table)) (def mins []) (def i 0) (while (< i (count commands)) (do (def count_v 0) (def j 0) (def cmd (nth commands i)) (while (< j (count cmd)) (do (def ch (subs cmd j (+ j 1))) (when (and (>= (compare ch "A") 0) (<= (compare ch "Z") 0)) (def count_v (+ count_v 1))) (def j (+ j 1)))) (def mins (conj mins count_v)) (def i (+ i 1)))) (def sentence "riG   rePEAT copies  put mo   rest    types   fup.    6       poweRin") (def words (fields sentence)) (def results (validate commands words mins)) (def out1 "user words:  ") (def k 0) (while (< k (count words)) (do (def out1 (str (str out1 (padRight (nth words k) (count (nth results k)))) " ")) (def k (+ k 1)))) (println out1) (println (str "full words:  " (join results " ")))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/abc-problem.bench
+++ b/tests/rosetta/transpiler/Clojure/abc-problem.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 46947,
+  "memory_bytes": 21618536,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/abc-problem.clj
+++ b/tests/rosetta/transpiler/Clojure/abc-problem.clj
@@ -22,6 +22,17 @@
   (do (def sp (newSpeller "BO XK DQ CP NA GT RE TG QD FS JW HU VI AN OB ER FS LY PC ZM")) (doseq [word ["A" "BARK" "BOOK" "TREAT" "COMMON" "SQUAD" "CONFUSE"]] (println (str (str word " ") (str (sp word)))))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
 Completed: 20/332
-Last updated: 2025-07-26 19:36 +0700
+Last updated: 2025-07-26 19:58 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -23,9 +23,9 @@ Last updated: 2025-07-26 19:36 +0700
 | 16 | Duffinian-numbers |   |  |  |
 | 17 | a+b | ✓ | 13.848ms | 18.3 MB |
 | 18 | abbreviations-automatic |   |  |  |
-| 19 | abbreviations-easy | ✓ |  |  |
+| 19 | abbreviations-easy | ✓ | 48.779ms | 22.1 MB |
 | 20 | abbreviations-simple |   |  |  |
-| 21 | abc-problem | ✓ |  |  |
+| 21 | abc-problem | ✓ | 46.947ms | 20.6 MB |
 | 22 | abelian-sandpile-model-identity | ✓ |  |  |
 | 23 | abelian-sandpile-model |   |  |  |
 | 24 | abstract-type | ✓ |  |  |


### PR DESCRIPTION
## Summary
- update Clojure transpiler outputs for abbreviations-easy and abc-problem
- add benchmark results
- refresh ROSETTA progress table

## Testing
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -tags slow -run Rosetta -index 21 -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6884ce7cbe88832081802192f3302dc0