### PR TITLE
Add second Mochi solution for Faces-from-a-mesh

### DIFF
--- a/tests/rosetta/x/Mochi/faces-from-a-mesh-2.mochi
+++ b/tests/rosetta/x/Mochi/faces-from-a-mesh-2.mochi
@@ -1,0 +1,174 @@
+// Another Mochi implementation of "Faces from a mesh"
+// Ported from Go version
+
+type Edge { a: int, b: int }
+
+fun contains(xs: list<int>, v: int): bool {
+  for x in xs { if x == v { return true } }
+  return false
+}
+
+fun copyInts(xs: list<int>): list<int> {
+  var out: list<int> = []
+  for x in xs { out = append(out, x) }
+  return out
+}
+
+fun sliceEqual(a: list<int>, b: list<int>): bool {
+  var i = 0
+  while i < len(a) {
+    if a[i] != b[i] { return false }
+    i = i + 1
+  }
+  return true
+}
+
+fun reverse(xs: list<int>) {
+  var i = 0
+  var j = len(xs) - 1
+  while i < j {
+    let t = xs[i]
+    xs[i] = xs[j]
+    xs[j] = t
+    i = i + 1
+    j = j - 1
+  }
+}
+
+fun perimEqual(p1: list<int>, p2: list<int>): bool {
+  if len(p1) != len(p2) { return false }
+  for v in p1 { if !contains(p2, v) { return false } }
+  var c = copyInts(p1)
+  var r = 0
+  while r < 2 {
+    var i = 0
+    while i < len(c) {
+      if sliceEqual(c, p2) { return true }
+      let t = c[len(c)-1]
+      var j = len(c)-1
+      while j > 0 {
+        c[j] = c[j-1]
+        j = j - 1
+      }
+      c[0] = t
+      i = i + 1
+    }
+    reverse(c)
+    r = r + 1
+  }
+  return false
+}
+
+fun sortEdges(es: list<Edge>): list<Edge> {
+  var arr = es
+  var n = len(arr)
+  var i = 0
+  while i < n {
+    var j = 0
+    while j < n-1 {
+      let a = arr[j]
+      let b = arr[j+1]
+      if a.a > b.a || (a.a == b.a && a.b > b.b) {
+        arr[j] = b
+        arr[j+1] = a
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  return arr
+}
+
+fun concat(a: list<Edge>, b: list<Edge>): list<Edge> {
+  var out: list<Edge> = []
+  for x in a { out = append(out, x) }
+  for x in b { out = append(out, x) }
+  return out
+}
+
+fun faceToPerim(face: list<Edge>): any {
+  var le = len(face)
+  if le == 0 { return nil }
+  var edges: list<Edge> = []
+  var i = 0
+  while i < le {
+    let e = face[i]
+    if e.b <= e.a { return nil }
+    edges = append(edges, e)
+    i = i + 1
+  }
+  edges = sortEdges(edges)
+  var firstEdge = edges[0]
+  var perim: list<int> = [firstEdge.a, firstEdge.b]
+  var first = firstEdge.a
+  var last = firstEdge.b
+  edges = edges[1:len(edges)]
+  le = len(edges)
+  var done = false
+  while le > 0 && (!done) {
+    var idx = 0
+    var found = false
+    while idx < le {
+      let e = edges[idx]
+      if e.a == last {
+        perim = append(perim, e.b)
+        last = e.b
+        found = true
+      } else if e.b == last {
+        perim = append(perim, e.a)
+        last = e.a
+        found = true
+      }
+      if found {
+        edges = concat(edges[:idx], edges[idx+1:len(edges)])
+        le = le - 1
+        if last == first {
+          if le == 0 { done = true } else { return nil }
+        }
+        break
+      }
+      idx = idx + 1
+    }
+    if !found { return nil }
+  }
+  return perim[:len(perim)-1]
+}
+
+fun listStr(xs: list<int>): string {
+  var s = "["
+  var i = 0
+  while i < len(xs) {
+    s = s + str(xs[i])
+    if i < len(xs)-1 { s = s + " " }
+    i = i + 1
+  }
+  s = s + "]"
+  return s
+}
+
+fun main() {
+  print("Perimeter format equality checks:")
+  print("  Q == R is " + str(perimEqual([8,1,3], [1,3,8])))
+  print("  U == V is " + str(perimEqual([18,8,14,10,12,17,19], [8,14,10,12,17,19,18])))
+
+  let e = [Edge{a:7,b:11}, Edge{a:1,b:11}, Edge{a:1,b:7}]
+  let f = [Edge{a:11,b:23}, Edge{a:1,b:17}, Edge{a:17,b:23}, Edge{a:1,b:11}]
+  let g = [Edge{a:8,b:14}, Edge{a:17,b:19}, Edge{a:10,b:12}, Edge{a:10,b:14}, Edge{a:12,b:17}, Edge{a:8,b:18}, Edge{a:18,b:19}]
+  let h = [Edge{a:1,b:3}, Edge{a:9,b:11}, Edge{a:3,b:11}, Edge{a:1,b:11}]
+
+  print("\nEdge to perimeter format translations:")
+  var faces = [e, f, g, h]
+  var names = ["E", "F", "G", "H"]
+  var idx = 0
+  while idx < len(faces) {
+    let per = faceToPerim(faces[idx])
+    if per == nil {
+      print("  " + names[idx] + " => Invalid edge format")
+    } else {
+      print("  " + names[idx] + " => " + listStr(per as list<int>))
+    }
+    idx = idx + 1
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/faces-from-a-mesh-2.out
+++ b/tests/rosetta/x/Mochi/faces-from-a-mesh-2.out
@@ -1,0 +1,9 @@
+Perimeter format equality checks:
+  Q == R is true
+  U == V is true
+
+Edge to perimeter format translations:
+  E => [1 7 11]
+  F => [1 11 23 17]
+  G => [8 14 10 12 17 19 18]
+  H => Invalid edge format


### PR DESCRIPTION
## Summary
- add a second Mochi implementation for the "Faces from a mesh" Rosetta task
- include matching `.out` file with expected output

## Testing
- `MOCHI_ROSETTA_ONLY=faces-from-a-mesh-2 go test ./runtime/vm -run Rosetta -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6885db6b74f08320b11e0a18d7309bba