### PR TITLE
Add Mochi solution for Empty-string Rosetta task

### DIFF
--- a/tests/rosetta/x/Mochi/empty-string-1.mochi
+++ b/tests/rosetta/x/Mochi/empty-string-1.mochi
@@ -1,0 +1,15 @@
+// Mochi translation of Rosetta task "Empty-string" (variant 1)
+// Demonstrates creating and testing empty strings.
+
+fun main() {
+  var s: string
+  var s2 = ""
+  s = ""
+
+  print(s == "")
+  print(len(s) == 0)
+  print(s != "")
+  print(len(s) != 0)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/empty-string-1.out
+++ b/tests/rosetta/x/Mochi/empty-string-1.out
@@ -1,0 +1,4 @@
+true
+true
+false
+false

--- a/tests/rosetta/x/Mochi/empty-string-2.mochi
+++ b/tests/rosetta/x/Mochi/empty-string-2.mochi
@@ -1,0 +1,19 @@
+// Mochi translation of Rosetta task "Empty-string" (variant 2)
+// Checks if strings are empty or not and prints the result.
+
+fun check(s: string) {
+  if len(s) == 0 {
+    print("empty")
+  } else {
+    print("not empty")
+  }
+}
+
+fun main() {
+  let str1 = ""
+  let str2 = " "
+  check(str1)
+  check(str2)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/empty-string-2.out
+++ b/tests/rosetta/x/Mochi/empty-string-2.out
@@ -1,0 +1,2 @@
+empty
+not empty


### PR DESCRIPTION
## Summary
- download Empty-string Go task using `DownloadTaskByNumber`
- add two Mochi implementations for the Empty-string task
- include outputs produced by `runtime/vm`

## Testing
- `go test ./tools/rosetta -run TestDownloadTaskByNumber -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_68851720626c832093a878827c3aeedf