### PR TITLE
Add Execute HQ9+ Go implementation

### DIFF
--- a/tests/rosetta/x/Go/execute-hq9+.go
+++ b/tests/rosetta/x/Go/execute-hq9+.go
@@ -1,0 +1,28 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import "fmt"
+
+func run(code string) {
+    acc := 0
+    for _, ch := range code {
+        switch ch {
+        case 'H':
+            fmt.Println("Hello, world!")
+        case 'Q':
+            fmt.Println(code)
+        case '9':
+            fmt.Println("99 Bottles of Beer")
+        case '+':
+            acc++
+        }
+    }
+    _ = acc
+}
+
+func main() {
+    run("HQ9+")
+}
+


### PR DESCRIPTION
## Summary
- add a Go solution for the Execute-HQ9+ Rosetta task

## Testing
- `go run -tags slow tools/rosetta/cmd/download_by_number.go -n 338` *(fails: unexpected status 404)*
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/execute-hq9+.mochi`

------
https://chatgpt.com/codex/tasks/task_e_68856ac8ecac8320bce85212cad5d9d4