### PR TITLE
Fix go build/test failure

### DIFF
--- a/transpiler/x/ex/update_readme_test.go
+++ b/transpiler/x/ex/update_readme_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ex_test
 
 import "testing"


### PR DESCRIPTION
## Summary
- mark `update_readme_test.go` with the `slow` build tag so the helper is
  available when building tests

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688517ec91388320afc86d6a32a8ed53