### PR TITLE
Implement Fork task logic in Mochi

### DIFF
--- a/tests/rosetta/x/Go/fork.go
+++ b/tests/rosetta/x/Go/fork.go
@@ -4,26 +4,26 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 )
 
 func main() {
-    fmt.Printf("PID: %v\n", os.Getpid())
-    if len(os.Args) < 2 {
-        fmt.Println("Done.")
-        return
-    }
-    cp, err := os.StartProcess(os.Args[0], nil,
-        &os.ProcAttr{Files: []*os.File{nil, os.Stdout}},
-    )
-    if err != nil {
-        fmt.Println(err)
-    }
-    // Child process running independently at this point.
-    // We have its PID and can print it.
-    fmt.Printf("Child's PID: %v\n", cp.Pid)
-    if _, err = cp.Wait(); err != nil {
-        fmt.Println(err)
-    }
+	fmt.Printf("PID: %v\n", os.Getpid())
+	if len(os.Args) < 2 {
+		fmt.Println("Done.")
+		return
+	}
+	cp, err := os.StartProcess(os.Args[0], nil,
+		&os.ProcAttr{Files: []*os.File{nil, os.Stdout}},
+	)
+	if err != nil {
+		fmt.Println(err)
+	}
+	// Child process running independently at this point.
+	// We have its PID and can print it.
+	fmt.Printf("Child's PID: %v\n", cp.Pid)
+	if _, err = cp.Wait(); err != nil {
+		fmt.Println(err)
+	}
 }

--- a/tests/rosetta/x/Mochi/fork.mochi
+++ b/tests/rosetta/x/Mochi/fork.mochi
@@ -1,2 +1,26 @@
-print("PID: 1")
-print("Done.")
+// Mochi translation of the Rosetta "Fork" task.
+// The VM lacks real process creation APIs so we
+// model the behaviour by invoking the program logic
+// recursively. When invoked with an argument, the
+// "parent" prints its PID, announces the child PID
+// and then calls the child function which prints its
+// own PID and exits.
+
+var nextPID = 1
+
+fun run(hasArg: bool) {
+  let pid = nextPID
+  nextPID = nextPID + 1
+
+  print("PID: " + str(pid))
+  if !hasArg {
+    print("Done.")
+    return
+  }
+
+  let childPID = nextPID
+  print("Child's PID: " + str(childPID))
+  run(false)
+}
+
+run(true)

--- a/tests/rosetta/x/Mochi/fork.out
+++ b/tests/rosetta/x/Mochi/fork.out
@@ -1,2 +1,4 @@
 PID: 1
+Child's PID: 2
+PID: 2
 Done.


### PR DESCRIPTION
## Summary
- refresh Go source for Rosetta `Fork` task using DownloadTaskByNumber
- implement sequential simulation of `fork` logic in Mochi
- update expected output for the new Mochi implementation

## Testing
- `go test -tags slow ./tools/rosetta -run TestDownloadTaskByNumber -count=1`
- `go test ./runtime/vm -run TestVM -count=1 -timeout 60s`


------
https://chatgpt.com/codex/tasks/task_e_68855b926cb48320b72ec0d6f2a67b0c