### PR TITLE
Update rosetta bench outputs and limit copy depth

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-26 23:52 UTC
+Last updated: 2025-07-27 04:18 UTC
 
-## Rosetta Golden Test Checklist (259/439)
+## Rosetta Golden Test Checklist (266/452)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 116µs | 11.7 KB |
@@ -275,14 +275,14 @@ Last updated: 2025-07-26 23:52 UTC
 | 266 | cumulative-standard-deviation | ✓ | 147µs | 72.6 KB |
 | 267 | currency | ✓ | 208µs | 86.5 KB |
 | 268 | currying | ✓ |  |  |
-| 269 | curzon-numbers | ✓ |  |  |
-| 270 | cusip | ✓ |  |  |
-| 271 | cyclops-numbers |   |  |  |
-| 272 | damm-algorithm |   |  |  |
-| 273 | date-format |   |  |  |
-| 274 | date-manipulation |   |  |  |
-| 275 | day-of-the-week |   |  |  |
-| 276 | de-bruijn-sequences |   |  |  |
+| 269 | curzon-numbers | ✓ | 2.658207s |  |
+| 270 | cusip | ✓ | 127µs | 74.6 KB |
+| 271 | cyclops-numbers | ✓ | 53µs | 136 B |
+| 272 | damm-algorithm | ✓ | 71µs | 24.2 KB |
+| 273 | date-format | ✓ | 48µs | 18.7 KB |
+| 274 | date-manipulation | ✓ | 587µs | 604.8 KB |
+| 275 | day-of-the-week | ✓ | 569µs | 835.0 KB |
+| 276 | de-bruijn-sequences | ✓ | 12.726256s | 214.4 KB |
 | 277 | deal-cards-for-freecell |   |  |  |
 | 278 | death-star |   |  |  |
 | 279 | deceptive-numbers |   |  |  |
@@ -367,82 +367,95 @@ Last updated: 2025-07-26 23:52 UTC
 | 358 | erd-s-nicolas-numbers |   |  |  |
 | 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
 | 360 | esthetic-numbers |   |  |  |
-| 361 | events |   |  |  |
-| 362 | evolutionary-algorithm |   |  |  |
-| 363 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
-| 364 | exceptions |   |  |  |
-| 365 | executable-library |   |  |  |
-| 366 | execute-a-markov-algorithm |   |  |  |
-| 367 | execute-a-system-command |   |  |  |
-| 368 | execute-brain- |   |  |  |
-| 369 | execute-computer-zero |   |  |  |
-| 370 | execute-hq9+ |   |  |  |
-| 371 | execute-snusp |   |  |  |
-| 372 | exponentiation-operator |   |  |  |
-| 373 | exponentiation-order |   |  |  |
-| 374 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
-| 375 | extend-your-language |   |  |  |
-| 376 | extensible-prime-generator |   |  |  |
-| 377 | extreme-floating-point-values |   |  |  |
-| 378 | faces-from-a-mesh |   |  |  |
-| 379 | fasta-format |   |  |  |
-| 380 | faulhabers-triangle |   |  |  |
-| 381 | feigenbaum-constant-calculation |   |  |  |
-| 382 | fermat-numbers |   |  |  |
-| 383 | fibonacci-n-step-number-sequences |   |  |  |
-| 384 | fibonacci-sequence-1 |   |  |  |
-| 385 | fibonacci-sequence-2 |   |  |  |
-| 386 | fibonacci-sequence-3 |   |  |  |
-| 387 | fibonacci-sequence-4 |   |  |  |
-| 388 | fibonacci-word-fractal |   |  |  |
-| 389 | fibonacci-word |   |  |  |
-| 390 | file-extension-is-in-extensions-list |   |  |  |
-| 391 | file-input-output-1 |   |  |  |
-| 392 | file-input-output-2 |   |  |  |
-| 393 | file-modification-time |   |  |  |
-| 394 | file-size-distribution |   |  |  |
-| 395 | file-size |   |  |  |
-| 396 | filter |   |  |  |
-| 397 | find-chess960-starting-position-identifier |   |  |  |
-| 398 | find-common-directory-path |   |  |  |
-| 399 | find-duplicate-files |   |  |  |
-| 400 | find-if-a-point-is-within-a-triangle |   |  |  |
-| 401 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
-| 402 | find-limit-of-recursion |   |  |  |
-| 403 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
-| 404 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
-| 405 | find-the-intersection-of-two-lines |   |  |  |
-| 406 | find-the-last-sunday-of-each-month |   |  |  |
-| 407 | find-the-missing-permutation |   |  |  |
-| 408 | fivenum-1 |   |  |  |
-| 409 | fivenum-2 |   |  |  |
-| 410 | fixed-length-records-1 |   |  |  |
-| 411 | fixed-length-records-2 |   |  |  |
-| 412 | fizzbuzz-1 |   |  |  |
-| 413 | fizzbuzz-2 |   |  |  |
-| 414 | flatten-a-list-1 |   |  |  |
-| 415 | flatten-a-list-2 |   |  |  |
-| 416 | flipping-bits-game |   |  |  |
-| 417 | flow-control-structures-1 |   |  |  |
-| 418 | flow-control-structures-2 |   |  |  |
-| 419 | flow-control-structures-3 |   |  |  |
-| 420 | flow-control-structures-4 |   |  |  |
-| 421 | floyd-warshall-algorithm |   |  |  |
-| 422 | floyds-triangle |   |  |  |
-| 423 | forest-fire |   |  |  |
-| 424 | fork |   |  |  |
-| 425 | ftp |   |  |  |
-| 426 | gamma-function |   |  |  |
-| 427 | general-fizzbuzz |   |  |  |
-| 428 | generic-swap |   |  |  |
-| 429 | get-system-command-output |   |  |  |
-| 430 | giuga-numbers |   |  |  |
-| 431 | globally-replace-text-in-several-files |   |  |  |
-| 432 | goldbachs-comet |   |  |  |
-| 433 | golden-ratio-convergence |   |  |  |
-| 434 | graph-colouring |   |  |  |
-| 435 | gray-code |   |  |  |
-| 436 | http |   |  |  |
-| 437 | loops-increment-loop-index-within-loop-body |   |  |  |
-| 438 | md5 |   |  |  |
-| 439 | nim-game |   |  |  |
+| 361 | ethiopian-multiplication |   |  |  |
+| 362 | euclid-mullin-sequence |   |  |  |
+| 363 | euler-method |   |  |  |
+| 364 | eulers-constant-0.5772... |   |  |  |
+| 365 | eulers-identity |   |  |  |
+| 366 | eulers-sum-of-powers-conjecture | ✓ |  |  |
+| 367 | evaluate-binomial-coefficients |   |  |  |
+| 368 | even-or-odd |   |  |  |
+| 369 | events |   |  |  |
+| 370 | evolutionary-algorithm |   |  |  |
+| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
+| 372 | exceptions |   |  |  |
+| 373 | executable-library |   |  |  |
+| 374 | execute-a-markov-algorithm |   |  |  |
+| 375 | execute-a-system-command |   |  |  |
+| 376 | execute-brain- |   |  |  |
+| 377 | execute-computer-zero |   |  |  |
+| 378 | execute-hq9+ |   |  |  |
+| 379 | execute-snusp |   |  |  |
+| 380 | exponentiation-operator |   |  |  |
+| 381 | exponentiation-order |   |  |  |
+| 382 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
+| 383 | extend-your-language |   |  |  |
+| 384 | extensible-prime-generator |   |  |  |
+| 385 | extreme-floating-point-values |   |  |  |
+| 386 | faces-from-a-mesh |   |  |  |
+| 387 | fasta-format |   |  |  |
+| 388 | faulhabers-triangle |   |  |  |
+| 389 | feigenbaum-constant-calculation |   |  |  |
+| 390 | fermat-numbers |   |  |  |
+| 391 | fibonacci-n-step-number-sequences |   |  |  |
+| 392 | fibonacci-sequence-1 |   |  |  |
+| 393 | fibonacci-sequence-2 |   |  |  |
+| 394 | fibonacci-sequence-3 |   |  |  |
+| 395 | fibonacci-sequence-4 |   |  |  |
+| 396 | fibonacci-word-fractal |   |  |  |
+| 397 | fibonacci-word |   |  |  |
+| 398 | file-extension-is-in-extensions-list |   |  |  |
+| 399 | file-input-output-1 |   |  |  |
+| 400 | file-input-output-2 |   |  |  |
+| 401 | file-modification-time |   |  |  |
+| 402 | file-size-distribution |   |  |  |
+| 403 | file-size |   |  |  |
+| 404 | filter |   |  |  |
+| 405 | find-chess960-starting-position-identifier |   |  |  |
+| 406 | find-common-directory-path |   |  |  |
+| 407 | find-duplicate-files |   |  |  |
+| 408 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 409 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 410 | find-limit-of-recursion |   |  |  |
+| 411 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 412 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 413 | find-the-intersection-of-two-lines |   |  |  |
+| 414 | find-the-last-sunday-of-each-month |   |  |  |
+| 415 | find-the-missing-permutation |   |  |  |
+| 416 | fivenum-1 |   |  |  |
+| 417 | fivenum-2 |   |  |  |
+| 418 | fixed-length-records-1 |   |  |  |
+| 419 | fixed-length-records-2 |   |  |  |
+| 420 | fizzbuzz-1 |   |  |  |
+| 421 | fizzbuzz-2 |   |  |  |
+| 422 | flatten-a-list-1 |   |  |  |
+| 423 | flatten-a-list-2 |   |  |  |
+| 424 | flipping-bits-game |   |  |  |
+| 425 | flow-control-structures-1 |   |  |  |
+| 426 | flow-control-structures-2 |   |  |  |
+| 427 | flow-control-structures-3 |   |  |  |
+| 428 | flow-control-structures-4 |   |  |  |
+| 429 | floyd-warshall-algorithm |   |  |  |
+| 430 | floyds-triangle |   |  |  |
+| 431 | forest-fire |   |  |  |
+| 432 | fork |   |  |  |
+| 433 | ftp |   |  |  |
+| 434 | gamma-function |   |  |  |
+| 435 | general-fizzbuzz |   |  |  |
+| 436 | generic-swap |   |  |  |
+| 437 | get-system-command-output |   |  |  |
+| 438 | giuga-numbers |   |  |  |
+| 439 | globally-replace-text-in-several-files |   |  |  |
+| 440 | goldbachs-comet |   |  |  |
+| 441 | golden-ratio-convergence |   |  |  |
+| 442 | graph-colouring |   |  |  |
+| 443 | gray-code |   |  |  |
+| 444 | http |   |  |  |
+| 445 | image-noise |   |  |  |
+| 446 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 447 | md5 |   |  |  |
+| 448 | nim-game |   |  |  |
+| 449 | plasma-effect |   |  |  |
+| 450 | sorting-algorithms-bubble-sort |   |  |  |
+| 451 | window-management |   |  |  |
+| 452 | zumkeller-numbers |   |  |  |

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -7729,18 +7729,26 @@ func formatValue(v Value) string {
 	}
 }
 
-func copyValue(v Value) Value {
+const maxCopyDepth = 1024
+
+func copyValue(v Value) Value { return copyValueDepth(v, 0) }
+
+func copyValueDepth(v Value, depth int) Value {
+	if depth > maxCopyDepth {
+		// Avoid runaway recursion on cyclic values.
+		return v
+	}
 	switch v.Tag {
 	case ValueList:
 		l := make([]Value, len(v.List))
 		for i, x := range v.List {
-			l[i] = copyValue(x)
+			l[i] = copyValueDepth(x, depth+1)
 		}
 		return Value{Tag: ValueList, List: l}
 	case ValueMap:
 		m := make(map[string]Value, len(v.Map))
 		for k, x := range v.Map {
-			m[k] = copyValue(x)
+			m[k] = copyValueDepth(x, depth+1)
 		}
 		return Value{Tag: ValueMap, Map: m}
 	default:

--- a/tests/rosetta/ir/curzon-numbers.bench
+++ b/tests/rosetta/ir/curzon-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 2658207,
+  "memory_bytes": -205128,
+  "name": "main"
+}

--- a/tests/rosetta/ir/cusip.bench
+++ b/tests/rosetta/ir/cusip.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 127,
+  "memory_bytes": 76392,
+  "name": "main"
+}

--- a/tests/rosetta/ir/cusip.ir
+++ b/tests/rosetta/ir/cusip.ir
@@ -1,37 +1,36 @@
-func main (regs=19)
+func main (regs=18)
   // let candidates = ["037833100","17275R102","38259P508","594918104","68389X106","68389X105"]
   Const        r1, ["037833100", "17275R102", "38259P508", "594918104", "68389X106", "68389X105"]
   Move         r0, r1
   SetGlobal    0,0,0,0
   // for cand in candidates {
-  Const        r2, ["037833100", "17275R102", "38259P508", "594918104", "68389X106", "68389X105"]
-  IterPrep     r3, r2
-  Len          r4, r3
-  Const        r5, 0
+  IterPrep     r2, r0
+  Len          r3, r2
+  Const        r4, 0
 L2:
-  LessInt      r6, r5, r4
-  JumpIfFalse  r6, L0
-  Index        r7, r3, r5
-  Move         r8, r7
+  LessInt      r5, r4, r3
+  JumpIfFalse  r5, L0
+  Index        r6, r2, r4
+  Move         r7, r6
   // var b = "incorrect"
-  Const        r9, "incorrect"
-  Move         r10, r9
+  Const        r8, "incorrect"
+  Move         r9, r8
   // if isCusip(cand) { b = "correct" }
-  Move         r11, r8
-  Call         r12, isCusip, r11
-  JumpIfFalse  r12, L1
-  Const        r13, "correct"
-  Move         r10, r13
+  Move         r10, r7
+  Call         r11, isCusip, r10
+  JumpIfFalse  r11, L1
+  Const        r12, "correct"
+  Move         r9, r12
 L1:
   // print(cand + " -> " + b)
-  Const        r14, " -> "
-  Add          r15, r8, r14
-  Add          r16, r15, r10
-  Print        r16
+  Const        r13, " -> "
+  Add          r14, r7, r13
+  Add          r15, r14, r9
+  Print        r15
   // for cand in candidates {
-  Const        r17, 1
-  AddInt       r18, r5, r17
-  Move         r5, r18
+  Const        r16, 1
+  AddInt       r17, r4, r16
+  Move         r4, r17
   Jump         L2
 L0:
   Return       r0

--- a/tests/rosetta/ir/cyclops-numbers.bench
+++ b/tests/rosetta/ir/cyclops-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 53,
+  "memory_bytes": 136,
+  "name": "main"
+}

--- a/tests/rosetta/ir/cyclops-numbers.ir
+++ b/tests/rosetta/ir/cyclops-numbers.ir
@@ -1,0 +1,781 @@
+func main (regs=1)
+  Return       r0
+
+  // fun digits(n: int): list<int> {
+func digits (regs=22)
+  // if n == 0 { return [0] }
+  Const        r1, 0
+  Equal        r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, [0]
+  Return       r3
+L0:
+  // var rev: list<int> = []
+  Const        r4, []
+  Move         r5, r4
+  // var x = n
+  Move         r6, r0
+L2:
+  // while x > 0 {
+  Const        r1, 0
+  Less         r7, r1, r6
+  JumpIfFalse  r7, L1
+  // rev = append(rev, x % 10)
+  Const        r8, 10
+  Mod          r9, r6, r8
+  Append       r10, r5, r9
+  Move         r5, r10
+  // x = (x / 10) as int
+  Const        r8, 10
+  Div          r11, r6, r8
+  Cast         r12, r11, int
+  Move         r6, r12
+  // while x > 0 {
+  Jump         L2
+L1:
+  // var out: list<int> = []
+  Const        r4, []
+  Move         r13, r4
+  // var i = len(rev) - 1
+  Len          r14, r5
+  Const        r15, 1
+  SubInt       r16, r14, r15
+  Move         r17, r16
+L4:
+  // while i >= 0 {
+  Const        r1, 0
+  LessEqInt    r18, r1, r17
+  JumpIfFalse  r18, L3
+  // out = append(out, rev[i])
+  Index        r19, r5, r17
+  Append       r20, r13, r19
+  Move         r13, r20
+  // i = i - 1
+  Const        r15, 1
+  SubInt       r21, r17, r15
+  Move         r17, r21
+  // while i >= 0 {
+  Jump         L4
+L3:
+  // return out
+  Return       r13
+
+  // fun commatize(n: int): string {
+func commatize (regs=22)
+  // var s = str(n)
+  Str          r1, r0
+  Move         r2, r1
+  // var out = ""
+  Const        r3, ""
+  Move         r4, r3
+  // var i = len(s)
+  Len          r5, r2
+  Move         r6, r5
+L1:
+  // while i > 3 {
+  Const        r7, 3
+  LessInt      r8, r7, r6
+  JumpIfFalse  r8, L0
+  // out = "," + s[i-3:i] + out
+  Const        r9, ","
+  Const        r7, 3
+  SubInt       r11, r6, r7
+  Move         r10, r11
+  Move         r12, r6
+  Slice        r13, r2, r10, r12
+  Add          r14, r9, r13
+  Add          r15, r14, r4
+  Move         r4, r15
+  // i = i - 3
+  Const        r7, 3
+  SubInt       r16, r6, r7
+  Move         r6, r16
+  // while i > 3 {
+  Jump         L1
+L0:
+  // out = s[0:i] + out
+  Const        r18, 0
+  Move         r17, r18
+  Move         r19, r6
+  Slice        r20, r2, r17, r19
+  Add          r21, r20, r4
+  Move         r4, r21
+  // return out
+  Return       r4
+
+  // fun isPrime(n: int): bool {
+func isPrime (regs=24)
+  // if n < 2 { return false }
+  Const        r1, 2
+  Less         r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, false
+  Return       r3
+L0:
+  // if n % 2 == 0 { return n == 2 }
+  Const        r1, 2
+  Mod          r4, r0, r1
+  Const        r5, 0
+  Equal        r6, r4, r5
+  JumpIfFalse  r6, L1
+  Const        r1, 2
+  Equal        r7, r0, r1
+  Return       r7
+L1:
+  // if n % 3 == 0 { return n == 3 }
+  Const        r8, 3
+  Mod          r9, r0, r8
+  Const        r5, 0
+  Equal        r10, r9, r5
+  JumpIfFalse  r10, L2
+  Const        r8, 3
+  Equal        r11, r0, r8
+  Return       r11
+L2:
+  // var d = 5
+  Const        r12, 5
+  Move         r13, r12
+L6:
+  // while d * d <= n {
+  MulInt       r14, r13, r13
+  LessEq       r15, r14, r0
+  JumpIfFalse  r15, L3
+  // if n % d == 0 { return false }
+  Mod          r16, r0, r13
+  Const        r5, 0
+  Equal        r17, r16, r5
+  JumpIfFalse  r17, L4
+  Const        r3, false
+  Return       r3
+L4:
+  // d = d + 2
+  Const        r1, 2
+  AddInt       r18, r13, r1
+  Move         r13, r18
+  // if n % d == 0 { return false }
+  Mod          r19, r0, r13
+  Const        r5, 0
+  Equal        r20, r19, r5
+  JumpIfFalse  r20, L5
+  Const        r3, false
+  Return       r3
+L5:
+  // d = d + 4
+  Const        r21, 4
+  AddInt       r22, r13, r21
+  Move         r13, r22
+  // while d * d <= n {
+  Jump         L6
+L3:
+  // return true
+  Const        r23, true
+  Return       r23
+
+  // fun split(s: string, sep: string): list<string> {
+func split (regs=30)
+  // var parts: list<string> = []
+  Const        r2, []
+  Move         r3, r2
+  // var cur = ""
+  Const        r4, ""
+  Move         r5, r4
+  // var i = 0
+  Const        r6, 0
+  Move         r7, r6
+L3:
+  // while i < len(s) {
+  Len          r8, r0
+  LessInt      r9, r7, r8
+  JumpIfFalse  r9, L0
+  // if i + len(sep) <= len(s) && substring(s, i, i+len(sep)) == sep {
+  Len          r10, r1
+  AddInt       r11, r7, r10
+  Len          r12, r0
+  LessEqInt    r13, r11, r12
+  Len          r14, r1
+  AddInt       r15, r7, r14
+  Slice        r16, r0, r7, r15
+  Equal        r17, r16, r1
+  Move         r18, r13
+  JumpIfFalse  r18, L1
+  Move         r18, r17
+L1:
+  JumpIfFalse  r18, L2
+  // parts = append(parts, cur)
+  Append       r19, r3, r5
+  Move         r3, r19
+  // cur = ""
+  Const        r4, ""
+  Move         r5, r4
+  // i = i + len(sep)
+  Len          r20, r1
+  AddInt       r21, r7, r20
+  Move         r7, r21
+  // if i + len(sep) <= len(s) && substring(s, i, i+len(sep)) == sep {
+  Jump         L3
+L2:
+  // cur = cur + s[i:i+1]
+  Move         r22, r7
+  Const        r24, 1
+  AddInt       r25, r7, r24
+  Move         r23, r25
+  Slice        r26, r0, r22, r23
+  Add          r27, r5, r26
+  Move         r5, r27
+  // i = i + 1
+  Const        r24, 1
+  AddInt       r28, r7, r24
+  Move         r7, r28
+  // while i < len(s) {
+  Jump         L3
+L0:
+  // parts = append(parts, cur)
+  Append       r29, r3, r5
+  Move         r3, r29
+  // return parts
+  Return       r3
+
+  // fun parseIntStr(str: string): int {
+func parseIntStr (regs=30)
+  // var i = 0
+  Const        r1, 0
+  Move         r2, r1
+  // var neg = false
+  Const        r3, false
+  Move         r4, r3
+  // if len(str) > 0 && str[0:1] == "-" {
+  Len          r5, r0
+  Const        r1, 0
+  LessInt      r6, r1, r5
+  Const        r1, 0
+  Move         r7, r1
+  Const        r9, 1
+  Move         r8, r9
+  Slice        r10, r0, r7, r8
+  Const        r11, "-"
+  Equal        r12, r10, r11
+  Move         r13, r6
+  JumpIfFalse  r13, L0
+  Move         r13, r12
+L0:
+  JumpIfFalse  r13, L1
+  // neg = true
+  Const        r14, true
+  Move         r4, r14
+  // i = 1
+  Const        r9, 1
+  Move         r2, r9
+L1:
+  // var n = 0
+  Const        r1, 0
+  Move         r15, r1
+  // let digits = {
+  Const        r16, {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  Move         r17, r16
+L3:
+  // while i < len(str) {
+  Len          r18, r0
+  LessInt      r19, r2, r18
+  JumpIfFalse  r19, L2
+  // n = n * 10 + digits[str[i:i+1]]
+  Const        r20, 10
+  MulInt       r21, r15, r20
+  Move         r22, r2
+  Const        r9, 1
+  AddInt       r24, r2, r9
+  Move         r23, r24
+  Slice        r25, r0, r22, r23
+  Index        r26, r17, r25
+  Add          r27, r21, r26
+  Move         r15, r27
+  // i = i + 1
+  Const        r9, 1
+  AddInt       r28, r2, r9
+  Move         r2, r28
+  // while i < len(str) {
+  Jump         L3
+L2:
+  // if neg { n = -n }
+  JumpIfFalse  r4, L4
+  Neg          r29, r15
+  Move         r15, r29
+L4:
+  // return n
+  Return       r15
+
+  // fun reverseStr(s: string): string {
+func reverseStr (regs=15)
+  // var out = ""
+  Const        r1, ""
+  Move         r2, r1
+  // var i = len(s) - 1
+  Len          r3, r0
+  Const        r4, 1
+  SubInt       r5, r3, r4
+  Move         r6, r5
+L1:
+  // while i >= 0 {
+  Const        r7, 0
+  LessEqInt    r8, r7, r6
+  JumpIfFalse  r8, L0
+  // out = out + s[i:i+1]
+  Move         r9, r6
+  Const        r4, 1
+  AddInt       r11, r6, r4
+  Move         r10, r11
+  Slice        r12, r0, r9, r10
+  Add          r13, r2, r12
+  Move         r2, r13
+  // i = i - 1
+  Const        r4, 1
+  SubInt       r14, r6, r4
+  Move         r6, r14
+  // while i >= 0 {
+  Jump         L1
+L0:
+  // return out
+  Return       r2
+
+  // fun pad(s: string, w: int): string {
+func pad (regs=7)
+  // var out = s
+  Move         r2, r0
+L1:
+  // while len(out) < w { out = " " + out }
+  Len          r3, r2
+  Less         r4, r3, r1
+  JumpIfFalse  r4, L0
+  Const        r5, " "
+  Add          r6, r5, r2
+  Move         r2, r6
+  Jump         L1
+L0:
+  // return out
+  Return       r2
+
+  // fun findFirst(list: list<int>): list<int> {
+func findFirst (regs=15)
+  // var i = 0
+  Const        r1, 0
+  Move         r2, r1
+L2:
+  // while i < len(list) {
+  Len          r3, r0
+  LessInt      r4, r2, r3
+  JumpIfFalse  r4, L0
+  // if list[i] > 10000000 { return [list[i], i] }
+  Index        r5, r0, r2
+  Const        r6, 10000000
+  Less         r7, r6, r5
+  JumpIfFalse  r7, L1
+  Index        r10, r0, r2
+  Move         r8, r10
+  Move         r9, r2
+  MakeList     r11, 2, r8
+  Return       r11
+L1:
+  // i = i + 1
+  Const        r12, 1
+  AddInt       r13, r2, r12
+  Move         r2, r13
+  // while i < len(list) {
+  Jump         L2
+L0:
+  // return [-1, -1]
+  Const        r14, [-1, -1]
+  Return       r14
+
+  // fun main() {
+func main (regs=194)
+  // let ranges = [[0,0],[101,909],[11011,99099],[1110111,9990999],[111101111,119101111]]
+  Const        r0, [[0, 0], [101, 909], [11011, 99099], [1110111, 9990999], [111101111, 119101111]]
+  Move         r1, r0
+  // var cyclops: list<int> = []
+  Const        r2, []
+  Move         r3, r2
+  // for r in ranges {
+  IterPrep     r4, r1
+  Len          r5, r4
+  Const        r6, 0
+L7:
+  LessInt      r7, r6, r5
+  JumpIfFalse  r7, L0
+  Index        r8, r4, r6
+  Move         r9, r8
+  // let start = r[0]
+  Const        r10, 0
+  Index        r11, r9, r10
+  Move         r12, r11
+  // let end = r[1]
+  Const        r13, 1
+  Index        r14, r9, r13
+  Move         r15, r14
+  // let numDigits = len(str(start))
+  Str          r16, r12
+  Len          r17, r16
+  Move         r18, r17
+  // let center = numDigits / 2
+  Const        r19, 2
+  DivInt       r20, r18, r19
+  Move         r21, r20
+  // var i = start
+  Move         r22, r12
+L6:
+  // while i <= end {
+  LessEq       r23, r22, r15
+  JumpIfFalse  r23, L1
+  // let ds = digits(i)
+  Move         r24, r22
+  Call         r25, digits, r24
+  Move         r26, r25
+  // if ds[center] == 0 {
+  Index        r27, r26, r21
+  Const        r10, 0
+  Equal        r28, r27, r10
+  JumpIfFalse  r28, L2
+  // var count = 0
+  Const        r10, 0
+  Move         r29, r10
+  // for d in ds { if d == 0 { count = count + 1 } }
+  IterPrep     r30, r26
+  Len          r31, r30
+  Const        r32, 0
+L5:
+  LessInt      r33, r32, r31
+  JumpIfFalse  r33, L3
+  Index        r34, r30, r32
+  Move         r35, r34
+  Const        r10, 0
+  Equal        r36, r35, r10
+  JumpIfFalse  r36, L4
+  Const        r13, 1
+  AddInt       r37, r29, r13
+  Move         r29, r37
+L4:
+  Const        r38, 1
+  AddInt       r39, r32, r38
+  Move         r32, r39
+  Jump         L5
+L3:
+  // if count == 1 { cyclops = append(cyclops, i) }
+  Const        r13, 1
+  EqualInt     r40, r29, r13
+  JumpIfFalse  r40, L2
+  Append       r41, r3, r22
+  Move         r3, r41
+L2:
+  // i = i + 1
+  Const        r13, 1
+  Add          r42, r22, r13
+  Move         r22, r42
+  // while i <= end {
+  Jump         L6
+L1:
+  // for r in ranges {
+  Const        r43, 1
+  AddInt       r44, r6, r43
+  Move         r6, r44
+  Jump         L7
+L0:
+  // print("The first 50 cyclops numbers are:")
+  Const        r45, "The first 50 cyclops numbers are:"
+  Print        r45
+  // var idx = 0
+  Const        r10, 0
+  Move         r46, r10
+L9:
+  // while idx < 50 {
+  Const        r47, 50
+  LessInt      r48, r46, r47
+  JumpIfFalse  r48, L8
+  // print(pad(commatize(cyclops[idx]), 6) + " ")
+  Index        r52, r3, r46
+  Move         r51, r52
+  Call         r53, commatize, r51
+  Move         r49, r53
+  Const        r54, 6
+  Move         r50, r54
+  Call2        r55, pad, r49, r50
+  Const        r56, " "
+  Add          r57, r55, r56
+  Print        r57
+  // idx = idx + 1
+  Const        r13, 1
+  AddInt       r58, r46, r13
+  Move         r46, r58
+  // if idx % 10 == 0 { print("\n") }
+  Const        r59, 10
+  ModInt       r60, r46, r59
+  Const        r10, 0
+  EqualInt     r61, r60, r10
+  JumpIfFalse  r61, L9
+  Const        r62, "\n"
+  Print        r62
+  // while idx < 50 {
+  Jump         L9
+L8:
+  // let fi = findFirst(cyclops)
+  Move         r63, r3
+  Call         r64, findFirst, r63
+  Move         r65, r64
+  // print("\nFirst such number > 10 million is " + commatize(fi[0]) + " at zero-based index " + commatize(fi[1]))
+  Const        r66, "\nFirst such number > 10 million is "
+  Const        r10, 0
+  Index        r68, r65, r10
+  Move         r67, r68
+  Call         r69, commatize, r67
+  Add          r70, r66, r69
+  Const        r71, " at zero-based index "
+  Add          r72, r70, r71
+  Const        r13, 1
+  Index        r74, r65, r13
+  Move         r73, r74
+  Call         r75, commatize, r73
+  Add          r76, r72, r75
+  Print        r76
+  // var primes: list<int> = []
+  Const        r2, []
+  Move         r77, r2
+  // for n in cyclops { if isPrime(n) { primes = append(primes, n) } }
+  IterPrep     r78, r3
+  Len          r79, r78
+  Const        r80, 0
+L12:
+  LessInt      r81, r80, r79
+  JumpIfFalse  r81, L10
+  Index        r82, r78, r80
+  Move         r83, r82
+  Move         r84, r83
+  Call         r85, isPrime, r84
+  JumpIfFalse  r85, L11
+  Append       r86, r77, r83
+  Move         r77, r86
+L11:
+  Const        r87, 1
+  AddInt       r88, r80, r87
+  Move         r80, r88
+  Jump         L12
+L10:
+  // print("\n\nThe first 50 prime cyclops numbers are:")
+  Const        r89, "\n\nThe first 50 prime cyclops numbers are:"
+  Print        r89
+  // idx = 0
+  Const        r10, 0
+  Move         r46, r10
+L14:
+  // while idx < 50 {
+  Const        r47, 50
+  LessInt      r90, r46, r47
+  JumpIfFalse  r90, L13
+  // print(pad(commatize(primes[idx]), 6) + " ")
+  Index        r94, r77, r46
+  Move         r93, r94
+  Call         r95, commatize, r93
+  Move         r91, r95
+  Const        r54, 6
+  Move         r92, r54
+  Call2        r96, pad, r91, r92
+  Const        r56, " "
+  Add          r97, r96, r56
+  Print        r97
+  // idx = idx + 1
+  Const        r13, 1
+  AddInt       r98, r46, r13
+  Move         r46, r98
+  // if idx % 10 == 0 { print("\n") }
+  Const        r59, 10
+  ModInt       r99, r46, r59
+  Const        r10, 0
+  EqualInt     r100, r99, r10
+  JumpIfFalse  r100, L14
+  Const        r62, "\n"
+  Print        r62
+  // while idx < 50 {
+  Jump         L14
+L13:
+  // let fp = findFirst(primes)
+  Move         r101, r77
+  Call         r102, findFirst, r101
+  Move         r103, r102
+  // print("\nFirst such number > 10 million is " + commatize(fp[0]) + " at zero-based index " + commatize(fp[1]))
+  Const        r66, "\nFirst such number > 10 million is "
+  Const        r10, 0
+  Index        r105, r103, r10
+  Move         r104, r105
+  Call         r106, commatize, r104
+  Add          r107, r66, r106
+  Const        r71, " at zero-based index "
+  Add          r108, r107, r71
+  Const        r13, 1
+  Index        r110, r103, r13
+  Move         r109, r110
+  Call         r111, commatize, r109
+  Add          r112, r108, r111
+  Print        r112
+  // var bpcyclops: list<int> = []
+  Const        r2, []
+  Move         r113, r2
+  // var ppcyclops: list<int> = []
+  Const        r2, []
+  Move         r114, r2
+  // for p in primes {
+  IterPrep     r115, r77
+  Len          r116, r115
+  Const        r117, 0
+L18:
+  LessInt      r118, r117, r116
+  JumpIfFalse  r118, L15
+  Index        r119, r115, r117
+  Move         r120, r119
+  // let ps = str(p)
+  Str          r121, r120
+  Move         r122, r121
+  // let splitp = split(ps, "0")
+  Move         r123, r122
+  Const        r125, "0"
+  Move         r124, r125
+  Call2        r126, split, r123, r124
+  Move         r127, r126
+  // let noMiddle = parseIntStr(splitp[0] + splitp[1])
+  Const        r10, 0
+  Index        r129, r127, r10
+  Const        r13, 1
+  Index        r130, r127, r13
+  Add          r131, r129, r130
+  Move         r128, r131
+  Call         r132, parseIntStr, r128
+  Move         r133, r132
+  // if isPrime(noMiddle) { bpcyclops = append(bpcyclops, p) }
+  Move         r134, r133
+  Call         r135, isPrime, r134
+  JumpIfFalse  r135, L16
+  Append       r136, r113, r120
+  Move         r113, r136
+L16:
+  // if ps == reverseStr(ps) { ppcyclops = append(ppcyclops, p) }
+  Move         r137, r122
+  Call         r138, reverseStr, r137
+  Equal        r139, r122, r138
+  JumpIfFalse  r139, L17
+  Append       r140, r114, r120
+  Move         r114, r140
+L17:
+  // for p in primes {
+  Const        r141, 1
+  AddInt       r142, r117, r141
+  Move         r117, r142
+  Jump         L18
+L15:
+  // print("\n\nThe first 50 blind prime cyclops numbers are:")
+  Const        r143, "\n\nThe first 50 blind prime cyclops numbers are:"
+  Print        r143
+  // idx = 0
+  Const        r10, 0
+  Move         r46, r10
+L20:
+  // while idx < 50 {
+  Const        r47, 50
+  LessInt      r144, r46, r47
+  JumpIfFalse  r144, L19
+  // print(pad(commatize(bpcyclops[idx]), 6) + " ")
+  Index        r148, r113, r46
+  Move         r147, r148
+  Call         r149, commatize, r147
+  Move         r145, r149
+  Const        r54, 6
+  Move         r146, r54
+  Call2        r150, pad, r145, r146
+  Const        r56, " "
+  Add          r151, r150, r56
+  Print        r151
+  // idx = idx + 1
+  Const        r13, 1
+  AddInt       r152, r46, r13
+  Move         r46, r152
+  // if idx % 10 == 0 { print("\n") }
+  Const        r59, 10
+  ModInt       r153, r46, r59
+  Const        r10, 0
+  EqualInt     r154, r153, r10
+  JumpIfFalse  r154, L20
+  Const        r62, "\n"
+  Print        r62
+  // while idx < 50 {
+  Jump         L20
+L19:
+  // let fb = findFirst(bpcyclops)
+  Move         r155, r113
+  Call         r156, findFirst, r155
+  Move         r157, r156
+  // print("\nFirst such number > 10 million is " + commatize(fb[0]) + " at zero-based index " + commatize(fb[1]))
+  Const        r66, "\nFirst such number > 10 million is "
+  Const        r10, 0
+  Index        r159, r157, r10
+  Move         r158, r159
+  Call         r160, commatize, r158
+  Add          r161, r66, r160
+  Const        r71, " at zero-based index "
+  Add          r162, r161, r71
+  Const        r13, 1
+  Index        r164, r157, r13
+  Move         r163, r164
+  Call         r165, commatize, r163
+  Add          r166, r162, r165
+  Print        r166
+  // print("\n\nThe first 50 palindromic prime cyclops numbers are:")
+  Const        r167, "\n\nThe first 50 palindromic prime cyclops numbers are:"
+  Print        r167
+  // idx = 0
+  Const        r10, 0
+  Move         r46, r10
+L22:
+  // while idx < 50 {
+  Const        r47, 50
+  LessInt      r168, r46, r47
+  JumpIfFalse  r168, L21
+  // print(pad(commatize(ppcyclops[idx]), 9) + " ")
+  Index        r172, r114, r46
+  Move         r171, r172
+  Call         r173, commatize, r171
+  Move         r169, r173
+  Const        r174, 9
+  Move         r170, r174
+  Call2        r175, pad, r169, r170
+  Const        r56, " "
+  Add          r176, r175, r56
+  Print        r176
+  // idx = idx + 1
+  Const        r13, 1
+  AddInt       r177, r46, r13
+  Move         r46, r177
+  // if idx % 8 == 0 { print("\n") }
+  Const        r178, 8
+  ModInt       r179, r46, r178
+  Const        r10, 0
+  EqualInt     r180, r179, r10
+  JumpIfFalse  r180, L22
+  Const        r62, "\n"
+  Print        r62
+  // while idx < 50 {
+  Jump         L22
+L21:
+  // let fpp = findFirst(ppcyclops)
+  Move         r181, r114
+  Call         r182, findFirst, r181
+  Move         r183, r182
+  // print("\n\nFirst such number > 10 million is " + commatize(fpp[0]) + " at zero-based index " + commatize(fpp[1]))
+  Const        r184, "\n\nFirst such number > 10 million is "
+  Const        r10, 0
+  Index        r186, r183, r10
+  Move         r185, r186
+  Call         r187, commatize, r185
+  Add          r188, r184, r187
+  Const        r71, " at zero-based index "
+  Add          r189, r188, r71
+  Const        r13, 1
+  Index        r191, r183, r13
+  Move         r190, r191
+  Call         r192, commatize, r190
+  Add          r193, r189, r192
+  Print        r193
+  Return       r0

--- a/tests/rosetta/ir/damm-algorithm.bench
+++ b/tests/rosetta/ir/damm-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 71,
+  "memory_bytes": 24792,
+  "name": "main"
+}

--- a/tests/rosetta/ir/damm-algorithm.ir
+++ b/tests/rosetta/ir/damm-algorithm.ir
@@ -1,0 +1,99 @@
+func main (regs=1)
+  // main()
+  Call         r0, main, 
+  Return       r0
+
+  // fun damm(s: string): bool {
+func damm (regs=23)
+  // let tbl = [
+  Const        r1, [[0, 3, 1, 7, 5, 9, 8, 6, 4, 2], [7, 0, 9, 2, 1, 5, 4, 8, 6, 3], [4, 2, 0, 6, 8, 7, 1, 3, 5, 9], [1, 7, 5, 0, 9, 8, 3, 4, 2, 6], [6, 1, 2, 3, 0, 4, 5, 9, 7, 8], [3, 6, 7, 4, 2, 0, 9, 5, 8, 1], [5, 8, 6, 9, 7, 2, 0, 1, 3, 4], [8, 9, 4, 5, 3, 6, 2, 0, 1, 7], [9, 4, 3, 8, 6, 1, 7, 2, 0, 5], [2, 5, 8, 1, 4, 3, 6, 7, 9, 0]]
+  Move         r2, r1
+  // let digits = {
+  Const        r3, {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  Move         r4, r3
+  // var interim: int = 0
+  Const        r5, 0
+  Move         r6, r5
+  // var i: int = 0
+  Const        r5, 0
+  Move         r7, r5
+L1:
+  // while i < len(s) {
+  Len          r8, r0
+  LessInt      r9, r7, r8
+  JumpIfFalse  r9, L0
+  // let digit = digits[s[i:i+1]] as int
+  Move         r10, r7
+  Const        r12, 1
+  AddInt       r13, r7, r12
+  Move         r11, r13
+  Slice        r14, r0, r10, r11
+  Index        r15, r4, r14
+  Cast         r16, r15, int
+  Move         r17, r16
+  // let row = tbl[interim]
+  Index        r18, r2, r6
+  Move         r19, r18
+  // interim = row[digit]
+  Index        r20, r19, r17
+  Move         r6, r20
+  // i = i + 1
+  Const        r12, 1
+  AddInt       r21, r7, r12
+  Move         r7, r21
+  // while i < len(s) {
+  Jump         L1
+L0:
+  // return interim == 0
+  Const        r5, 0
+  Equal        r22, r6, r5
+  Return       r22
+
+  // fun padLeft(s: string, width: int): string {
+func padLeft (regs=6)
+L1:
+  // while len(s) < width {
+  Len          r2, r0
+  Less         r3, r2, r1
+  JumpIfFalse  r3, L0
+  // s = " " + s
+  Const        r4, " "
+  Add          r5, r4, r0
+  Move         r0, r5
+  // while len(s) < width {
+  Jump         L1
+L0:
+  // return s
+  Return       r0
+
+  // fun main() {
+func main (regs=19)
+  // for s in ["5724", "5727", "112946", "112949"] {
+  Const        r0, ["5724", "5727", "112946", "112949"]
+  IterPrep     r1, r0
+  Len          r2, r1
+  Const        r3, 0
+L1:
+  LessInt      r4, r3, r2
+  JumpIfFalse  r4, L0
+  Index        r5, r1, r3
+  Move         r6, r5
+  // print(padLeft(s, 6) + "  " + str(damm(s)))
+  Move         r7, r6
+  Const        r9, 6
+  Move         r8, r9
+  Call2        r10, padLeft, r7, r8
+  Const        r11, "  "
+  Add          r12, r10, r11
+  Move         r13, r6
+  Call         r14, damm, r13
+  Str          r15, r14
+  Add          r16, r12, r15
+  Print        r16
+  // for s in ["5724", "5727", "112946", "112949"] {
+  Const        r17, 1
+  AddInt       r18, r3, r17
+  Move         r3, r18
+  Jump         L1
+L0:
+  Return       r0

--- a/tests/rosetta/ir/date-format.bench
+++ b/tests/rosetta/ir/date-format.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 48,
+  "memory_bytes": 19144,
+  "name": "main"
+}

--- a/tests/rosetta/ir/date-format.ir
+++ b/tests/rosetta/ir/date-format.ir
@@ -1,0 +1,166 @@
+func main (regs=1)
+  // main()
+  Call         r0, main, 
+  Return       r0
+
+  // fun pad2(n: int): string {
+func pad2 (regs=7)
+  // if n < 10 { return "0" + str(n) }
+  Const        r1, 10
+  Less         r2, r0, r1
+  JumpIfFalse  r2, L0
+  Const        r3, "0"
+  Str          r4, r0
+  Add          r5, r3, r4
+  Return       r5
+L0:
+  // return str(n)
+  Str          r6, r0
+  Return       r6
+
+  // fun weekdayName(z: int): string {
+func weekdayName (regs=8)
+  // let names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+  Const        r1, ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+  Move         r2, r1
+  // return names[(z + 4) % 7]
+  Const        r3, 4
+  Add          r4, r0, r3
+  Const        r5, 7
+  Mod          r6, r4, r5
+  Index        r7, r2, r6
+  Return       r7
+
+  // fun main() {
+func main (regs=95)
+  // let ts = (now() / 1000000000) as int
+  Now          r0
+  Const        r1, 1000000000
+  DivInt       r2, r0, r1
+  Cast         r3, r2, int
+  Move         r4, r3
+  // var days = (ts / 86400) as int
+  Const        r5, 86400
+  Div          r6, r4, r5
+  Cast         r7, r6, int
+  Move         r8, r7
+  // var z = days + 719468
+  Const        r9, 719468
+  Add          r10, r8, r9
+  Move         r11, r10
+  // var era = (z / 146097) as int
+  Const        r12, 146097
+  Div          r13, r11, r12
+  Cast         r14, r13, int
+  Move         r15, r14
+  // var doe = z - era * 146097
+  Const        r12, 146097
+  Mul          r16, r15, r12
+  Sub          r17, r11, r16
+  Move         r18, r17
+  // var yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365 as int
+  Const        r19, 1460
+  Div          r20, r18, r19
+  Const        r21, 36524
+  Div          r22, r18, r21
+  Const        r23, 146096
+  Div          r24, r18, r23
+  Sub          r25, r18, r20
+  Add          r26, r25, r22
+  Sub          r27, r26, r24
+  Const        r28, 365
+  Div          r29, r27, r28
+  Move         r30, r29
+  // var y = yoe + era * 400
+  Const        r31, 400
+  Mul          r32, r15, r31
+  Add          r33, r30, r32
+  Move         r34, r33
+  // var doy = doe - (365 * yoe + yoe/4 - yoe/100)
+  Const        r28, 365
+  Mul          r35, r28, r30
+  Const        r36, 4
+  Div          r37, r30, r36
+  Const        r38, 100
+  Div          r39, r30, r38
+  Add          r40, r35, r37
+  Sub          r41, r40, r39
+  Sub          r42, r18, r41
+  Move         r43, r42
+  // var mp = (5 * doy + 2) / 153 as int
+  Const        r44, 5
+  Mul          r45, r44, r43
+  Const        r46, 2
+  Add          r47, r45, r46
+  Const        r48, 153
+  Div          r49, r47, r48
+  Move         r50, r49
+  // var d = (doy - ((153 * mp + 2) / 5 as int) + 1) as int
+  Const        r48, 153
+  Mul          r51, r48, r50
+  Const        r46, 2
+  Add          r52, r51, r46
+  Const        r44, 5
+  Div          r53, r52, r44
+  Sub          r54, r43, r53
+  Const        r55, 1
+  Add          r56, r54, r55
+  Cast         r57, r56, int
+  Move         r58, r57
+  // var m = (mp + 3) as int
+  Const        r59, 3
+  Add          r60, r50, r59
+  Cast         r61, r60, int
+  Move         r62, r61
+  // if m > 12 {
+  Const        r63, 12
+  Less         r64, r63, r62
+  JumpIfFalse  r64, L0
+  // y = y + 1
+  Const        r55, 1
+  Add          r65, r34, r55
+  Move         r34, r65
+  // m = m - 12
+  Const        r63, 12
+  Sub          r66, r62, r63
+  Move         r62, r66
+L0:
+  // let iso = str(y) + "-" + pad2(m) + "-" + pad2(d)
+  Str          r67, r34
+  Const        r68, "-"
+  Add          r69, r67, r68
+  Move         r70, r62
+  Call         r71, pad2, r70
+  Add          r72, r69, r71
+  Const        r68, "-"
+  Add          r73, r72, r68
+  Move         r74, r58
+  Call         r75, pad2, r74
+  Add          r76, r73, r75
+  Move         r77, r76
+  // print(iso)
+  Print        r77
+  // let months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+  Const        r78, ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+  Move         r79, r78
+  // let line = weekdayName(days) + ", " + months[m-1] + " " + str(d) + ", " + str(y)
+  Move         r80, r8
+  Call         r81, weekdayName, r80
+  Const        r82, ", "
+  Add          r83, r81, r82
+  Const        r55, 1
+  Sub          r84, r62, r55
+  Index        r85, r79, r84
+  Add          r86, r83, r85
+  Const        r87, " "
+  Add          r88, r86, r87
+  Str          r89, r58
+  Add          r90, r88, r89
+  Const        r82, ", "
+  Add          r91, r90, r82
+  Str          r92, r34
+  Add          r93, r91, r92
+  Move         r94, r93
+  // print(line)
+  Print        r94
+  Return       r0

--- a/tests/rosetta/ir/date-manipulation.bench
+++ b/tests/rosetta/ir/date-manipulation.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 587,
+  "memory_bytes": 619312,
+  "name": "main"
+}

--- a/tests/rosetta/ir/date-manipulation.ir
+++ b/tests/rosetta/ir/date-manipulation.ir
@@ -1,0 +1,701 @@
+func main (regs=3)
+  // let months = {
+  Const        r1, {"April": 4, "August": 8, "December": 12, "February": 2, "January": 1, "July": 7, "June": 6, "March": 3, "May": 5, "November": 11, "October": 10, "September": 9}
+  Move         r0, r1
+  SetGlobal    0,0,0,0
+  // main()
+  Call         r2, main, 
+  Return       r0
+
+  // fun isLeap(y: int): bool {
+func isLeap (regs=14)
+  // if y % 400 == 0 { return true }
+  Const        r2, 400
+  Mod          r3, r1, r2
+  Const        r4, 0
+  Equal        r5, r3, r4
+  JumpIfFalse  r5, L0
+  Const        r6, true
+  Return       r6
+L0:
+  // if y % 100 == 0 { return false }
+  Const        r7, 100
+  Mod          r8, r1, r7
+  Const        r4, 0
+  Equal        r9, r8, r4
+  JumpIfFalse  r9, L1
+  Const        r10, false
+  Return       r10
+L1:
+  // return y % 4 == 0
+  Const        r11, 4
+  Mod          r12, r1, r11
+  Const        r4, 0
+  Equal        r13, r12, r4
+  Return       r13
+
+  // fun daysInMonth(y: int, m: int): int {
+func daysInMonth (regs=28)
+  // let feb = if isLeap(y) { 29 } else { 28 }
+  Move         r3, r1
+  Call         r4, isLeap, r3
+  Const        r5, 29
+  Const        r6, 28
+  Select       7,4,5,6
+  Move         r8, r7
+  // let lengths = [31, feb, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  Const        r21, 31
+  Move         r9, r21
+  Move         r10, r8
+  Const        r21, 31
+  Move         r11, r21
+  Const        r22, 30
+  Move         r12, r22
+  Const        r21, 31
+  Move         r13, r21
+  Const        r22, 30
+  Move         r14, r22
+  Const        r21, 31
+  Move         r15, r21
+  Const        r21, 31
+  Move         r16, r21
+  Const        r22, 30
+  Move         r17, r22
+  Const        r21, 31
+  Move         r18, r21
+  Const        r22, 30
+  Move         r19, r22
+  Const        r21, 31
+  Move         r20, r21
+  MakeList     r23, 12, r9
+  Move         r24, r23
+  // return lengths[m-1]
+  Const        r25, 1
+  Sub          r26, r2, r25
+  Index        r27, r24, r26
+  Return       r27
+
+  // fun daysBeforeYear(y: int): int {
+func daysBeforeYear (regs=14)
+  // var days = 0
+  Const        r2, 0
+  Move         r3, r2
+  // var yy = 1970
+  Const        r4, 1970
+  Move         r5, r4
+L2:
+  // while yy < y {
+  Less         r6, r5, r1
+  JumpIfFalse  r6, L0
+  // days = days + 365
+  Const        r7, 365
+  AddInt       r8, r3, r7
+  Move         r3, r8
+  // if isLeap(yy) { days = days + 1 }
+  Move         r9, r5
+  Call         r10, isLeap, r9
+  JumpIfFalse  r10, L1
+  Const        r11, 1
+  AddInt       r12, r3, r11
+  Move         r3, r12
+L1:
+  // yy = yy + 1
+  Const        r11, 1
+  AddInt       r13, r5, r11
+  Move         r5, r13
+  // while yy < y {
+  Jump         L2
+L0:
+  // return days
+  Return       r3
+
+  // fun daysBeforeMonth(y: int, m: int): int {
+func daysBeforeMonth (regs=13)
+  // var days = 0
+  Const        r3, 0
+  Move         r4, r3
+  // var mm = 1
+  Const        r5, 1
+  Move         r6, r5
+L1:
+  // while mm < m {
+  Less         r7, r6, r2
+  JumpIfFalse  r7, L0
+  // days = days + daysInMonth(y, mm)
+  Move         r8, r1
+  Move         r9, r6
+  Call2        r10, daysInMonth, r8, r9
+  Add          r11, r4, r10
+  Move         r4, r11
+  // mm = mm + 1
+  Const        r5, 1
+  AddInt       r12, r6, r5
+  Move         r6, r12
+  // while mm < m {
+  Jump         L1
+L0:
+  // return days
+  Return       r4
+
+  // fun epochSeconds(y: int, m: int, d: int, h: int, mi: int): int {
+func epochSeconds (regs=24)
+  // let days = daysBeforeYear(y) + daysBeforeMonth(y, m) + (d - 1)
+  Move         r6, r1
+  Call         r7, daysBeforeYear, r6
+  Move         r8, r1
+  Move         r9, r2
+  Call2        r10, daysBeforeMonth, r8, r9
+  Add          r11, r7, r10
+  Const        r12, 1
+  Sub          r13, r3, r12
+  Add          r14, r11, r13
+  Move         r15, r14
+  // return days * 86400 + h * 3600 + mi * 60
+  Const        r16, 86400
+  Mul          r17, r15, r16
+  Const        r18, 3600
+  Mul          r19, r4, r18
+  Const        r20, 60
+  Mul          r21, r5, r20
+  Add          r22, r17, r19
+  Add          r23, r22, r21
+  Return       r23
+
+  // fun fromEpoch(sec: int): list<int> {
+func fromEpoch (regs=43)
+  // var days = sec / 86400
+  Const        r2, 86400
+  Div          r3, r1, r2
+  Move         r4, r3
+  // var rem = sec % 86400
+  Const        r2, 86400
+  Mod          r5, r1, r2
+  Move         r6, r5
+  // var y = 1970
+  Const        r7, 1970
+  Move         r8, r7
+L1:
+  // while true {
+  Const        r9, true
+  JumpIfFalse  r9, L0
+  // let dy = if isLeap(y) { 366 } else { 365 }
+  Move         r10, r8
+  Call         r11, isLeap, r10
+  Const        r12, 366
+  Const        r13, 365
+  Select       14,11,12,13
+  Move         r15, r14
+  // if days >= dy {
+  LessEq       r16, r15, r4
+  JumpIfFalse  r16, L0
+  // days = days - dy
+  Sub          r17, r4, r15
+  Move         r4, r17
+  // y = y + 1
+  Const        r18, 1
+  AddInt       r19, r8, r18
+  Move         r8, r19
+  // if days >= dy {
+  Jump         L1
+L0:
+  // var m = 1
+  Const        r18, 1
+  Move         r20, r18
+L3:
+  // while true {
+  Const        r9, true
+  JumpIfFalse  r9, L2
+  // let dim = daysInMonth(y, m)
+  Move         r21, r8
+  Move         r22, r20
+  Call2        r23, daysInMonth, r21, r22
+  Move         r24, r23
+  // if days >= dim {
+  LessEq       r25, r24, r4
+  JumpIfFalse  r25, L2
+  // days = days - dim
+  Sub          r26, r4, r24
+  Move         r4, r26
+  // m = m + 1
+  Const        r18, 1
+  AddInt       r27, r20, r18
+  Move         r20, r27
+  // if days >= dim {
+  Jump         L3
+L2:
+  // let d = days + 1
+  Const        r18, 1
+  Add          r28, r4, r18
+  Move         r29, r28
+  // let h = rem / 3600
+  Const        r30, 3600
+  Div          r31, r6, r30
+  Move         r32, r31
+  // let mi = (rem % 3600) / 60
+  Const        r30, 3600
+  Mod          r33, r6, r30
+  Const        r34, 60
+  Div          r35, r33, r34
+  Move         r36, r35
+  // return [y, m, d, h, mi]
+  Move         r37, r8
+  Move         r38, r20
+  Move         r39, r29
+  Move         r40, r32
+  Move         r41, r36
+  MakeList     r42, 5, r37
+  Return       r42
+
+  // fun pad2(n: int): string {
+func pad2 (regs=8)
+  // if n < 10 { return "0" + str(n) }
+  Const        r2, 10
+  Less         r3, r1, r2
+  JumpIfFalse  r3, L0
+  Const        r4, "0"
+  Str          r5, r1
+  Add          r6, r4, r5
+  Return       r6
+L0:
+  // return str(n)
+  Str          r7, r1
+  Return       r7
+
+  // fun absInt(n: int): int { if n < 0 { return -n } return n }
+func absInt (regs=5)
+  // fun absInt(n: int): int { if n < 0 { return -n } return n }
+  Const        r2, 0
+  Less         r3, r1, r2
+  JumpIfFalse  r3, L0
+  Neg          r4, r1
+  Return       r4
+L0:
+  Return       r1
+
+  // fun formatDate(parts: list<int>, offset: int, abbr: string): string {
+func formatDate (regs=62)
+  // let y = parts[0]
+  Const        r4, 0
+  Index        r5, r1, r4
+  Move         r6, r5
+  // let m = parts[1]
+  Const        r7, 1
+  Index        r8, r1, r7
+  Move         r9, r8
+  // let d = parts[2]
+  Const        r10, 2
+  Index        r11, r1, r10
+  Move         r12, r11
+  // let h = parts[3]
+  Const        r13, 3
+  Index        r14, r1, r13
+  Move         r15, r14
+  // let mi = parts[4]
+  Const        r16, 4
+  Index        r17, r1, r16
+  Move         r18, r17
+  // var sign = "+"
+  Const        r19, "+"
+  Move         r20, r19
+  // if offset < 0 {
+  Const        r4, 0
+  Less         r21, r2, r4
+  JumpIfFalse  r21, L0
+  // sign = "-"
+  Const        r22, "-"
+  Move         r20, r22
+L0:
+  // let off = absInt(offset) / 60
+  Move         r23, r2
+  Call         r24, absInt, r23
+  Const        r25, 60
+  Div          r26, r24, r25
+  Move         r27, r26
+  // let offh = pad2(off / 60)
+  Const        r25, 60
+  Div          r29, r27, r25
+  Move         r28, r29
+  Call         r30, pad2, r28
+  Move         r31, r30
+  // let offm = pad2(off % 60)
+  Const        r25, 60
+  Mod          r33, r27, r25
+  Move         r32, r33
+  Call         r34, pad2, r32
+  Move         r35, r34
+  // return str(y) + "-" + pad2(m) + "-" + pad2(d) + " " + pad2(h) + ":" + pad2(mi) + ":00 " + sign + offh + offm + " " + abbr
+  Str          r36, r6
+  Const        r22, "-"
+  Add          r37, r36, r22
+  Move         r38, r9
+  Call         r39, pad2, r38
+  Add          r40, r37, r39
+  Const        r22, "-"
+  Add          r41, r40, r22
+  Move         r42, r12
+  Call         r43, pad2, r42
+  Add          r44, r41, r43
+  Const        r45, " "
+  Add          r46, r44, r45
+  Move         r47, r15
+  Call         r48, pad2, r47
+  Add          r49, r46, r48
+  Const        r50, ":"
+  Add          r51, r49, r50
+  Move         r52, r18
+  Call         r53, pad2, r52
+  Add          r54, r51, r53
+  Const        r55, ":00 "
+  Add          r56, r54, r55
+  Add          r57, r56, r20
+  Add          r58, r57, r31
+  Add          r59, r58, r35
+  Const        r45, " "
+  Add          r60, r59, r45
+  Add          r61, r60, r3
+  Return       r61
+
+  // fun parseIntStr(str: string): int {
+func parseIntStr (regs=27)
+  // var i = 0
+  Const        r2, 0
+  Move         r3, r2
+  // var neg = false
+  Const        r4, false
+  Move         r5, r4
+  // if len(str) > 0 && substring(str,0,1) == "-" {
+  Len          r6, r1
+  Const        r2, 0
+  LessInt      r7, r2, r6
+  Const        r2, 0
+  Const        r8, 1
+  Slice        r9, r1, r2, r8
+  Const        r10, "-"
+  Equal        r11, r9, r10
+  Move         r12, r7
+  JumpIfFalse  r12, L0
+  Move         r12, r11
+L0:
+  JumpIfFalse  r12, L1
+  // neg = true
+  Const        r13, true
+  Move         r5, r13
+  // i = 1
+  Const        r8, 1
+  Move         r3, r8
+L1:
+  // var n = 0
+  Const        r2, 0
+  Move         r14, r2
+  // let digits = {
+  Const        r15, {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9}
+  Move         r16, r15
+L3:
+  // while i < len(str) {
+  Len          r17, r1
+  LessInt      r18, r3, r17
+  JumpIfFalse  r18, L2
+  // n = n*10 + digits[substring(str,i,i+1)]
+  Const        r19, 10
+  MulInt       r20, r14, r19
+  Const        r8, 1
+  AddInt       r21, r3, r8
+  Slice        r22, r1, r3, r21
+  Index        r23, r16, r22
+  Add          r24, r20, r23
+  Move         r14, r24
+  // i = i + 1
+  Const        r8, 1
+  AddInt       r25, r3, r8
+  Move         r3, r25
+  // while i < len(str) {
+  Jump         L3
+L2:
+  // if neg { n = -n }
+  JumpIfFalse  r5, L4
+  Neg          r26, r14
+  Move         r14, r26
+L4:
+  // return n
+  Return       r14
+
+  // fun indexOf(s: string, ch: string): int {
+func indexOf (regs=13)
+  // var i = 0
+  Const        r3, 0
+  Move         r4, r3
+L2:
+  // while i < len(s) {
+  Len          r5, r1
+  LessInt      r6, r4, r5
+  JumpIfFalse  r6, L0
+  // if substring(s, i, i+1) == ch { return i }
+  Const        r7, 1
+  AddInt       r8, r4, r7
+  Slice        r9, r1, r4, r8
+  Equal        r10, r9, r2
+  JumpIfFalse  r10, L1
+  Return       r4
+L1:
+  // i = i + 1
+  Const        r7, 1
+  AddInt       r11, r4, r7
+  Move         r4, r11
+  // while i < len(s) {
+  Jump         L2
+L0:
+  // return -1
+  Const        r7, 1
+  NegInt       r12, r7
+  Return       r12
+
+  // fun parseTime(s: string): list<int> {
+func parseTime (regs=40)
+  // let c = indexOf(s, ":")
+  Move         r2, r1
+  Const        r4, ":"
+  Move         r3, r4
+  Call2        r5, indexOf, r2, r3
+  Move         r6, r5
+  // let h = parseIntStr(substring(s, 0, c))
+  Const        r8, 0
+  Slice        r9, r1, r8, r6
+  Move         r7, r9
+  Call         r10, parseIntStr, r7
+  Move         r11, r10
+  // let mi = parseIntStr(substring(s, c+1, c+3))
+  Const        r13, 1
+  Add          r14, r6, r13
+  Const        r15, 3
+  Add          r16, r6, r15
+  Slice        r17, r1, r14, r16
+  Move         r12, r17
+  Call         r18, parseIntStr, r12
+  Move         r19, r18
+  // let ampm = substring(s, len(s)-2, len(s))
+  Len          r20, r1
+  Const        r21, 2
+  SubInt       r22, r20, r21
+  Len          r23, r1
+  Slice        r24, r1, r22, r23
+  Move         r25, r24
+  // var hh = h
+  Move         r26, r11
+  // if ampm == "pm" && h != 12 { hh = h + 12 }
+  Const        r27, "pm"
+  Equal        r28, r25, r27
+  Const        r29, 12
+  NotEqual     r30, r11, r29
+  Move         r31, r28
+  JumpIfFalse  r31, L0
+  Move         r31, r30
+L0:
+  JumpIfFalse  r31, L1
+  Const        r29, 12
+  Add          r32, r11, r29
+  Move         r26, r32
+L1:
+  // if ampm == "am" && h == 12 { hh = 0 }
+  Const        r33, "am"
+  Equal        r34, r25, r33
+  Const        r29, 12
+  Equal        r35, r11, r29
+  Move         r36, r34
+  JumpIfFalse  r36, L2
+  Move         r36, r35
+L2:
+  JumpIfFalse  r36, L3
+  Const        r8, 0
+  Move         r26, r8
+L3:
+  // return [hh, mi]
+  Move         r37, r26
+  Move         r38, r19
+  MakeList     r39, 2, r37
+  Return       r39
+
+  // fun main() {
+func main (regs=111)
+  // let input = "March 7 2009 7:30pm EST"
+  Const        r1, "March 7 2009 7:30pm EST"
+  Move         r2, r1
+  // print("Input:              " + input)
+  Const        r3, "Input:              "
+  Const        r4, "Input:              March 7 2009 7:30pm EST"
+  Print        r4
+  // let parts = []
+  Const        r5, []
+  Move         r6, r5
+  // var cur = ""
+  Const        r7, ""
+  Move         r8, r7
+  // var i = 0
+  Const        r9, 0
+  Move         r10, r9
+L3:
+  // while i < len(input) {
+  Const        r11, 23
+  LessInt      r12, r10, r11
+  JumpIfFalse  r12, L0
+  // let ch = substring(input, i, i+1)
+  Const        r13, 1
+  AddInt       r14, r10, r13
+  Slice        r15, r2, r10, r14
+  Move         r16, r15
+  // if ch == " " {
+  Const        r17, " "
+  Equal        r18, r16, r17
+  JumpIfFalse  r18, L1
+  // if len(cur) > 0 { parts = append(parts, cur); cur = "" }
+  Len          r19, r8
+  Const        r9, 0
+  LessInt      r20, r9, r19
+  JumpIfFalse  r20, L2
+  Append       r21, r6, r8
+  Move         r6, r21
+  Const        r7, ""
+  Move         r8, r7
+  // if ch == " " {
+  Jump         L2
+L1:
+  // cur = cur + ch
+  Add          r22, r8, r16
+  Move         r8, r22
+L2:
+  // i = i + 1
+  Const        r13, 1
+  AddInt       r23, r10, r13
+  Move         r10, r23
+  // while i < len(input) {
+  Jump         L3
+L0:
+  // if len(cur) > 0 { parts = append(parts, cur) }
+  Len          r24, r8
+  Const        r9, 0
+  LessInt      r25, r9, r24
+  JumpIfFalse  r25, L4
+  Append       r26, r6, r8
+  Move         r6, r26
+L4:
+  // let month = months[parts[0]]
+  Const        r9, 0
+  Index        r27, r6, r9
+  Index        r28, r0, r27
+  Move         r29, r28
+  // let day = parseIntStr(parts[1])
+  Const        r13, 1
+  Index        r31, r6, r13
+  Move         r30, r31
+  Call         r32, parseIntStr, r30
+  Move         r33, r32
+  // let year = parseIntStr(parts[2])
+  Const        r35, 2
+  Index        r36, r6, r35
+  Move         r34, r36
+  Call         r37, parseIntStr, r34
+  Move         r38, r37
+  // let tm = parseTime(parts[3])
+  Const        r40, 3
+  Index        r41, r6, r40
+  Move         r39, r41
+  Call         r42, parseTime, r39
+  Move         r43, r42
+  // let hour = tm[0]
+  Const        r9, 0
+  Index        r44, r43, r9
+  Move         r45, r44
+  // let minute = tm[1]
+  Const        r13, 1
+  Index        r46, r43, r13
+  Move         r47, r46
+  // let tz = parts[4]
+  Const        r48, 4
+  Index        r49, r6, r48
+  Move         r50, r49
+  // let zoneOffsets = { "EST": -18000, "EDT": -14400, "MST": -25200 }
+  Const        r51, {"EDT": -14400, "EST": -18000, "MST": -25200}
+  Move         r52, r51
+  // let local = epochSeconds(year, month, day, hour, minute)
+  Move         r53, r38
+  Move         r54, r29
+  Move         r55, r33
+  Move         r56, r45
+  Move         r57, r47
+  Call         r58, epochSeconds, r53, r54, r55, r56, r57
+  Move         r59, r58
+  // let utc = local - zoneOffsets[tz]
+  Index        r60, r52, r50
+  Sub          r61, r59, r60
+  Move         r62, r61
+  // let utc12 = utc + 43200
+  Const        r63, 43200
+  Add          r64, r62, r63
+  Move         r65, r64
+  // let startDST = epochSeconds(2009,3,8,7,0)
+  Const        r71, 2009
+  Move         r66, r71
+  Const        r40, 3
+  Move         r67, r40
+  Const        r72, 8
+  Move         r68, r72
+  Const        r73, 7
+  Move         r69, r73
+  Const        r9, 0
+  Move         r70, r9
+  Call         r74, epochSeconds, r66, r67, r68, r69, r70
+  Move         r75, r74
+  // var offEast = -18000
+  Const        r76, 18000
+  Const        r77, -18000
+  Move         r78, r77
+  // if utc12 >= startDST {
+  LessEq       r79, r75, r65
+  JumpIfFalse  r79, L5
+  // offEast = -14400
+  Const        r80, 14400
+  Const        r81, -14400
+  Move         r78, r81
+L5:
+  // let eastParts = fromEpoch(utc12 + offEast)
+  Add          r83, r65, r78
+  Move         r82, r83
+  Call         r84, fromEpoch, r82
+  Move         r85, r84
+  // var eastAbbr = "EST"
+  Const        r86, "EST"
+  Move         r87, r86
+  // if offEast == (-14400) {
+  Const        r88, -14400
+  EqualInt     r89, r78, r88
+  JumpIfFalse  r89, L6
+  // eastAbbr = "EDT"
+  Const        r90, "EDT"
+  Move         r87, r90
+L6:
+  // print("+12 hrs:            " + formatDate(eastParts, offEast, eastAbbr))
+  Const        r91, "+12 hrs:            "
+  Move         r92, r85
+  Move         r93, r78
+  Move         r94, r87
+  Call         r95, formatDate, r92, r93, r94
+  Add          r96, r91, r95
+  Print        r96
+  // let offAZ = -25200
+  Const        r97, 25200
+  Const        r98, -25200
+  Move         r99, r98
+  // let azParts = fromEpoch(utc12 + offAZ)
+  Add          r101, r65, r99
+  Move         r100, r101
+  Call         r102, fromEpoch, r100
+  Move         r103, r102
+  // print("+12 hrs in Arizona: " + formatDate(azParts, offAZ, "MST"))
+  Const        r104, "+12 hrs in Arizona: "
+  Move         r105, r103
+  Move         r106, r99
+  Const        r108, "MST"
+  Move         r107, r108
+  Call         r109, formatDate, r105, r106, r107
+  Add          r110, r104, r109
+  Print        r110
+  Return       r0

--- a/tests/rosetta/ir/day-of-the-week.bench
+++ b/tests/rosetta/ir/day-of-the-week.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 569,
+  "memory_bytes": 855064,
+  "name": "main"
+}

--- a/tests/rosetta/ir/day-of-the-week.ir
+++ b/tests/rosetta/ir/day-of-the-week.ir
@@ -1,0 +1,92 @@
+func main (regs=19)
+  // for year in 2008..2122 {
+  Const        r0, 2008
+  Const        r1, 2122
+  Move         r2, r0
+L2:
+  LessInt      r3, r2, r1
+  JumpIfFalse  r3, L0
+  // if weekday(year, 12, 25) == 1 {
+  Move         r4, r2
+  Const        r7, 12
+  Move         r5, r7
+  Const        r8, 25
+  Move         r6, r8
+  Call         r9, weekday, r4, r5, r6
+  Const        r10, 1
+  Equal        r11, r9, r10
+  JumpIfFalse  r11, L1
+  // print("25 December " + str(year) + " is Sunday")
+  Const        r12, "25 December "
+  Str          r13, r2
+  Add          r14, r12, r13
+  Const        r15, " is Sunday"
+  Add          r16, r14, r15
+  Print        r16
+L1:
+  // for year in 2008..2122 {
+  Const        r17, 1
+  AddInt       r18, r2, r17
+  Move         r2, r18
+  Jump         L2
+L0:
+  Return       r0
+
+  // fun weekday(y: int, m: int, d: int): int {
+func weekday (regs=39)
+  // var yy = y
+  Move         r3, r0
+  // var mm = m
+  Move         r4, r1
+  // if mm < 3 {
+  Const        r5, 3
+  Less         r6, r4, r5
+  JumpIfFalse  r6, L0
+  // mm = mm + 12
+  Const        r7, 12
+  Add          r8, r4, r7
+  Move         r4, r8
+  // yy = yy - 1
+  Const        r9, 1
+  Sub          r10, r3, r9
+  Move         r3, r10
+L0:
+  // let k = yy % 100
+  Const        r11, 100
+  Mod          r12, r3, r11
+  Move         r13, r12
+  // let j = (yy / 100) as int
+  Const        r11, 100
+  Div          r14, r3, r11
+  Cast         r15, r14, int
+  Move         r16, r15
+  // let a = ((13*(mm+1))/5) as int
+  Const        r17, 13
+  Const        r9, 1
+  Add          r18, r4, r9
+  Mul          r19, r17, r18
+  Const        r20, 5
+  Div          r21, r19, r20
+  Cast         r22, r21, int
+  Move         r23, r22
+  // let b = (k/4) as int
+  Const        r24, 4
+  Div          r25, r13, r24
+  Cast         r26, r25, int
+  Move         r27, r26
+  // let c = (j/4) as int
+  Const        r24, 4
+  Div          r28, r16, r24
+  Cast         r29, r28, int
+  Move         r30, r29
+  // return (d + a + k + b + c + 5*j) % 7
+  Const        r20, 5
+  Mul          r31, r20, r16
+  Add          r32, r2, r23
+  Add          r33, r32, r13
+  Add          r34, r33, r27
+  Add          r35, r34, r30
+  Add          r36, r35, r31
+  Const        r37, 7
+  Mod          r38, r36, r37
+  Return       r38

--- a/tests/rosetta/ir/de-bruijn-sequences.bench
+++ b/tests/rosetta/ir/de-bruijn-sequences.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 12726256,
+  "memory_bytes": 219576,
+  "name": "main"
+}

--- a/tests/rosetta/ir/de-bruijn-sequences.ir
+++ b/tests/rosetta/ir/de-bruijn-sequences.ir
@@ -1,0 +1,567 @@
+func main (regs=1)
+  // main()
+  Call         r0, main, 
+  Return       r0
+
+  // fun dbRec(k: int, n: int, t: int, p: int, a: list<int>, seq: list<int>): list<int> {
+func dbRec (regs=40)
+  // if t > n {
+  Less         r6, r1, r2
+  JumpIfFalse  r6, L0
+  // if n % p == 0 {
+  Mod          r7, r1, r3
+  Const        r8, 0
+  Equal        r9, r7, r8
+  JumpIfFalse  r9, L1
+  // var j = 1
+  Const        r10, 1
+  Move         r11, r10
+L2:
+  // while j <= p {
+  LessEq       r12, r11, r3
+  JumpIfFalse  r12, L1
+  // seq = append(seq, a[j])
+  Index        r13, r4, r11
+  Append       r14, r5, r13
+  Move         r5, r14
+  // j = j + 1
+  Const        r10, 1
+  AddInt       r15, r11, r10
+  Move         r11, r15
+  // while j <= p {
+  Jump         L2
+L0:
+  // a[t] = a[t-p]
+  Sub          r16, r2, r3
+  Index        r17, r4, r16
+  SetIndex     r4, r2, r17
+  // seq = dbRec(k, n, t+1, p, a, seq)
+  Move         r18, r0
+  Move         r19, r1
+  Const        r10, 1
+  Add          r24, r2, r10
+  Move         r20, r24
+  Move         r21, r3
+  Move         r22, r4
+  Move         r23, r5
+  Call         r25, dbRec, r18, r19, r20, r21, r22, r23
+  Move         r5, r25
+  // var j = a[t-p] + 1
+  Sub          r26, r2, r3
+  Index        r27, r4, r26
+  Const        r10, 1
+  Add          r28, r27, r10
+  Move         r29, r28
+L3:
+  // while j < k {
+  Less         r30, r29, r0
+  JumpIfFalse  r30, L1
+  // a[t] = j
+  SetIndex     r4, r2, r29
+  // seq = dbRec(k, n, t+1, t, a, seq)
+  Move         r31, r0
+  Move         r32, r1
+  Const        r10, 1
+  Add          r37, r2, r10
+  Move         r33, r37
+  Move         r34, r2
+  Move         r35, r4
+  Move         r36, r5
+  Call         r38, dbRec, r31, r32, r33, r34, r35, r36
+  Move         r5, r38
+  // j = j + 1
+  Const        r10, 1
+  Add          r39, r29, r10
+  Move         r29, r39
+  // while j < k {
+  Jump         L3
+L1:
+  // return seq
+  Return       r5
+
+  // fun deBruijn(k: int, n: int): string {
+func deBruijn (regs=41)
+  // let digits = "0123456789"
+  Const        r2, "0123456789"
+  Move         r3, r2
+  // var alphabet = digits
+  Move         r4, r3
+  // if k < 10 { alphabet = digits[0:k] }
+  Const        r5, 10
+  Less         r6, r0, r5
+  JumpIfFalse  r6, L0
+  Const        r8, 0
+  Move         r7, r8
+  Move         r9, r0
+  Slice        r10, r3, r7, r9
+  Move         r4, r10
+L0:
+  // var a: list<int> = []
+  Const        r11, []
+  Move         r12, r11
+  // var i = 0
+  Const        r8, 0
+  Move         r13, r8
+L2:
+  // while i < k*n { a = append(a, 0); i = i + 1 }
+  Mul          r14, r0, r1
+  Less         r15, r13, r14
+  JumpIfFalse  r15, L1
+  Const        r8, 0
+  Append       r16, r12, r8
+  Move         r12, r16
+  Const        r17, 1
+  AddInt       r18, r13, r17
+  Move         r13, r18
+  Jump         L2
+L1:
+  // var seq: list<int> = []
+  Const        r11, []
+  Move         r19, r11
+  // seq = dbRec(k, n, 1, 1, a, seq)
+  Move         r20, r0
+  Move         r21, r1
+  Const        r17, 1
+  Move         r22, r17
+  Const        r17, 1
+  Move         r23, r17
+  Move         r24, r12
+  Move         r25, r19
+  Call         r26, dbRec, r20, r21, r22, r23, r24, r25
+  Move         r19, r26
+  // var b = ""
+  Const        r27, ""
+  Move         r28, r27
+  // var idx = 0
+  Const        r8, 0
+  Move         r29, r8
+L4:
+  // while idx < len(seq) {
+  Len          r30, r19
+  LessInt      r31, r29, r30
+  JumpIfFalse  r31, L3
+  // b = b + alphabet[seq[idx]]
+  Index        r32, r19, r29
+  Index        r33, r4, r32
+  Add          r34, r28, r33
+  Move         r28, r34
+  // idx = idx + 1
+  Const        r17, 1
+  AddInt       r35, r29, r17
+  Move         r29, r35
+  // while idx < len(seq) {
+  Jump         L4
+L3:
+  // b = b + b[0:n-1]
+  Const        r8, 0
+  Move         r36, r8
+  Const        r17, 1
+  Sub          r38, r1, r17
+  Move         r37, r38
+  Slice        r39, r28, r36, r37
+  Add          r40, r28, r39
+  Move         r28, r40
+  // return b
+  Return       r28
+
+  // fun allDigits(s: string): bool {
+func allDigits (regs=19)
+  // var i = 0
+  Const        r1, 0
+  Move         r2, r1
+L3:
+  // while i < len(s) {
+  Len          r3, r0
+  LessInt      r4, r2, r3
+  JumpIfFalse  r4, L0
+  // let ch = s[i:i+1]
+  Move         r5, r2
+  Const        r7, 1
+  AddInt       r8, r2, r7
+  Move         r6, r8
+  Slice        r9, r0, r5, r6
+  Move         r10, r9
+  // if ch < "0" || ch > "9" { return false }
+  Const        r11, "0"
+  Less         r12, r10, r11
+  Const        r13, "9"
+  Less         r14, r13, r10
+  Move         r15, r12
+  JumpIfTrue   r15, L1
+  Move         r15, r14
+L1:
+  JumpIfFalse  r15, L2
+  Const        r16, false
+  Return       r16
+L2:
+  // i = i + 1
+  Const        r7, 1
+  AddInt       r17, r2, r7
+  Move         r2, r17
+  // while i < len(s) {
+  Jump         L3
+L0:
+  // return true
+  Const        r18, true
+  Return       r18
+
+  // fun parseIntStr(str: string): int {
+func parseIntStr (regs=16)
+  // var n = 0
+  Const        r1, 0
+  Move         r2, r1
+  // var i = 0
+  Const        r1, 0
+  Move         r3, r1
+L1:
+  // while i < len(str) {
+  Len          r4, r0
+  LessInt      r5, r3, r4
+  JumpIfFalse  r5, L0
+  // n = n * 10 + (str[i:i+1] as int)
+  Const        r6, 10
+  MulInt       r7, r2, r6
+  Move         r8, r3
+  Const        r10, 1
+  AddInt       r11, r3, r10
+  Move         r9, r11
+  Slice        r12, r0, r8, r9
+  Cast         r13, r12, int
+  Add          r14, r7, r13
+  Move         r2, r14
+  // i = i + 1
+  Const        r10, 1
+  AddInt       r15, r3, r10
+  Move         r3, r15
+  // while i < len(str) {
+  Jump         L1
+L0:
+  // return n
+  Return       r2
+
+  // fun validate(db: string) {
+func validate (regs=79)
+  // let le = len(db)
+  Len          r1, r0
+  Move         r2, r1
+  // var found: list<int> = []
+  Const        r3, []
+  Move         r4, r3
+  // var i = 0
+  Const        r5, 0
+  Move         r6, r5
+L1:
+  // while i < 10000 {
+  Const        r7, 10000
+  LessInt      r8, r6, r7
+  JumpIfFalse  r8, L0
+  // found = append(found, 0)
+  Const        r5, 0
+  Append       r9, r4, r5
+  Move         r4, r9
+  // i = i + 1
+  Const        r10, 1
+  AddInt       r11, r6, r10
+  Move         r6, r11
+  // while i < 10000 {
+  Jump         L1
+L0:
+  // var j = 0
+  Const        r5, 0
+  Move         r12, r5
+L4:
+  // while j < le - 3 {
+  Const        r13, 3
+  SubInt       r14, r2, r13
+  LessInt      r15, r12, r14
+  JumpIfFalse  r15, L2
+  // let s = db[j:j + 4]
+  Move         r16, r12
+  Const        r18, 4
+  AddInt       r19, r12, r18
+  Move         r17, r19
+  Slice        r20, r0, r16, r17
+  Move         r21, r20
+  // if allDigits(s) {
+  Move         r22, r21
+  Call         r23, allDigits, r22
+  JumpIfFalse  r23, L3
+  // let n = parseIntStr(s)
+  Move         r24, r21
+  Call         r25, parseIntStr, r24
+  Move         r26, r25
+  // found[n] = found[n] + 1
+  Index        r27, r4, r26
+  Const        r10, 1
+  Add          r28, r27, r10
+  SetIndex     r4, r26, r28
+L3:
+  // j = j + 1
+  Const        r10, 1
+  AddInt       r29, r12, r10
+  Move         r12, r29
+  // while j < le - 3 {
+  Jump         L4
+L2:
+  // var errs: list<string> = []
+  Const        r3, []
+  Move         r30, r3
+  // var k = 0
+  Const        r5, 0
+  Move         r31, r5
+L8:
+  // while k < 10000 {
+  Const        r7, 10000
+  LessInt      r32, r31, r7
+  JumpIfFalse  r32, L5
+  // if found[k] == 0 {
+  Index        r33, r4, r31
+  Const        r5, 0
+  Equal        r34, r33, r5
+  JumpIfFalse  r34, L6
+  // errs = append(errs, "    PIN number " + padLeft(k, 4) + " missing")
+  Const        r35, "    PIN number "
+  Move         r36, r31
+  Const        r18, 4
+  Move         r37, r18
+  Call2        r38, padLeft, r36, r37
+  Add          r39, r35, r38
+  Const        r40, " missing"
+  Add          r41, r39, r40
+  Append       r42, r30, r41
+  Move         r30, r42
+  // if found[k] == 0 {
+  Jump         L7
+L6:
+  // } else if found[k] > 1 {
+  Index        r43, r4, r31
+  Const        r10, 1
+  Less         r44, r10, r43
+  JumpIfFalse  r44, L7
+  // errs = append(errs, "    PIN number " + padLeft(k, 4) + " occurs " + str(found[k]) + " times")
+  Const        r35, "    PIN number "
+  Move         r45, r31
+  Const        r18, 4
+  Move         r46, r18
+  Call2        r47, padLeft, r45, r46
+  Add          r48, r35, r47
+  Const        r49, " occurs "
+  Add          r50, r48, r49
+  Index        r51, r4, r31
+  Str          r52, r51
+  Add          r53, r50, r52
+  Const        r54, " times"
+  Add          r55, r53, r54
+  Append       r56, r30, r55
+  Move         r30, r56
+L7:
+  // k = k + 1
+  Const        r10, 1
+  AddInt       r57, r31, r10
+  Move         r31, r57
+  // while k < 10000 {
+  Jump         L8
+L5:
+  // let lerr = len(errs)
+  Len          r58, r30
+  Move         r59, r58
+  // if lerr == 0 {
+  Const        r5, 0
+  EqualInt     r60, r59, r5
+  JumpIfFalse  r60, L9
+  // print("  No errors found")
+  Const        r61, "  No errors found"
+  Print        r61
+  // if lerr == 0 {
+  Jump         L10
+L9:
+  // var pl = "s"
+  Const        r62, "s"
+  Move         r63, r62
+  // if lerr == 1 { pl = "" }
+  Const        r10, 1
+  EqualInt     r64, r59, r10
+  JumpIfFalse  r64, L11
+  Const        r65, ""
+  Move         r63, r65
+L11:
+  // print("  " + str(lerr) + " error" + pl + " found:")
+  Const        r66, "  "
+  Str          r67, r59
+  Add          r68, r66, r67
+  Const        r69, " error"
+  Add          r70, r68, r69
+  Add          r71, r70, r63
+  Const        r72, " found:"
+  Add          r73, r71, r72
+  Print        r73
+  // let msg = joinStr(errs, "\n")
+  Move         r74, r30
+  Const        r76, "\n"
+  Move         r75, r76
+  Call2        r77, joinStr, r74, r75
+  Move         r78, r77
+  // print(msg)
+  Print        r78
+L10:
+  Return       r0
+
+  // fun padLeft(n: int, width: int): string {
+func padLeft (regs=8)
+  // var s = str(n)
+  Str          r2, r0
+  Move         r3, r2
+L1:
+  // while len(s) < width { s = "0" + s }
+  Len          r4, r3
+  Less         r5, r4, r1
+  JumpIfFalse  r5, L0
+  Const        r6, "0"
+  Add          r7, r6, r3
+  Move         r3, r7
+  Jump         L1
+L0:
+  // return s
+  Return       r3
+
+  // fun joinStr(xs: list<string>, sep: string): string {
+func joinStr (regs=14)
+  // var res = ""
+  Const        r2, ""
+  Move         r3, r2
+  // var i = 0
+  Const        r4, 0
+  Move         r5, r4
+L2:
+  // while i < len(xs) {
+  Len          r6, r0
+  LessInt      r7, r5, r6
+  JumpIfFalse  r7, L0
+  // if i > 0 { res = res + sep }
+  Const        r4, 0
+  LessInt      r8, r4, r5
+  JumpIfFalse  r8, L1
+  Add          r9, r3, r1
+  Move         r3, r9
+L1:
+  // res = res + xs[i]
+  Index        r10, r0, r5
+  Add          r11, r3, r10
+  Move         r3, r11
+  // i = i + 1
+  Const        r12, 1
+  AddInt       r13, r5, r12
+  Move         r5, r13
+  // while i < len(xs) {
+  Jump         L2
+L0:
+  // return res
+  Return       r3
+
+  // fun reverse(s: string): string {
+func reverse (regs=15)
+  // var out = ""
+  Const        r1, ""
+  Move         r2, r1
+  // var i = len(s) - 1
+  Len          r3, r0
+  Const        r4, 1
+  SubInt       r5, r3, r4
+  Move         r6, r5
+L1:
+  // while i >= 0 {
+  Const        r7, 0
+  LessEqInt    r8, r7, r6
+  JumpIfFalse  r8, L0
+  // out = out + s[i:i + 1]
+  Move         r9, r6
+  Const        r4, 1
+  AddInt       r11, r6, r4
+  Move         r10, r11
+  Slice        r12, r0, r9, r10
+  Add          r13, r2, r12
+  Move         r2, r13
+  // i = i - 1
+  Const        r4, 1
+  SubInt       r14, r6, r4
+  Move         r6, r14
+  // while i >= 0 {
+  Jump         L1
+L0:
+  // return out
+  Return       r2
+
+  // fun main() {
+func main (regs=45)
+  // var db = deBruijn(10, 4)
+  Const        r2, 10
+  Move         r0, r2
+  Const        r3, 4
+  Move         r1, r3
+  Call2        r4, deBruijn, r0, r1
+  Move         r5, r4
+  // let le = len(db)
+  Len          r6, r5
+  Move         r7, r6
+  // print("The length of the de Bruijn sequence is " + str(le))
+  Const        r8, "The length of the de Bruijn sequence is "
+  Str          r9, r7
+  Add          r10, r8, r9
+  Print        r10
+  // print("\nThe first 130 digits of the de Bruijn sequence are:")
+  Const        r11, "\nThe first 130 digits of the de Bruijn sequence are:"
+  Print        r11
+  // print(db[0:130])
+  Const        r13, 0
+  Move         r12, r13
+  Const        r15, 130
+  Move         r14, r15
+  Slice        r16, r5, r12, r14
+  Print        r16
+  // print("\nThe last 130 digits of the de Bruijn sequence are:")
+  Const        r17, "\nThe last 130 digits of the de Bruijn sequence are:"
+  Print        r17
+  // print(db[le-130:])
+  Const        r15, 130
+  SubInt       r19, r7, r15
+  Move         r18, r19
+  Const        r20, nil
+  Slice        r21, r5, r18, r20
+  Print        r21
+  // print("\nValidating the de Bruijn sequence:")
+  Const        r22, "\nValidating the de Bruijn sequence:"
+  Print        r22
+  // validate(db)
+  Move         r23, r5
+  Call         r24, validate, r23
+  // print("\nValidating the reversed de Bruijn sequence:")
+  Const        r25, "\nValidating the reversed de Bruijn sequence:"
+  Print        r25
+  // let dbr = reverse(db)
+  Reverse      r26, r5
+  Move         r27, r26
+  // validate(dbr)
+  Move         r28, r27
+  Call         r29, validate, r28
+  // db = db[0:4443] + "." + db[4444:len(db)]
+  Const        r13, 0
+  Move         r30, r13
+  Const        r32, 4443
+  Move         r31, r32
+  Slice        r33, r5, r30, r31
+  Const        r34, "."
+  Add          r35, r33, r34
+  Const        r37, 4444
+  Move         r36, r37
+  Len          r39, r5
+  Move         r38, r39
+  Slice        r40, r5, r36, r38
+  Add          r41, r35, r40
+  Move         r5, r41
+  // print("\nValidating the overlaid de Bruijn sequence:")
+  Const        r42, "\nValidating the overlaid de Bruijn sequence:"
+  Print        r42
+  // validate(db)
+  Move         r43, r5
+  Call         r44, validate, r43
+  Return       r0

--- a/tests/rosetta/ir/deal-cards-for-freecell.ir
+++ b/tests/rosetta/ir/deal-cards-for-freecell.ir
@@ -1,0 +1,179 @@
+func main (regs=18)
+  // var seed = 1
+  Const        r3, 1
+  Move         r0, r3
+  SetGlobal    0,0,0,0
+  // let suits = "CDHS"
+  Const        r4, "CDHS"
+  Move         r1, r4
+  SetGlobal    1,1,0,0
+  // let nums = "A23456789TJQK"
+  Const        r5, "A23456789TJQK"
+  Move         r2, r5
+  SetGlobal    2,2,0,0
+  // print("")
+  Const        r6, ""
+  Print        r6
+  // print("Game #1")
+  Const        r7, "Game #1"
+  Print        r7
+  // show(deal(1))
+  Const        r3, 1
+  Move         r9, r3
+  Call         r10, deal, r9
+  Move         r8, r10
+  Call         r11, show, r8
+  // print("")
+  Const        r6, ""
+  Print        r6
+  // print("Game #617")
+  Const        r12, "Game #617"
+  Print        r12
+  // show(deal(617))
+  Const        r15, 617
+  Move         r14, r15
+  Call         r16, deal, r14
+  Move         r13, r16
+  Call         r17, show, r13
+  Return       r0
+
+  // fun rnd(): int {
+func rnd (regs=11)
+  // seed = (seed * 214013 + 2531011) % 2147483648
+  Const        r3, 214013
+  Mul          r4, r0, r3
+  Const        r5, 2531011
+  Add          r6, r4, r5
+  Const        r7, 2147483648
+  Mod          r8, r6, r7
+  Move         r0, r8
+  SetGlobal    0,0,0,0
+  // return seed / 65536
+  Const        r9, 65536
+  Div          r10, r0, r9
+  Return       r10
+
+  // fun deal(game: int): list<int> {
+func deal (regs=25)
+  // seed = game
+  Move         r0, r3
+  SetGlobal    0,0,0,0
+  // var deck: list<int> = []
+  Const        r4, []
+  Move         r5, r4
+  // var i = 0
+  Const        r6, 0
+  Move         r7, r6
+L1:
+  // while i < 52 {
+  Const        r8, 52
+  LessInt      r9, r7, r8
+  JumpIfFalse  r9, L0
+  // deck = append(deck, 51 - i)
+  Const        r10, 51
+  SubInt       r11, r10, r7
+  Append       r12, r5, r11
+  Move         r5, r12
+  // i = i + 1
+  Const        r13, 1
+  AddInt       r14, r7, r13
+  Move         r7, r14
+  // while i < 52 {
+  Jump         L1
+L0:
+  // i = 0
+  Const        r6, 0
+  Move         r7, r6
+L3:
+  // while i < 51 {
+  Const        r10, 51
+  LessInt      r15, r7, r10
+  JumpIfFalse  r15, L2
+  // let j = 51 - (rnd() % (52 - i))
+  Const        r10, 51
+  Call         r16, rnd, 
+  Const        r8, 52
+  SubInt       r17, r8, r7
+  Mod          r18, r16, r17
+  Sub          r19, r10, r18
+  Move         r20, r19
+  // let tmp = deck[i]
+  Index        r21, r5, r7
+  Move         r22, r21
+  // deck[i] = deck[j]
+  Index        r23, r5, r20
+  SetIndex     r5, r7, r23
+  // deck[j] = tmp
+  SetIndex     r5, r20, r22
+  // i = i + 1
+  Const        r13, 1
+  AddInt       r24, r7, r13
+  Move         r7, r24
+  // while i < 51 {
+  Jump         L3
+L2:
+  // return deck
+  Return       r5
+
+  // fun show(cards: list<int>) {
+func show (regs=38)
+  // var i = 0
+  Const        r4, 0
+  Move         r5, r4
+L3:
+  // while i < len(cards) {
+  Len          r6, r3
+  LessInt      r7, r5, r6
+  JumpIfFalse  r7, L0
+  // let c = cards[i]
+  Index        r8, r3, r5
+  Move         r9, r8
+  // stdout.write(" " + substring(nums, c / 4, c / 4 + 1) + substring(suits, c % 4, c % 4 + 1))
+  Const        r11, "write"
+  Index        r12, r10, r11
+  Const        r14, " "
+  Const        r15, 4
+  Div          r16, r9, r15
+  Const        r15, 4
+  Div          r17, r9, r15
+  Const        r18, 1
+  Add          r19, r17, r18
+  Slice        r20, r2, r16, r19
+  Add          r21, r14, r20
+  Const        r15, 4
+  Mod          r22, r9, r15
+  Const        r15, 4
+  Mod          r23, r9, r15
+  Const        r18, 1
+  Add          r24, r23, r18
+  Slice        r25, r1, r22, r24
+  Add          r26, r21, r25
+  Move         r13, r26
+  CallV        r27, r12, 1, r13
+  // if (i + 1) % 8 == 0 || i + 1 == len(cards) { print("") }
+  Const        r18, 1
+  AddInt       r28, r5, r18
+  Const        r29, 8
+  ModInt       r30, r28, r29
+  Const        r18, 1
+  AddInt       r31, r5, r18
+  Const        r4, 0
+  EqualInt     r32, r30, r4
+  Len          r33, r3
+  EqualInt     r34, r31, r33
+  Move         r35, r32
+  JumpIfTrue   r35, L1
+  Move         r35, r34
+L1:
+  JumpIfFalse  r35, L2
+  Const        r36, ""
+  Print        r36
+L2:
+  // i = i + 1
+  Const        r18, 1
+  AddInt       r37, r5, r18
+  Move         r5, r37
+  // while i < len(cards) {
+  Jump         L3
+L0:
+  Return       r0

--- a/tests/rosetta/x/Mochi/curzon-numbers.out
+++ b/tests/rosetta/x/Mochi/curzon-numbers.out
@@ -43,3 +43,8 @@ The first 50 Curzon numbers using a base of 10 :
 
 One thousandth: 46845
 
+{
+  "duration_us": 2273907,
+  "memory_bytes": 38376,
+  "name": "main"
+}

--- a/tests/rosetta/x/Mochi/index.txt
+++ b/tests/rosetta/x/Mochi/index.txt
@@ -1,446 +1,452 @@
-1 100-doors-2.mochi
-2 100-doors-3.mochi
-3 100-doors.mochi
-4 100-prisoners.mochi
-5 15-puzzle-game.mochi
-6 15-puzzle-solver.mochi
-7 2048.mochi
-8 21-game.mochi
-9 24-game-solve.mochi
-10 24-game.mochi
-11 4-rings-or-4-squares-puzzle.mochi
-12 9-billion-names-of-god-the-integer.mochi
-13 99-bottles-of-beer-2.mochi
-14 99-bottles-of-beer.mochi
-15 DNS-query.mochi
-16 Duffinian-numbers.mochi
-17 a+b.mochi
-18 abbreviations-automatic.mochi
-19 abbreviations-easy.mochi
-20 abbreviations-simple.mochi
-21 abc-problem.mochi
-22 abelian-sandpile-model-identity.mochi
-23 abelian-sandpile-model.mochi
-24 abstract-type.mochi
-25 abundant-deficient-and-perfect-number-classifications.mochi
-26 abundant-odd-numbers.mochi
-27 accumulator-factory.mochi
-28 achilles-numbers.mochi
-29 ackermann-function-2.mochi
-30 ackermann-function-3.mochi
-31 ackermann-function.mochi
-32 active-directory-connect.mochi
-33 active-directory-search-for-a-user.mochi
-34 active-object.mochi
-35 add-a-variable-to-a-class-instance-at-runtime.mochi
-36 additive-primes.mochi
-37 address-of-a-variable.mochi
-38 adfgvx-cipher.mochi
-39 aks-test-for-primes.mochi
-40 algebraic-data-types.mochi
-41 align-columns.mochi
-42 aliquot-sequence-classifications.mochi
-43 almkvist-giullera-formula-for-pi.mochi
-44 almost-prime.mochi
-45 amb.mochi
-46 amicable-pairs.mochi
-47 anagrams-deranged-anagrams.mochi
-48 anagrams.mochi
-49 angle-difference-between-two-bearings-1.mochi
-50 angle-difference-between-two-bearings-2.mochi
-51 angles-geometric-normalization-and-conversion.mochi
-52 animate-a-pendulum.mochi
-53 animation.mochi
-54 anonymous-recursion-1.mochi
-55 anonymous-recursion-2.mochi
-56 anonymous-recursion.mochi
-57 anti-primes.mochi
-58 append-a-record-to-the-end-of-a-text-file.mochi
-59 apply-a-callback-to-an-array-1.mochi
-60 apply-a-callback-to-an-array-2.mochi
-61 apply-a-digital-filter-direct-form-ii-transposed-.mochi
-62 approximate-equality.mochi
-63 arbitrary-precision-integers-included-.mochi
-64 archimedean-spiral.mochi
-65 arena-storage-pool.mochi
-66 arithmetic-complex.mochi
-67 arithmetic-derivative.mochi
-68 arithmetic-evaluation.mochi
-69 arithmetic-geometric-mean-calculate-pi.mochi
-70 arithmetic-geometric-mean.mochi
-71 arithmetic-integer-1.mochi
-72 arithmetic-integer-2.mochi
-73 arithmetic-numbers.mochi
-74 arithmetic-rational.mochi
-75 array-concatenation.mochi
-76 array-length.mochi
-77 arrays.mochi
-78 ascending-primes.mochi
-79 ascii-art-diagram-converter.mochi
-80 assertions.mochi
-81 associative-array-creation.mochi
-82 associative-array-iteration.mochi
-83 associative-array-merging.mochi
-84 atomic-updates.mochi
-85 attractive-numbers.mochi
-86 average-loop-length.mochi
-87 averages-arithmetic-mean.mochi
-88 averages-mean-time-of-day.mochi
-89 averages-median-1.mochi
-90 averages-median-2.mochi
-91 averages-median-3.mochi
-92 averages-mode.mochi
-93 averages-pythagorean-means.mochi
-94 averages-root-mean-square.mochi
-95 averages-simple-moving-average.mochi
-96 avl-tree.mochi
-97 b-zier-curves-intersections.mochi
-98 babbage-problem.mochi
-99 babylonian-spiral.mochi
-100 balanced-brackets.mochi
-101 balanced-ternary.mochi
-102 barnsley-fern.mochi
-103 base64-decode-data.mochi
-104 bell-numbers.mochi
-105 benfords-law.mochi
-106 bernoulli-numbers.mochi
-107 best-shuffle.mochi
-108 bifid-cipher.mochi
-109 bin-given-limits.mochi
-110 binary-digits.mochi
-111 binary-search.mochi
-112 binary-strings.mochi
-113 bioinformatics-base-count.mochi
-114 bioinformatics-global-alignment.mochi
-115 bioinformatics-sequence-mutation.mochi
-116 biorhythms.mochi
-117 bitcoin-address-validation.mochi
-118 bitmap-b-zier-curves-cubic.mochi
-119 bitmap-b-zier-curves-quadratic.mochi
-120 bitmap-bresenhams-line-algorithm.mochi
-121 bitmap-flood-fill.mochi
-122 bitmap-histogram.mochi
-123 bitmap-midpoint-circle-algorithm.mochi
-124 bitmap-ppm-conversion-through-a-pipe.mochi
-125 bitmap-read-a-ppm-file.mochi
-126 bitmap-read-an-image-through-a-pipe.mochi
-127 bitmap-write-a-ppm-file.mochi
-128 bitmap.mochi
-129 bitwise-io-1.mochi
-130 bitwise-io-2.mochi
-131 bitwise-operations.mochi
-132 blum-integer.mochi
-133 boolean-values.mochi
-134 box-the-compass.mochi
-135 boyer-moore-string-search.mochi
-136 brazilian-numbers.mochi
-137 break-oo-privacy.mochi
-138 brilliant-numbers.mochi
-139 brownian-tree.mochi
-140 bulls-and-cows-player.mochi
-141 bulls-and-cows.mochi
-142 burrows-wheeler-transform.mochi
-143 caesar-cipher-1.mochi
-144 caesar-cipher-2.mochi
-145 calculating-the-value-of-e.mochi
-146 calendar---for-real-programmers-1.mochi
-147 calendar---for-real-programmers-2.mochi
-148 calendar.mochi
-149 calkin-wilf-sequence.mochi
-150 call-a-foreign-language-function.mochi
-151 call-a-function-1.mochi
-152 call-a-function-10.mochi
-153 call-a-function-11.mochi
-154 call-a-function-12.mochi
-155 call-a-function-2.mochi
-156 call-a-function-3.mochi
-157 call-a-function-4.mochi
-158 call-a-function-5.mochi
-159 call-a-function-6.mochi
-160 call-a-function-7.mochi
-161 call-a-function-8.mochi
-162 call-a-function-9.mochi
-163 call-an-object-method-1.mochi
-164 call-an-object-method-2.mochi
-165 call-an-object-method-3.mochi
-166 call-an-object-method.mochi
-167 camel-case-and-snake-case.mochi
-168 canny-edge-detector.mochi
-169 canonicalize-cidr.mochi
-170 cantor-set.mochi
-171 carmichael-3-strong-pseudoprimes.mochi
-172 cartesian-product-of-two-or-more-lists-1.mochi
-173 cartesian-product-of-two-or-more-lists-2.mochi
-174 cartesian-product-of-two-or-more-lists-3.mochi
-175 cartesian-product-of-two-or-more-lists-4.mochi
-176 case-sensitivity-of-identifiers.mochi
-177 casting-out-nines.mochi
-178 catalan-numbers-1.mochi
-179 catalan-numbers-2.mochi
-180 catalan-numbers-pascals-triangle.mochi
-181 catamorphism.mochi
-182 catmull-clark-subdivision-surface.mochi
-183 chaocipher.mochi
-184 chaos-game.mochi
-185 character-codes-1.mochi
-186 character-codes-2.mochi
-187 character-codes-3.mochi
-188 character-codes-4.mochi
-189 character-codes-5.mochi
-190 chat-server.mochi
-191 check-machin-like-formulas.mochi
-192 check-that-file-exists.mochi
-193 checkpoint-synchronization-1.mochi
-194 checkpoint-synchronization-2.mochi
-195 checkpoint-synchronization-3.mochi
-196 checkpoint-synchronization-4.mochi
-197 chernicks-carmichael-numbers.mochi
-198 cheryls-birthday.mochi
-199 chinese-remainder-theorem.mochi
-200 chinese-zodiac.mochi
-201 cholesky-decomposition-1.mochi
-202 cholesky-decomposition.mochi
-203 chowla-numbers.mochi
-204 church-numerals-1.mochi
-205 church-numerals-2.mochi
-206 circles-of-given-radius-through-two-points.mochi
-207 circular-primes.mochi
-208 cistercian-numerals.mochi
-209 comma-quibbling.mochi
-210 compiler-virtual-machine-interpreter.mochi
-211 composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
-212 compound-data-type.mochi
-213 concurrent-computing-1.mochi
-214 concurrent-computing-2.mochi
-215 concurrent-computing-3.mochi
-216 conditional-structures-1.mochi
-217 conditional-structures-10.mochi
-218 conditional-structures-2.mochi
-219 conditional-structures-3.mochi
-220 conditional-structures-4.mochi
-221 conditional-structures-5.mochi
-222 conditional-structures-6.mochi
-223 conditional-structures-7.mochi
-224 conditional-structures-8.mochi
-225 conditional-structures-9.mochi
-226 consecutive-primes-with-ascending-or-descending-differences.mochi
-227 constrained-genericity-1.mochi
-228 constrained-genericity-2.mochi
-229 constrained-genericity-3.mochi
-230 constrained-genericity-4.mochi
-231 constrained-random-points-on-a-circle-1.mochi
-232 constrained-random-points-on-a-circle-2.mochi
-233 continued-fraction.mochi
-234 convert-decimal-number-to-rational.mochi
-235 convert-seconds-to-compound-duration.mochi
-236 convex-hull.mochi
-237 conways-game-of-life.mochi
-238 copy-a-string-1.mochi
-239 copy-a-string-2.mochi
-240 copy-stdin-to-stdout-1.mochi
-241 copy-stdin-to-stdout-2.mochi
-242 count-in-factors.mochi
-243 count-in-octal-1.mochi
-244 count-in-octal-2.mochi
-245 count-in-octal-3.mochi
-246 count-in-octal-4.mochi
-247 count-occurrences-of-a-substring.mochi
-248 count-the-coins-1.mochi
-249 count-the-coins-2.mochi
-250 cramers-rule.mochi
-251 crc-32-1.mochi
-252 crc-32-2.mochi
-253 create-a-file-on-magnetic-tape.mochi
-254 create-a-file.mochi
-255 create-a-two-dimensional-array-at-runtime-1.mochi
-256 create-an-html-table.mochi
-257 create-an-object-at-a-given-address.mochi
-258 csv-data-manipulation.mochi
-259 csv-to-html-translation-1.mochi
-260 csv-to-html-translation-2.mochi
-261 csv-to-html-translation-3.mochi
-262 csv-to-html-translation-4.mochi
-263 csv-to-html-translation-5.mochi
-264 cuban-primes.mochi
-265 cullen-and-woodall-numbers.mochi
-266 cumulative-standard-deviation.mochi
-267 currency.mochi
-268 currying.mochi
-269 curzon-numbers.mochi
-270 cusip.mochi
-271 cyclops-numbers.mochi
-272 damm-algorithm.mochi
-273 date-format.mochi
-274 date-manipulation.mochi
-275 day-of-the-week.mochi
-276 de-bruijn-sequences.mochi
-277 deal-cards-for-freecell.mochi
-278 death-star.mochi
-279 deceptive-numbers.mochi
-280 deconvolution-1d-2.mochi
-281 deconvolution-1d-3.mochi
-282 deconvolution-1d.mochi
-283 deepcopy-1.mochi
-284 define-a-primitive-data-type.mochi
-285 delegates.mochi
-286 demings-funnel.mochi
-287 department-numbers.mochi
-288 descending-primes.mochi
-289 detect-division-by-zero.mochi
-290 determine-if-a-string-has-all-the-same-characters.mochi
-291 determine-if-a-string-has-all-unique-characters.mochi
-292 determine-if-a-string-is-collapsible.mochi
-293 determine-if-a-string-is-numeric-1.mochi
-294 determine-if-a-string-is-numeric-2.mochi
-295 determine-if-a-string-is-squeezable.mochi
-296 determine-if-only-one-instance-is-running.mochi
-297 determine-if-two-triangles-overlap.mochi
-298 determine-sentence-type.mochi
-299 dice-game-probabilities-1.mochi
-300 dice-game-probabilities-2.mochi
-301 digital-root-multiplicative-digital-root.mochi
-302 dijkstras-algorithm.mochi
-303 dinesmans-multiple-dwelling-problem.mochi
-304 dining-philosophers-1.mochi
-305 dining-philosophers-2.mochi
-306 disarium-numbers.mochi
-307 discordian-date.mochi
-308 display-a-linear-combination.mochi
-309 display-an-outline-as-a-nested-table.mochi
-310 distance-and-bearing.mochi
-311 distributed-programming.mochi
-312 diversity-prediction-theorem.mochi
-313 documentation.mochi
-314 doomsday-rule.mochi
-315 dot-product.mochi
-316 doubly-linked-list-definition-1.mochi
-317 doubly-linked-list-definition-2.mochi
-318 doubly-linked-list-element-definition.mochi
-319 doubly-linked-list-traversal.mochi
-320 dragon-curve.mochi
-321 draw-a-clock.mochi
-322 draw-a-cuboid.mochi
-323 draw-a-pixel-1.mochi
-324 draw-a-rotating-cube.mochi
-325 draw-a-sphere.mochi
-326 dutch-national-flag-problem.mochi
-327 dynamic-variable-names.mochi
-328 earliest-difference-between-prime-gaps.mochi
-329 eban-numbers.mochi
-330 ecdsa-example.mochi
-331 echo-server.mochi
-332 eertree.mochi
-333 egyptian-division.mochi
-334 ekg-sequence-convergence.mochi
-335 element-wise-operations.mochi
-336 elementary-cellular-automaton-infinite-length.mochi
-337 elementary-cellular-automaton-random-number-generator.mochi
-338 elementary-cellular-automaton.mochi
-339 elliptic-curve-arithmetic.mochi
-340 elliptic-curve-digital-signature-algorithm.mochi
-341 emirp-primes.mochi
-342 empty-directory.mochi
-343 empty-program.mochi
-344 empty-string-1.mochi
-345 empty-string-2.mochi
-346 enforced-immutability.mochi
-347 entropy-1.mochi
-348 entropy-2.mochi
-349 entropy-narcissist.mochi
-350 enumerations-1.mochi
-351 enumerations-2.mochi
-352 enumerations-3.mochi
-353 enumerations-4.mochi
-354 environment-variables-1.mochi
-355 environment-variables-2.mochi
-356 equal-prime-and-composite-sums.mochi
-357 equilibrium-index.mochi
-358 erd-s-nicolas-numbers.mochi
-359 erd-s-selfridge-categorization-of-primes.mochi
-360 esthetic-numbers.mochi
-361 ethiopian-multiplication.mochi
-362 euler-method.mochi
-363 events.mochi
-364 evolutionary-algorithm.mochi
-365 exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
-366 exceptions.mochi
-367 executable-library.mochi
-368 execute-a-markov-algorithm.mochi
-369 execute-a-system-command.mochi
-370 execute-brain-.mochi
-371 execute-computer-zero.mochi
-372 execute-hq9+.mochi
-373 execute-snusp.mochi
-374 exponentiation-operator.mochi
-375 exponentiation-order.mochi
-376 exponentiation-with-infix-operators-in-or-operating-on-the-base.mochi
-377 extend-your-language.mochi
-378 extensible-prime-generator.mochi
-379 extreme-floating-point-values.mochi
-380 faces-from-a-mesh.mochi
-381 fasta-format.mochi
-382 faulhabers-triangle.mochi
-383 feigenbaum-constant-calculation.mochi
-384 fermat-numbers.mochi
-385 fibonacci-n-step-number-sequences.mochi
-386 fibonacci-sequence-1.mochi
-387 fibonacci-sequence-2.mochi
-388 fibonacci-sequence-3.mochi
-389 fibonacci-sequence-4.mochi
-390 fibonacci-word-fractal.mochi
-391 fibonacci-word.mochi
-392 file-extension-is-in-extensions-list.mochi
-393 file-input-output-1.mochi
-394 file-input-output-2.mochi
-395 file-modification-time.mochi
-396 file-size-distribution.mochi
-397 file-size.mochi
-398 filter.mochi
-399 find-chess960-starting-position-identifier.mochi
-400 find-common-directory-path.mochi
-401 find-duplicate-files.mochi
-402 find-if-a-point-is-within-a-triangle.mochi
-403 find-largest-left-truncatable-prime-in-a-given-base.mochi
-404 find-limit-of-recursion.mochi
-405 find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
-406 find-the-intersection-of-a-line-with-a-plane.mochi
-407 find-the-intersection-of-two-lines.mochi
-408 find-the-last-sunday-of-each-month.mochi
-409 find-the-missing-permutation.mochi
-410 fivenum-1.mochi
-411 fivenum-2.mochi
-412 fixed-length-records-1.mochi
-413 fixed-length-records-2.mochi
-414 fizzbuzz-1.mochi
-415 fizzbuzz-2.mochi
-416 flatten-a-list-1.mochi
-417 flatten-a-list-2.mochi
-418 flipping-bits-game.mochi
-419 flow-control-structures-1.mochi
-420 flow-control-structures-2.mochi
-421 flow-control-structures-3.mochi
-422 flow-control-structures-4.mochi
-423 floyd-warshall-algorithm.mochi
-424 floyds-triangle.mochi
-425 forest-fire.mochi
-426 fork.mochi
-427 ftp.mochi
-428 gamma-function.mochi
-429 general-fizzbuzz.mochi
-430 generic-swap.mochi
-431 get-system-command-output.mochi
-432 giuga-numbers.mochi
-433 globally-replace-text-in-several-files.mochi
-434 goldbachs-comet.mochi
-435 golden-ratio-convergence.mochi
-436 graph-colouring.mochi
-437 gray-code.mochi
-438 http.mochi
-439 image-noise.mochi
-440 loops-increment-loop-index-within-loop-body.mochi
-441 md5.mochi
-442 nim-game.mochi
-443 plasma-effect.mochi
-444 sorting-algorithms-bubble-sort.mochi
-445 window-management.mochi
-446 zumkeller-numbers.mochi
+  1	100-doors-2.mochi
+  2	100-doors-3.mochi
+  3	100-doors.mochi
+  4	100-prisoners.mochi
+  5	15-puzzle-game.mochi
+  6	15-puzzle-solver.mochi
+  7	2048.mochi
+  8	21-game.mochi
+  9	24-game-solve.mochi
+ 10	24-game.mochi
+ 11	4-rings-or-4-squares-puzzle.mochi
+ 12	9-billion-names-of-god-the-integer.mochi
+ 13	99-bottles-of-beer-2.mochi
+ 14	99-bottles-of-beer.mochi
+ 15	DNS-query.mochi
+ 16	Duffinian-numbers.mochi
+ 17	a+b.mochi
+ 18	abbreviations-automatic.mochi
+ 19	abbreviations-easy.mochi
+ 20	abbreviations-simple.mochi
+ 21	abc-problem.mochi
+ 22	abelian-sandpile-model-identity.mochi
+ 23	abelian-sandpile-model.mochi
+ 24	abstract-type.mochi
+ 25	abundant-deficient-and-perfect-number-classifications.mochi
+ 26	abundant-odd-numbers.mochi
+ 27	accumulator-factory.mochi
+ 28	achilles-numbers.mochi
+ 29	ackermann-function-2.mochi
+ 30	ackermann-function-3.mochi
+ 31	ackermann-function.mochi
+ 32	active-directory-connect.mochi
+ 33	active-directory-search-for-a-user.mochi
+ 34	active-object.mochi
+ 35	add-a-variable-to-a-class-instance-at-runtime.mochi
+ 36	additive-primes.mochi
+ 37	address-of-a-variable.mochi
+ 38	adfgvx-cipher.mochi
+ 39	aks-test-for-primes.mochi
+ 40	algebraic-data-types.mochi
+ 41	align-columns.mochi
+ 42	aliquot-sequence-classifications.mochi
+ 43	almkvist-giullera-formula-for-pi.mochi
+ 44	almost-prime.mochi
+ 45	amb.mochi
+ 46	amicable-pairs.mochi
+ 47	anagrams-deranged-anagrams.mochi
+ 48	anagrams.mochi
+ 49	angle-difference-between-two-bearings-1.mochi
+ 50	angle-difference-between-two-bearings-2.mochi
+ 51	angles-geometric-normalization-and-conversion.mochi
+ 52	animate-a-pendulum.mochi
+ 53	animation.mochi
+ 54	anonymous-recursion-1.mochi
+ 55	anonymous-recursion-2.mochi
+ 56	anonymous-recursion.mochi
+ 57	anti-primes.mochi
+ 58	append-a-record-to-the-end-of-a-text-file.mochi
+ 59	apply-a-callback-to-an-array-1.mochi
+ 60	apply-a-callback-to-an-array-2.mochi
+ 61	apply-a-digital-filter-direct-form-ii-transposed-.mochi
+ 62	approximate-equality.mochi
+ 63	arbitrary-precision-integers-included-.mochi
+ 64	archimedean-spiral.mochi
+ 65	arena-storage-pool.mochi
+ 66	arithmetic-complex.mochi
+ 67	arithmetic-derivative.mochi
+ 68	arithmetic-evaluation.mochi
+ 69	arithmetic-geometric-mean-calculate-pi.mochi
+ 70	arithmetic-geometric-mean.mochi
+ 71	arithmetic-integer-1.mochi
+ 72	arithmetic-integer-2.mochi
+ 73	arithmetic-numbers.mochi
+ 74	arithmetic-rational.mochi
+ 75	array-concatenation.mochi
+ 76	array-length.mochi
+ 77	arrays.mochi
+ 78	ascending-primes.mochi
+ 79	ascii-art-diagram-converter.mochi
+ 80	assertions.mochi
+ 81	associative-array-creation.mochi
+ 82	associative-array-iteration.mochi
+ 83	associative-array-merging.mochi
+ 84	atomic-updates.mochi
+ 85	attractive-numbers.mochi
+ 86	average-loop-length.mochi
+ 87	averages-arithmetic-mean.mochi
+ 88	averages-mean-time-of-day.mochi
+ 89	averages-median-1.mochi
+ 90	averages-median-2.mochi
+ 91	averages-median-3.mochi
+ 92	averages-mode.mochi
+ 93	averages-pythagorean-means.mochi
+ 94	averages-root-mean-square.mochi
+ 95	averages-simple-moving-average.mochi
+ 96	avl-tree.mochi
+ 97	b-zier-curves-intersections.mochi
+ 98	babbage-problem.mochi
+ 99	babylonian-spiral.mochi
+100	balanced-brackets.mochi
+101	balanced-ternary.mochi
+102	barnsley-fern.mochi
+103	base64-decode-data.mochi
+104	bell-numbers.mochi
+105	benfords-law.mochi
+106	bernoulli-numbers.mochi
+107	best-shuffle.mochi
+108	bifid-cipher.mochi
+109	bin-given-limits.mochi
+110	binary-digits.mochi
+111	binary-search.mochi
+112	binary-strings.mochi
+113	bioinformatics-base-count.mochi
+114	bioinformatics-global-alignment.mochi
+115	bioinformatics-sequence-mutation.mochi
+116	biorhythms.mochi
+117	bitcoin-address-validation.mochi
+118	bitmap-b-zier-curves-cubic.mochi
+119	bitmap-b-zier-curves-quadratic.mochi
+120	bitmap-bresenhams-line-algorithm.mochi
+121	bitmap-flood-fill.mochi
+122	bitmap-histogram.mochi
+123	bitmap-midpoint-circle-algorithm.mochi
+124	bitmap-ppm-conversion-through-a-pipe.mochi
+125	bitmap-read-a-ppm-file.mochi
+126	bitmap-read-an-image-through-a-pipe.mochi
+127	bitmap-write-a-ppm-file.mochi
+128	bitmap.mochi
+129	bitwise-io-1.mochi
+130	bitwise-io-2.mochi
+131	bitwise-operations.mochi
+132	blum-integer.mochi
+133	boolean-values.mochi
+134	box-the-compass.mochi
+135	boyer-moore-string-search.mochi
+136	brazilian-numbers.mochi
+137	break-oo-privacy.mochi
+138	brilliant-numbers.mochi
+139	brownian-tree.mochi
+140	bulls-and-cows-player.mochi
+141	bulls-and-cows.mochi
+142	burrows-wheeler-transform.mochi
+143	caesar-cipher-1.mochi
+144	caesar-cipher-2.mochi
+145	calculating-the-value-of-e.mochi
+146	calendar---for-real-programmers-1.mochi
+147	calendar---for-real-programmers-2.mochi
+148	calendar.mochi
+149	calkin-wilf-sequence.mochi
+150	call-a-foreign-language-function.mochi
+151	call-a-function-1.mochi
+152	call-a-function-10.mochi
+153	call-a-function-11.mochi
+154	call-a-function-12.mochi
+155	call-a-function-2.mochi
+156	call-a-function-3.mochi
+157	call-a-function-4.mochi
+158	call-a-function-5.mochi
+159	call-a-function-6.mochi
+160	call-a-function-7.mochi
+161	call-a-function-8.mochi
+162	call-a-function-9.mochi
+163	call-an-object-method-1.mochi
+164	call-an-object-method-2.mochi
+165	call-an-object-method-3.mochi
+166	call-an-object-method.mochi
+167	camel-case-and-snake-case.mochi
+168	canny-edge-detector.mochi
+169	canonicalize-cidr.mochi
+170	cantor-set.mochi
+171	carmichael-3-strong-pseudoprimes.mochi
+172	cartesian-product-of-two-or-more-lists-1.mochi
+173	cartesian-product-of-two-or-more-lists-2.mochi
+174	cartesian-product-of-two-or-more-lists-3.mochi
+175	cartesian-product-of-two-or-more-lists-4.mochi
+176	case-sensitivity-of-identifiers.mochi
+177	casting-out-nines.mochi
+178	catalan-numbers-1.mochi
+179	catalan-numbers-2.mochi
+180	catalan-numbers-pascals-triangle.mochi
+181	catamorphism.mochi
+182	catmull-clark-subdivision-surface.mochi
+183	chaocipher.mochi
+184	chaos-game.mochi
+185	character-codes-1.mochi
+186	character-codes-2.mochi
+187	character-codes-3.mochi
+188	character-codes-4.mochi
+189	character-codes-5.mochi
+190	chat-server.mochi
+191	check-machin-like-formulas.mochi
+192	check-that-file-exists.mochi
+193	checkpoint-synchronization-1.mochi
+194	checkpoint-synchronization-2.mochi
+195	checkpoint-synchronization-3.mochi
+196	checkpoint-synchronization-4.mochi
+197	chernicks-carmichael-numbers.mochi
+198	cheryls-birthday.mochi
+199	chinese-remainder-theorem.mochi
+200	chinese-zodiac.mochi
+201	cholesky-decomposition-1.mochi
+202	cholesky-decomposition.mochi
+203	chowla-numbers.mochi
+204	church-numerals-1.mochi
+205	church-numerals-2.mochi
+206	circles-of-given-radius-through-two-points.mochi
+207	circular-primes.mochi
+208	cistercian-numerals.mochi
+209	comma-quibbling.mochi
+210	compiler-virtual-machine-interpreter.mochi
+211	composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k.mochi
+212	compound-data-type.mochi
+213	concurrent-computing-1.mochi
+214	concurrent-computing-2.mochi
+215	concurrent-computing-3.mochi
+216	conditional-structures-1.mochi
+217	conditional-structures-10.mochi
+218	conditional-structures-2.mochi
+219	conditional-structures-3.mochi
+220	conditional-structures-4.mochi
+221	conditional-structures-5.mochi
+222	conditional-structures-6.mochi
+223	conditional-structures-7.mochi
+224	conditional-structures-8.mochi
+225	conditional-structures-9.mochi
+226	consecutive-primes-with-ascending-or-descending-differences.mochi
+227	constrained-genericity-1.mochi
+228	constrained-genericity-2.mochi
+229	constrained-genericity-3.mochi
+230	constrained-genericity-4.mochi
+231	constrained-random-points-on-a-circle-1.mochi
+232	constrained-random-points-on-a-circle-2.mochi
+233	continued-fraction.mochi
+234	convert-decimal-number-to-rational.mochi
+235	convert-seconds-to-compound-duration.mochi
+236	convex-hull.mochi
+237	conways-game-of-life.mochi
+238	copy-a-string-1.mochi
+239	copy-a-string-2.mochi
+240	copy-stdin-to-stdout-1.mochi
+241	copy-stdin-to-stdout-2.mochi
+242	count-in-factors.mochi
+243	count-in-octal-1.mochi
+244	count-in-octal-2.mochi
+245	count-in-octal-3.mochi
+246	count-in-octal-4.mochi
+247	count-occurrences-of-a-substring.mochi
+248	count-the-coins-1.mochi
+249	count-the-coins-2.mochi
+250	cramers-rule.mochi
+251	crc-32-1.mochi
+252	crc-32-2.mochi
+253	create-a-file-on-magnetic-tape.mochi
+254	create-a-file.mochi
+255	create-a-two-dimensional-array-at-runtime-1.mochi
+256	create-an-html-table.mochi
+257	create-an-object-at-a-given-address.mochi
+258	csv-data-manipulation.mochi
+259	csv-to-html-translation-1.mochi
+260	csv-to-html-translation-2.mochi
+261	csv-to-html-translation-3.mochi
+262	csv-to-html-translation-4.mochi
+263	csv-to-html-translation-5.mochi
+264	cuban-primes.mochi
+265	cullen-and-woodall-numbers.mochi
+266	cumulative-standard-deviation.mochi
+267	currency.mochi
+268	currying.mochi
+269	curzon-numbers.mochi
+270	cusip.mochi
+271	cyclops-numbers.mochi
+272	damm-algorithm.mochi
+273	date-format.mochi
+274	date-manipulation.mochi
+275	day-of-the-week.mochi
+276	de-bruijn-sequences.mochi
+277	deal-cards-for-freecell.mochi
+278	death-star.mochi
+279	deceptive-numbers.mochi
+280	deconvolution-1d-2.mochi
+281	deconvolution-1d-3.mochi
+282	deconvolution-1d.mochi
+283	deepcopy-1.mochi
+284	define-a-primitive-data-type.mochi
+285	delegates.mochi
+286	demings-funnel.mochi
+287	department-numbers.mochi
+288	descending-primes.mochi
+289	detect-division-by-zero.mochi
+290	determine-if-a-string-has-all-the-same-characters.mochi
+291	determine-if-a-string-has-all-unique-characters.mochi
+292	determine-if-a-string-is-collapsible.mochi
+293	determine-if-a-string-is-numeric-1.mochi
+294	determine-if-a-string-is-numeric-2.mochi
+295	determine-if-a-string-is-squeezable.mochi
+296	determine-if-only-one-instance-is-running.mochi
+297	determine-if-two-triangles-overlap.mochi
+298	determine-sentence-type.mochi
+299	dice-game-probabilities-1.mochi
+300	dice-game-probabilities-2.mochi
+301	digital-root-multiplicative-digital-root.mochi
+302	dijkstras-algorithm.mochi
+303	dinesmans-multiple-dwelling-problem.mochi
+304	dining-philosophers-1.mochi
+305	dining-philosophers-2.mochi
+306	disarium-numbers.mochi
+307	discordian-date.mochi
+308	display-a-linear-combination.mochi
+309	display-an-outline-as-a-nested-table.mochi
+310	distance-and-bearing.mochi
+311	distributed-programming.mochi
+312	diversity-prediction-theorem.mochi
+313	documentation.mochi
+314	doomsday-rule.mochi
+315	dot-product.mochi
+316	doubly-linked-list-definition-1.mochi
+317	doubly-linked-list-definition-2.mochi
+318	doubly-linked-list-element-definition.mochi
+319	doubly-linked-list-traversal.mochi
+320	dragon-curve.mochi
+321	draw-a-clock.mochi
+322	draw-a-cuboid.mochi
+323	draw-a-pixel-1.mochi
+324	draw-a-rotating-cube.mochi
+325	draw-a-sphere.mochi
+326	dutch-national-flag-problem.mochi
+327	dynamic-variable-names.mochi
+328	earliest-difference-between-prime-gaps.mochi
+329	eban-numbers.mochi
+330	ecdsa-example.mochi
+331	echo-server.mochi
+332	eertree.mochi
+333	egyptian-division.mochi
+334	ekg-sequence-convergence.mochi
+335	element-wise-operations.mochi
+336	elementary-cellular-automaton-infinite-length.mochi
+337	elementary-cellular-automaton-random-number-generator.mochi
+338	elementary-cellular-automaton.mochi
+339	elliptic-curve-arithmetic.mochi
+340	elliptic-curve-digital-signature-algorithm.mochi
+341	emirp-primes.mochi
+342	empty-directory.mochi
+343	empty-program.mochi
+344	empty-string-1.mochi
+345	empty-string-2.mochi
+346	enforced-immutability.mochi
+347	entropy-1.mochi
+348	entropy-2.mochi
+349	entropy-narcissist.mochi
+350	enumerations-1.mochi
+351	enumerations-2.mochi
+352	enumerations-3.mochi
+353	enumerations-4.mochi
+354	environment-variables-1.mochi
+355	environment-variables-2.mochi
+356	equal-prime-and-composite-sums.mochi
+357	equilibrium-index.mochi
+358	erd-s-nicolas-numbers.mochi
+359	erd-s-selfridge-categorization-of-primes.mochi
+360	esthetic-numbers.mochi
+361	ethiopian-multiplication.mochi
+362	euclid-mullin-sequence.mochi
+363	euler-method.mochi
+364	eulers-constant-0.5772....mochi
+365	eulers-identity.mochi
+366	eulers-sum-of-powers-conjecture.mochi
+367	evaluate-binomial-coefficients.mochi
+368	even-or-odd.mochi
+369	events.mochi
+370	evolutionary-algorithm.mochi
+371	exceptions-catch-an-exception-thrown-in-a-nested-call.mochi
+372	exceptions.mochi
+373	executable-library.mochi
+374	execute-a-markov-algorithm.mochi
+375	execute-a-system-command.mochi
+376	execute-brain-.mochi
+377	execute-computer-zero.mochi
+378	execute-hq9+.mochi
+379	execute-snusp.mochi
+380	exponentiation-operator.mochi
+381	exponentiation-order.mochi
+382	exponentiation-with-infix-operators-in-or-operating-on-the-base.mochi
+383	extend-your-language.mochi
+384	extensible-prime-generator.mochi
+385	extreme-floating-point-values.mochi
+386	faces-from-a-mesh.mochi
+387	fasta-format.mochi
+388	faulhabers-triangle.mochi
+389	feigenbaum-constant-calculation.mochi
+390	fermat-numbers.mochi
+391	fibonacci-n-step-number-sequences.mochi
+392	fibonacci-sequence-1.mochi
+393	fibonacci-sequence-2.mochi
+394	fibonacci-sequence-3.mochi
+395	fibonacci-sequence-4.mochi
+396	fibonacci-word-fractal.mochi
+397	fibonacci-word.mochi
+398	file-extension-is-in-extensions-list.mochi
+399	file-input-output-1.mochi
+400	file-input-output-2.mochi
+401	file-modification-time.mochi
+402	file-size-distribution.mochi
+403	file-size.mochi
+404	filter.mochi
+405	find-chess960-starting-position-identifier.mochi
+406	find-common-directory-path.mochi
+407	find-duplicate-files.mochi
+408	find-if-a-point-is-within-a-triangle.mochi
+409	find-largest-left-truncatable-prime-in-a-given-base.mochi
+410	find-limit-of-recursion.mochi
+411	find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
+412	find-the-intersection-of-a-line-with-a-plane.mochi
+413	find-the-intersection-of-two-lines.mochi
+414	find-the-last-sunday-of-each-month.mochi
+415	find-the-missing-permutation.mochi
+416	fivenum-1.mochi
+417	fivenum-2.mochi
+418	fixed-length-records-1.mochi
+419	fixed-length-records-2.mochi
+420	fizzbuzz-1.mochi
+421	fizzbuzz-2.mochi
+422	flatten-a-list-1.mochi
+423	flatten-a-list-2.mochi
+424	flipping-bits-game.mochi
+425	flow-control-structures-1.mochi
+426	flow-control-structures-2.mochi
+427	flow-control-structures-3.mochi
+428	flow-control-structures-4.mochi
+429	floyd-warshall-algorithm.mochi
+430	floyds-triangle.mochi
+431	forest-fire.mochi
+432	fork.mochi
+433	ftp.mochi
+434	gamma-function.mochi
+435	general-fizzbuzz.mochi
+436	generic-swap.mochi
+437	get-system-command-output.mochi
+438	giuga-numbers.mochi
+439	globally-replace-text-in-several-files.mochi
+440	goldbachs-comet.mochi
+441	golden-ratio-convergence.mochi
+442	graph-colouring.mochi
+443	gray-code.mochi
+444	http.mochi
+445	image-noise.mochi
+446	loops-increment-loop-index-within-loop-body.mochi
+447	md5.mochi
+448	nim-game.mochi
+449	plasma-effect.mochi
+450	sorting-algorithms-bubble-sort.mochi
+451	window-management.mochi
+452	zumkeller-numbers.mochi


### PR DESCRIPTION
## Summary
- regenerate rosetta IR/bench outputs for indices 269-276
- limit recursive value copying depth to avoid runaway recursion
- update rosetta checklist and index

## Testing
- `MOCHI_ROSETTA_ONLY=deal-cards-for-freecell MOCHI_BENCHMARK=1 go test ./runtime/vm -tags slow -run TestVM_Rosetta_Golden -update -v` *(fails: stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_6885a77619d0832091e49e738ee856f1