### PR TITLE
Add Execute-Computer-Zero interpreter

### DIFF
--- a/tests/rosetta/x/Mochi/execute-computer-zero.mochi
+++ b/tests/rosetta/x/Mochi/execute-computer-zero.mochi
@@ -1,11 +1,55 @@
+fun floorMod(a: int, b: int): int {
+  var r = a % b
+  if r < 0 { r = r + b }
+  return r
+}
+
+fun run(bc: list<int>): int {
+  var acc = 0
+  var pc = 0
+  while pc < 32 {
+    let op = bc[pc] / 32
+    let arg = bc[pc] % 32
+    pc = pc + 1
+    if op == 0 {
+      // NOP
+    } else if op == 1 {
+      acc = bc[arg]
+    } else if op == 2 {
+      bc[arg] = acc
+    } else if op == 3 {
+      acc = floorMod(acc + bc[arg], 256)
+    } else if op == 4 {
+      acc = floorMod(acc - bc[arg], 256)
+    } else if op == 5 {
+      if acc == 0 { pc = arg }
+    } else if op == 6 {
+      pc = arg
+    } else if op == 7 {
+      break
+    } else {
+      break
+    }
+  }
+  return acc
+}
+
 fun main() {
-  print("4")
-  print("56")
-  print("55")
-  print("6")
-  print("1")
-  print("255")
-  print("0")
+  let programs: list<list<int>> = [
+    [35,100,224,2,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    [44,106,76,43,141,75,168,192,44,224,8,7,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    [46,79,109,78,47,77,48,145,171,80,192,46,224,1,1,0,8,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    [45,111,69,112,71,0,78,0,171,79,192,46,224,32,0,28,1,0,0,0,6,0,2,26,5,20,3,30,1,22,4,24],
+    [35,132,224,0,255,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    [35,132,224,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+    [35,100,224,1,255,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+  ]
+  var i = 0
+  while i < len(programs) {
+    let res = run(programs[i])
+    print(str(res))
+    i = i + 1
+  }
 }
 
 main()


### PR DESCRIPTION
## Summary
- add an interpreter implementation in Mochi for Execute-Computer-Zero

## Testing
- `go test ./runtime/vm -run Execute-Computer-Zero -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6885a3784a948320822f5baf3d3930b8