### PR TITLE
Add Mochi solution for Rosetta task 335

### DIFF
--- a/tests/rosetta/x/Go/executable-library-1.go
+++ b/tests/rosetta/x/Go/executable-library-1.go
@@ -10,31 +10,31 @@ import "fmt"
 // 1st arg is the number to generate the sequence for.
 // 2nd arg is a slice to recycle, to reduce garbage.
 func hailstone(n int, recycle []int) []int {
-    s := append(recycle[:0], n)
-    for n > 1 {
-        if n&1 == 0 {
-            n = n / 2
-        } else {
-            n = 3*n + 1
-        }
-        s = append(s, n)
-    }
-    return s
+	s := append(recycle[:0], n)
+	for n > 1 {
+		if n&1 == 0 {
+			n = n / 2
+		} else {
+			n = 3*n + 1
+		}
+		s = append(s, n)
+	}
+	return s
 }
 
 func libMain() {
-    seq := hailstone(27, nil)
-    fmt.Println("\nHailstone sequence for the number 27:")
-    fmt.Println("  has", len(seq), "elements")
-    fmt.Println("  starts with", seq[0:4])
-    fmt.Println("  ends with", seq[len(seq)-4:])
+	seq := hailstone(27, nil)
+	fmt.Println("\nHailstone sequence for the number 27:")
+	fmt.Println("  has", len(seq), "elements")
+	fmt.Println("  starts with", seq[0:4])
+	fmt.Println("  ends with", seq[len(seq)-4:])
 
-    var longest, length int
-    for i := 1; i < 100000; i++ {
-        if le := len(hailstone(i, nil)); le > length {
-            longest = i
-            length = le
-        }
-    }
-    fmt.Printf("\n%d has the longest Hailstone sequence, its length being %d.\n", longest, length)
+	var longest, length int
+	for i := 1; i < 100000; i++ {
+		if le := len(hailstone(i, nil)); le > length {
+			longest = i
+			length = le
+		}
+	}
+	fmt.Printf("\n%d has the longest Hailstone sequence, its length being %d.\n", longest, length)
 }

--- a/tests/rosetta/x/Go/executable-library-2.go
+++ b/tests/rosetta/x/Go/executable-library-2.go
@@ -5,5 +5,5 @@
 package main
 
 func main() {
-    libMain()
+	libMain()
 }

--- a/tests/rosetta/x/Go/executable-library-3.go
+++ b/tests/rosetta/x/Go/executable-library-3.go
@@ -7,16 +7,16 @@ package main
 import "fmt"
 
 func main() {
-    freq := make(map[int]int)
-    for i := 1; i < 100000; i++ {
-        freq[len(hailstone(i, nil))]++
-    }
-    var mk, mv int
-    for k, v := range freq {
-        if v > mv {
-            mk = k
-            mv = v
-        }
-    }
-    fmt.Printf("\nThe Hailstone length returned most is %d, which occurs %d times.\n", mk, mv)
+	freq := make(map[int]int)
+	for i := 1; i < 100000; i++ {
+		freq[len(hailstone(i, nil))]++
+	}
+	var mk, mv int
+	for k, v := range freq {
+		if v > mv {
+			mk = k
+			mv = v
+		}
+	}
+	fmt.Printf("\nThe Hailstone length returned most is %d, which occurs %d times.\n", mk, mv)
 }

--- a/tests/rosetta/x/Mochi/executable-library.mochi
+++ b/tests/rosetta/x/Mochi/executable-library.mochi
@@ -1,5 +1,50 @@
-fun main() {
-  print("executable library example")
+fun hailstone(n: int): list<int> {
+  var seq: list<int> = []
+  var x = n
+  seq = append(seq, x)
+  while x > 1 {
+    if x % 2 == 0 {
+      x = x / 2
+    } else {
+      x = 3 * x + 1
+    }
+    seq = append(seq, x)
+  }
+  return seq
 }
 
-main()
+fun listString(xs: list<int>): string {
+  var s = "["
+  var i = 0
+  while i < len(xs) {
+    s = s + str(xs[i])
+    if i < len(xs) - 1 { s = s + " " }
+    i = i + 1
+  }
+  s = s + "]"
+  return s
+}
+
+fun libMain() {
+  let seq = hailstone(27)
+  print("")
+  print("Hailstone sequence for the number 27:")
+  print("  has " + str(len(seq)) + " elements")
+  print("  starts with " + listString(seq[0:4]))
+  print("  ends with " + listString(seq[len(seq)-4:len(seq)]))
+  var longest = 0
+  var length = 0
+  var i = 1
+  while i < 100000 {
+    let l = len(hailstone(i))
+    if l > length {
+      longest = i
+      length = l
+    }
+    i = i + 1
+  }
+  print("")
+  print(str(longest) + " has the longest Hailstone sequence, its length being " + str(length) + ".")
+}
+
+libMain()

--- a/tests/rosetta/x/Mochi/executable-library.out
+++ b/tests/rosetta/x/Mochi/executable-library.out
@@ -1,1 +1,7 @@
-executable library example
+
+Hailstone sequence for the number 27:
+  has 112 elements
+  starts with [27 82 41 124]
+  ends with [8 4 2 1]
+
+77031 has the longest Hailstone sequence, its length being 351.


### PR DESCRIPTION
## Summary
- refresh Rosetta task 335 (Executable-library)
- format Go sources for the task
- implement full logic in `executable-library.mochi`
- add new output matching VM execution

## Testing
- `go vet ./...`
- `go run -tags slow ./tools/rosetta/cmd/download_by_number.go -n 335 -refresh`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/executable-library.mochi > /tmp/test.out`

------
https://chatgpt.com/codex/tasks/task_e_68856aacf7648320a5ae586f4c9b7807