### PR TITLE
Add release notes for v0.10.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # 📦 CHANGELOG.md
 
+## [0.10.42] – 2025-07-27T09:00:51+00:00
+
+### Added
+
+* Numerous new Rosetta programs such as Faulhabers formula, factorions and HQ9+
+* Deterministic `now` builtin with updated VM outputs
+* Dart transpiler gains slice support, BigInt indexing and block lambdas
+* C# adds delegate calls and literal match cases with improved indexing
+* C++ supports const maps, auto params and benchmark timing helpers
+* TypeScript compiler introduces async fetch and map containment
+* Python enumerations and environment variables improved
+
+### Changed
+
+* Rosetta progress index regenerated with refreshed outputs across languages
+* Documentation clarified for the Computer Zero interpreter
+
+### Fixed
+
+* Various closure ordering and map field bugs across backends
 ## [0.10.41] – 2025-07-26T12:01:29+07:00
 
 ### Added

--- a/releases/v0.10.42.md
+++ b/releases/v0.10.42.md
@@ -1,0 +1,20 @@
+# Jul 2025 (v0.10.42)
+
+Released on Sun Jul 27 09:00:51 2025 +0000.
+
+Mochi v0.10.42 expands compiler features with deterministic time handling and many new Rosetta programs.
+
+## Compilers
+
+- Dozens of new Rosetta implementations including Faulhaber's formula, factorions and HQ9+
+- Dart transpiler supports slices, BigInt indexing and block lambdas
+- C# adds delegate calls, literal match cases and improved array indexing
+- C++ handles const maps with auto parameters and benchmark timing
+- TypeScript introduces async fetch and map containment helpers
+- Python enumerations and environment variable handling improved
+- Rosetta outputs refreshed across languages
+
+## Documentation
+
+- Clarified Computer Zero interpreter usage
+- Progress index regenerated with new outputs


### PR DESCRIPTION
## Summary
- add release notes for v0.10.42
- update CHANGELOG for v0.10.42

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6885e9b1ec1c83209338f97c0580452a