### PR TITLE
Implement exceptions task logic

### DIFF
--- a/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
+++ b/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
@@ -1,5 +1,57 @@
+// Mochi translation of Go "exceptions-catch-an-exception-thrown-in-a-nested-call"
+// Simplified simulation without real exceptions.
+
+fun trace(indent: int, msg: string) {
+  var line = ""
+  var i = 0
+  while i < indent {
+    line = line + "  "
+    i = i + 1
+  }
+  print(line + msg)
+}
+
+fun runTry(callNum: int, handle: string): bool {
+  trace(2, "try: start")
+  trace(3, "bar: start")
+  trace(4, "baz: start")
+  if callNum == 1 {
+    trace(5, "baz: panicking with exception U0")
+    trace(4, "Panic mode!")
+    if handle == "U0" {
+      trace(4, "handling exception")
+      trace(5, "U0 handled")
+      trace(4, "panic over")
+      return true
+    }
+    trace(4, "can't recover this one!")
+    return false
+  }
+  trace(5, "baz: panicking with exception U1")
+  trace(4, "Panic mode!")
+  if handle == "U1" {
+    trace(4, "handling exception")
+    trace(5, "U1 handled")
+    trace(4, "panic over")
+    return true
+  }
+  trace(4, "can't recover this one!")
+  return false
+}
+
 fun main() {
-  print("demonstration of nested exceptions")
+  trace(0, "main: start")
+  trace(1, "foo: start")
+  var ok = runTry(1, "U0")
+  if ok {
+    ok = runTry(2, "U0")
+    if ok {
+      trace(1, "complete")
+      trace(0, "complete")
+      return
+    }
+  }
+  print("panic: U1")
 }
 
 main()

--- a/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.out
+++ b/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.out
@@ -1,1 +1,17 @@
-demonstration of nested exceptions
+main: start
+  foo: start
+    try: start
+      bar: start
+        baz: start
+          baz: panicking with exception U0
+        Panic mode!
+        handling exception
+          U0 handled
+        panic over
+    try: start
+      bar: start
+        baz: start
+          baz: panicking with exception U1
+        Panic mode!
+        can't recover this one!
+panic: U1

--- a/tests/rosetta/x/Mochi/exceptions.mochi
+++ b/tests/rosetta/x/Mochi/exceptions.mochi
@@ -1,6 +1,24 @@
+// Mochi translation of Go "exceptions" example
+// Uses explicit checks instead of real exceptions.
+
+type IndexRes {
+  ok: bool
+  val: int
+}
+
+fun safeIndex(xs: list<int>, i: int): IndexRes {
+  if i < 0 || i >= len(xs) { return IndexRes{ ok: false, val: 0 } }
+  return IndexRes{ ok: true, val: xs[i] }
+}
+
 fun foo() {
   print("let's foo...")
-  print("Recovered from runtime error: index out of range [12] with length 0")
+  let r = safeIndex([], 12)
+  if !r.ok {
+    print("Recovered from runtime error: index out of range [12] with length 0")
+    return
+  }
+  print("there's no point in going on.")
 }
 
 fun main() {


### PR DESCRIPTION
## Summary
- run `DownloadTaskByNumber` for task 334 to ensure Go sources exist
- implement the logic for the **Exceptions** Rosetta tasks in Mochi
- generate golden outputs with `cmd/mochi`

## Testing
- `go run -tags slow ./tools/rosetta/cmd/download_by_number.go -n 334`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/exceptions.mochi`


------
https://chatgpt.com/codex/tasks/task_e_68856aa38e78832092b3f1048fd9be2a