### PR TITLE
Add Mochi implementation for Egyptian division Rosetta task

### DIFF
--- a/tests/rosetta/x/Mochi/egyptian-division.mochi
+++ b/tests/rosetta/x/Mochi/egyptian-division.mochi
@@ -1,0 +1,40 @@
+// Mochi translation of Rosetta "Egyptian division" task
+
+// Result type holding quotient and remainder
+type DivResult { q: int, r: int }
+
+fun egyptianDivide(dividend: int, divisor: int): DivResult {
+  if dividend < 0 || divisor <= 0 { panic("Invalid argument(s)") }
+  if dividend < divisor { return DivResult{ q: 0, r: dividend } }
+
+  var powers: list<int> = [1]
+  var doublings: list<int> = [divisor]
+  var doubling = divisor * 2
+  while doubling <= dividend {
+    powers = append(powers, powers[len(powers)-1] * 2)
+    doublings = append(doublings, doubling)
+    doubling = doubling * 2
+  }
+
+  var ans = 0
+  var accum = 0
+  var i = len(doublings) - 1
+  while i >= 0 {
+    if accum + doublings[i] <= dividend {
+      accum = accum + doublings[i]
+      ans = ans + powers[i]
+      if accum == dividend { break }
+    }
+    i = i - 1
+  }
+  return DivResult{ q: ans, r: dividend - accum }
+}
+
+fun main() {
+  let dividend = 580
+  let divisor = 34
+  let res = egyptianDivide(dividend, divisor)
+  print(str(dividend) + " divided by " + str(divisor) + " is " + str(res.q) + " with remainder " + str(res.r))
+}
+
+main()

--- a/tests/rosetta/x/Mochi/egyptian-division.out
+++ b/tests/rosetta/x/Mochi/egyptian-division.out
@@ -1,0 +1,1 @@
+580 divided by 34 is 17 with remainder 2


### PR DESCRIPTION
## Summary
- add Mochi translation of the Egyptian division task
- include expected output for runtime/vm

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/egyptian-division.mochi`


------
https://chatgpt.com/codex/tasks/task_e_688508e661108320a20f6c1233a15122