### PR TITLE
Add exponentiation-operator implementations

### DIFF
--- a/tests/rosetta/x/Go/exponentiation-operator-2.go
+++ b/tests/rosetta/x/Go/exponentiation-operator-2.go
@@ -1,0 +1,80 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "errors"
+    "fmt"
+)
+
+func expI(b, p int) (int, error) {
+    if p < 0 {
+        return 0, errors.New("negative power not allowed")
+    }
+    r := 1
+    for i := 1; i <= p; i++ {
+        r *= b
+    }
+    return r, nil
+}
+
+func expF(b float32, p int) float32 {
+    var neg bool
+    if p < 0 {
+        neg = true
+        p = -p
+    }
+    r := float32(1)
+    for pow := b; p > 0; pow *= pow {
+        if p&1 == 1 {
+            r *= pow
+        }
+        p >>= 1
+    }
+    if neg {
+        r = 1 / r
+    }
+    return r
+}
+
+func main() {
+    ti := func(b, p int) {
+        fmt.Printf("%d^%d: ", b, p)
+        e, err := expI(b, p)
+        if err != nil {
+            fmt.Println(err)
+        } else {
+            fmt.Println(e)
+        }
+    }
+
+    fmt.Println("expI tests")
+    ti(2, 10)
+    ti(2, -10)
+    ti(-2, 10)
+    ti(-2, 11)
+    ti(11, 0)
+
+    fmt.Println("overflow undetected")
+    ti(10, 10)
+
+    tf := func(b float32, p int) {
+        fmt.Printf("%g^%d: %g\n", b, p, expF(b, p))
+    }
+
+    fmt.Println("\nexpF tests:")
+    tf(2, 10)
+    tf(2, -10)
+    tf(-2, 10)
+    tf(-2, 11)
+    tf(11, 0)
+
+    fmt.Println("disallowed in expI, allowed here")
+    tf(0, -1)
+
+    fmt.Println("other interesting cases for 32 bit float type")
+    tf(10, 39)
+    tf(10, -39)
+    tf(-10, 39)
+}

--- a/tests/rosetta/x/Mochi/exponentiation-operator-2.mochi
+++ b/tests/rosetta/x/Mochi/exponentiation-operator-2.mochi
@@ -1,0 +1,63 @@
+// Another Mochi implementation of Rosetta "Exponentiation operator" task
+
+fun expI(b: int, p: int): int {
+  var r = 1
+  var i = 0
+  while i < p {
+    r = r * b
+    i = i + 1
+  }
+  return r
+}
+
+fun expF(b: float, p: int): float {
+  var r = 1.0
+  var pow = b
+  var n = p
+  var neg = false
+  if p < 0 {
+    n = -p
+    neg = true
+  }
+  while n > 0 {
+    if n % 2 == 1 { r = r * pow }
+    pow = pow * pow
+    n = n / 2
+  }
+  if neg { r = 1.0 / r }
+  return r
+}
+
+fun printExpF(b: float, p: int) {
+  if b == 0.0 && p < 0 {
+    print(str(b) + "^" + str(p) + ": +Inf")
+  } else {
+    print(str(b) + "^" + str(p) + ": " + str(expF(b, p)))
+  }
+}
+
+fun main() {
+  print("expI tests")
+  for pair in [[2,10],[2,-10],[-2,10],[-2,11],[11,0]] {
+    if pair[1] < 0 {
+      print(str(pair[0]) + "^" + str(pair[1]) + ": negative power not allowed")
+    } else {
+      print(str(pair[0]) + "^" + str(pair[1]) + ": " + str(expI(pair[0], pair[1])))
+    }
+  }
+  print("overflow undetected")
+  print("10^10: " + str(expI(10,10)))
+
+  print("\nexpF tests:")
+  for pair in [[2.0,10],[2.0,-10],[-2.0,10],[-2.0,11],[11.0,0]] {
+    printExpF(pair[0], pair[1])
+  }
+  print("disallowed in expI, allowed here")
+  printExpF(0.0,-1)
+  print("other interesting cases for 32 bit float type")
+  printExpF(10.0,39)
+  printExpF(10.0,-39)
+  printExpF(-10.0,39)
+}
+
+main()

--- a/tests/rosetta/x/Mochi/exponentiation-operator-2.out
+++ b/tests/rosetta/x/Mochi/exponentiation-operator-2.out
@@ -1,0 +1,21 @@
+expI tests
+2^10: 1024
+2^-10: negative power not allowed
+-2^10: 1024
+-2^11: -2048
+11^0: 1
+overflow undetected
+10^10: 10000000000
+
+expF tests:
+2^10: 1024
+2^-10: 0.0009765625
+-2^10: 1024
+-2^11: -2048
+11^0: 1
+disallowed in expI, allowed here
+0^-1: +Inf
+other interesting cases for 32 bit float type
+10^39: 1.0000000000000001e+39
+10^-39: 1e-39
+-10^39: -1.0000000000000001e+39


### PR DESCRIPTION
## Summary
- fetch Rosetta task 342 (Exponentiation-operator) with rosetta tool
- add Go copy of the program
- create a new Mochi version runnable by `runtime/vm`
- include the expected output file

## Testing
- `go test ./runtime/vm -run Rosetta -tags slow` *(fails: signal killed)*

------
https://chatgpt.com/codex/tasks/task_e_6885db240b588320b0199deb548996c7