### PR TITLE
Fix union tags in Clojure transpiler

### DIFF
--- a/tests/rosetta/transpiler/Clojure/abstract-type.bench
+++ b/tests/rosetta/transpiler/Clojure/abstract-type.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 24271,
+  "memory_bytes": 20975048,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/abstract-type.clj
+++ b/tests/rosetta/transpiler/Clojure/abstract-type.clj
@@ -2,26 +2,40 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare beastKind beastName beastCry bprint main)
 
 (defn beastKind [b]
-  (try (throw (ex-info "return" {:v (cond (and (map? b) (contains? b :kind) (contains? b :name)) (let [k (:kind b) _ (:name b)] k) (and (map? b) (contains? b :kind) (contains? b :name)) (let [k (:kind b) _ (:name b)] k))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (try (throw (ex-info "return" {:v (cond (and (map? b) (= (:__tag b) "Dog") (contains? b :kind) (contains? b :name)) (let [k (:kind b) _ (:name b)] k) (and (map? b) (= (:__tag b) "Cat") (contains? b :kind) (contains? b :name)) (let [k (:kind b) _ (:name b)] k))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn beastName [b]
-  (try (throw (ex-info "return" {:v (cond (and (map? b) (contains? b :kind) (contains? b :name)) (let [_ (:kind b) n (:name b)] n) (and (map? b) (contains? b :kind) (contains? b :name)) (let [_ (:kind b) n (:name b)] n))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (try (throw (ex-info "return" {:v (cond (and (map? b) (= (:__tag b) "Dog") (contains? b :kind) (contains? b :name)) (let [_ (:kind b) n (:name b)] n) (and (map? b) (= (:__tag b) "Cat") (contains? b :kind) (contains? b :name)) (let [_ (:kind b) n (:name b)] n))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn beastCry [b]
-  (try (throw (ex-info "return" {:v (cond (and (map? b) (contains? b :kind) (contains? b :name)) (let [_ (:kind b) _ (:name b)] "Woof") (and (map? b) (contains? b :kind) (contains? b :name)) (let [_ (:kind b) _ (:name b)] "Meow"))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (try (throw (ex-info "return" {:v (cond (and (map? b) (= (:__tag b) "Dog") (contains? b :kind) (contains? b :name)) (let [_ (:kind b) _ (:name b)] "Woof") (and (map? b) (= (:__tag b) "Cat") (contains? b :kind) (contains? b :name)) (let [_ (:kind b) _ (:name b)] "Meow"))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn bprint [b]
   (println (str (str (str (str (str (beastName b) ", who's a ") (beastKind b)) ", cries: \"") (beastCry b)) "\".")))
 
 (defn main []
-  (do (def d {:kind "labrador" :name "Max"}) (def c {:kind "siamese" :name "Sammy"}) (bprint d) (bprint c)))
+  (do (def d {:__tag "Dog" :kind "labrador" :name "Max"}) (def c {:__tag "Cat" :kind "siamese" :name "Sammy"}) (bprint d) (bprint c)))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/abstract-type.out
+++ b/tests/rosetta/transpiler/Clojure/abstract-type.out
@@ -1,2 +1,2 @@
 Max, who's a labrador, cries: "Woof".
-Sammy, who's a siamese, cries: "Woof".
+Sammy, who's a siamese, cries: "Meow".

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 20/341
-Last updated: 2025-07-27 01:03 +0700
+Completed: 20/465
+Last updated: 2025-07-27 16:10 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -28,7 +28,7 @@ Last updated: 2025-07-27 01:03 +0700
 | 21 | abc-problem | ✓ | 46.947ms | 20.6 MB |
 | 22 | abelian-sandpile-model-identity | ✓ |  |  |
 | 23 | abelian-sandpile-model |   |  |  |
-| 24 | abstract-type | ✓ |  |  |
+| 24 | abstract-type | ✓ | 24.271ms | 20.0 MB |
 | 25 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
 | 26 | abundant-odd-numbers |   |  |  |
 | 27 | accumulator-factory |   |  |  |
@@ -334,15 +334,139 @@ Last updated: 2025-07-27 01:03 +0700
 | 327 | dynamic-variable-names |   |  |  |
 | 328 | earliest-difference-between-prime-gaps |   |  |  |
 | 329 | eban-numbers |   |  |  |
-| 330 | echo-server |   |  |  |
-| 331 | eertree |   |  |  |
-| 332 | egyptian-division |   |  |  |
-| 333 | ekg-sequence-convergence |   |  |  |
-| 334 | element-wise-operations |   |  |  |
-| 335 | elementary-cellular-automaton-infinite-length |   |  |  |
-| 336 | elementary-cellular-automaton-random-number-generator |   |  |  |
-| 337 | elementary-cellular-automaton |   |  |  |
-| 338 | elliptic-curve-arithmetic |   |  |  |
-| 339 | emirp-primes |   |  |  |
-| 340 | empty-directory |   |  |  |
-| 341 | md5 |   |  |  |
+| 330 | ecdsa-example |   |  |  |
+| 331 | echo-server |   |  |  |
+| 332 | eertree |   |  |  |
+| 333 | egyptian-division |   |  |  |
+| 334 | ekg-sequence-convergence |   |  |  |
+| 335 | element-wise-operations |   |  |  |
+| 336 | elementary-cellular-automaton-infinite-length |   |  |  |
+| 337 | elementary-cellular-automaton-random-number-generator |   |  |  |
+| 338 | elementary-cellular-automaton |   |  |  |
+| 339 | elliptic-curve-arithmetic |   |  |  |
+| 340 | elliptic-curve-digital-signature-algorithm |   |  |  |
+| 341 | emirp-primes |   |  |  |
+| 342 | empty-directory |   |  |  |
+| 343 | empty-program |   |  |  |
+| 344 | empty-string-1 |   |  |  |
+| 345 | empty-string-2 |   |  |  |
+| 346 | enforced-immutability |   |  |  |
+| 347 | entropy-1 |   |  |  |
+| 348 | entropy-2 |   |  |  |
+| 349 | entropy-narcissist |   |  |  |
+| 350 | enumerations-1 |   |  |  |
+| 351 | enumerations-2 |   |  |  |
+| 352 | enumerations-3 |   |  |  |
+| 353 | enumerations-4 |   |  |  |
+| 354 | environment-variables-1 |   |  |  |
+| 355 | environment-variables-2 |   |  |  |
+| 356 | equal-prime-and-composite-sums |   |  |  |
+| 357 | equilibrium-index |   |  |  |
+| 358 | erd-s-nicolas-numbers |   |  |  |
+| 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
+| 360 | esthetic-numbers |   |  |  |
+| 361 | ethiopian-multiplication |   |  |  |
+| 362 | euclid-mullin-sequence |   |  |  |
+| 363 | euler-method |   |  |  |
+| 364 | eulers-constant-0.5772... |   |  |  |
+| 365 | eulers-identity |   |  |  |
+| 366 | eulers-sum-of-powers-conjecture |   |  |  |
+| 367 | evaluate-binomial-coefficients |   |  |  |
+| 368 | even-or-odd |   |  |  |
+| 369 | events |   |  |  |
+| 370 | evolutionary-algorithm |   |  |  |
+| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
+| 372 | exceptions |   |  |  |
+| 373 | executable-library |   |  |  |
+| 374 | execute-a-markov-algorithm |   |  |  |
+| 375 | execute-a-system-command |   |  |  |
+| 376 | execute-brain- |   |  |  |
+| 377 | execute-computer-zero-1 |   |  |  |
+| 378 | execute-computer-zero |   |  |  |
+| 379 | execute-hq9+ |   |  |  |
+| 380 | execute-snusp |   |  |  |
+| 381 | exponentiation-operator-2 |   |  |  |
+| 382 | exponentiation-operator |   |  |  |
+| 383 | exponentiation-order |   |  |  |
+| 384 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
+| 385 | extend-your-language |   |  |  |
+| 386 | extensible-prime-generator |   |  |  |
+| 387 | extreme-floating-point-values |   |  |  |
+| 388 | faces-from-a-mesh-2 |   |  |  |
+| 389 | faces-from-a-mesh |   |  |  |
+| 390 | factorial-base-numbers-indexing-permutations-of-a-collection |   |  |  |
+| 391 | factorial-primes |   |  |  |
+| 392 | factorial |   |  |  |
+| 393 | factorions |   |  |  |
+| 394 | factors-of-a-mersenne-number |   |  |  |
+| 395 | factors-of-an-integer |   |  |  |
+| 396 | fairshare-between-two-and-more |   |  |  |
+| 397 | farey-sequence |   |  |  |
+| 398 | fast-fourier-transform |   |  |  |
+| 399 | fasta-format |   |  |  |
+| 400 | faulhabers-formula |   |  |  |
+| 401 | faulhabers-triangle |   |  |  |
+| 402 | feigenbaum-constant-calculation |   |  |  |
+| 403 | fermat-numbers |   |  |  |
+| 404 | fibonacci-n-step-number-sequences |   |  |  |
+| 405 | fibonacci-sequence-1 |   |  |  |
+| 406 | fibonacci-sequence-2 |   |  |  |
+| 407 | fibonacci-sequence-3 |   |  |  |
+| 408 | fibonacci-sequence-4 |   |  |  |
+| 409 | fibonacci-word-fractal |   |  |  |
+| 410 | fibonacci-word |   |  |  |
+| 411 | file-extension-is-in-extensions-list |   |  |  |
+| 412 | file-input-output-1 |   |  |  |
+| 413 | file-input-output-2 |   |  |  |
+| 414 | file-modification-time |   |  |  |
+| 415 | file-size-distribution |   |  |  |
+| 416 | file-size |   |  |  |
+| 417 | filter |   |  |  |
+| 418 | find-chess960-starting-position-identifier |   |  |  |
+| 419 | find-common-directory-path |   |  |  |
+| 420 | find-duplicate-files |   |  |  |
+| 421 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 422 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 423 | find-limit-of-recursion |   |  |  |
+| 424 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 425 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 426 | find-the-intersection-of-two-lines |   |  |  |
+| 427 | find-the-last-sunday-of-each-month |   |  |  |
+| 428 | find-the-missing-permutation |   |  |  |
+| 429 | fivenum-1 |   |  |  |
+| 430 | fivenum-2 |   |  |  |
+| 431 | fixed-length-records-1 |   |  |  |
+| 432 | fixed-length-records-2 |   |  |  |
+| 433 | fizzbuzz-1 |   |  |  |
+| 434 | fizzbuzz-2 |   |  |  |
+| 435 | flatten-a-list-1 |   |  |  |
+| 436 | flatten-a-list-2 |   |  |  |
+| 437 | flipping-bits-game |   |  |  |
+| 438 | flow-control-structures-1 |   |  |  |
+| 439 | flow-control-structures-2 |   |  |  |
+| 440 | flow-control-structures-3 |   |  |  |
+| 441 | flow-control-structures-4 |   |  |  |
+| 442 | floyd-warshall-algorithm |   |  |  |
+| 443 | floyds-triangle |   |  |  |
+| 444 | forest-fire |   |  |  |
+| 445 | fork |   |  |  |
+| 446 | ftp |   |  |  |
+| 447 | gamma-function |   |  |  |
+| 448 | general-fizzbuzz |   |  |  |
+| 449 | generic-swap |   |  |  |
+| 450 | get-system-command-output |   |  |  |
+| 451 | giuga-numbers |   |  |  |
+| 452 | globally-replace-text-in-several-files |   |  |  |
+| 453 | goldbachs-comet |   |  |  |
+| 454 | golden-ratio-convergence |   |  |  |
+| 455 | graph-colouring |   |  |  |
+| 456 | gray-code |   |  |  |
+| 457 | http |   |  |  |
+| 458 | image-noise |   |  |  |
+| 459 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 460 | md5 |   |  |  |
+| 461 | nim-game |   |  |  |
+| 462 | plasma-effect |   |  |  |
+| 463 | sorting-algorithms-bubble-sort |   |  |  |
+| 464 | window-management |   |  |  |
+| 465 | zumkeller-numbers |   |  |  |


### PR DESCRIPTION
## Summary
- support union variants in the Clojure transpiler
- regenerate `abstract-type` Rosetta example
- update Clojure Rosetta table with benchmark results

## Testing
- `go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index=24 -update -count=1`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index=24 -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6885eace65b083209003fca52b7976c5