### PR TITLE
Add Window-management Rosetta example

### DIFF
--- a/tests/rosetta/x/Go/window-management.go
+++ b/tests/rosetta/x/Go/window-management.go
@@ -1,0 +1,103 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "github.com/gotk3/gotk3/gtk"
+    "log"
+    "time"
+)
+
+func check(err error, msg string) {
+    if err != nil {
+        log.Fatal(msg, err)
+    }
+}
+
+func main() {
+    gtk.Init(nil)
+
+    window, err := gtk.WindowNew(gtk.WINDOW_TOPLEVEL)
+    check(err, "Unable to create window:")
+    window.SetResizable(true)
+    window.SetTitle("Window management")
+    window.SetBorderWidth(5)
+    window.Connect("destroy", func() {
+        gtk.MainQuit()
+    })
+
+    stackbox, err := gtk.BoxNew(gtk.ORIENTATION_VERTICAL, 10)
+    check(err, "Unable to create stack box:")
+
+    bmax, err := gtk.ButtonNewWithLabel("Maximize")
+    check(err, "Unable to create maximize button:")
+    bmax.Connect("clicked", func() {
+        window.Maximize()
+    })
+
+    bunmax, err := gtk.ButtonNewWithLabel("Unmaximize")
+    check(err, "Unable to create unmaximize button:")
+    bunmax.Connect("clicked", func() {
+        window.Unmaximize()
+    })
+
+    bicon, err := gtk.ButtonNewWithLabel("Iconize")
+    check(err, "Unable to create iconize button:")
+    bicon.Connect("clicked", func() {
+        window.Iconify()
+    })
+
+    bdeicon, err := gtk.ButtonNewWithLabel("Deiconize")
+    check(err, "Unable to create deiconize button:")
+    bdeicon.Connect("clicked", func() {
+        window.Deiconify()
+    })
+
+    bhide, err := gtk.ButtonNewWithLabel("Hide")
+    check(err, "Unable to create hide button:")
+    bhide.Connect("clicked", func() {
+        // not working on Ubuntu 16.04 but window 'dims' after a few seconds
+        window.Hide()
+        time.Sleep(10 * time.Second)
+        window.Show()
+    })
+
+    bshow, err := gtk.ButtonNewWithLabel("Show")
+    check(err, "Unable to create show button:")
+    bshow.Connect("clicked", func() {
+        window.Show()
+    })
+
+    bmove, err := gtk.ButtonNewWithLabel("Move")
+    check(err, "Unable to create move button:")
+    isShifted := false
+    bmove.Connect("clicked", func() {
+        w, h := window.GetSize()
+        if isShifted {
+            window.Move(w-10, h-10)
+        } else {
+            window.Move(w+10, h+10)
+        }
+        isShifted = !isShifted
+    })
+
+    bquit, err := gtk.ButtonNewWithLabel("Quit")
+    check(err, "Unable to create quit button:")
+    bquit.Connect("clicked", func() {
+        window.Destroy()
+    })
+
+    stackbox.PackStart(bmax, true, true, 0)
+    stackbox.PackStart(bunmax, true, true, 0)
+    stackbox.PackStart(bicon, true, true, 0)
+    stackbox.PackStart(bdeicon, true, true, 0)
+    stackbox.PackStart(bhide, true, true, 0)
+    stackbox.PackStart(bshow, true, true, 0)
+    stackbox.PackStart(bmove, true, true, 0)
+    stackbox.PackStart(bquit, true, true, 0)
+
+    window.Add(stackbox)
+    window.ShowAll()
+    gtk.Main()
+}

--- a/tests/rosetta/x/Mochi/window-management.mochi
+++ b/tests/rosetta/x/Mochi/window-management.mochi
@@ -1,0 +1,85 @@
+// Simulation of window management actions in Mochi
+
+type Window {
+  x: int
+  y: int
+  w: int
+  h: int
+  maximized: bool
+  iconified: bool
+  visible: bool
+  shifted: bool
+}
+
+fun showState(w: Window, label: string) {
+  print(label + ": pos=(" + str(w.x) + "," + str(w.y) + ") size=(" + str(w.w) + "x" + str(w.h) + ") max=" + str(w.maximized) + " icon=" + str(w.iconified) + " visible=" + str(w.visible))
+}
+
+fun maximize(w: Window): Window {
+  w.maximized = true
+  w.w = 800
+  w.h = 600
+  return w
+}
+
+fun unmaximize(w: Window): Window {
+  w.maximized = false
+  w.w = 640
+  w.h = 480
+  return w
+}
+
+fun iconify(w: Window): Window {
+  w.iconified = true
+  w.visible = false
+  return w
+}
+
+fun deiconify(w: Window): Window {
+  w.iconified = false
+  w.visible = true
+  return w
+}
+
+fun hide(w: Window): Window {
+  w.visible = false
+  return w
+}
+
+fun showWindow(w: Window): Window {
+  w.visible = true
+  return w
+}
+
+fun move(w: Window): Window {
+  if w.shifted {
+    w.x = w.x - 10
+    w.y = w.y - 10
+  } else {
+    w.x = w.x + 10
+    w.y = w.y + 10
+  }
+  w.shifted = !w.shifted
+  return w
+}
+
+fun main() {
+  var win = Window{ x: 100, y: 100, w: 640, h: 480, maximized: false, iconified: false, visible: true, shifted: false }
+  showState(win, "Start")
+  win = maximize(win)
+  showState(win, "Maximize")
+  win = unmaximize(win)
+  showState(win, "Unmaximize")
+  win = iconify(win)
+  showState(win, "Iconify")
+  win = deiconify(win)
+  showState(win, "Deiconify")
+  win = hide(win)
+  showState(win, "Hide")
+  win = showWindow(win)
+  showState(win, "Show")
+  win = move(win)
+  showState(win, "Move")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/window-management.out
+++ b/tests/rosetta/x/Mochi/window-management.out
@@ -1,0 +1,8 @@
+Start: pos=(100,100) size=(640x480) max=false icon=false visible=true
+Maximize: pos=(100,100) size=(800x600) max=true icon=false visible=true
+Unmaximize: pos=(100,100) size=(640x480) max=false icon=false visible=true
+Iconify: pos=(100,100) size=(640x480) max=false icon=true visible=false
+Deiconify: pos=(100,100) size=(640x480) max=false icon=false visible=true
+Hide: pos=(100,100) size=(640x480) max=false icon=false visible=false
+Show: pos=(100,100) size=(640x480) max=false icon=false visible=true
+Move: pos=(110,110) size=(640x480) max=false icon=false visible=true


### PR DESCRIPTION
## Summary
- download Rosetta Code task 1200 (Window-management) in Go
- implement Window-management simulation in Mochi
- record the expected VM output for the Mochi program

## Testing
- `MOCHI_ROSETTA_ONLY=window-management go test ./runtime/vm -run Rosetta -tags slow -update`

------
https://chatgpt.com/codex/tasks/task_e_688560a20fbc8320b6c0aa331f6a9855