### PR TITLE
Add Mochi version of Erd's Nicolas numbers

### DIFF
--- a/tests/rosetta/x/Mochi/erd-s-nicolas-numbers.mochi
+++ b/tests/rosetta/x/Mochi/erd-s-nicolas-numbers.mochi
@@ -1,0 +1,35 @@
+// Translated from Go version in tests/rosetta/x/Go/erd-s-nicolas-numbers.go
+// WARNING: This program uses a large amount of memory and time for
+// maxNumber = 100000000.
+// It mirrors the sieve-based approach from the Go example.
+
+const maxNumber = 100000000
+
+var dsum: list<int> = []
+var dcount: list<int> = []
+var i = 0
+while i <= maxNumber {
+  dsum = append(dsum, 1)
+  dcount = append(dcount, 1)
+  i = i + 1
+}
+
+fun pad8(n: int): string {
+  var s = str(n)
+  while len(s) < 8 { s = " " + s }
+  return s
+}
+
+i = 2
+while i <= maxNumber {
+  var j = i + i
+  while j <= maxNumber {
+    if dsum[j] == j {
+      print(pad8(j) + " equals the sum of its first " + str(dcount[j]) + " divisors")
+    }
+    dsum[j] = dsum[j] + i
+    dcount[j] = dcount[j] + 1
+    j = j + i
+  }
+  i = i + 1
+}

--- a/tests/rosetta/x/Mochi/erd-s-nicolas-numbers.out
+++ b/tests/rosetta/x/Mochi/erd-s-nicolas-numbers.out
@@ -1,0 +1,10 @@
+      24 equals the sum of its first 6 divisors
+    2016 equals the sum of its first 31 divisors
+    8190 equals the sum of its first 43 divisors
+   42336 equals the sum of its first 66 divisors
+   45864 equals the sum of its first 66 divisors
+  714240 equals the sum of its first 113 divisors
+  392448 equals the sum of its first 68 divisors
+ 1571328 equals the sum of its first 115 divisors
+61900800 equals the sum of its first 280 divisors
+91963648 equals the sum of its first 142 divisors


### PR DESCRIPTION
## Summary
- add Mochi program for Erd's Nicolas numbers
- include output produced by the Go reference implementation

## Testing
- `go test -tags slow ./...` *(fails: tests require heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688514f7de608320a900a30e5f31b103