### PR TITLE
Add Rosetta events example

### DIFF
--- a/tests/rosetta/x/Mochi/events.mochi
+++ b/tests/rosetta/x/Mochi/events.mochi
@@ -1,9 +1,18 @@
+type Event {
+  set: bool
+}
+
 fun main() {
   print("program start")
+  var ev = Event{set: false}
   print("program sleeping")
   print("task start")
+  ev.set = true
   print("program signaling event")
-  print("event reset by task")
+  if ev.set {
+    print("event reset by task")
+    ev.set = false
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary
- add `events.mochi` example using a simple `Event` record

## Testing
- `MOCHI_ROSETTA_ONLY=events go test ./runtime/vm -run Rosetta_Golden -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68856a89ab388320adc3bff4f84edae8