### PR TITLE
Add Mochi solution for environment variables

### DIFF
--- a/tests/rosetta/x/Mochi/environment-variables-1.mochi
+++ b/tests/rosetta/x/Mochi/environment-variables-1.mochi
@@ -1,0 +1,6 @@
+// Mochi translation of Rosetta "Environment variables" task (version 1)
+// Prints the value of the SHELL environment variable.
+
+import go "os" as os auto
+
+print(os.Getenv("SHELL"))

--- a/tests/rosetta/x/Mochi/environment-variables-1.out
+++ b/tests/rosetta/x/Mochi/environment-variables-1.out
@@ -1,0 +1,1 @@
+/bin/bash

--- a/tests/rosetta/x/Mochi/environment-variables-2.mochi
+++ b/tests/rosetta/x/Mochi/environment-variables-2.mochi
@@ -1,0 +1,19 @@
+// Mochi translation of Rosetta "Environment variables" task (version 2)
+// Searches the environment list for the SHELL variable.
+
+import go "os" as os auto
+
+fun hasPrefix(s: string, p: string): bool {
+  if len(p) > len(s) { return false }
+  return substring(s, 0, len(p)) == p
+}
+
+let name = "SHELL"
+let prefix = name + "="
+for v in os.Environ() {
+  if hasPrefix(v, prefix) {
+    print(name + " has value " + substring(v, len(prefix), len(v)))
+    return
+  }
+}
+print(name + " not found")

--- a/tests/rosetta/x/Mochi/environment-variables-2.out
+++ b/tests/rosetta/x/Mochi/environment-variables-2.out
@@ -1,0 +1,1 @@
+SHELL has value /bin/bash


### PR DESCRIPTION
## Summary
- download Rosetta task 317 (Environment-variables) for Go
- implement two Mochi versions showing environment variable access
- capture VM output for both examples

## Testing
- `SHELL=/bin/bash go run ./cmd/mochi run tests/rosetta/x/Mochi/environment-variables-1.mochi`
- `SHELL=/bin/bash go run ./cmd/mochi run tests/rosetta/x/Mochi/environment-variables-2.mochi`

------
https://chatgpt.com/codex/tasks/task_e_688514da5a788320b04fc95ec48cc228