### PR TITLE
Add functional Exceptions example

### DIFF
--- a/tests/rosetta/x/Mochi/exceptions.mochi
+++ b/tests/rosetta/x/Mochi/exceptions.mochi
@@ -1,10 +1,19 @@
-fun foo() {
+fun foo(): string {
   print("let's foo...")
-  print("Recovered from runtime error: index out of range [12] with length 0")
+  var a: list<int> = []
+  if 12 >= len(a) {
+    // Return an error string similar to the Go runtime message
+    return "runtime error: index out of range [12] with length " + str(len(a))
+  }
+  a[12] = 0
+  return ""
 }
 
 fun main() {
-  foo()
+  let err = foo()
+  if len(err) > 0 {
+    print("Recovered from " + err)
+  }
   print("glad that's over.")
 }
 


### PR DESCRIPTION
## Summary
- update the Mochi example for the `Exceptions` Rosetta task to compute
  the error message instead of printing static text

## Testing
- `go test ./runtime/vm -run Rosetta_Golden -tags=slow` *(fails: first failing program 100-prisoners)*

------
https://chatgpt.com/codex/tasks/task_e_68856a9a18d08320bf4ddc76715c0a59