### PR TITLE
Fix C++ transpiler function types

### DIFF
--- a/tests/rosetta/transpiler/CPP/call-a-function-3.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-3.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 50,
+  "memory_bytes": 13344768,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-4.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-4.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 48,
+  "memory_bytes": 13295616,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-5.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-5.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 252,
+  "memory_bytes": 13590528,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-6.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-6.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 253,
+  "memory_bytes": 13176832,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-7.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-7.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 22,
+  "memory_bytes": 13414400,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-8.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-8.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 57,
+  "memory_bytes": 13500416,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-a-function-9.bench
+++ b/tests/rosetta/transpiler/CPP/call-a-function-9.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 56,
+  "memory_bytes": 13410304,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/CPP/call-an-object-method-1.bench
+++ b/tests/rosetta/transpiler/CPP/call-an-object-method-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 15,
+  "memory_bytes": 12898304,
+  "name": "main"
+}

--- a/transpiler/x/cpp/ROSETTA.md
+++ b/transpiler/x/cpp/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This directory stores C++ code generated from Mochi programs in `tests/rosetta/x/Mochi`. Each file is compiled and executed during tests. Successful runs keep the generated `.cpp` source along with a matching `.out` file. Failures are recorded in `.error` files when tests run with `-update`.
 
-Checklist of programs that currently transpile and run (140/465) - Last updated 2025-07-27 15:57 +0700:
+Checklist of programs that currently transpile and run (140/465) - Last updated 2025-07-27 16:50 +0700:
 | Index | Name | Status | Duration | Memory |
 | ---: | --- | :---: | ---: | ---: |
 | 1 | 100-doors-2 | ✓ | 222.0µs | 13.12MB |
@@ -160,14 +160,14 @@ Checklist of programs that currently transpile and run (140/465) - Last updated 
 | 153 | call-a-function-11 | ✓ | 311.0µs | 12.50MB |
 | 154 | call-a-function-12 | ✓ | 250.0µs | 12.89MB |
 | 155 | call-a-function-2 | ✓ | 41.0µs | 12.65MB |
-| 156 | call-a-function-3 | ✓ |  |  |
-| 157 | call-a-function-4 | ✓ |  |  |
-| 158 | call-a-function-5 | ✓ |  |  |
-| 159 | call-a-function-6 | ✓ |  |  |
-| 160 | call-a-function-7 | ✓ |  |  |
-| 161 | call-a-function-8 | ✓ |  |  |
-| 162 | call-a-function-9 | ✓ |  |  |
-| 163 | call-an-object-method-1 | ✓ |  |  |
+| 156 | call-a-function-3 | ✓ | 50.0µs | 12.73MB |
+| 157 | call-a-function-4 | ✓ | 48.0µs | 12.68MB |
+| 158 | call-a-function-5 | ✓ | 252.0µs | 12.96MB |
+| 159 | call-a-function-6 | ✓ | 253.0µs | 12.57MB |
+| 160 | call-a-function-7 | ✓ | 22.0µs | 12.79MB |
+| 161 | call-a-function-8 | ✓ | 57.0µs | 12.88MB |
+| 162 | call-a-function-9 | ✓ | 56.0µs | 12.79MB |
+| 163 | call-an-object-method-1 | ✓ | 15.0µs | 12.30MB |
 | 164 | call-an-object-method-2 |   |  |  |
 | 165 | call-an-object-method-3 |   |  |  |
 | 166 | call-an-object-method |   |  |  |

--- a/transpiler/x/cpp/transpiler.go
+++ b/transpiler/x/cpp/transpiler.go
@@ -5850,9 +5850,30 @@ func cppTypeFrom(tp types.Type) string {
 		return "std::any"
 	case types.FuncType:
 		if currentProgram != nil {
-			currentProgram.addInclude("<any>")
+			currentProgram.addInclude("<functional>")
 		}
-		return "std::any"
+		ret := "void"
+		if t.Return != nil {
+			ret = cppTypeFrom(t.Return)
+		}
+		if ret == "auto" {
+			if currentProgram != nil {
+				currentProgram.addInclude("<any>")
+			}
+			ret = "std::any"
+		}
+		var params []string
+		for _, p := range t.Params {
+			pt := cppTypeFrom(p)
+			if pt == "auto" {
+				if currentProgram != nil {
+					currentProgram.addInclude("<any>")
+				}
+				pt = "std::any"
+			}
+			params = append(params, pt)
+		}
+		return fmt.Sprintf("std::function<%s(%s)>", ret, strings.Join(params, ", "))
 	case types.ListType:
 		return fmt.Sprintf("std::vector<%s>", cppTypeFrom(t.Elem))
 	case types.MapType:


### PR DESCRIPTION
## Summary
- improve C++ type generation for `fun` types, producing `std::function`
- regenerate Rosetta benchmarks for indices 156–163

## Testing
- `ROSETTA_INDEX=161 MOCHI_BENCHMARK=1 go test ./transpiler/x/cpp -tags slow -run TestCPPTranspiler_Rosetta_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6885f9343ed08320bb10f06fbc22c922