### PR TITLE
Add Empty-directory Rosetta example

### DIFF
--- a/tests/rosetta/x/Mochi/empty-directory.mochi
+++ b/tests/rosetta/x/Mochi/empty-directory.mochi
@@ -1,0 +1,24 @@
+// Mochi translation of Rosetta "Empty-directory" task
+// Simulates a minimal filesystem as Mochi lacks standard directory APIs.
+
+fun isEmptyDir(fs: map<string, list<string>>, name: string): bool {
+  if name in fs {
+    return len(fs[name]) == 0
+  }
+  // non-existent directories are considered empty
+  return true
+}
+
+fun main() {
+  var fs: map<string, list<string>> = {}
+  fs["/tmp"] = []
+  fs["/var"] = ["log"]
+
+  if isEmptyDir(fs, "/tmp") {
+    print("/tmp is empty")
+  } else {
+    print("/tmp is not empty")
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/empty-directory.out
+++ b/tests/rosetta/x/Mochi/empty-directory.out
@@ -1,0 +1,1 @@
+/tmp is empty


### PR DESCRIPTION
## Summary
- download Rosetta task #310 via tools/rosetta
- add Mochi translation for `Empty-directory`
- store expected output for the program

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/empty-directory.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68850935a16483209b4b900cc38a9bdb