### PR TITLE
Update VM Rosetta outputs for indices 170-189

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-27 05:21 UTC
+Last updated: 2025-07-27 05:45 UTC
 
 ## Rosetta Golden Test Checklist (286/452)
 | Index | Name | Status | Duration | Memory |
@@ -176,26 +176,26 @@ Last updated: 2025-07-27 05:21 UTC
 | 167 | camel-case-and-snake-case | ✓ | 738µs | 463.0 KB |
 | 168 | canny-edge-detector | ✓ | 388µs | 112.5 KB |
 | 169 | canonicalize-cidr | ✓ | 2.048ms | 559.1 KB |
-| 170 | cantor-set | ✓ | 1.394ms | 728.5 KB |
-| 171 | carmichael-3-strong-pseudoprimes | ✓ | 42.69ms | 404.5 KB |
-| 172 | cartesian-product-of-two-or-more-lists-1 | ✓ | 75µs | 39.7 KB |
-| 173 | cartesian-product-of-two-or-more-lists-2 | ✓ | 575µs | 337.4 KB |
-| 174 | cartesian-product-of-two-or-more-lists-3 | ✓ | 586µs | 414.8 KB |
-| 175 | cartesian-product-of-two-or-more-lists-4 | ✓ | 467µs | 574.6 KB |
-| 176 | case-sensitivity-of-identifiers | ✓ | 80µs | 23.5 KB |
-| 177 | casting-out-nines | ✓ | 12.302ms | 1.8 MB |
-| 178 | catalan-numbers-1 | ✓ | 118µs | 60.6 KB |
-| 179 | catalan-numbers-2 | ✓ | 594µs | 329.7 KB |
-| 180 | catalan-numbers-pascals-triangle | ✓ | 330µs | 546.0 KB |
-| 181 | catamorphism | ✓ | 75µs | 34.4 KB |
-| 182 | catmull-clark-subdivision-surface | ✓ | 2.131ms | 736.3 KB |
-| 183 | chaocipher | ✓ | 711µs | 617.6 KB |
-| 184 | chaos-game | ✓ | 1.25584s |  |
-| 185 | character-codes-1 | ✓ | 43µs | 4.0 KB |
-| 186 | character-codes-2 | ✓ | 28µs | 3.8 KB |
-| 187 | character-codes-3 | ✓ | 40µs | 8.4 KB |
-| 188 | character-codes-4 | ✓ | 38µs | 8.8 KB |
-| 189 | character-codes-5 | ✓ | 42µs | 7.0 KB |
+| 170 | cantor-set | ✓ | 5.813ms |  |
+| 171 | carmichael-3-strong-pseudoprimes | ✓ | 148.196ms |  |
+| 172 | cartesian-product-of-two-or-more-lists-1 | ✓ | 955µs | 47.7 KB |
+| 173 | cartesian-product-of-two-or-more-lists-2 | ✓ | 1.684ms | 426.9 KB |
+| 174 | cartesian-product-of-two-or-more-lists-3 | ✓ | 2.623ms | 470.5 KB |
+| 175 | cartesian-product-of-two-or-more-lists-4 | ✓ | 1.94ms | 649.9 KB |
+| 176 | case-sensitivity-of-identifiers | ✓ | 644µs | 23.5 KB |
+| 177 | casting-out-nines | ✓ | 41.748ms | 914.3 KB |
+| 178 | catalan-numbers-1 | ✓ | 842µs | 127.7 KB |
+| 179 | catalan-numbers-2 | ✓ | 1.999ms | 449.3 KB |
+| 180 | catalan-numbers-pascals-triangle | ✓ | 1.821ms | 648.1 KB |
+| 181 | catamorphism | ✓ | 772µs | 30.4 KB |
+| 182 | catmull-clark-subdivision-surface | ✓ | 6.025ms | 693.1 KB |
+| 183 | chaocipher | ✓ | 8.466ms |  |
+| 184 | chaos-game | ✓ | 1.915336s |  |
+| 185 | character-codes-1 | ✓ | 440µs | 4.0 KB |
+| 186 | character-codes-2 | ✓ | 949µs | 3.8 KB |
+| 187 | character-codes-3 | ✓ | 404µs | 8.4 KB |
+| 188 | character-codes-4 | ✓ | 502µs | 8.8 KB |
+| 189 | character-codes-5 | ✓ | 459µs | 7.0 KB |
 | 190 | chat-server | ✓ | 154µs | 32.4 KB |
 | 191 | check-machin-like-formulas |   |  |  |
 | 192 | check-that-file-exists | ✓ | 43µs | 10.6 KB |

--- a/tests/rosetta/ir/cantor-set.bench
+++ b/tests/rosetta/ir/cantor-set.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1394,
-  "memory_bytes": 745936,
+  "duration_us": 5813,
+  "memory_bytes": -1211048,
   "name": "main"
 }

--- a/tests/rosetta/ir/cantor-set.ir
+++ b/tests/rosetta/ir/cantor-set.ir
@@ -1,4 +1,4 @@
-func main (regs=90)
+func main (regs=98)
   // let width = 81
   Const        r4, 81
   Move         r0, r4
@@ -13,10 +13,9 @@ func main (regs=90)
   SetGlobal    2,2,0,0
   // for i in 0..height {
   Const        r7, 0
-  Const        r5, 5
   Move         r8, r7
 L3:
-  LessInt      r9, r8, r5
+  LessInt      r9, r8, r1
   JumpIfFalse  r9, L0
   // var row = ""
   Const        r10, ""
@@ -26,8 +25,7 @@ L3:
   Move         r12, r7
 L2:
   // while j < width {
-  Const        r4, 81
-  LessInt      r13, r12, r4
+  LessInt      r13, r12, r0
   JumpIfFalse  r13, L1
   // row = row + "*"
   Const        r14, "*"
@@ -51,146 +49,158 @@ L1:
   Jump         L3
 L0:
   // var stack: list<map<string, int>> = [{"start": 0, "len": width, "index": 1}]
-  Const        r21, [{"index": 1, "len": 81, "start": 0}]
-  Move         r3, r21
+  Const        r22, "start"
+  Const        r7, 0
+  Const        r23, "len"
+  Const        r24, "index"
+  Const        r16, 1
+  Move         r25, r22
+  Move         r26, r7
+  Move         r27, r23
+  Move         r28, r0
+  Move         r29, r24
+  Move         r30, r16
+  MakeMap      r31, 3, r25
+  Move         r21, r31
+  MakeList     r32, 1, r21
+  Move         r3, r32
   SetGlobal    3,3,0,0
 L6:
   // while len(stack) > 0 {
-  Len          r22, r3
+  Len          r33, r3
   Const        r7, 0
-  LessInt      r23, r7, r22
-  JumpIfFalse  r23, L4
+  LessInt      r34, r7, r33
+  JumpIfFalse  r34, L4
   // var frame = stack[len(stack)-1]
-  Len          r24, r3
+  Len          r35, r3
   Const        r16, 1
-  SubInt       r25, r24, r16
-  Index        r26, r3, r25
-  Move         r27, r26
+  SubInt       r36, r35, r16
+  Index        r37, r3, r36
+  Move         r38, r37
   // stack = stack[:len(stack)-1]
-  Const        r28, nil
-  Len          r30, r3
+  Const        r39, nil
+  Len          r41, r3
   Const        r16, 1
-  SubInt       r31, r30, r16
-  Move         r29, r31
-  Slice        r32, r3, r28, r29
-  Move         r3, r32
+  SubInt       r42, r41, r16
+  Move         r40, r42
+  Slice        r43, r3, r39, r40
+  Move         r3, r43
   SetGlobal    3,3,0,0
   // let start = frame["start"]
-  Const        r33, "start"
-  Index        r34, r27, r33
-  Move         r35, r34
-  // let lenSeg = frame["len"]
-  Const        r36, "len"
-  Index        r37, r27, r36
-  Move         r38, r37
-  // let index = frame["index"]
-  Const        r39, "index"
-  Index        r40, r27, r39
-  Move         r41, r40
-  // let seg = (lenSeg / 3) as int
-  Const        r42, 3
-  Div          r43, r38, r42
-  Cast         r44, r43, int
+  Const        r22, "start"
+  Index        r44, r38, r22
   Move         r45, r44
+  // let lenSeg = frame["len"]
+  Const        r23, "len"
+  Index        r46, r38, r23
+  Move         r47, r46
+  // let index = frame["index"]
+  Const        r24, "index"
+  Index        r48, r38, r24
+  Move         r49, r48
+  // let seg = (lenSeg / 3) as int
+  Const        r50, 3
+  Div          r51, r47, r50
+  Cast         r52, r51, int
+  Move         r53, r52
   // if seg == 0 { continue }
   Const        r7, 0
-  Equal        r46, r45, r7
-  JumpIfFalse  r46, L5
+  Equal        r54, r53, r7
+  JumpIfFalse  r54, L5
   Jump         L6
 L5:
   // var i = index
-  Move         r8, r41
+  Move         r8, r49
 L10:
   // while i < height {
-  Const        r5, 5
-  Less         r47, r8, r5
-  JumpIfFalse  r47, L7
+  Less         r55, r8, r1
+  JumpIfFalse  r55, L7
   // var j = start + seg
-  Add          r48, r35, r45
-  Move         r49, r48
+  Add          r56, r45, r53
+  Move         r57, r56
 L9:
   // while j < start + 2 * seg {
-  Const        r50, 2
-  Mul          r51, r50, r45
-  Add          r52, r35, r51
-  Less         r53, r49, r52
-  JumpIfFalse  r53, L8
+  Const        r58, 2
+  Mul          r59, r58, r53
+  Add          r60, r45, r59
+  Less         r61, r57, r60
+  JumpIfFalse  r61, L8
   // lines[i] = setChar(lines[i], j, " ")
-  Index        r57, r2, r8
-  Move         r54, r57
-  Move         r55, r49
-  Const        r58, " "
-  Move         r56, r58
-  Call         r59, setChar, r54, r55, r56
-  SetIndex     r2, r8, r59
+  Index        r65, r2, r8
+  Move         r62, r65
+  Move         r63, r57
+  Const        r66, " "
+  Move         r64, r66
+  Call         r67, setChar, r62, r63, r64
+  SetIndex     r2, r8, r67
   SetGlobal    2,2,0,0
   // j = j + 1
   Const        r16, 1
-  Add          r60, r49, r16
-  Move         r49, r60
+  Add          r68, r57, r16
+  Move         r57, r68
   // while j < start + 2 * seg {
   Jump         L9
 L8:
   // i = i + 1
   Const        r16, 1
-  Add          r61, r8, r16
-  Move         r8, r61
+  Add          r69, r8, r16
+  Move         r8, r69
   // while i < height {
   Jump         L10
 L7:
   // stack = append(stack, {"start": start, "len": seg, "index": index + 1})
-  Const        r33, "start"
-  Const        r36, "len"
-  Const        r39, "index"
+  Const        r22, "start"
+  Const        r23, "len"
+  Const        r24, "index"
   Const        r16, 1
-  Add          r62, r41, r16
-  Move         r63, r33
-  Move         r64, r35
-  Move         r65, r36
-  Move         r66, r45
-  Move         r67, r39
-  Move         r68, r62
-  MakeMap      r69, 3, r63
-  Append       r70, r3, r69
-  Move         r3, r70
+  Add          r70, r49, r16
+  Move         r71, r22
+  Move         r72, r45
+  Move         r73, r23
+  Move         r74, r53
+  Move         r75, r24
+  Move         r76, r70
+  MakeMap      r77, 3, r71
+  Append       r78, r3, r77
+  Move         r3, r78
   SetGlobal    3,3,0,0
   // stack = append(stack, {"start": start + seg * 2, "len": seg, "index": index + 1})
-  Const        r33, "start"
-  Const        r50, 2
-  Mul          r71, r45, r50
-  Add          r72, r35, r71
-  Const        r36, "len"
-  Const        r39, "index"
+  Const        r22, "start"
+  Const        r58, 2
+  Mul          r79, r53, r58
+  Add          r80, r45, r79
+  Const        r23, "len"
+  Const        r24, "index"
   Const        r16, 1
-  Add          r73, r41, r16
-  Move         r74, r33
-  Move         r75, r72
-  Move         r76, r36
-  Move         r77, r45
-  Move         r78, r39
-  Move         r79, r73
-  MakeMap      r80, 3, r74
-  Append       r81, r3, r80
-  Move         r3, r81
+  Add          r81, r49, r16
+  Move         r82, r22
+  Move         r83, r80
+  Move         r84, r23
+  Move         r85, r53
+  Move         r86, r24
+  Move         r87, r81
+  MakeMap      r88, 3, r82
+  Append       r89, r3, r88
+  Move         r3, r89
   SetGlobal    3,3,0,0
   // while len(stack) > 0 {
   Jump         L6
 L4:
   // for line in lines {
-  IterPrep     r82, r2
-  Len          r83, r82
-  Const        r84, 0
+  IterPrep     r90, r2
+  Len          r91, r90
+  Const        r92, 0
 L12:
-  LessInt      r85, r84, r83
-  JumpIfFalse  r85, L11
-  Index        r86, r82, r84
-  Move         r87, r86
+  LessInt      r93, r92, r91
+  JumpIfFalse  r93, L11
+  Index        r94, r90, r92
+  Move         r95, r94
   // print(line)
-  Print        r87
+  Print        r95
   // for line in lines {
-  Const        r88, 1
-  AddInt       r89, r84, r88
-  Move         r84, r89
+  Const        r96, 1
+  AddInt       r97, r92, r96
+  Move         r92, r97
   Jump         L12
 L11:
   Return       r0

--- a/tests/rosetta/ir/carmichael-3-strong-pseudoprimes.bench
+++ b/tests/rosetta/ir/carmichael-3-strong-pseudoprimes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 42690,
-  "memory_bytes": 414216,
+  "duration_us": 148196,
+  "memory_bytes": -680784,
   "name": "main"
 }

--- a/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-1.bench
+++ b/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 75,
-  "memory_bytes": 40664,
+  "duration_us": 955,
+  "memory_bytes": 48840,
   "name": "main"
 }

--- a/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-2.bench
+++ b/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 575,
-  "memory_bytes": 345496,
+  "duration_us": 1684,
+  "memory_bytes": 437112,
   "name": "main"
 }

--- a/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-3.bench
+++ b/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 586,
-  "memory_bytes": 424712,
+  "duration_us": 2623,
+  "memory_bytes": 481784,
   "name": "main"
 }

--- a/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-4.bench
+++ b/tests/rosetta/ir/cartesian-product-of-two-or-more-lists-4.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 467,
-  "memory_bytes": 588344,
+  "duration_us": 1940,
+  "memory_bytes": 665448,
   "name": "main"
 }

--- a/tests/rosetta/ir/case-sensitivity-of-identifiers.bench
+++ b/tests/rosetta/ir/case-sensitivity-of-identifiers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 80,
+  "duration_us": 644,
   "memory_bytes": 24072,
   "name": "main"
 }

--- a/tests/rosetta/ir/casting-out-nines.bench
+++ b/tests/rosetta/ir/casting-out-nines.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 12302,
-  "memory_bytes": 1890168,
+  "duration_us": 41748,
+  "memory_bytes": 936232,
   "name": "main"
 }

--- a/tests/rosetta/ir/casting-out-nines.ir
+++ b/tests/rosetta/ir/casting-out-nines.ir
@@ -173,10 +173,9 @@ L3:
   LessInt      r14, r11, r13
   JumpIfFalse  r14, L1
   // if substring(digits, j, j+1) == s[i:i+1] {
-  Const        r4, "0123456789abcdefghijklmnopqrstuvwxyz"
   Const        r15, 1
   AddInt       r16, r11, r15
-  Slice        r17, r4, r11, r16
+  Slice        r17, r5, r11, r16
   Move         r18, r8
   Const        r15, 1
   AddInt       r20, r8, r15

--- a/tests/rosetta/ir/catalan-numbers-1.bench
+++ b/tests/rosetta/ir/catalan-numbers-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 118,
-  "memory_bytes": 62088,
+  "duration_us": 842,
+  "memory_bytes": 130744,
   "name": "main"
 }

--- a/tests/rosetta/ir/catalan-numbers-2.bench
+++ b/tests/rosetta/ir/catalan-numbers-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 594,
-  "memory_bytes": 337640,
+  "duration_us": 1999,
+  "memory_bytes": 460056,
   "name": "main"
 }

--- a/tests/rosetta/ir/catalan-numbers-pascals-triangle.bench
+++ b/tests/rosetta/ir/catalan-numbers-pascals-triangle.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 330,
-  "memory_bytes": 559144,
+  "duration_us": 1821,
+  "memory_bytes": 663640,
   "name": "main"
 }

--- a/tests/rosetta/ir/catalan-numbers-pascals-triangle.ir
+++ b/tests/rosetta/ir/catalan-numbers-pascals-triangle.ir
@@ -1,4 +1,4 @@
-func main (regs=52)
+func main (regs=53)
   // let n = 15
   Const        r2, 15
   Move         r0, r2
@@ -9,122 +9,124 @@ func main (regs=52)
   SetGlobal    1,1,0,0
   // for _ in 0..(n+2) {
   Const        r4, 0
-  Const        r5, 17
-  Move         r6, r4
+  Const        r5, 2
+  Const        r6, 17
+  Move         r7, r4
 L1:
-  LessInt      r7, r6, r5
-  JumpIfFalse  r7, L0
+  LessInt      r8, r7, r6
+  JumpIfFalse  r8, L0
   // t = append(t, 0)
   Const        r4, 0
-  Append       r8, r1, r4
-  Move         r1, r8
+  Append       r9, r1, r4
+  Move         r1, r9
   SetGlobal    1,1,0,0
   // for _ in 0..(n+2) {
-  Const        r9, 1
-  AddInt       r10, r6, r9
-  Move         r6, r10
+  Const        r10, 1
+  AddInt       r11, r7, r10
+  Move         r7, r11
   Jump         L1
 L0:
   // t[1] = 1
-  Const        r11, 1
-  Const        r11, 1
-  SetIndex     r1, r11, r11
+  Const        r12, 1
+  Const        r12, 1
+  SetIndex     r1, r12, r12
   SetGlobal    1,1,0,0
   // for i in 1..(n+1) {
-  Const        r11, 1
-  Const        r12, 16
-  Move         r13, r11
+  Const        r12, 1
+  Const        r12, 1
+  AddInt       r13, r0, r12
+  Move         r14, r12
 L9:
-  LessInt      r14, r13, r12
-  JumpIfFalse  r14, L2
+  LessInt      r15, r14, r13
+  JumpIfFalse  r15, L2
   // var j = i
-  Move         r15, r13
+  Move         r16, r14
 L4:
   // while j > 1 {
-  Const        r11, 1
-  LessInt      r16, r11, r15
-  JumpIfFalse  r16, L3
+  Const        r12, 1
+  LessInt      r17, r12, r16
+  JumpIfFalse  r17, L3
   // t[j] = t[j] + t[j-1]
-  Index        r17, r1, r15
-  Const        r11, 1
-  SubInt       r18, r15, r11
-  Index        r19, r1, r18
-  Add          r20, r17, r19
-  SetIndex     r1, r15, r20
+  Index        r18, r1, r16
+  Const        r12, 1
+  SubInt       r19, r16, r12
+  Index        r20, r1, r19
+  Add          r21, r18, r20
+  SetIndex     r1, r16, r21
   SetGlobal    1,1,0,0
   // j = j - 1
-  Const        r11, 1
-  SubInt       r21, r15, r11
-  Move         r15, r21
+  Const        r12, 1
+  SubInt       r22, r16, r12
+  Move         r16, r22
   // while j > 1 {
   Jump         L4
 L3:
   // t[(i+1) as int] = t[i]
-  Index        r22, r1, r13
-  Const        r11, 1
-  AddInt       r23, r13, r11
-  Cast         r24, r23, int
-  SetIndex     r1, r24, r22
+  Index        r23, r1, r14
+  Const        r12, 1
+  AddInt       r24, r14, r12
+  Cast         r25, r24, int
+  SetIndex     r1, r25, r23
   SetGlobal    1,1,0,0
   // j = i + 1
-  Const        r11, 1
-  AddInt       r25, r13, r11
-  Move         r15, r25
+  Const        r12, 1
+  AddInt       r26, r14, r12
+  Move         r16, r26
 L6:
   // while j > 1 {
-  Const        r11, 1
-  LessInt      r26, r11, r15
-  JumpIfFalse  r26, L5
+  Const        r12, 1
+  LessInt      r27, r12, r16
+  JumpIfFalse  r27, L5
   // t[j] = t[j] + t[j-1]
-  Index        r27, r1, r15
-  Const        r11, 1
-  SubInt       r28, r15, r11
-  Index        r29, r1, r28
-  Add          r30, r27, r29
-  SetIndex     r1, r15, r30
+  Index        r28, r1, r16
+  Const        r12, 1
+  SubInt       r29, r16, r12
+  Index        r30, r1, r29
+  Add          r31, r28, r30
+  SetIndex     r1, r16, r31
   SetGlobal    1,1,0,0
   // j = j - 1
-  Const        r11, 1
-  SubInt       r31, r15, r11
-  Move         r15, r31
+  Const        r12, 1
+  SubInt       r32, r16, r12
+  Move         r16, r32
   // while j > 1 {
   Jump         L6
 L5:
   // let cat = t[i+1] - t[i]
-  Const        r11, 1
-  AddInt       r32, r13, r11
-  Index        r33, r1, r32
-  Index        r34, r1, r13
-  Sub          r35, r33, r34
-  Move         r36, r35
+  Const        r12, 1
+  AddInt       r33, r14, r12
+  Index        r34, r1, r33
+  Index        r35, r1, r14
+  Sub          r36, r34, r35
+  Move         r37, r36
   // if i < 10 {
-  Const        r37, 10
-  LessInt      r38, r13, r37
-  JumpIfFalse  r38, L7
+  Const        r38, 10
+  LessInt      r39, r14, r38
+  JumpIfFalse  r39, L7
   // print(" " + str(i) + " : " + str(cat))
-  Const        r39, " "
-  Str          r40, r13
-  Add          r41, r39, r40
-  Const        r42, " : "
-  Add          r43, r41, r42
-  Str          r44, r36
-  Add          r45, r43, r44
-  Print        r45
+  Const        r40, " "
+  Str          r41, r14
+  Add          r42, r40, r41
+  Const        r43, " : "
+  Add          r44, r42, r43
+  Str          r45, r37
+  Add          r46, r44, r45
+  Print        r46
   // if i < 10 {
   Jump         L8
 L7:
   // print(str(i) + " : " + str(cat))
-  Str          r46, r13
-  Const        r42, " : "
-  Add          r47, r46, r42
-  Str          r48, r36
-  Add          r49, r47, r48
-  Print        r49
+  Str          r47, r14
+  Const        r43, " : "
+  Add          r48, r47, r43
+  Str          r49, r37
+  Add          r50, r48, r49
+  Print        r50
 L8:
   // for i in 1..(n+1) {
-  Const        r50, 1
-  AddInt       r51, r13, r50
-  Move         r13, r51
+  Const        r51, 1
+  AddInt       r52, r14, r51
+  Move         r14, r52
   Jump         L9
 L2:
   Return       r0

--- a/tests/rosetta/ir/catamorphism.bench
+++ b/tests/rosetta/ir/catamorphism.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 75,
-  "memory_bytes": 35224,
+  "duration_us": 772,
+  "memory_bytes": 31160,
   "name": "main"
 }

--- a/tests/rosetta/ir/catamorphism.ir
+++ b/tests/rosetta/ir/catamorphism.ir
@@ -1,32 +1,26 @@
-func main (regs=20)
+func main (regs=14)
   // let n = [1, 2, 3, 4, 5]
   Const        r1, [1, 2, 3, 4, 5]
   Move         r0, r1
   SetGlobal    0,0,0,0
   // print(fold(fun(a: int, b: int): int => add(a, b), n))
-  Move         r4, r0
-  MakeClosure  r5, fn5, 1, r4
-  Move         r2, r5
-  Const        r6, [1, 2, 3, 4, 5]
-  Move         r3, r6
-  Call2        r7, fold, r2, r3
-  Print        r7
+  MakeClosure  r4, fn5, 0, r0
+  Move         r2, r4
+  Move         r3, r0
+  Call2        r5, fold, r2, r3
+  Print        r5
   // print(fold(fun(a: int, b: int): int => sub(a, b), n))
-  Move         r10, r0
-  MakeClosure  r11, fn6, 1, r10
-  Move         r8, r11
-  Const        r12, [1, 2, 3, 4, 5]
-  Move         r9, r12
-  Call2        r13, fold, r8, r9
-  Print        r13
+  MakeClosure  r8, fn6, 0, r0
+  Move         r6, r8
+  Move         r7, r0
+  Call2        r9, fold, r6, r7
+  Print        r9
   // print(fold(fun(a: int, b: int): int => mul(a, b), n))
-  Move         r16, r0
-  MakeClosure  r17, fn7, 1, r16
-  Move         r14, r17
-  Const        r18, [1, 2, 3, 4, 5]
-  Move         r15, r18
-  Call2        r19, fold, r14, r15
-  Print        r19
+  MakeClosure  r12, fn7, 0, r0
+  Move         r10, r12
+  Move         r11, r0
+  Call2        r13, fold, r10, r11
+  Print        r13
   Return       r0
 
   // fun add(a: int, b: int): int { return a + b }
@@ -78,25 +72,25 @@ L0:
   Return       r5
 
   // print(fold(fun(a: int, b: int): int => add(a, b), n))
-func fn5 (regs=7)
+func fn5 (regs=6)
   // print(fold(fun(a: int, b: int): int => add(a, b), n))
+  Move         r3, r1
   Move         r4, r2
-  Move         r5, r3
-  Call2        r6, add, r4, r5
-  Return       r6
+  Call2        r5, add, r3, r4
+  Return       r5
 
   // print(fold(fun(a: int, b: int): int => sub(a, b), n))
-func fn6 (regs=7)
+func fn6 (regs=6)
   // print(fold(fun(a: int, b: int): int => sub(a, b), n))
+  Move         r3, r1
   Move         r4, r2
-  Move         r5, r3
-  Call2        r6, sub, r4, r5
-  Return       r6
+  Call2        r5, sub, r3, r4
+  Return       r5
 
   // print(fold(fun(a: int, b: int): int => mul(a, b), n))
-func fn7 (regs=7)
+func fn7 (regs=6)
   // print(fold(fun(a: int, b: int): int => mul(a, b), n))
+  Move         r3, r1
   Move         r4, r2
-  Move         r5, r3
-  Call2        r6, mul, r4, r5
-  Return       r6
+  Call2        r5, mul, r3, r4
+  Return       r5

--- a/tests/rosetta/ir/catmull-clark-subdivision-surface.bench
+++ b/tests/rosetta/ir/catmull-clark-subdivision-surface.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 2131,
-  "memory_bytes": 753968,
+  "duration_us": 6025,
+  "memory_bytes": 709728,
   "name": "main"
 }

--- a/tests/rosetta/ir/catmull-clark-subdivision-surface.ir
+++ b/tests/rosetta/ir/catmull-clark-subdivision-surface.ir
@@ -1419,7 +1419,7 @@ L1:
   Return       r10
 
   // fun main() {
-func main (regs=132)
+func main (regs=131)
   // Point{x: -1.0, y: 1.0, z: 1.0},
   Const        r8, 1.0
   NegFloat     r9, r8
@@ -1553,71 +1553,70 @@ func main (regs=132)
   // var outputPoints = inputPoints
   Move         r97, r94
   // var outputFaces = inputFaces
-  Const        r98, [[0, 1, 2, 3], [3, 2, 4, 5], [5, 4, 6, 7], [7, 0, 3, 5], [7, 6, 1, 0], [6, 1, 2, 4]]
-  Move         r99, r98
+  Move         r98, r96
   // var i = 0
-  Const        r100, 0
-  Move         r101, r100
+  Const        r99, 0
+  Move         r100, r99
 L1:
   // while i < 1 {
-  Const        r102, 1
-  LessInt      r103, r101, r102
-  JumpIfFalse  r103, L0
+  Const        r101, 1
+  LessInt      r102, r100, r101
+  JumpIfFalse  r102, L0
   // let res = cmcSubdiv(outputPoints, outputFaces)
-  Move         r104, r97
-  Move         r105, r99
-  Call2        r106, cmcSubdiv, r104, r105
-  Move         r107, r106
+  Move         r103, r97
+  Move         r104, r98
+  Call2        r105, cmcSubdiv, r103, r104
+  Move         r106, r105
   // outputPoints = res[0]
-  Const        r100, 0
-  Index        r108, r107, r100
-  Move         r97, r108
+  Const        r99, 0
+  Index        r107, r106, r99
+  Move         r97, r107
   // outputFaces = res[1]
-  Const        r102, 1
-  Index        r109, r107, r102
-  Move         r99, r109
+  Const        r101, 1
+  Index        r108, r106, r101
+  Move         r98, r108
   // i = i + 1
-  Const        r102, 1
-  AddInt       r110, r101, r102
-  Move         r101, r110
+  Const        r101, 1
+  AddInt       r109, r100, r101
+  Move         r100, r109
   // while i < 1 {
   Jump         L1
 L0:
   // for p in outputPoints { print(formatPoint(p)) }
-  IterPrep     r111, r97
-  Len          r112, r111
-  Const        r113, 0
+  IterPrep     r110, r97
+  Len          r111, r110
+  Const        r112, 0
 L3:
-  LessInt      r114, r113, r112
-  JumpIfFalse  r114, L2
-  Index        r115, r111, r113
+  LessInt      r113, r112, r111
+  JumpIfFalse  r113, L2
+  Index        r114, r110, r112
+  Move         r115, r114
   Move         r116, r115
-  Move         r117, r116
-  Call         r118, formatPoint, r117
-  Print        r118
-  Const        r119, 1
-  AddInt       r120, r113, r119
-  Move         r113, r120
+  Call         r117, formatPoint, r116
+  Print        r117
+  Const        r118, 1
+  AddInt       r119, r112, r118
+  Move         r112, r119
   Jump         L3
 L2:
   // print("")
-  Const        r121, ""
-  Print        r121
+  Const        r120, ""
+  Print        r120
   // for f in outputFaces { print(formatFace(f)) }
-  IterPrep     r122, r99
-  Len          r123, r122
-  Const        r124, 0
+  IterPrep     r121, r98
+  Len          r122, r121
+  Const        r123, 0
 L5:
-  LessInt      r125, r124, r123
-  JumpIfFalse  r125, L4
-  Index        r126, r122, r124
+  LessInt      r124, r123, r122
+  JumpIfFalse  r124, L4
+  Index        r125, r121, r123
+  Move         r126, r125
   Move         r127, r126
-  Move         r128, r127
-  Call         r129, formatFace, r128
-  Print        r129
-  Const        r130, 1
-  AddInt       r131, r124, r130
-  Move         r124, r131
+  Call         r128, formatFace, r127
+  Print        r128
+  Const        r129, 1
+  AddInt       r130, r123, r129
+  Move         r123, r130
   Jump         L5
 L4:
   Return       r0

--- a/tests/rosetta/ir/chaocipher.bench
+++ b/tests/rosetta/ir/chaocipher.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 711,
-  "memory_bytes": 632376,
+  "duration_us": 8466,
+  "memory_bytes": -1652464,
   "name": "main"
 }

--- a/tests/rosetta/ir/chaocipher.ir
+++ b/tests/rosetta/ir/chaocipher.ir
@@ -203,15 +203,13 @@ func main (regs=11)
   Const        r0, "WELLDONEISBETTERTHANWELLSAID"
   Move         r1, r0
   // let cipher = chao(plain, true)
-  Const        r0, "WELLDONEISBETTERTHANWELLSAID"
-  Move         r2, r0
+  Move         r2, r1
   Const        r4, true
   Move         r3, r4
   Call2        r5, chao, r2, r3
   Move         r6, r5
   // print(plain)
-  Const        r0, "WELLDONEISBETTERTHANWELLSAID"
-  Print        r0
+  Print        r1
   // print(cipher)
   Print        r6
   // print(chao(cipher, false))

--- a/tests/rosetta/ir/chaos-game.bench
+++ b/tests/rosetta/ir/chaos-game.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1255840,
-  "memory_bytes": -389528,
+  "duration_us": 1915336,
+  "memory_bytes": -758728,
   "name": "main"
 }

--- a/tests/rosetta/ir/chaos-game.ir
+++ b/tests/rosetta/ir/chaos-game.ir
@@ -1,195 +1,218 @@
-func main (regs=67)
+func main (regs=89)
   // let width = 60
   Const        r10, 60
   Move         r0, r10
   SetGlobal    0,0,0,0
   // let height = (width as float * 0.86602540378) as int
-  Const        r11, 51
-  Move         r1, r11
+  Cast         r11, r0, float
+  Const        r12, 0.86602540378
+  MulFloat     r13, r11, r12
+  Cast         r14, r13, int
+  Move         r1, r14
   SetGlobal    1,1,0,0
   // let iterations = 5000
-  Const        r12, 5000
-  Move         r2, r12
+  Const        r15, 5000
+  Move         r2, r15
   SetGlobal    2,2,0,0
   // var grid: list<list<string>> = []
-  Const        r13, []
-  Move         r3, r13
+  Const        r16, []
+  Move         r3, r16
   SetGlobal    3,3,0,0
   // var y = 0
-  Const        r14, 0
-  Move         r4, r14
+  Const        r17, 0
+  Move         r4, r17
   SetGlobal    4,4,0,0
 L3:
   // while y < height {
-  Const        r11, 51
-  LessInt      r15, r4, r11
-  JumpIfFalse  r15, L0
+  Less         r18, r4, r1
+  JumpIfFalse  r18, L0
   // var line: list<string> = []
-  Const        r13, []
-  Move         r16, r13
+  Const        r16, []
+  Move         r19, r16
   // var x = 0
-  Const        r14, 0
-  Move         r17, r14
+  Const        r17, 0
+  Move         r20, r17
 L2:
   // while x < width {
-  Const        r10, 60
-  LessInt      r18, r17, r10
-  JumpIfFalse  r18, L1
+  LessInt      r21, r20, r0
+  JumpIfFalse  r21, L1
   // line = append(line, " ")
-  Const        r19, " "
-  Append       r20, r16, r19
-  Move         r16, r20
+  Const        r22, " "
+  Append       r23, r19, r22
+  Move         r19, r23
   // x = x + 1
-  Const        r21, 1
-  AddInt       r22, r17, r21
-  Move         r17, r22
+  Const        r24, 1
+  AddInt       r25, r20, r24
+  Move         r20, r25
   // while x < width {
   Jump         L2
 L1:
   // grid = append(grid, line)
-  Append       r23, r3, r16
-  Move         r3, r23
+  Append       r26, r3, r19
+  Move         r3, r26
   SetGlobal    3,3,0,0
   // y = y + 1
-  Const        r21, 1
-  AddInt       r24, r4, r21
-  Move         r4, r24
+  Const        r24, 1
+  AddInt       r27, r4, r24
+  Move         r4, r27
   SetGlobal    4,4,0,0
   // while y < height {
   Jump         L3
 L0:
   // var seed = 1
-  Const        r21, 1
-  Move         r5, r21
+  Const        r24, 1
+  Move         r5, r24
   SetGlobal    5,5,0,0
   // let vertices: list<list<int>> = [[0, height - 1], [width - 1, height - 1], [(width / 2) as int, 0]]
-  Const        r25, [[0, 50], [59, 50], [30, 0]]
-  Move         r6, r25
+  Const        r17, 0
+  Move         r31, r17
+  Const        r24, 1
+  Sub          r33, r1, r24
+  Move         r32, r33
+  MakeList     r34, 2, r31
+  Move         r28, r34
+  Const        r24, 1
+  SubInt       r37, r0, r24
+  Move         r35, r37
+  Const        r24, 1
+  Sub          r38, r1, r24
+  Move         r36, r38
+  MakeList     r39, 2, r35
+  Move         r29, r39
+  Const        r42, 2
+  DivInt       r43, r0, r42
+  Cast         r44, r43, int
+  Move         r40, r44
+  Const        r17, 0
+  Move         r41, r17
+  MakeList     r45, 2, r40
+  Move         r30, r45
+  MakeList     r46, 3, r28
+  Move         r6, r46
   SetGlobal    6,6,0,0
   // var px = (width / 2) as int
-  Const        r26, 30
-  Move         r7, r26
+  Const        r42, 2
+  DivInt       r47, r0, r42
+  Cast         r48, r47, int
+  Move         r7, r48
   SetGlobal    7,7,0,0
   // var py = (height / 2) as int
-  Const        r27, 25
-  Move         r8, r27
+  Const        r42, 2
+  Div          r49, r1, r42
+  Cast         r50, r49, int
+  Move         r8, r50
   SetGlobal    8,8,0,0
   // var i = 0
-  Const        r14, 0
-  Move         r9, r14
+  Const        r17, 0
+  Move         r9, r17
   SetGlobal    9,9,0,0
 L7:
   // while i < iterations {
-  Const        r12, 5000
-  LessInt      r28, r9, r12
-  JumpIfFalse  r28, L4
+  LessInt      r51, r9, r2
+  JumpIfFalse  r51, L4
   // var r = randInt(seed, 3)
-  Move         r29, r5
-  Const        r31, 3
-  Move         r30, r31
-  Call2        r32, randInt, r29, r30
-  Move         r33, r32
+  Move         r52, r5
+  Const        r54, 3
+  Move         r53, r54
+  Call2        r55, randInt, r52, r53
+  Move         r56, r55
   // seed = r[0]
-  Const        r14, 0
-  Index        r34, r33, r14
-  Move         r5, r34
+  Const        r17, 0
+  Index        r57, r56, r17
+  Move         r5, r57
   SetGlobal    5,5,0,0
   // let idx = r[1] as int
-  Const        r21, 1
-  Index        r35, r33, r21
-  Cast         r36, r35, int
-  Move         r37, r36
+  Const        r24, 1
+  Index        r58, r56, r24
+  Cast         r59, r58, int
+  Move         r60, r59
   // let v = vertices[idx]
-  Index        r38, r6, r37
-  Move         r39, r38
+  Index        r61, r6, r60
+  Move         r62, r61
   // px = ((px + v[0]) / 2) as int
-  Const        r14, 0
-  Index        r40, r39, r14
-  Add          r41, r7, r40
+  Const        r17, 0
+  Index        r63, r62, r17
+  Add          r64, r7, r63
   Const        r42, 2
-  Div          r43, r41, r42
-  Cast         r44, r43, int
-  Move         r7, r44
+  Div          r65, r64, r42
+  Cast         r66, r65, int
+  Move         r7, r66
   SetGlobal    7,7,0,0
   // py = ((py + v[1]) / 2) as int
-  Const        r21, 1
-  Index        r45, r39, r21
-  Add          r46, r8, r45
+  Const        r24, 1
+  Index        r67, r62, r24
+  Add          r68, r8, r67
   Const        r42, 2
-  Div          r47, r46, r42
-  Cast         r48, r47, int
-  Move         r8, r48
+  Div          r69, r68, r42
+  Cast         r70, r69, int
+  Move         r8, r70
   SetGlobal    8,8,0,0
   // if px >= 0 && px < width && py >= 0 && py < height {
-  Const        r14, 0
-  LessEq       r49, r14, r7
-  Const        r10, 60
-  Less         r50, r7, r10
-  Const        r14, 0
-  LessEq       r51, r14, r8
-  Const        r11, 51
-  Less         r52, r8, r11
-  Move         r53, r49
-  JumpIfFalse  r53, L5
-  Move         r53, r50
-  JumpIfFalse  r53, L5
-  Move         r53, r51
-  JumpIfFalse  r53, L5
-  Move         r53, r52
+  Const        r17, 0
+  LessEq       r71, r17, r7
+  Less         r72, r7, r0
+  Const        r17, 0
+  LessEq       r73, r17, r8
+  Less         r74, r8, r1
+  Move         r75, r71
+  JumpIfFalse  r75, L5
+  Move         r75, r72
+  JumpIfFalse  r75, L5
+  Move         r75, r73
+  JumpIfFalse  r75, L5
+  Move         r75, r74
 L5:
-  JumpIfFalse  r53, L6
+  JumpIfFalse  r75, L6
   // grid[py][px] = "*"
-  Index        r54, r3, r8
-  Const        r55, "*"
-  SetIndex     r54, r7, r55
+  Index        r76, r3, r8
+  Const        r77, "*"
+  SetIndex     r76, r7, r77
   SetGlobal    3,3,0,0
 L6:
   // i = i + 1
-  Const        r21, 1
-  AddInt       r56, r9, r21
-  Move         r9, r56
+  Const        r24, 1
+  AddInt       r78, r9, r24
+  Move         r9, r78
   SetGlobal    9,9,0,0
   // while i < iterations {
   Jump         L7
 L4:
   // y = 0
-  Const        r14, 0
-  Move         r4, r14
+  Const        r17, 0
+  Move         r4, r17
   SetGlobal    4,4,0,0
 L11:
   // while y < height {
-  Const        r11, 51
-  LessInt      r57, r4, r11
-  JumpIfFalse  r57, L8
+  Less         r79, r4, r1
+  JumpIfFalse  r79, L8
   // var line = ""
-  Const        r58, ""
-  Move         r59, r58
+  Const        r80, ""
+  Move         r81, r80
   // var x = 0
-  Const        r14, 0
-  Move         r60, r14
+  Const        r17, 0
+  Move         r82, r17
 L10:
   // while x < width {
-  Const        r10, 60
-  LessInt      r61, r60, r10
-  JumpIfFalse  r61, L9
+  LessInt      r83, r82, r0
+  JumpIfFalse  r83, L9
   // line = line + grid[y][x]
-  Index        r62, r3, r4
-  Index        r63, r62, r60
-  Add          r64, r59, r63
-  Move         r59, r64
+  Index        r84, r3, r4
+  Index        r85, r84, r82
+  Add          r86, r81, r85
+  Move         r81, r86
   // x = x + 1
-  Const        r21, 1
-  AddInt       r65, r60, r21
-  Move         r60, r65
+  Const        r24, 1
+  AddInt       r87, r82, r24
+  Move         r82, r87
   // while x < width {
   Jump         L10
 L9:
   // print(line)
-  Print        r59
+  Print        r81
   // y = y + 1
-  Const        r21, 1
-  AddInt       r66, r4, r21
-  Move         r4, r66
+  Const        r24, 1
+  AddInt       r88, r4, r24
+  Move         r4, r88
   SetGlobal    4,4,0,0
   // while y < height {
   Jump         L11

--- a/tests/rosetta/ir/character-codes-1.bench
+++ b/tests/rosetta/ir/character-codes-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 43,
+  "duration_us": 440,
   "memory_bytes": 4056,
   "name": "main"
 }

--- a/tests/rosetta/ir/character-codes-2.bench
+++ b/tests/rosetta/ir/character-codes-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 28,
+  "duration_us": 949,
   "memory_bytes": 3912,
   "name": "main"
 }

--- a/tests/rosetta/ir/character-codes-3.bench
+++ b/tests/rosetta/ir/character-codes-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 40,
+  "duration_us": 404,
   "memory_bytes": 8600,
   "name": "main"
 }

--- a/tests/rosetta/ir/character-codes-4.bench
+++ b/tests/rosetta/ir/character-codes-4.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 38,
+  "duration_us": 502,
   "memory_bytes": 8968,
   "name": "main"
 }

--- a/tests/rosetta/ir/character-codes-5.bench
+++ b/tests/rosetta/ir/character-codes-5.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 42,
+  "duration_us": 459,
   "memory_bytes": 7192,
   "name": "main"
 }


### PR DESCRIPTION
## Summary
- regenerate IR and benchmark data for Rosetta programs 170-189
- refresh progress table in `runtime/vm/ROSETTA.md`
- update benchmark for `cantor-set`

## Testing
- `MOCHI_ROSETTA_INDEX=170 MOCHI_BENCHMARK=1 go test ./runtime/vm -run Rosetta_Golden -tags slow -count=1`
- executed loop over indices 170-189 with benchmarking enabled

------
https://chatgpt.com/codex/tasks/task_e_6885bb11fe308320abd7c45195fa0348