### PR TITLE
Add computed extensible prime generator

### DIFF
--- a/tests/rosetta/x/Mochi/extensible-prime-generator.mochi
+++ b/tests/rosetta/x/Mochi/extensible-prime-generator.mochi
@@ -1,18 +1,58 @@
 // Mochi translation of Rosetta "Extensible prime generator" task
-// Precomputed output to avoid heavy computation.
+// Generates primes using trial division and reproduces the Go output.
 
-fun joinInts(xs: list<int>): string {
-  var s = ""
-  var i = 0
-  while i < len(xs) {
-    if i > 0 { s = s + " " }
-    s = s + str(xs[i])
-    i = i + 1
+fun nextPrime(primes: list<int>, start: int): int {
+  var n = start
+  while true {
+    var isP = true
+    var i = 0
+    while i < len(primes) {
+      let p = primes[i]
+      if p * p > n { break }
+      if n % p == 0 { isP = false; break }
+      i = i + 1
+    }
+    if isP { return n }
+    n = n + 2
   }
-  return s
 }
 
-print("First twenty: " + joinInts([2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71]))
-print("Between 100 and 150: 101 103 107 109 113 127 131 137 139 149")
-print("Number beween 7,700 and 8,000: 30")
-print("10,000th prime: 104729")
+fun main() {
+  var primes: list<int> = [2]
+  var cand = 3
+  while len(primes) < 10000 {
+    cand = nextPrime(primes, cand)
+    primes = append(primes, cand)
+    cand = cand + 2
+  }
+
+  var line = "First twenty:"
+  var i = 0
+  while i < 20 {
+    line = line + " " + str(primes[i])
+    i = i + 1
+  }
+  print(line)
+
+  var idx = 0
+  while primes[idx] <= 100 { idx = idx + 1 }
+  line = "Between 100 and 150: " + str(primes[idx])
+  idx = idx + 1
+  while primes[idx] < 150 {
+    line = line + " " + str(primes[idx])
+    idx = idx + 1
+  }
+  print(line)
+
+  while primes[idx] <= 7700 { idx = idx + 1 }
+  var count = 0
+  while primes[idx] < 8000 {
+    count = count + 1
+    idx = idx + 1
+  }
+  print("Number beween 7,700 and 8,000: " + str(count))
+
+  print("10,000th prime: " + str(primes[9999]))
+}
+
+main()


### PR DESCRIPTION
## Summary
- download Rosetta task 346 for Go (Extensible-prime-generator)
- implement the same algorithm in Mochi instead of printing constants
- ensure output matches reference

## Testing
- `go run -tags slow ./tools/rosetta/cmd/download_by_number.go -n 346 -refresh`
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/extensible-prime-generator.mochi > /tmp/extensible.out`


------
https://chatgpt.com/codex/tasks/task_e_6885db4bf05c8320880ce9fef1265603