### PR TITLE
Update clj transpiler for rosetta tests

### DIFF
--- a/tests/rosetta/transpiler/Clojure/24-game-solve.bench
+++ b/tests/rosetta/transpiler/Clojure/24-game-solve.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 128127,
-  "memory_bytes": 24439784,
+  "duration_us": 73371,
+  "memory_bytes": 24037064,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Clojure/24-game-solve.out
+++ b/tests/rosetta/transpiler/Clojure/24-game-solve.out
@@ -1,5 +1,4 @@
-WARNING: rest already refers to: #'clojure.core/rest in namespace: main, being replaced by: #'main/rest
- 5
+5
  8
  6
  1
@@ -16,7 +15,7 @@ No solution
  4
  2
 :  
-(4 * (4 + 2))
+((1 + 3) * (4 + 2))
  5
  1
  8
@@ -46,7 +45,7 @@ No solution
  8
  8
 :  
-(8 + (8 + 8))
+No solution
  6
  6
  4

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -108,4 +108,4 @@ Compiled programs: 101/104
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-26 19:01 +0700
+Last updated: 2025-07-27 00:51 +0700

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 20/332
-Last updated: 2025-07-26 19:58 +0700
+Completed: 20/341
+Last updated: 2025-07-27 01:03 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -13,7 +13,7 @@ Last updated: 2025-07-26 19:58 +0700
 | 6 | 15-puzzle-solver | ✓ | 50.367ms | 17.6 MB |
 | 7 | 2048 |   |  |  |
 | 8 | 21-game |   |  |  |
-| 9 | 24-game-solve | ✓ | 128.127ms | 23.3 MB |
+| 9 | 24-game-solve | ✓ | 73.371ms | 22.9 MB |
 | 10 | 24-game |   |  |  |
 | 11 | 4-rings-or-4-squares-puzzle |   |  |  |
 | 12 | 9-billion-names-of-god-the-integer | ✓ | 7.099292s | 46.6 MB |
@@ -335,5 +335,14 @@ Last updated: 2025-07-26 19:58 +0700
 | 328 | earliest-difference-between-prime-gaps |   |  |  |
 | 329 | eban-numbers |   |  |  |
 | 330 | echo-server |   |  |  |
-| 331 | ekg-sequence-convergence |   |  |  |
-| 332 | md5 |   |  |  |
+| 331 | eertree |   |  |  |
+| 332 | egyptian-division |   |  |  |
+| 333 | ekg-sequence-convergence |   |  |  |
+| 334 | element-wise-operations |   |  |  |
+| 335 | elementary-cellular-automaton-infinite-length |   |  |  |
+| 336 | elementary-cellular-automaton-random-number-generator |   |  |  |
+| 337 | elementary-cellular-automaton |   |  |  |
+| 338 | elliptic-curve-arithmetic |   |  |  |
+| 339 | emirp-primes |   |  |  |
+| 340 | empty-directory |   |  |  |
+| 341 | md5 |   |  |  |

--- a/transpiler/x/clj/transpiler.go
+++ b/transpiler/x/clj/transpiler.go
@@ -613,6 +613,7 @@ var renameVars map[string]string
 var reservedNames = map[string]bool{
 	"count": true,
 	"in":    true,
+	"rest":  true,
 }
 
 // builtin replacements for some heavy numeric helpers


### PR DESCRIPTION
## Summary
- reserve `rest` name in clj transpiler to avoid namespace warning
- regenerate Rosetta outputs for `24-game-solve`
- refresh README and ROSETTA tables

## Testing
- `go test ./transpiler/x/clj -run TestRosettaClojure -tags slow -index=9`


------
https://chatgpt.com/codex/tasks/task_e_6885161b7f508320a30e0fa7d2ba8364