### PR TITLE
Add int builtin support in VM

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-26 23:42 UTC
+Last updated: 2025-07-26 23:52 UTC
 
-## Rosetta Golden Test Checklist (259/435)
+## Rosetta Golden Test Checklist (259/439)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
@@ -273,7 +273,7 @@ Last updated: 2025-07-26 23:42 UTC
 | 264 | cuban-primes | ✓ |  |  |
 | 265 | cullen-and-woodall-numbers | ✓ |  |  |
 | 266 | cumulative-standard-deviation | ✓ | 147µs | 72.6 KB |
-| 267 | currency | ✓ |  |  |
+| 267 | currency | ✓ | 208µs | 86.5 KB |
 | 268 | currying | ✓ |  |  |
 | 269 | curzon-numbers | ✓ |  |  |
 | 270 | cusip | ✓ |  |  |
@@ -336,109 +336,113 @@ Last updated: 2025-07-26 23:42 UTC
 | 327 | dynamic-variable-names |   |  |  |
 | 328 | earliest-difference-between-prime-gaps |   |  |  |
 | 329 | eban-numbers |   |  |  |
-| 330 | echo-server |   |  |  |
-| 331 | eertree |   |  |  |
-| 332 | egyptian-division |   |  |  |
-| 333 | ekg-sequence-convergence |   |  |  |
-| 334 | element-wise-operations |   |  |  |
-| 335 | elementary-cellular-automaton-infinite-length |   |  |  |
-| 336 | elementary-cellular-automaton-random-number-generator |   |  |  |
-| 337 | elementary-cellular-automaton |   |  |  |
-| 338 | elliptic-curve-arithmetic |   |  |  |
-| 339 | elliptic-curve-digital-signature-algorithm |   |  |  |
-| 340 | emirp-primes |   |  |  |
-| 341 | empty-directory |   |  |  |
-| 342 | empty-program |   |  |  |
-| 343 | empty-string-1 |   |  |  |
-| 344 | empty-string-2 |   |  |  |
-| 345 | enforced-immutability | ✓ |  |  |
-| 346 | entropy-1 | ✓ |  |  |
-| 347 | entropy-2 | ✓ |  |  |
-| 348 | entropy-narcissist |   |  |  |
-| 349 | enumerations-1 |   |  |  |
-| 350 | enumerations-2 |   |  |  |
-| 351 | enumerations-3 |   |  |  |
-| 352 | enumerations-4 |   |  |  |
-| 353 | environment-variables-1 |   |  |  |
-| 354 | environment-variables-2 |   |  |  |
-| 355 | equal-prime-and-composite-sums |   |  |  |
-| 356 | equilibrium-index | ✓ |  |  |
-| 357 | erd-s-nicolas-numbers |   |  |  |
-| 358 | erd-s-selfridge-categorization-of-primes |   |  |  |
-| 359 | esthetic-numbers |   |  |  |
-| 360 | events |   |  |  |
-| 361 | evolutionary-algorithm |   |  |  |
-| 362 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
-| 363 | exceptions |   |  |  |
-| 364 | executable-library |   |  |  |
-| 365 | execute-a-markov-algorithm |   |  |  |
-| 366 | execute-a-system-command |   |  |  |
-| 367 | execute-brain- |   |  |  |
-| 368 | execute-computer-zero |   |  |  |
-| 369 | execute-hq9+ |   |  |  |
-| 370 | execute-snusp |   |  |  |
-| 371 | exponentiation-operator |   |  |  |
-| 372 | exponentiation-order |   |  |  |
-| 373 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
-| 374 | extend-your-language |   |  |  |
-| 375 | extensible-prime-generator |   |  |  |
-| 376 | extreme-floating-point-values |   |  |  |
-| 377 | faces-from-a-mesh |   |  |  |
-| 378 | fasta-format |   |  |  |
-| 379 | faulhabers-triangle |   |  |  |
-| 380 | feigenbaum-constant-calculation |   |  |  |
-| 381 | fermat-numbers |   |  |  |
-| 382 | fibonacci-n-step-number-sequences |   |  |  |
-| 383 | fibonacci-sequence-1 |   |  |  |
-| 384 | fibonacci-sequence-2 |   |  |  |
-| 385 | fibonacci-sequence-3 |   |  |  |
-| 386 | fibonacci-sequence-4 |   |  |  |
-| 387 | fibonacci-word-fractal |   |  |  |
-| 388 | fibonacci-word |   |  |  |
-| 389 | file-extension-is-in-extensions-list |   |  |  |
-| 390 | file-input-output-1 |   |  |  |
-| 391 | file-input-output-2 |   |  |  |
-| 392 | file-modification-time |   |  |  |
-| 393 | file-size-distribution |   |  |  |
-| 394 | file-size |   |  |  |
-| 395 | filter |   |  |  |
-| 396 | find-chess960-starting-position-identifier |   |  |  |
-| 397 | find-common-directory-path |   |  |  |
-| 398 | find-duplicate-files |   |  |  |
-| 399 | find-if-a-point-is-within-a-triangle |   |  |  |
-| 400 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
-| 401 | find-limit-of-recursion |   |  |  |
-| 402 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
-| 403 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
-| 404 | find-the-intersection-of-two-lines |   |  |  |
-| 405 | find-the-last-sunday-of-each-month |   |  |  |
-| 406 | find-the-missing-permutation |   |  |  |
-| 407 | fivenum-1 |   |  |  |
-| 408 | fivenum-2 |   |  |  |
-| 409 | fixed-length-records-1 |   |  |  |
-| 410 | fixed-length-records-2 |   |  |  |
-| 411 | fizzbuzz-1 |   |  |  |
-| 412 | fizzbuzz-2 |   |  |  |
-| 413 | flatten-a-list-1 |   |  |  |
-| 414 | flatten-a-list-2 |   |  |  |
-| 415 | flipping-bits-game |   |  |  |
-| 416 | flow-control-structures-1 |   |  |  |
-| 417 | flow-control-structures-2 |   |  |  |
-| 418 | flow-control-structures-3 |   |  |  |
-| 419 | flow-control-structures-4 |   |  |  |
-| 420 | floyd-warshall-algorithm |   |  |  |
-| 421 | floyds-triangle |   |  |  |
-| 422 | forest-fire |   |  |  |
-| 423 | fork |   |  |  |
-| 424 | ftp |   |  |  |
-| 425 | gamma-function |   |  |  |
-| 426 | general-fizzbuzz |   |  |  |
-| 427 | generic-swap |   |  |  |
-| 428 | get-system-command-output |   |  |  |
-| 429 | giuga-numbers |   |  |  |
-| 430 | globally-replace-text-in-several-files |   |  |  |
-| 431 | goldbachs-comet |   |  |  |
-| 432 | golden-ratio-convergence |   |  |  |
-| 433 | graph-colouring |   |  |  |
-| 434 | gray-code |   |  |  |
-| 435 | md5 |   |  |  |
+| 330 | ecdsa-example |   |  |  |
+| 331 | echo-server |   |  |  |
+| 332 | eertree |   |  |  |
+| 333 | egyptian-division |   |  |  |
+| 334 | ekg-sequence-convergence |   |  |  |
+| 335 | element-wise-operations |   |  |  |
+| 336 | elementary-cellular-automaton-infinite-length |   |  |  |
+| 337 | elementary-cellular-automaton-random-number-generator |   |  |  |
+| 338 | elementary-cellular-automaton |   |  |  |
+| 339 | elliptic-curve-arithmetic |   |  |  |
+| 340 | elliptic-curve-digital-signature-algorithm |   |  |  |
+| 341 | emirp-primes |   |  |  |
+| 342 | empty-directory |   |  |  |
+| 343 | empty-program |   |  |  |
+| 344 | empty-string-1 |   |  |  |
+| 345 | empty-string-2 |   |  |  |
+| 346 | enforced-immutability | ✓ |  |  |
+| 347 | entropy-1 | ✓ |  |  |
+| 348 | entropy-2 | ✓ |  |  |
+| 349 | entropy-narcissist |   |  |  |
+| 350 | enumerations-1 |   |  |  |
+| 351 | enumerations-2 |   |  |  |
+| 352 | enumerations-3 |   |  |  |
+| 353 | enumerations-4 |   |  |  |
+| 354 | environment-variables-1 |   |  |  |
+| 355 | environment-variables-2 |   |  |  |
+| 356 | equal-prime-and-composite-sums |   |  |  |
+| 357 | equilibrium-index | ✓ |  |  |
+| 358 | erd-s-nicolas-numbers |   |  |  |
+| 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
+| 360 | esthetic-numbers |   |  |  |
+| 361 | events |   |  |  |
+| 362 | evolutionary-algorithm |   |  |  |
+| 363 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
+| 364 | exceptions |   |  |  |
+| 365 | executable-library |   |  |  |
+| 366 | execute-a-markov-algorithm |   |  |  |
+| 367 | execute-a-system-command |   |  |  |
+| 368 | execute-brain- |   |  |  |
+| 369 | execute-computer-zero |   |  |  |
+| 370 | execute-hq9+ |   |  |  |
+| 371 | execute-snusp |   |  |  |
+| 372 | exponentiation-operator |   |  |  |
+| 373 | exponentiation-order |   |  |  |
+| 374 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
+| 375 | extend-your-language |   |  |  |
+| 376 | extensible-prime-generator |   |  |  |
+| 377 | extreme-floating-point-values |   |  |  |
+| 378 | faces-from-a-mesh |   |  |  |
+| 379 | fasta-format |   |  |  |
+| 380 | faulhabers-triangle |   |  |  |
+| 381 | feigenbaum-constant-calculation |   |  |  |
+| 382 | fermat-numbers |   |  |  |
+| 383 | fibonacci-n-step-number-sequences |   |  |  |
+| 384 | fibonacci-sequence-1 |   |  |  |
+| 385 | fibonacci-sequence-2 |   |  |  |
+| 386 | fibonacci-sequence-3 |   |  |  |
+| 387 | fibonacci-sequence-4 |   |  |  |
+| 388 | fibonacci-word-fractal |   |  |  |
+| 389 | fibonacci-word |   |  |  |
+| 390 | file-extension-is-in-extensions-list |   |  |  |
+| 391 | file-input-output-1 |   |  |  |
+| 392 | file-input-output-2 |   |  |  |
+| 393 | file-modification-time |   |  |  |
+| 394 | file-size-distribution |   |  |  |
+| 395 | file-size |   |  |  |
+| 396 | filter |   |  |  |
+| 397 | find-chess960-starting-position-identifier |   |  |  |
+| 398 | find-common-directory-path |   |  |  |
+| 399 | find-duplicate-files |   |  |  |
+| 400 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 401 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 402 | find-limit-of-recursion |   |  |  |
+| 403 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 404 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 405 | find-the-intersection-of-two-lines |   |  |  |
+| 406 | find-the-last-sunday-of-each-month |   |  |  |
+| 407 | find-the-missing-permutation |   |  |  |
+| 408 | fivenum-1 |   |  |  |
+| 409 | fivenum-2 |   |  |  |
+| 410 | fixed-length-records-1 |   |  |  |
+| 411 | fixed-length-records-2 |   |  |  |
+| 412 | fizzbuzz-1 |   |  |  |
+| 413 | fizzbuzz-2 |   |  |  |
+| 414 | flatten-a-list-1 |   |  |  |
+| 415 | flatten-a-list-2 |   |  |  |
+| 416 | flipping-bits-game |   |  |  |
+| 417 | flow-control-structures-1 |   |  |  |
+| 418 | flow-control-structures-2 |   |  |  |
+| 419 | flow-control-structures-3 |   |  |  |
+| 420 | flow-control-structures-4 |   |  |  |
+| 421 | floyd-warshall-algorithm |   |  |  |
+| 422 | floyds-triangle |   |  |  |
+| 423 | forest-fire |   |  |  |
+| 424 | fork |   |  |  |
+| 425 | ftp |   |  |  |
+| 426 | gamma-function |   |  |  |
+| 427 | general-fizzbuzz |   |  |  |
+| 428 | generic-swap |   |  |  |
+| 429 | get-system-command-output |   |  |  |
+| 430 | giuga-numbers |   |  |  |
+| 431 | globally-replace-text-in-several-files |   |  |  |
+| 432 | goldbachs-comet |   |  |  |
+| 433 | golden-ratio-convergence |   |  |  |
+| 434 | graph-colouring |   |  |  |
+| 435 | gray-code |   |  |  |
+| 436 | http |   |  |  |
+| 437 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 438 | md5 |   |  |  |
+| 439 | nim-game |   |  |  |

--- a/tests/rosetta/ir/currency.bench
+++ b/tests/rosetta/ir/currency.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 208,
+  "memory_bytes": 88544,
+  "name": "main"
+}

--- a/tests/rosetta/ir/currying.ir
+++ b/tests/rosetta/ir/currying.ir
@@ -13,6 +13,7 @@ func pow (regs=11)
   Move         r5, r4
 L1:
   // while i < int(exp) {
+  Cast         r6, r1, int
   Less         r7, r5, r6
   JumpIfFalse  r7, L0
   // result = result * base

--- a/tests/rosetta/x/Mochi/index.txt
+++ b/tests/rosetta/x/Mochi/index.txt
@@ -1,439 +1,444 @@
-1 100-doors-2.mochi
-2 100-doors-3.mochi
-3 100-doors.mochi
-4 100-prisoners.mochi
-5 15-puzzle-game.mochi
-6 15-puzzle-solver.mochi
-7 2048.mochi
-8 21-game.mochi
-9 24-game-solve.mochi
-10 24-game.mochi
-11 4-rings-or-4-squares-puzzle.mochi
-12 9-billion-names-of-god-the-integer.mochi
-13 99-bottles-of-beer-2.mochi
-14 99-bottles-of-beer.mochi
-15 DNS-query.mochi
-16 Duffinian-numbers.mochi
-17 a+b.mochi
-18 abbreviations-automatic.mochi
-19 abbreviations-easy.mochi
-20 abbreviations-simple.mochi
-21 abc-problem.mochi
-22 abelian-sandpile-model-identity.mochi
-23 abelian-sandpile-model.mochi
-24 abstract-type.mochi
-25 abundant-deficient-and-perfect-number-classifications.mochi
-26 abundant-odd-numbers.mochi
-27 accumulator-factory.mochi
-28 achilles-numbers.mochi
-29 ackermann-function-2.mochi
-30 ackermann-function-3.mochi
-31 ackermann-function.mochi
-32 active-directory-connect.mochi
-33 active-directory-search-for-a-user.mochi
-34 active-object.mochi
-35 add-a-variable-to-a-class-instance-at-runtime.mochi
-36 additive-primes.mochi
-37 address-of-a-variable.mochi
-38 adfgvx-cipher.mochi
-39 aks-test-for-primes.mochi
-40 algebraic-data-types.mochi
-41 align-columns.mochi
-42 aliquot-sequence-classifications.mochi
-43 almkvist-giullera-formula-for-pi.mochi
-44 almost-prime.mochi
-45 amb.mochi
-46 amicable-pairs.mochi
-47 anagrams-deranged-anagrams.mochi
-48 anagrams.mochi
-49 angle-difference-between-two-bearings-1.mochi
-50 angle-difference-between-two-bearings-2.mochi
-51 angles-geometric-normalization-and-conversion.mochi
-52 animate-a-pendulum.mochi
-53 animation.mochi
-54 anonymous-recursion-1.mochi
-55 anonymous-recursion-2.mochi
-56 anonymous-recursion.mochi
-57 anti-primes.mochi
-58 append-a-record-to-the-end-of-a-text-file.mochi
-59 apply-a-callback-to-an-array-1.mochi
-60 apply-a-callback-to-an-array-2.mochi
-61 apply-a-digital-filter-direct-form-ii-transposed-.mochi
-62 approximate-equality.mochi
-63 arbitrary-precision-integers-included-.mochi
-64 archimedean-spiral.mochi
-65 arena-storage-pool.mochi
-66 arithmetic-complex.mochi
-67 arithmetic-derivative.mochi
-68 arithmetic-evaluation.mochi
-69 arithmetic-geometric-mean-calculate-pi.mochi
-70 arithmetic-geometric-mean.mochi
-71 arithmetic-integer-1.mochi
-72 arithmetic-integer-2.mochi
-73 arithmetic-numbers.mochi
-74 arithmetic-rational.mochi
-75 array-concatenation.mochi
-76 array-length.mochi
-77 arrays.mochi
-78 ascending-primes.mochi
-79 ascii-art-diagram-converter.mochi
-80 assertions.mochi
-81 associative-array-creation.mochi
-82 associative-array-iteration.mochi
-83 associative-array-merging.mochi
-84 atomic-updates.mochi
-85 attractive-numbers.mochi
-86 average-loop-length.mochi
-87 averages-arithmetic-mean.mochi
-88 averages-mean-time-of-day.mochi
-89 averages-median-1.mochi
-90 averages-median-2.mochi
-91 averages-median-3.mochi
-92 averages-mode.mochi
-93 averages-pythagorean-means.mochi
-94 averages-root-mean-square.mochi
-95 averages-simple-moving-average.mochi
-96 avl-tree.mochi
-97 b-zier-curves-intersections.mochi
-98 babbage-problem.mochi
-99 babylonian-spiral.mochi
-100 balanced-brackets.mochi
-101 balanced-ternary.mochi
-102 barnsley-fern.mochi
-103 base64-decode-data.mochi
-104 bell-numbers.mochi
-105 benfords-law.mochi
-106 bernoulli-numbers.mochi
-107 best-shuffle.mochi
-108 bifid-cipher.mochi
-109 bin-given-limits.mochi
-110 binary-digits.mochi
-111 binary-search.mochi
-112 binary-strings.mochi
-113 bioinformatics-base-count.mochi
-114 bioinformatics-global-alignment.mochi
-115 bioinformatics-sequence-mutation.mochi
-116 biorhythms.mochi
-117 bitcoin-address-validation.mochi
-118 bitmap-b-zier-curves-cubic.mochi
-119 bitmap-b-zier-curves-quadratic.mochi
-120 bitmap-bresenhams-line-algorithm.mochi
-121 bitmap-flood-fill.mochi
-122 bitmap-histogram.mochi
-123 bitmap-midpoint-circle-algorithm.mochi
-124 bitmap-ppm-conversion-through-a-pipe.mochi
-125 bitmap-read-a-ppm-file.mochi
-126 bitmap-read-an-image-through-a-pipe.mochi
-127 bitmap-write-a-ppm-file.mochi
-128 bitmap.mochi
-129 bitwise-io-1.mochi
-130 bitwise-io-2.mochi
-131 bitwise-operations.mochi
-132 blum-integer.mochi
-133 boolean-values.mochi
-134 box-the-compass.mochi
-135 boyer-moore-string-search.mochi
-136 brazilian-numbers.mochi
-137 break-oo-privacy.mochi
-138 brilliant-numbers.mochi
-139 brownian-tree.mochi
-140 bulls-and-cows-player.mochi
-141 bulls-and-cows.mochi
-142 burrows-wheeler-transform.mochi
-143 caesar-cipher-1.mochi
-144 caesar-cipher-2.mochi
-145 calculating-the-value-of-e.mochi
-146 calendar---for-real-programmers-1.mochi
-147 calendar---for-real-programmers-2.mochi
-148 calendar.mochi
-149 calkin-wilf-sequence.mochi
-150 call-a-foreign-language-function.mochi
-151 call-a-function-1.mochi
-152 call-a-function-10.mochi
-153 call-a-function-11.mochi
-154 call-a-function-12.mochi
-155 call-a-function-2.mochi
-156 call-a-function-3.mochi
-157 call-a-function-4.mochi
-158 call-a-function-5.mochi
-159 call-a-function-6.mochi
-160 call-a-function-7.mochi
-161 call-a-function-8.mochi
-162 call-a-function-9.mochi
-163 call-an-object-method-1.mochi
-164 call-an-object-method-2.mochi
-165 call-an-object-method-3.mochi
-166 call-an-object-method.mochi
-167 camel-case-and-snake-case.mochi
-168 canny-edge-detector.mochi
-169 canonicalize-cidr.mochi
-170 cantor-set.mochi
-171 carmichael-3-strong-pseudoprimes.mochi
-172 cartesian-product-of-two-or-more-lists-1.mochi
-173 cartesian-product-of-two-or-more-lists-2.mochi
-174 cartesian-product-of-two-or-more-lists-3.mochi
-175 cartesian-product-of-two-or-more-lists-4.mochi
-176 case-sensitivity-of-identifiers.mochi
-177 casting-out-nines.mochi
-178 catalan-numbers-1.mochi
-179 catalan-numbers-2.mochi
-180 catalan-numbers-pascals-triangle.mochi
-181 catamorphism.mochi
-182 catmull-clark-subdivision-surface.mochi
-183 chaocipher.mochi
-184 chaos-game.mochi
-185 character-codes-1.mochi
-186 character-codes-2.mochi
-187 character-codes-3.mochi
-188 character-codes-4.mochi
-189 character-codes-5.mochi
-190 chat-server.mochi
-191 check-machin-like-formulas.mochi
-192 check-that-file-exists.mochi
-193 checkpoint-synchronization-1.mochi
-194 checkpoint-synchronization-2.mochi
-195 checkpoint-synchronization-3.mochi
-196 checkpoint-synchronization-4.mochi
-197 chernicks-carmichael-numbers.mochi
-198 cheryls-birthday.mochi
-199 chinese-remainder-theorem.mochi
-200 chinese-zodiac.mochi
-201 cholesky-decomposition-1.mochi
-202 cholesky-decomposition.mochi
-203 chowla-numbers.mochi
-204 church-numerals-1.mochi
-205 church-numerals-2.mochi
-206 circles-of-given-radius-through-two-points.mochi
-207 circular-primes.mochi
-208 cistercian-numerals.mochi
-209 comma-quibbling.mochi
-210 compiler-virtual-machine-interpreter.mochi
-211 composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
-212 compound-data-type.mochi
-213 concurrent-computing-1.mochi
-214 concurrent-computing-2.mochi
-215 concurrent-computing-3.mochi
-216 conditional-structures-1.mochi
-217 conditional-structures-10.mochi
-218 conditional-structures-2.mochi
-219 conditional-structures-3.mochi
-220 conditional-structures-4.mochi
-221 conditional-structures-5.mochi
-222 conditional-structures-6.mochi
-223 conditional-structures-7.mochi
-224 conditional-structures-8.mochi
-225 conditional-structures-9.mochi
-226 consecutive-primes-with-ascending-or-descending-differences.mochi
-227 constrained-genericity-1.mochi
-228 constrained-genericity-2.mochi
-229 constrained-genericity-3.mochi
-230 constrained-genericity-4.mochi
-231 constrained-random-points-on-a-circle-1.mochi
-232 constrained-random-points-on-a-circle-2.mochi
-233 continued-fraction.mochi
-234 convert-decimal-number-to-rational.mochi
-235 convert-seconds-to-compound-duration.mochi
-236 convex-hull.mochi
-237 conways-game-of-life.mochi
-238 copy-a-string-1.mochi
-239 copy-a-string-2.mochi
-240 copy-stdin-to-stdout-1.mochi
-241 copy-stdin-to-stdout-2.mochi
-242 count-in-factors.mochi
-243 count-in-octal-1.mochi
-244 count-in-octal-2.mochi
-245 count-in-octal-3.mochi
-246 count-in-octal-4.mochi
-247 count-occurrences-of-a-substring.mochi
-248 count-the-coins-1.mochi
-249 count-the-coins-2.mochi
-250 cramers-rule.mochi
-251 crc-32-1.mochi
-252 crc-32-2.mochi
-253 create-a-file-on-magnetic-tape.mochi
-254 create-a-file.mochi
-255 create-a-two-dimensional-array-at-runtime-1.mochi
-256 create-an-html-table.mochi
-257 create-an-object-at-a-given-address.mochi
-258 csv-data-manipulation.mochi
-259 csv-to-html-translation-1.mochi
-260 csv-to-html-translation-2.mochi
-261 csv-to-html-translation-3.mochi
-262 csv-to-html-translation-4.mochi
-263 csv-to-html-translation-5.mochi
-264 cuban-primes.mochi
-265 cullen-and-woodall-numbers.mochi
-266 cumulative-standard-deviation.mochi
-267 currency.mochi
-268 currying.mochi
-269 curzon-numbers.mochi
-270 cusip.mochi
-271 cyclops-numbers.mochi
-272 damm-algorithm.mochi
-273 date-format.mochi
-274 date-manipulation.mochi
-275 day-of-the-week.mochi
-276 de-bruijn-sequences.mochi
-277 deal-cards-for-freecell.mochi
-278 death-star.mochi
-279 deceptive-numbers.mochi
-280 deconvolution-1d-2.mochi
-281 deconvolution-1d-3.mochi
-282 deconvolution-1d.mochi
-283 deepcopy-1.mochi
-284 define-a-primitive-data-type.mochi
-285 delegates.mochi
-286 demings-funnel.mochi
-287 department-numbers.mochi
-288 descending-primes.mochi
-289 detect-division-by-zero.mochi
-290 determine-if-a-string-has-all-the-same-characters.mochi
-291 determine-if-a-string-has-all-unique-characters.mochi
-292 determine-if-a-string-is-collapsible.mochi
-293 determine-if-a-string-is-numeric-1.mochi
-294 determine-if-a-string-is-numeric-2.mochi
-295 determine-if-a-string-is-squeezable.mochi
-296 determine-if-only-one-instance-is-running.mochi
-297 determine-if-two-triangles-overlap.mochi
-298 determine-sentence-type.mochi
-299 dice-game-probabilities-1.mochi
-300 dice-game-probabilities-2.mochi
-301 digital-root-multiplicative-digital-root.mochi
-302 dijkstras-algorithm.mochi
-303 dinesmans-multiple-dwelling-problem.mochi
-304 dining-philosophers-1.mochi
-305 dining-philosophers-2.mochi
-306 disarium-numbers.mochi
-307 discordian-date.mochi
-308 display-a-linear-combination.mochi
-309 display-an-outline-as-a-nested-table.mochi
-310 distance-and-bearing.mochi
-311 distributed-programming.mochi
-312 diversity-prediction-theorem.mochi
-313 documentation.mochi
-314 doomsday-rule.mochi
-315 dot-product.mochi
-316 doubly-linked-list-definition-1.mochi
-317 doubly-linked-list-definition-2.mochi
-318 doubly-linked-list-element-definition.mochi
-319 doubly-linked-list-traversal.mochi
-320 dragon-curve.mochi
-321 draw-a-clock.mochi
-322 draw-a-cuboid.mochi
-323 draw-a-pixel-1.mochi
-324 draw-a-rotating-cube.mochi
-325 draw-a-sphere.mochi
-326 dutch-national-flag-problem.mochi
-327 dynamic-variable-names.mochi
-328 earliest-difference-between-prime-gaps.mochi
-329 eban-numbers.mochi
-330 ecdsa-example.mochi
-331 echo-server.mochi
-332 eertree.mochi
-333 egyptian-division.mochi
-334 ekg-sequence-convergence.mochi
-335 element-wise-operations.mochi
-336 elementary-cellular-automaton-infinite-length.mochi
-337 elementary-cellular-automaton-random-number-generator.mochi
-338 elementary-cellular-automaton.mochi
-339 elliptic-curve-arithmetic.mochi
-340 elliptic-curve-digital-signature-algorithm.mochi
-341 emirp-primes.mochi
-342 empty-directory.mochi
-343 empty-program.mochi
-344 empty-string-1.mochi
-345 empty-string-2.mochi
-346 enforced-immutability.mochi
-347 entropy-1.mochi
-348 entropy-2.mochi
-349 entropy-narcissist.mochi
-350 enumerations-1.mochi
-351 enumerations-2.mochi
-352 enumerations-3.mochi
-353 enumerations-4.mochi
-354 environment-variables-1.mochi
-355 environment-variables-2.mochi
-356 equal-prime-and-composite-sums.mochi
-357 equilibrium-index.mochi
-358 erd-s-nicolas-numbers.mochi
-359 erd-s-selfridge-categorization-of-primes.mochi
-360 esthetic-numbers.mochi
-361 events.mochi
-362 evolutionary-algorithm.mochi
-363 exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
-364 exceptions.mochi
-365 executable-library.mochi
-366 execute-a-markov-algorithm.mochi
-367 execute-a-system-command.mochi
-368 execute-brain-.mochi
-369 execute-computer-zero.mochi
-370 execute-hq9+.mochi
-371 execute-snusp.mochi
-372 exponentiation-operator.mochi
-373 exponentiation-order.mochi
-374 exponentiation-with-infix-operators-in-or-operating-on-the-base.mochi
-375 extend-your-language.mochi
-376 extensible-prime-generator.mochi
-377 extreme-floating-point-values.mochi
-378 faces-from-a-mesh.mochi
-379 fasta-format.mochi
-380 faulhabers-triangle.mochi
-381 feigenbaum-constant-calculation.mochi
-382 fermat-numbers.mochi
-383 fibonacci-n-step-number-sequences.mochi
-384 fibonacci-sequence-1.mochi
-385 fibonacci-sequence-2.mochi
-386 fibonacci-sequence-3.mochi
-387 fibonacci-sequence-4.mochi
-388 fibonacci-word-fractal.mochi
-389 fibonacci-word.mochi
-390 file-extension-is-in-extensions-list.mochi
-391 file-input-output-1.mochi
-392 file-input-output-2.mochi
-393 file-modification-time.mochi
-394 file-size-distribution.mochi
-395 file-size.mochi
-396 filter.mochi
-397 find-chess960-starting-position-identifier.mochi
-398 find-common-directory-path.mochi
-399 find-duplicate-files.mochi
-400 find-if-a-point-is-within-a-triangle.mochi
-401 find-largest-left-truncatable-prime-in-a-given-base.mochi
-402 find-limit-of-recursion.mochi
-403 find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
-404 find-the-intersection-of-a-line-with-a-plane.mochi
-405 find-the-intersection-of-two-lines.mochi
-406 find-the-last-sunday-of-each-month.mochi
-407 find-the-missing-permutation.mochi
-408 fivenum-1.mochi
-409 fivenum-2.mochi
-410 fixed-length-records-1.mochi
-411 fixed-length-records-2.mochi
-412 fizzbuzz-1.mochi
-413 fizzbuzz-2.mochi
-414 flatten-a-list-1.mochi
-415 flatten-a-list-2.mochi
-416 flipping-bits-game.mochi
-417 flow-control-structures-1.mochi
-418 flow-control-structures-2.mochi
-419 flow-control-structures-3.mochi
-420 flow-control-structures-4.mochi
-421 floyd-warshall-algorithm.mochi
-422 floyds-triangle.mochi
-423 forest-fire.mochi
-424 fork.mochi
-425 ftp.mochi
-426 gamma-function.mochi
-427 general-fizzbuzz.mochi
-428 generic-swap.mochi
-429 get-system-command-output.mochi
-430 giuga-numbers.mochi
-431 globally-replace-text-in-several-files.mochi
-432 goldbachs-comet.mochi
-433 golden-ratio-convergence.mochi
-434 graph-colouring.mochi
-435 gray-code.mochi
-436 http.mochi
-437 loops-increment-loop-index-within-loop-body.mochi
-438 md5.mochi
-439 nim-game.mochi
+     1	100-doors-2.mochi
+     2	100-doors-3.mochi
+     3	100-doors.mochi
+     4	100-prisoners.mochi
+     5	15-puzzle-game.mochi
+     6	15-puzzle-solver.mochi
+     7	2048.mochi
+     8	21-game.mochi
+     9	24-game-solve.mochi
+    10	24-game.mochi
+    11	4-rings-or-4-squares-puzzle.mochi
+    12	9-billion-names-of-god-the-integer.mochi
+    13	99-bottles-of-beer-2.mochi
+    14	99-bottles-of-beer.mochi
+    15	DNS-query.mochi
+    16	Duffinian-numbers.mochi
+    17	a+b.mochi
+    18	abbreviations-automatic.mochi
+    19	abbreviations-easy.mochi
+    20	abbreviations-simple.mochi
+    21	abc-problem.mochi
+    22	abelian-sandpile-model-identity.mochi
+    23	abelian-sandpile-model.mochi
+    24	abstract-type.mochi
+    25	abundant-deficient-and-perfect-number-classifications.mochi
+    26	abundant-odd-numbers.mochi
+    27	accumulator-factory.mochi
+    28	achilles-numbers.mochi
+    29	ackermann-function-2.mochi
+    30	ackermann-function-3.mochi
+    31	ackermann-function.mochi
+    32	active-directory-connect.mochi
+    33	active-directory-search-for-a-user.mochi
+    34	active-object.mochi
+    35	add-a-variable-to-a-class-instance-at-runtime.mochi
+    36	additive-primes.mochi
+    37	address-of-a-variable.mochi
+    38	adfgvx-cipher.mochi
+    39	aks-test-for-primes.mochi
+    40	algebraic-data-types.mochi
+    41	align-columns.mochi
+    42	aliquot-sequence-classifications.mochi
+    43	almkvist-giullera-formula-for-pi.mochi
+    44	almost-prime.mochi
+    45	amb.mochi
+    46	amicable-pairs.mochi
+    47	anagrams-deranged-anagrams.mochi
+    48	anagrams.mochi
+    49	angle-difference-between-two-bearings-1.mochi
+    50	angle-difference-between-two-bearings-2.mochi
+    51	angles-geometric-normalization-and-conversion.mochi
+    52	animate-a-pendulum.mochi
+    53	animation.mochi
+    54	anonymous-recursion-1.mochi
+    55	anonymous-recursion-2.mochi
+    56	anonymous-recursion.mochi
+    57	anti-primes.mochi
+    58	append-a-record-to-the-end-of-a-text-file.mochi
+    59	apply-a-callback-to-an-array-1.mochi
+    60	apply-a-callback-to-an-array-2.mochi
+    61	apply-a-digital-filter-direct-form-ii-transposed-.mochi
+    62	approximate-equality.mochi
+    63	arbitrary-precision-integers-included-.mochi
+    64	archimedean-spiral.mochi
+    65	arena-storage-pool.mochi
+    66	arithmetic-complex.mochi
+    67	arithmetic-derivative.mochi
+    68	arithmetic-evaluation.mochi
+    69	arithmetic-geometric-mean-calculate-pi.mochi
+    70	arithmetic-geometric-mean.mochi
+    71	arithmetic-integer-1.mochi
+    72	arithmetic-integer-2.mochi
+    73	arithmetic-numbers.mochi
+    74	arithmetic-rational.mochi
+    75	array-concatenation.mochi
+    76	array-length.mochi
+    77	arrays.mochi
+    78	ascending-primes.mochi
+    79	ascii-art-diagram-converter.mochi
+    80	assertions.mochi
+    81	associative-array-creation.mochi
+    82	associative-array-iteration.mochi
+    83	associative-array-merging.mochi
+    84	atomic-updates.mochi
+    85	attractive-numbers.mochi
+    86	average-loop-length.mochi
+    87	averages-arithmetic-mean.mochi
+    88	averages-mean-time-of-day.mochi
+    89	averages-median-1.mochi
+    90	averages-median-2.mochi
+    91	averages-median-3.mochi
+    92	averages-mode.mochi
+    93	averages-pythagorean-means.mochi
+    94	averages-root-mean-square.mochi
+    95	averages-simple-moving-average.mochi
+    96	avl-tree.mochi
+    97	b-zier-curves-intersections.mochi
+    98	babbage-problem.mochi
+    99	babylonian-spiral.mochi
+   100	balanced-brackets.mochi
+   101	balanced-ternary.mochi
+   102	barnsley-fern.mochi
+   103	base64-decode-data.mochi
+   104	bell-numbers.mochi
+   105	benfords-law.mochi
+   106	bernoulli-numbers.mochi
+   107	best-shuffle.mochi
+   108	bifid-cipher.mochi
+   109	bin-given-limits.mochi
+   110	binary-digits.mochi
+   111	binary-search.mochi
+   112	binary-strings.mochi
+   113	bioinformatics-base-count.mochi
+   114	bioinformatics-global-alignment.mochi
+   115	bioinformatics-sequence-mutation.mochi
+   116	biorhythms.mochi
+   117	bitcoin-address-validation.mochi
+   118	bitmap-b-zier-curves-cubic.mochi
+   119	bitmap-b-zier-curves-quadratic.mochi
+   120	bitmap-bresenhams-line-algorithm.mochi
+   121	bitmap-flood-fill.mochi
+   122	bitmap-histogram.mochi
+   123	bitmap-midpoint-circle-algorithm.mochi
+   124	bitmap-ppm-conversion-through-a-pipe.mochi
+   125	bitmap-read-a-ppm-file.mochi
+   126	bitmap-read-an-image-through-a-pipe.mochi
+   127	bitmap-write-a-ppm-file.mochi
+   128	bitmap.mochi
+   129	bitwise-io-1.mochi
+   130	bitwise-io-2.mochi
+   131	bitwise-operations.mochi
+   132	blum-integer.mochi
+   133	boolean-values.mochi
+   134	box-the-compass.mochi
+   135	boyer-moore-string-search.mochi
+   136	brazilian-numbers.mochi
+   137	break-oo-privacy.mochi
+   138	brilliant-numbers.mochi
+   139	brownian-tree.mochi
+   140	bulls-and-cows-player.mochi
+   141	bulls-and-cows.mochi
+   142	burrows-wheeler-transform.mochi
+   143	caesar-cipher-1.mochi
+   144	caesar-cipher-2.mochi
+   145	calculating-the-value-of-e.mochi
+   146	calendar---for-real-programmers-1.mochi
+   147	calendar---for-real-programmers-2.mochi
+   148	calendar.mochi
+   149	calkin-wilf-sequence.mochi
+   150	call-a-foreign-language-function.mochi
+   151	call-a-function-1.mochi
+   152	call-a-function-10.mochi
+   153	call-a-function-11.mochi
+   154	call-a-function-12.mochi
+   155	call-a-function-2.mochi
+   156	call-a-function-3.mochi
+   157	call-a-function-4.mochi
+   158	call-a-function-5.mochi
+   159	call-a-function-6.mochi
+   160	call-a-function-7.mochi
+   161	call-a-function-8.mochi
+   162	call-a-function-9.mochi
+   163	call-an-object-method-1.mochi
+   164	call-an-object-method-2.mochi
+   165	call-an-object-method-3.mochi
+   166	call-an-object-method.mochi
+   167	camel-case-and-snake-case.mochi
+   168	canny-edge-detector.mochi
+   169	canonicalize-cidr.mochi
+   170	cantor-set.mochi
+   171	carmichael-3-strong-pseudoprimes.mochi
+   172	cartesian-product-of-two-or-more-lists-1.mochi
+   173	cartesian-product-of-two-or-more-lists-2.mochi
+   174	cartesian-product-of-two-or-more-lists-3.mochi
+   175	cartesian-product-of-two-or-more-lists-4.mochi
+   176	case-sensitivity-of-identifiers.mochi
+   177	casting-out-nines.mochi
+   178	catalan-numbers-1.mochi
+   179	catalan-numbers-2.mochi
+   180	catalan-numbers-pascals-triangle.mochi
+   181	catamorphism.mochi
+   182	catmull-clark-subdivision-surface.mochi
+   183	chaocipher.mochi
+   184	chaos-game.mochi
+   185	character-codes-1.mochi
+   186	character-codes-2.mochi
+   187	character-codes-3.mochi
+   188	character-codes-4.mochi
+   189	character-codes-5.mochi
+   190	chat-server.mochi
+   191	check-machin-like-formulas.mochi
+   192	check-that-file-exists.mochi
+   193	checkpoint-synchronization-1.mochi
+   194	checkpoint-synchronization-2.mochi
+   195	checkpoint-synchronization-3.mochi
+   196	checkpoint-synchronization-4.mochi
+   197	chernicks-carmichael-numbers.mochi
+   198	cheryls-birthday.mochi
+   199	chinese-remainder-theorem.mochi
+   200	chinese-zodiac.mochi
+   201	cholesky-decomposition-1.mochi
+   202	cholesky-decomposition.mochi
+   203	chowla-numbers.mochi
+   204	church-numerals-1.mochi
+   205	church-numerals-2.mochi
+   206	circles-of-given-radius-through-two-points.mochi
+   207	circular-primes.mochi
+   208	cistercian-numerals.mochi
+   209	comma-quibbling.mochi
+   210	compiler-virtual-machine-interpreter.mochi
+   211	composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
+   212	compound-data-type.mochi
+   213	concurrent-computing-1.mochi
+   214	concurrent-computing-2.mochi
+   215	concurrent-computing-3.mochi
+   216	conditional-structures-1.mochi
+   217	conditional-structures-10.mochi
+   218	conditional-structures-2.mochi
+   219	conditional-structures-3.mochi
+   220	conditional-structures-4.mochi
+   221	conditional-structures-5.mochi
+   222	conditional-structures-6.mochi
+   223	conditional-structures-7.mochi
+   224	conditional-structures-8.mochi
+   225	conditional-structures-9.mochi
+   226	consecutive-primes-with-ascending-or-descending-differences.mochi
+   227	constrained-genericity-1.mochi
+   228	constrained-genericity-2.mochi
+   229	constrained-genericity-3.mochi
+   230	constrained-genericity-4.mochi
+   231	constrained-random-points-on-a-circle-1.mochi
+   232	constrained-random-points-on-a-circle-2.mochi
+   233	continued-fraction.mochi
+   234	convert-decimal-number-to-rational.mochi
+   235	convert-seconds-to-compound-duration.mochi
+   236	convex-hull.mochi
+   237	conways-game-of-life.mochi
+   238	copy-a-string-1.mochi
+   239	copy-a-string-2.mochi
+   240	copy-stdin-to-stdout-1.mochi
+   241	copy-stdin-to-stdout-2.mochi
+   242	count-in-factors.mochi
+   243	count-in-octal-1.mochi
+   244	count-in-octal-2.mochi
+   245	count-in-octal-3.mochi
+   246	count-in-octal-4.mochi
+   247	count-occurrences-of-a-substring.mochi
+   248	count-the-coins-1.mochi
+   249	count-the-coins-2.mochi
+   250	cramers-rule.mochi
+   251	crc-32-1.mochi
+   252	crc-32-2.mochi
+   253	create-a-file-on-magnetic-tape.mochi
+   254	create-a-file.mochi
+   255	create-a-two-dimensional-array-at-runtime-1.mochi
+   256	create-an-html-table.mochi
+   257	create-an-object-at-a-given-address.mochi
+   258	csv-data-manipulation.mochi
+   259	csv-to-html-translation-1.mochi
+   260	csv-to-html-translation-2.mochi
+   261	csv-to-html-translation-3.mochi
+   262	csv-to-html-translation-4.mochi
+   263	csv-to-html-translation-5.mochi
+   264	cuban-primes.mochi
+   265	cullen-and-woodall-numbers.mochi
+   266	cumulative-standard-deviation.mochi
+   267	currency.mochi
+   268	currying.mochi
+   269	curzon-numbers.mochi
+   270	cusip.mochi
+   271	cyclops-numbers.mochi
+   272	damm-algorithm.mochi
+   273	date-format.mochi
+   274	date-manipulation.mochi
+   275	day-of-the-week.mochi
+   276	de-bruijn-sequences.mochi
+   277	deal-cards-for-freecell.mochi
+   278	death-star.mochi
+   279	deceptive-numbers.mochi
+   280	deconvolution-1d-2.mochi
+   281	deconvolution-1d-3.mochi
+   282	deconvolution-1d.mochi
+   283	deepcopy-1.mochi
+   284	define-a-primitive-data-type.mochi
+   285	delegates.mochi
+   286	demings-funnel.mochi
+   287	department-numbers.mochi
+   288	descending-primes.mochi
+   289	detect-division-by-zero.mochi
+   290	determine-if-a-string-has-all-the-same-characters.mochi
+   291	determine-if-a-string-has-all-unique-characters.mochi
+   292	determine-if-a-string-is-collapsible.mochi
+   293	determine-if-a-string-is-numeric-1.mochi
+   294	determine-if-a-string-is-numeric-2.mochi
+   295	determine-if-a-string-is-squeezable.mochi
+   296	determine-if-only-one-instance-is-running.mochi
+   297	determine-if-two-triangles-overlap.mochi
+   298	determine-sentence-type.mochi
+   299	dice-game-probabilities-1.mochi
+   300	dice-game-probabilities-2.mochi
+   301	digital-root-multiplicative-digital-root.mochi
+   302	dijkstras-algorithm.mochi
+   303	dinesmans-multiple-dwelling-problem.mochi
+   304	dining-philosophers-1.mochi
+   305	dining-philosophers-2.mochi
+   306	disarium-numbers.mochi
+   307	discordian-date.mochi
+   308	display-a-linear-combination.mochi
+   309	display-an-outline-as-a-nested-table.mochi
+   310	distance-and-bearing.mochi
+   311	distributed-programming.mochi
+   312	diversity-prediction-theorem.mochi
+   313	documentation.mochi
+   314	doomsday-rule.mochi
+   315	dot-product.mochi
+   316	doubly-linked-list-definition-1.mochi
+   317	doubly-linked-list-definition-2.mochi
+   318	doubly-linked-list-element-definition.mochi
+   319	doubly-linked-list-traversal.mochi
+   320	dragon-curve.mochi
+   321	draw-a-clock.mochi
+   322	draw-a-cuboid.mochi
+   323	draw-a-pixel-1.mochi
+   324	draw-a-rotating-cube.mochi
+   325	draw-a-sphere.mochi
+   326	dutch-national-flag-problem.mochi
+   327	dynamic-variable-names.mochi
+   328	earliest-difference-between-prime-gaps.mochi
+   329	eban-numbers.mochi
+   330	ecdsa-example.mochi
+   331	echo-server.mochi
+   332	eertree.mochi
+   333	egyptian-division.mochi
+   334	ekg-sequence-convergence.mochi
+   335	element-wise-operations.mochi
+   336	elementary-cellular-automaton-infinite-length.mochi
+   337	elementary-cellular-automaton-random-number-generator.mochi
+   338	elementary-cellular-automaton.mochi
+   339	elliptic-curve-arithmetic.mochi
+   340	elliptic-curve-digital-signature-algorithm.mochi
+   341	emirp-primes.mochi
+   342	empty-directory.mochi
+   343	empty-program.mochi
+   344	empty-string-1.mochi
+   345	empty-string-2.mochi
+   346	enforced-immutability.mochi
+   347	entropy-1.mochi
+   348	entropy-2.mochi
+   349	entropy-narcissist.mochi
+   350	enumerations-1.mochi
+   351	enumerations-2.mochi
+   352	enumerations-3.mochi
+   353	enumerations-4.mochi
+   354	environment-variables-1.mochi
+   355	environment-variables-2.mochi
+   356	equal-prime-and-composite-sums.mochi
+   357	equilibrium-index.mochi
+   358	erd-s-nicolas-numbers.mochi
+   359	erd-s-selfridge-categorization-of-primes.mochi
+   360	esthetic-numbers.mochi
+   361	events.mochi
+   362	evolutionary-algorithm.mochi
+   363	exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
+   364	exceptions.mochi
+   365	executable-library.mochi
+   366	execute-a-markov-algorithm.mochi
+   367	execute-a-system-command.mochi
+   368	execute-brain-.mochi
+   369	execute-computer-zero.mochi
+   370	execute-hq9+.mochi
+   371	execute-snusp.mochi
+   372	exponentiation-operator.mochi
+   373	exponentiation-order.mochi
+   374	exponentiation-with-infix-operators-in-or-operating-on-the-base.mochi
+   375	extend-your-language.mochi
+   376	extensible-prime-generator.mochi
+   377	extreme-floating-point-values.mochi
+   378	faces-from-a-mesh.mochi
+   379	fasta-format.mochi
+   380	faulhabers-triangle.mochi
+   381	feigenbaum-constant-calculation.mochi
+   382	fermat-numbers.mochi
+   383	fibonacci-n-step-number-sequences.mochi
+   384	fibonacci-sequence-1.mochi
+   385	fibonacci-sequence-2.mochi
+   386	fibonacci-sequence-3.mochi
+   387	fibonacci-sequence-4.mochi
+   388	fibonacci-word-fractal.mochi
+   389	fibonacci-word.mochi
+   390	file-extension-is-in-extensions-list.mochi
+   391	file-input-output-1.mochi
+   392	file-input-output-2.mochi
+   393	file-modification-time.mochi
+   394	file-size-distribution.mochi
+   395	file-size.mochi
+   396	filter.mochi
+   397	find-chess960-starting-position-identifier.mochi
+   398	find-common-directory-path.mochi
+   399	find-duplicate-files.mochi
+   400	find-if-a-point-is-within-a-triangle.mochi
+   401	find-largest-left-truncatable-prime-in-a-given-base.mochi
+   402	find-limit-of-recursion.mochi
+   403	find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
+   404	find-the-intersection-of-a-line-with-a-plane.mochi
+   405	find-the-intersection-of-two-lines.mochi
+   406	find-the-last-sunday-of-each-month.mochi
+   407	find-the-missing-permutation.mochi
+   408	fivenum-1.mochi
+   409	fivenum-2.mochi
+   410	fixed-length-records-1.mochi
+   411	fixed-length-records-2.mochi
+   412	fizzbuzz-1.mochi
+   413	fizzbuzz-2.mochi
+   414	flatten-a-list-1.mochi
+   415	flatten-a-list-2.mochi
+   416	flipping-bits-game.mochi
+   417	flow-control-structures-1.mochi
+   418	flow-control-structures-2.mochi
+   419	flow-control-structures-3.mochi
+   420	flow-control-structures-4.mochi
+   421	floyd-warshall-algorithm.mochi
+   422	floyds-triangle.mochi
+   423	forest-fire.mochi
+   424	fork.mochi
+   425	ftp.mochi
+   426	gamma-function.mochi
+   427	general-fizzbuzz.mochi
+   428	generic-swap.mochi
+   429	get-system-command-output.mochi
+   430	giuga-numbers.mochi
+   431	globally-replace-text-in-several-files.mochi
+   432	goldbachs-comet.mochi
+   433	golden-ratio-convergence.mochi
+   434	graph-colouring.mochi
+   435	gray-code.mochi
+   436	http.mochi
+   437	image-noise.mochi
+   438	loops-increment-loop-index-within-loop-body.mochi
+   439	md5.mochi
+   440	nim-game.mochi
+   441	plasma-effect.mochi
+   442	sorting-algorithms-bubble-sort.mochi
+   443	window-management.mochi
+   444	zumkeller-numbers.mochi


### PR DESCRIPTION
## Summary
- add builtin `int` handling in VM compiler and runtime
- regenerate currying IR after compile fix
- record benchmark for currency example
- sort rosetta index list including missing files

## Testing
- `go test ./runtime/vm -tags slow -run TestVM_Rosetta_Golden -count=1 -v -parallel=1` *(fails: goroutine stack exceeds limit)*

------
https://chatgpt.com/codex/tasks/task_e_6885697a92308320b1236ce36f877746