### PR TITLE
Add nested exception example

### DIFF
--- a/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
+++ b/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
@@ -1,5 +1,56 @@
+var bazCall = 0
+
+fun baz(): string {
+  bazCall = bazCall + 1
+  print("baz: start")
+  if bazCall == 1 {
+    print("baz: raising U0")
+    return "U0"
+  }
+  if bazCall == 2 {
+    print("baz: raising U1")
+    return "U1"
+  }
+  print("baz: end")
+  return ""
+}
+
+fun bar(): string {
+  print("bar: start")
+  let err = baz()
+  if len(err) > 0 {
+    return err
+  }
+  print("bar: end")
+  return ""
+}
+
+fun foo(): string {
+  print("foo: start")
+  var err = bar()
+  if err == "U0" {
+    print("foo: caught U0")
+  } else if len(err) > 0 {
+    return err
+  }
+  err = bar()
+  if err == "U0" {
+    print("foo: caught U0")
+  } else if len(err) > 0 {
+    return err
+  }
+  print("foo: end")
+  return ""
+}
+
 fun main() {
-  print("demonstration of nested exceptions")
+  print("main: start")
+  let err = foo()
+  if len(err) > 0 {
+    print("main: unhandled " + err)
+  } else {
+    print("main: success")
+  }
 }
 
 main()

--- a/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.out
+++ b/tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.out
@@ -1,1 +1,10 @@
-demonstration of nested exceptions
+main: start
+foo: start
+bar: start
+baz: start
+baz: raising U0
+foo: caught U0
+bar: start
+baz: start
+baz: raising U1
+main: unhandled U1


### PR DESCRIPTION
## Summary
- download Go source for Rosetta task #334
- implement the same task in Mochi using error returns
- add golden output produced by `runtime/vm`

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/exceptions-catch-an-exception-thrown-in-a-nested-call.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6885a2f2d1c483208dc77aee1ff345ba