### PR TITLE
Add HTTP example for Mochi Rosetta

### DIFF
--- a/tests/rosetta/x/Mochi/http.mochi
+++ b/tests/rosetta/x/Mochi/http.mochi
@@ -1,0 +1,15 @@
+// Fetch a JSON resource over HTTP using Mochi's fetch expression
+
+type Todo {
+  userId: int
+  id: int
+  title: string
+  completed: bool
+}
+
+fun main() {
+  let todo: Todo = fetch "https://jsonplaceholder.typicode.com/todos/1"
+  print(todo.title)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/http.out
+++ b/tests/rosetta/x/Mochi/http.out
@@ -1,0 +1,1 @@
+delectus aut autem


### PR DESCRIPTION
## Summary
- add new Rosetta task example `http.mochi`
- store its output in `http.out`

Ran `go run -tags slow ./tools/rosetta/cmd/download_by_number.go -n 450 -refresh` to ensure the Go task is cached. No Go files changed because the HTTP task already existed.

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/http.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68855b9b6c4083208accf1785994487d