### PR TITLE
Update Clojure transpiler Rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Clojure/active-directory-connect.bench
+++ b/tests/rosetta/transpiler/Clojure/active-directory-connect.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 18043,
+  "memory_bytes": 19591520,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/active-directory-search-for-a-user.bench
+++ b/tests/rosetta/transpiler/Clojure/active-directory-search-for-a-user.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 19549,
+  "memory_bytes": 25493472,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/active-directory-search-for-a-user.clj
+++ b/tests/rosetta/transpiler/Clojure/active-directory-search-for-a-user.clj
@@ -6,6 +6,9 @@
 
 (defrecord Client [Base Host Port GroupFilter])
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare search_user main)
@@ -17,6 +20,17 @@
   (do (def client {"Base" "dc=example,dc=com" "Host" "ldap.example.com" "Port" 389 "GroupFilter" "(memberUid=%s)"}) (def directory {"username" ["admins" "users"] "john" ["users"]}) (def groups (search_user directory "username")) (if (> (count groups) 0) (do (def out "Groups: [") (def i 0) (while (< i (count groups)) (do (def out (str (str (str out "\"") (nth groups i)) "\"")) (when (< i (- (count groups) 1)) (def out (str out ", "))) (def i (+ i 1)))) (def out (str out "]")) (println out)) (println "User not found"))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/active-object.bench
+++ b/tests/rosetta/transpiler/Clojure/active-object.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 37262,
+  "memory_bytes": 20994664,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/add-a-variable-to-a-class-instance-at-runtime.bench
+++ b/tests/rosetta/transpiler/Clojure/add-a-variable-to-a-class-instance-at-runtime.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 15428,
+  "memory_bytes": 19678696,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/add-a-variable-to-a-class-instance-at-runtime.clj
+++ b/tests/rosetta/transpiler/Clojure/add-a-variable-to-a-class-instance-at-runtime.clj
@@ -2,14 +2,28 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare main)
 
 (defn main []
-  (do (def ss {:runtimeFields {}}) (println "Create two fields at runtime: \n") (def i 1) (while (<= i 2) (do (println (str (str "  Field #" (str i)) ":\n")) (println "       Enter name  : ") (def name (read-line)) (println "       Enter value : ") (def value (read-line)) (def fields (:runtimeFields ss)) (def fields (assoc fields name value)) (def ss (assoc ss :runtimeFields fields)) (println "\n") (def i (+ i 1)))) (while true (do (println "Which field do you want to inspect ? ") (def name (read-line)) (if (in name (:runtimeFields ss)) (do (def value (nth (:runtimeFields ss) name)) (println (str (str "Its value is '" value) "'")) (throw (ex-info "return" {:v nil}))) (println "There is no field of that name, try again\n"))))))
+  (try (do (def ss {:runtimeFields {}}) (println "Create two fields at runtime: \n") (def i 1) (while (<= i 2) (do (println (str (str "  Field #" (str i)) ":\n")) (println "       Enter name  : ") (def name (read-line)) (println "       Enter value : ") (def value (read-line)) (def fields (:runtimeFields ss)) (def fields (assoc fields name value)) (def ss (assoc ss :runtimeFields fields)) (println "\n") (def i (+ i 1)))) (while true (do (println "Which field do you want to inspect ? ") (def name (read-line)) (if (in name (:runtimeFields ss)) (do (def value (get (:runtimeFields ss) name)) (println (str (str "Its value is '" value) "'")) (throw (ex-info "return" {:v nil}))) (println "There is no field of that name, try again\n"))))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/additive-primes.bench
+++ b/tests/rosetta/transpiler/Clojure/additive-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 76429,
+  "memory_bytes": 21422744,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/additive-primes.clj
+++ b/tests/rosetta/transpiler/Clojure/additive-primes.clj
@@ -2,6 +2,9 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (declare isPrime sumDigits pad main)
@@ -13,12 +16,23 @@
   (try (do (def s 0) (def x n) (while (> x 0) (do (def s (+ s (mod x 10))) (def x (int (/ x 10))))) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn pad [n]
-  (do (when (< n 10) (throw (ex-info "return" {:v (str "  " (str n))}))) (if (< n 100) (str " " (str n)) (str n))))
+  (try (do (when (< n 10) (throw (ex-info "return" {:v (str "  " (str n))}))) (if (< n 100) (str " " (str n)) (str n))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (println "Additive primes less than 500:") (def count 0) (def line "") (def lineCount 0) (def i 2) (while (< i 500) (do (when (and (isPrime i) (isPrime (sumDigits i))) (do (def count (+ count 1)) (def line (str (str line (pad i)) "  ")) (def lineCount (+ lineCount 1)) (when (= lineCount 10) (do (println (subs line 0 (- (count line) 2))) (def line "") (def lineCount 0))))) (if (> i 2) (def i (+ i 2)) (def i (+ i 1))))) (when (> lineCount 0) (println (subs line 0 (- (count line) 2)))) (println (str (str count) " additive primes found."))))
+  (do (println "Additive primes less than 500:") (def count_v 0) (def line "") (def lineCount 0) (def i 2) (while (< i 500) (do (when (and (isPrime i) (isPrime (sumDigits i))) (do (def count_v (+ count_v 1)) (def line (str (str line (pad i)) "  ")) (def lineCount (+ lineCount 1)) (when (= lineCount 10) (do (println (subs line 0 (- (count line) 2))) (def line "") (def lineCount 0))))) (if (> i 2) (def i (+ i 2)) (def i (+ i 1))))) (when (> lineCount 0) (println (subs line 0 (- (count line) 2)))) (println (str (str count_v) " additive primes found."))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/address-of-a-variable.bench
+++ b/tests/rosetta/transpiler/Clojure/address-of-a-variable.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 14698,
+  "memory_bytes": 18774136,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/address-of-a-variable.clj
+++ b/tests/rosetta/transpiler/Clojure/address-of-a-variable.clj
@@ -2,12 +2,26 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
 (def myVar 3.14)
 
 (defn -main []
-  (println "value as float:" myVar)
-  (println "address: <not available>"))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (println "value as float:" myVar)
+      (println "address: <not available>")
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/adfgvx-cipher.clj
+++ b/tests/rosetta/transpiler/Clojure/adfgvx-cipher.clj
@@ -2,7 +2,12 @@
 
 (require 'clojure.set)
 
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare shuffleStr createPolybius createKey orderKey encrypt indexOf decrypt main)
 
 (def adfgvx "ADFGVX")
 
@@ -15,13 +20,13 @@
   (try (do (def shuffled (shuffleStr alphabet)) (def labels []) (def li 0) (while (< li (count adfgvx)) (do (def labels (conj labels (subs adfgvx li (+ li 1)))) (def li (+ li 1)))) (println "6 x 6 Polybius square:\n") (println "  | A D F G V X") (println "---------------") (def p []) (def i 0) (while (< i 6) (do (def row (subvec shuffled (* i 6) (* (+ i 1) 6))) (def p (conj p row)) (def line (str (nth labels i) " | ")) (def j 0) (while (< j 6) (do (def line (str (str line (subvec row j (+ j 1))) " ")) (def j (+ j 1)))) (println line) (def i (+ i 1)))) (throw (ex-info "return" {:v p}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn createKey [n]
-  (try (do (when (or (< n 7) (> n 12)) (println "Key should be within 7 and 12 letters long.")) (def pool "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") (def key "") (def i 0) (while (< i n) (do (def idx (mod (swap! nowSeed (fn [s] (mod (+ (* s 1664525) 1013904223) 2147483647))) (count pool))) (def key (str key (nth pool idx))) (def pool (+ (subs pool 0 idx) (subs pool (+ idx 1) (count pool)))) (def i (+ i 1)))) (println (str "\nThe key is " key)) (throw (ex-info "return" {:v key}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (try (do (when (or (< n 7) (> n 12)) (println "Key should be within 7 and 12 letters long.")) (def pool "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") (def key "") (def i 0) (while (< i n) (do (def idx (mod (swap! nowSeed (fn [s] (mod (+ (* s 1664525) 1013904223) 2147483647))) (count pool))) (def key (str key (nth pool idx))) (def pool (str (subs pool 0 idx) (subs pool (+ idx 1) (count pool)))) (def i (+ i 1)))) (println (str "\nThe key is " key)) (throw (ex-info "return" {:v key}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn orderKey [key]
   (try (do (def pairs []) (def i 0) (while (< i (count key)) (do (def pairs (conj pairs [(subs key i (+ i 1)) i])) (def i (+ i 1)))) (def n (count pairs)) (def m 0) (while (< m n) (do (def j 0) (while (< j (- n 1)) (do (when (> (nth (nth pairs j) 0) (nth (nth pairs (+ j 1)) 0)) (do (def tmp (nth pairs j)) (def pairs (assoc pairs j (nth pairs (+ j 1)))) (def pairs (assoc pairs (+ j 1) tmp)))) (def j (+ j 1)))) (def m (+ m 1)))) (def res []) (def i 0) (while (< i n) (do (def res (conj res (int (nth (nth pairs i) 1)))) (def i (+ i 1)))) (throw (ex-info "return" {:v res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn encrypt [polybius key plainText]
-  (try (do (def labels []) (def li 0) (while (< li (count adfgvx)) (do (def labels (conj labels (subs adfgvx li (+ li 1)))) (def li (+ li 1)))) (def temp "") (def i 0) (while (< i (count plainText)) (do (def r 0) (while (< r 6) (do (def c 0) (while (< c 6) (do (when (= (subvec (nth polybius r) c (+ c 1)) (subs plainText i (+ i 1))) (def temp (str (str temp (subvec labels r (+ r 1))) (subvec labels c (+ c 1))))) (def c (+ c 1)))) (def r (+ r 1)))) (def i (+ i 1)))) (def colLen (/ (count temp) (count key))) (when (> (mod (count temp) (count key)) 0) (def colLen (+ colLen 1))) (def table []) (def rIdx 0) (while (< rIdx colLen) (do (def row []) (def j 0) (while (< j (count key)) (do (def row (conj row "")) (def j (+ j 1)))) (def table (conj table row)) (def rIdx (+ rIdx 1)))) (def idx 0) (while (< idx (count temp)) (do (def row (/ idx (count key))) (def col (mod idx (count key))) (def table (assoc-in table [row col] (subs temp idx (+ idx 1)))) (def idx (+ idx 1)))) (def order (orderKey key)) (def cols []) (def ci 0) (while (< ci (count key)) (do (def colStr "") (def ri 0) (while (< ri colLen) (do (def colStr (str colStr (nth (nth table ri) (nth order ci)))) (def ri (+ ri 1)))) (def cols (conj cols colStr)) (def ci (+ ci 1)))) (def result "") (def ci 0) (while (< ci (count cols)) (do (def result (str result (nth cols ci))) (when (< ci (- (count cols) 1)) (def result (str result " "))) (def ci (+ ci 1)))) (throw (ex-info "return" {:v result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+  (try (do (def labels []) (def li 0) (while (< li (count adfgvx)) (do (def labels (conj labels (subs adfgvx li (+ li 1)))) (def li (+ li 1)))) (def temp "") (def i 0) (while (< i (count plainText)) (do (def r 0) (while (< r 6) (do (def c 0) (while (< c 6) (do (when (= (subs (nth polybius r) c (+ c 1)) (subs plainText i (+ i 1))) (def temp (str (str temp (subvec labels r (+ r 1))) (subvec labels c (+ c 1))))) (def c (+ c 1)))) (def r (+ r 1)))) (def i (+ i 1)))) (def colLen (/ (count temp) (count key))) (when (> (mod (count temp) (count key)) 0) (def colLen (+ colLen 1))) (def table []) (def rIdx 0) (while (< rIdx colLen) (do (def row []) (def j 0) (while (< j (count key)) (do (def row (conj row "")) (def j (+ j 1)))) (def table (conj table row)) (def rIdx (+ rIdx 1)))) (def idx 0) (while (< idx (count temp)) (do (def row (/ idx (count key))) (def col (mod idx (count key))) (def table (assoc-in table [row col] (subs temp idx (+ idx 1)))) (def idx (+ idx 1)))) (def order (orderKey key)) (def cols []) (def ci 0) (while (< ci (count key)) (do (def colStr "") (def ri 0) (while (< ri colLen) (do (def colStr (str colStr (nth (nth table ri) (nth order ci)))) (def ri (+ ri 1)))) (def cols (conj cols colStr)) (def ci (+ ci 1)))) (def result "") (def ci 0) (while (< ci (count cols)) (do (def result (str result (nth cols ci))) (when (< ci (- (count cols) 1)) (def result (str result " "))) (def ci (+ ci 1)))) (throw (ex-info "return" {:v result}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn indexOf [s ch]
   (try (do (def i 0) (while (< i (count s)) (do (when (= (subs s i (+ i 1)) ch) (throw (ex-info "return" {:v i}))) (def i (+ i 1)))) (throw (ex-info "return" {:v (- 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
@@ -33,6 +38,17 @@
   (do (def plainText "ATTACKAT1200AM") (def polybius (createPolybius)) (def key (createKey 9)) (println (str "\nPlaintext : " plainText)) (def cipherText (encrypt polybius key plainText)) (println (str "\nEncrypted : " cipherText)) (def plainText2 (decrypt polybius key cipherText)) (println (str "\nDecrypted : " plainText2))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/tests/rosetta/transpiler/Clojure/aks-test-for-primes.clj
+++ b/tests/rosetta/transpiler/Clojure/aks-test-for-primes.clj
@@ -1,0 +1,35 @@
+(ns main (:refer-clojure :exclude [poly aks main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare poly aks main)
+
+(defn poly [p]
+  (try (do (def s "") (def coef 1) (def i p) (when (not= coef 1) (def s (str s (str coef)))) (while (> i 0) (do (def s (str s "x")) (when (not= i 1) (def s (str (str s "^") (str i)))) (def coef (int (/ (* coef i) (+ (- p i) 1)))) (def d coef) (when (= (mod (- p (- i 1)) 2) 1) (def d (- d))) (if (< d 0) (def s (str (str s " - ") (str (- d)))) (def s (str (str s " + ") (str d)))) (def i (- i 1)))) (when (= s "") (def s "1")) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn aks [n]
+  (try (do (when (< n 2) (throw (ex-info "return" {:v false}))) (def c n) (def i 1) (while (< i n) (do (when (not= (mod c n) 0) (throw (ex-info "return" {:v false}))) (def c (int (/ (* c (- n i)) (+ i 1)))) (def i (+ i 1)))) (throw (ex-info "return" {:v true}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def p 0) (while (<= p 7) (do (println (str (str (str p) ":  ") (poly p))) (def p (+ p 1)))) (def first true) (def p 2) (def line "") (while (< p 50) (do (when (aks p) (if first (do (def line (str line (str p))) (def first false)) (def line (str (str line " ") (str p))))) (def p (+ p 1)))) (println line)))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/align-columns.bench
+++ b/tests/rosetta/transpiler/Clojure/align-columns.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 26040,
+  "memory_bytes": 23462480,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/align-columns.clj
+++ b/tests/rosetta/transpiler/Clojure/align-columns.clj
@@ -1,0 +1,50 @@
+(ns main (:refer-clojure :exclude [split rstripEmpty spaces pad newFormatter printFmt]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare split rstripEmpty spaces pad newFormatter printFmt)
+
+(defn split [s sep]
+  (try (do (def parts []) (def cur "") (def i 0) (while (< i (count s)) (if (and (and (> (count sep) 0) (<= (+ i (count sep)) (count s))) (= (subs s i (+ i (count sep))) sep)) (do (def parts (conj parts cur)) (def cur "") (def i (+ i (count sep)))) (do (def cur (str cur (subs s i (+ i 1)))) (def i (+ i 1))))) (def parts (conj parts cur)) (throw (ex-info "return" {:v parts}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn rstripEmpty [words]
+  (try (do (def n (count words)) (while (and (> n 0) (= (nth words (- n 1)) "")) (def n (- n 1))) (throw (ex-info "return" {:v (subvec words 0 n)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn spaces [n]
+  (try (do (def out "") (def i 0) (while (< i n) (do (def out (str out " ")) (def i (+ i 1)))) (throw (ex-info "return" {:v out}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn pad [word width align]
+  (try (do (def diff (- width (count word))) (when (= align 0) (throw (ex-info "return" {:v (str word (spaces diff))}))) (when (= align 2) (throw (ex-info "return" {:v (str (spaces diff) word)}))) (def left (int (/ diff 2))) (def right (- diff left)) (throw (ex-info "return" {:v (str (str (spaces left) word) (spaces right))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn newFormatter [text]
+  (try (do (def lines (split text "\n")) (def fmtLines []) (def width []) (def i 0) (loop [while_flag_1 true] (when (and while_flag_1 (< i (count lines))) (cond (= (count (nth lines i)) 0) (do (def i (+ i 1)) (recur true)) :else (do (def words (rstripEmpty (split (nth lines i) "$"))) (def fmtLines (conj fmtLines words)) (def j 0) (while (< j (count words)) (do (def wlen (count (nth words j))) (if (= j (count width)) (def width (conj width wlen)) (when (> wlen (nth width j)) (def width (assoc width j wlen)))) (def j (+ j 1)))) (def i (+ i 1)) (recur while_flag_1))))) (throw (ex-info "return" {:v {"text" fmtLines "width" width}}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn printFmt [f align]
+  (do (def lines (get f "text")) (def width (get f "width")) (def i 0) (while (< i (count lines)) (do (def words (nth lines i)) (def line "") (def j 0) (while (< j (count words)) (do (def line (str (str line (pad (nth words j) (nth width j) align)) " ")) (def j (+ j 1)))) (println line) (def i (+ i 1)))) (println "")))
+
+(def text (str (str (str (str (str "Given$a$text$file$of$many$lines,$where$fields$within$a$line\n" "are$delineated$by$a$single$'dollar'$character,$write$a$program\n") "that$aligns$each$column$of$fields$by$ensuring$that$words$in$each\n") "column$are$separated$by$at$least$one$space.\n") "Further,$allow$for$each$word$in$a$column$to$be$either$left\n") "justified,$right$justified,$or$center$justified$within$its$column."))
+
+(def f (newFormatter text))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (printFmt f 0)
+      (printFmt f 1)
+      (printFmt f 2)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/aliquot-sequence-classifications.clj
+++ b/tests/rosetta/transpiler/Clojure/aliquot-sequence-classifications.clj
@@ -1,0 +1,58 @@
+(ns main (:refer-clojure :exclude [indexOf contains maxOf intSqrt sumProperDivisors classifySequence padLeft padRight joinWithCommas main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare indexOf contains maxOf intSqrt sumProperDivisors classifySequence padLeft padRight joinWithCommas main)
+
+(def THRESHOLD 140737488355328)
+
+(defn indexOf [xs value]
+  (try (do (def i 0) (while (< i (count xs)) (do (when (= (nth xs i) value) (throw (ex-info "return" {:v i}))) (def i (+ i 1)))) (throw (ex-info "return" {:v (- 0 1)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn contains [xs value]
+  (try (throw (ex-info "return" {:v (not= (indexOf xs value) (- 0 1))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn maxOf [a b]
+  (try (if (> a b) (throw (ex-info "return" {:v a})) (throw (ex-info "return" {:v b}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn intSqrt [n]
+  (try (do (when (= n 0) (throw (ex-info "return" {:v 0}))) (def x n) (def y (/ (+ x 1) 2)) (while (< y x) (do (def x y) (def y (/ (+ x (/ n x)) 2)))) (throw (ex-info "return" {:v x}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn sumProperDivisors [n]
+  (try (do (when (< n 2) (throw (ex-info "return" {:v 0}))) (def sqrt (intSqrt n)) (def sum 1) (def i 2) (while (<= i sqrt) (do (when (= (mod n i) 0) (def sum (+ (+ sum i) (/ n i)))) (def i (+ i 1)))) (when (= (* sqrt sqrt) n) (def sum (- sum sqrt))) (throw (ex-info "return" {:v sum}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn classifySequence [k]
+  (try (do (def last k) (def seq [k]) (while true (do (def last (sumProperDivisors last)) (def seq (conj seq last)) (def n (count seq)) (def aliquot "") (if (= last 0) (def aliquot "Terminating") (if (and (= n 2) (= last k)) (def aliquot "Perfect") (if (and (= n 3) (= last k)) (def aliquot "Amicable") (if (and (>= n 4) (= last k)) (def aliquot (str (str "Sociable[" (str (- n 1))) "]")) (if (= last (nth seq (- n 2))) (def aliquot "Aspiring") (if (contains (subvec seq 1 (maxOf 1 (- n 2))) last) (do (def idx (indexOf seq last)) (def aliquot (str (str "Cyclic[" (str (- (- n 1) idx))) "]"))) (when (or (= n 16) (> last THRESHOLD)) (def aliquot "Non-Terminating")))))))) (when (not= aliquot "") (throw (ex-info "return" {:v {"seq" seq "aliquot" aliquot}}))))) (throw (ex-info "return" {:v {"seq" seq "aliquot" ""}}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn padLeft [n w]
+  (try (do (def s (str n)) (while (< (count s) w) (def s (str " " s))) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn padRight [s w]
+  (try (do (def r s) (while (< (count r) w) (def r (str r " "))) (throw (ex-info "return" {:v r}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn joinWithCommas [seq]
+  (try (do (def s "[") (def i 0) (while (< i (count seq)) (do (def s (str s (str (nth seq i)))) (when (< i (- (count seq) 1)) (def s (str s ", "))) (def i (+ i 1)))) (def s (str s "]")) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (println "Aliquot classifications - periods for Sociable/Cyclic in square brackets:\n") (def k 1) (while (<= k 10) (do (def res (classifySequence k)) (println (str (str (str (str (padLeft k 2) ": ") (padRight (str (get res "aliquot")) 15)) " ") (joinWithCommas (get res "seq")))) (def k (+ k 1)))) (println "") (def s [11 12 28 496 220 1184 12496 1264460 790 909 562 1064 1488]) (def i 0) (while (< i (count s)) (do (def val (nth s i)) (def res (classifySequence val)) (println (str (str (str (str (padLeft val 7) ": ") (padRight (str (get res "aliquot")) 15)) " ") (joinWithCommas (get res "seq")))) (def i (+ i 1)))) (println "") (def big 15355717786080) (def r (classifySequence big)) (println (str (str (str (str (str big) ": ") (padRight (str (get r "aliquot")) 15)) " ") (joinWithCommas (get r "seq"))))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/almkvist-giullera-formula-for-pi.clj
+++ b/tests/rosetta/transpiler/Clojure/almkvist-giullera-formula-for-pi.clj
@@ -1,0 +1,83 @@
+(ns main (:refer-clojure :exclude [bigCmp bigMulSmall bigMulBig bigMulPow10 bigDivSmall repeat sortInts primesUpTo factorialExp factorSmall computeIP formatTerm bigAbsDiff main]))
+
+(require 'clojure.set)
+
+(defn bigTrim [a]
+  a)
+
+(defn bigFromInt [x]
+  (bigint x))
+
+(defn bigAdd [a b]
+  (+ a b))
+
+(defn bigSub [a b]
+  (- a b))
+
+(defn bigToString [a]
+  (str a))
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare bigCmp bigMulSmall bigMulBig bigMulPow10 bigDivSmall repeat sortInts primesUpTo factorialExp factorSmall computeIP formatTerm bigAbsDiff main)
+
+(defn bigCmp [a b]
+  (try (do (when (> (count a) (count b)) (throw (ex-info "return" {:v 1}))) (when (< (count a) (count b)) (throw (ex-info "return" {:v (- 1)}))) (def i (- (count a) 1)) (while (>= i 0) (do (when (> (nth a i) (nth b i)) (throw (ex-info "return" {:v 1}))) (when (< (nth a i) (nth b i)) (throw (ex-info "return" {:v (- 1)}))) (def i (- i 1)))) (throw (ex-info "return" {:v 0}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn bigMulSmall [a m]
+  (try (do (when (= m 0) (throw (ex-info "return" {:v [0]}))) (def res []) (def carry 0) (def i 0) (while (< i (count a)) (do (def prod (+ (* (nth a i) m) carry)) (def res (conj res (mod prod 10))) (def carry (/ prod 10)) (def i (+ i 1)))) (while (> carry 0) (do (def res (conj res (mod carry 10))) (def carry (/ carry 10)))) (throw (ex-info "return" {:v (bigTrim res)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn bigMulBig [a b]
+  (try (do (def res []) (def i 0) (while (< i (+ (count a) (count b))) (do (def res (conj res 0)) (def i (+ i 1)))) (def i 0) (while (< i (count a)) (do (def carry 0) (def j 0) (while (< j (count b)) (do (def idx (+ i j)) (def prod (+ (+ (nth res idx) (* (nth a i) (nth b j))) carry)) (def res (assoc res idx (mod prod 10))) (def carry (/ prod 10)) (def j (+ j 1)))) (def idx (+ i (count b))) (while (> carry 0) (do (def prod (+ (nth res idx) carry)) (def res (assoc res idx (mod prod 10))) (def carry (/ prod 10)) (def idx (+ idx 1)))) (def i (+ i 1)))) (throw (ex-info "return" {:v (bigTrim res)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn bigMulPow10 [a k]
+  (try (do (def i 0) (while (< i k) (do (def a (+ [0] a)) (def i (+ i 1)))) (throw (ex-info "return" {:v a}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn bigDivSmall [a m]
+  (try (do (def res []) (def rem 0) (def i (- (count a) 1)) (while (>= i 0) (do (def cur (+ (* rem 10) (nth a i))) (def q (/ cur m)) (def rem (mod cur m)) (def res (+ [q] res)) (def i (- i 1)))) (throw (ex-info "return" {:v (bigTrim res)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn repeat [ch n]
+  (try (do (def s "") (def i 0) (while (< i n) (do (def s (str s ch)) (def i (+ i 1)))) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn sortInts [xs]
+  (try (do (def res []) (def tmp xs) (while (> (count tmp) 0) (do (def min (nth tmp 0)) (def idx 0) (def i 1) (while (< i (count tmp)) (do (when (< (nth tmp i) min) (do (def min (nth tmp i)) (def idx i))) (def i (+ i 1)))) (def res (+ res [min])) (def out []) (def j 0) (while (< j (count tmp)) (do (when (not= j idx) (def out (+ out [(nth tmp j)]))) (def j (+ j 1)))) (def tmp out))) (throw (ex-info "return" {:v res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn primesUpTo [n]
+  (try (do (def sieve []) (def i 0) (while (<= i n) (do (def sieve (conj sieve true)) (def i (+ i 1)))) (def p 2) (while (<= (* p p) n) (do (when (nth sieve p) (do (def m (* p p)) (while (<= m n) (do (def sieve (assoc sieve m false)) (def m (+ m p)))))) (def p (+ p 1)))) (def res []) (def x 2) (while (<= x n) (do (when (nth sieve x) (def res (conj res x))) (def x (+ x 1)))) (throw (ex-info "return" {:v res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn factorialExp [n primes]
+  (try (do (def m {}) (loop [p_seq primes] (when (seq p_seq) (let [p (first p_seq)] (cond (> p n) (recur nil) :else (do (def t n) (def e 0) (while (> t 0) (do (def t (/ t p)) (def e (+ e t)))) (def m (assoc m (str p) e)) (recur (rest p_seq))))))) (throw (ex-info "return" {:v m}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn factorSmall [x primes]
+  (try (do (def f {}) (def n x) (loop [p_seq primes] (when (seq p_seq) (let [p (first p_seq)] (cond (> (* p p) n) (recur nil) :else (do (def c 0) (while (= (mod n p) 0) (do (def c (+ c 1)) (def n (/ n p)))) (when (> c 0) (def f (assoc f (str p) c))) (recur (rest p_seq))))))) (when (> n 1) (def f (assoc f (str n) (+ ((:get f) (str n) 0) 1)))) (throw (ex-info "return" {:v f}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn computeIP [n primes]
+  (try (do (def exps (factorialExp (* 6 n) primes)) (def fn (factorialExp n primes)) (doseq [k fn] (def exps (assoc exps k (- ((:get exps) k 0) (* 6 (nth fn k)))))) (def exps (assoc exps "2" (+ ((:get exps) "2" 0) 5))) (def t2 (+ (+ (* (* 532 n) n) (* 126 n)) 9)) (def ft2 (factorSmall t2 primes)) (doseq [k ft2] (def exps (assoc exps k (+ ((:get exps) k 0) (nth ft2 k))))) (def exps (assoc exps "3" (- ((:get exps) "3" 0) 1))) (def keys []) (doseq [k exps] (def keys (conj keys (Integer/parseInt k)))) (def keys (sortInts keys)) (def res (bigFromInt 1)) (doseq [p keys] (do (def e (get exps (str p))) (def i 0) (while (< i e) (do (def res (bigMulSmall res p)) (def i (+ i 1)))))) (throw (ex-info "return" {:v res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn formatTerm [ip pw]
+  (try (do (def s (bigToString ip)) (when (>= pw (count s)) (do (def frac (+ (repeat "0" (- pw (count s))) s)) (when (< (count frac) 33) (def frac (+ frac (repeat "0" (- 33 (count frac)))))) (throw (ex-info "return" {:v (str "0." (subs frac 0 33))})))) (def intpart (subs s 0 (- (count s) pw))) (def frac (subs s (- (count s) pw) (count s))) (when (< (count frac) 33) (def frac (str frac (repeat "0" (- 33 (count frac)))))) (throw (ex-info "return" {:v (str (str intpart ".") (subs frac 0 33))}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn bigAbsDiff [a b]
+  (try (if (>= (bigCmp a b) 0) (bigSub a b) (bigSub b a)) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def primes (primesUpTo 2000)) (println "N                               Integer Portion  Pow  Nth Term (33 dp)") (def line (repeat "-" 89)) (println line) (def sum (bigFromInt 0)) (def prev (bigFromInt 0)) (def denomPow 0) (def n 0) (loop [while_flag_1 true] (when (and while_flag_1 true) (do (def ip (computeIP n primes)) (def pw (+ (* 6 n) 3)) (when (> pw denomPow) (do (def sum (bigMulPow10 sum (- pw denomPow))) (def prev (bigMulPow10 prev (- pw denomPow))) (def denomPow pw))) (when (< n 10) (do (def termStr (formatTerm ip pw)) (def ipStr (bigToString ip)) (while (< (count ipStr) 44) (def ipStr (str " " ipStr))) (def pwStr (str (- pw))) (while (< (count pwStr) 3) (def pwStr (str " " pwStr))) (def padTerm termStr) (while (< (count padTerm) 35) (def padTerm (str padTerm " "))) (println (str (str (str (str (str (str (str n) "  ") ipStr) "  ") pwStr) "  ") padTerm)))) (def sum (bigAdd sum ip)) (def diff (bigAbsDiff sum prev)) (cond (and (>= denomPow 70) (< (bigCmp diff (bigMulPow10 (bigFromInt 1) (- denomPow 70))) 0)) (recur false) :else (do (def prev sum) (def n (+ n 1)) (recur while_flag_1)))))) (def precision 70) (def target (bigMulPow10 (bigFromInt 1) (+ denomPow (* 2 precision)))) (def low (bigFromInt 0)) (def high (bigMulPow10 (bigFromInt 1) (+ precision 1))) (while (< (bigCmp low (bigSub high (bigFromInt 1))) 0) (do (def mid (bigDivSmall (bigAdd low high) 2)) (def prod (bigMulBig (bigMulBig mid mid) sum)) (if (<= (bigCmp prod target) 0) (def low mid) (def high (bigSub mid (bigFromInt 1)))))) (def piInt low) (def piStr (bigToString piInt)) (when (<= (count piStr) precision) (def piStr (+ (repeat "0" (+ (- precision (count piStr)) 1)) piStr))) (def out (str (str (subs piStr 0 (- (count piStr) precision)) ".") (subs piStr (- (count piStr) precision) (count piStr)))) (println "") (println "Pi to 70 decimal places is:") (println out)))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/almost-prime.clj
+++ b/tests/rosetta/transpiler/Clojure/almost-prime.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [kPrime gen main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,16 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare kPrime gen main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn kPrime [n k]
+  (try (do (def nf 0) (def i 2) (while (<= i n) (do (while (= (mod n i) 0) (do (when (= nf k) (throw (ex-info "return" {:v false}))) (def nf (+ nf 1)) (def n (/ n i)))) (def i (+ i 1)))) (throw (ex-info "return" {:v (= nf k)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn gen [k count]
+  (try (do (def r []) (def n 2) (while (< (count r) count_v) (do (when (kPrime n k) (def r (conj r n))) (def n (+ n 1)))) (throw (ex-info "return" {:v r}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (do (def k 1) (while (<= k 5) (do (println (str (str (str k) " ") (str (gen k 10)))) (def k (+ k 1))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/amb.clj
+++ b/tests/rosetta/transpiler/Clojure/amb.clj
@@ -1,0 +1,32 @@
+(ns main (:refer-clojure :exclude [amb main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare amb main)
+
+(defn amb [wordsets res idx]
+  (try (do (when (= idx (count wordsets)) (throw (ex-info "return" {:v true}))) (def prev "") (when (> idx 0) (def prev (nth res (- idx 1)))) (def i 0) (while (< i (count (nth wordsets idx))) (do (def w (nth (nth wordsets idx) i)) (when (or (= idx 0) (= (subs prev (- (count prev) 1) (count prev)) (subs w 0 1))) (do (def res (assoc res idx w)) (when (amb wordsets res (+ idx 1)) (throw (ex-info "return" {:v true}))))) (def i (+ i 1)))) (throw (ex-info "return" {:v false}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def wordset [["the" "that" "a"] ["frog" "elephant" "thing"] ["walked" "treaded" "grows"] ["slowly" "quickly"]]) (def res []) (def i 0) (while (< i (count wordset)) (do (def res (conj res "")) (def i (+ i 1)))) (if (amb wordset res 0) (do (def out (str "[" (nth res 0))) (def j 1) (while (< j (count res)) (do (def out (str (str out " ") (nth res j))) (def j (+ j 1)))) (def out (str out "]")) (println out)) (println "No amb found"))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/amicable-pairs.bench
+++ b/tests/rosetta/transpiler/Clojure/amicable-pairs.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 19466429,
+  "memory_bytes": 20364880,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/amicable-pairs.clj
+++ b/tests/rosetta/transpiler/Clojure/amicable-pairs.clj
@@ -1,0 +1,35 @@
+(ns main (:refer-clojure :exclude [pfacSum pad main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare pfacSum pad main)
+
+(defn pfacSum [i]
+  (try (do (def sum 0) (def p 1) (while (<= p (/ i 2)) (do (when (= (mod i p) 0) (def sum (+ sum p))) (def p (+ p 1)))) (throw (ex-info "return" {:v sum}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn pad [n width]
+  (try (do (def s (str n)) (while (< (count s) width) (def s (str " " s))) (throw (ex-info "return" {:v s}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def sums []) (def i 0) (while (< i 20000) (do (def sums (conj sums 0)) (def i (+ i 1)))) (def i 1) (while (< i 20000) (do (def sums (assoc sums i (pfacSum i))) (def i (+ i 1)))) (println "The amicable pairs below 20,000 are:") (def n 2) (while (< n 19999) (do (def m (nth sums n)) (when (and (and (> m n) (< m 20000)) (= n (nth sums m))) (println (str (str (str "  " (pad n 5)) " and ") (pad m 5)))) (def n (+ n 1))))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/anagrams-deranged-anagrams.clj
+++ b/tests/rosetta/transpiler/Clojure/anagrams-deranged-anagrams.clj
@@ -1,0 +1,35 @@
+(ns main (:refer-clojure :exclude [sortRunes deranged main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare sortRunes deranged main)
+
+(defn sortRunes [s]
+  (try (do (def arr []) (def i 0) (while (< i (count s)) (do (def arr (conj arr (subs s i (+ i 1)))) (def i (+ i 1)))) (def n (count arr)) (def m 0) (while (< m n) (do (def j 0) (while (< j (- n 1)) (do (when (> (nth arr j) (nth arr (+ j 1))) (do (def tmp (nth arr j)) (def arr (assoc arr j (nth arr (+ j 1)))) (def arr (assoc arr (+ j 1) tmp)))) (def j (+ j 1)))) (def m (+ m 1)))) (def out "") (def i 0) (while (< i n) (do (def out (str out (nth arr i))) (def i (+ i 1)))) (throw (ex-info "return" {:v out}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn deranged [a b]
+  (try (do (when (not= (count a) (count b)) (throw (ex-info "return" {:v false}))) (def i 0) (while (< i (count a)) (do (when (= (subs a i (+ i 1)) (subs b i (+ i 1))) (throw (ex-info "return" {:v false}))) (def i (+ i 1)))) (throw (ex-info "return" {:v true}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def words ["constitutionalism" "misconstitutional"]) (def m {}) (def bestLen 0) (def w1 "") (def w2 "") (loop [w_seq words] (when (seq w_seq) (let [w (first w_seq)] (cond (<= (count w) bestLen) (recur (rest w_seq)) (not (in k m)) (do (def m (assoc m k [w])) (recur (rest w_seq))) :else (do (def k (sortRunes w)) (loop [c_seq (nth m k)] (when (seq c_seq) (let [c (first c_seq)] (cond (deranged w c) (do (def bestLen (count w)) (def w1 c) (def w2 w) (recur nil)) :else (recur (rest c_seq)))))) (def m (assoc m k (conj (nth m k) w))) (recur (rest w_seq))))))) (println (str (str (str (str w1 " ") w2) " : Length ") (str bestLen)))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/anagrams.clj
+++ b/tests/rosetta/transpiler/Clojure/anagrams.clj
@@ -1,0 +1,35 @@
+(ns main (:refer-clojure :exclude [sortRunes sortStrings main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare sortRunes sortStrings main)
+
+(defn sortRunes [s]
+  (try (do (def arr []) (def i 0) (while (< i (count s)) (do (def arr (conj arr (subs s i (+ i 1)))) (def i (+ i 1)))) (def n (count arr)) (def m 0) (while (< m n) (do (def j 0) (while (< j (- n 1)) (do (when (> (nth arr j) (nth arr (+ j 1))) (do (def tmp (nth arr j)) (def arr (assoc arr j (nth arr (+ j 1)))) (def arr (assoc arr (+ j 1) tmp)))) (def j (+ j 1)))) (def m (+ m 1)))) (def out "") (def i 0) (while (< i n) (do (def out (str out (nth arr i))) (def i (+ i 1)))) (throw (ex-info "return" {:v out}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn sortStrings [xs]
+  (try (do (def res []) (def tmp xs) (while (> (count tmp) 0) (do (def min (nth tmp 0)) (def idx 0) (def i 1) (while (< i (count tmp)) (do (when (< (compare (nth tmp i) min) 0) (do (def min (nth tmp i)) (def idx i))) (def i (+ i 1)))) (def res (conj res min)) (def out []) (def j 0) (while (< j (count tmp)) (do (when (not= j idx) (def out (conj out (nth tmp j)))) (def j (+ j 1)))) (def tmp out))) (throw (ex-info "return" {:v res}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def words ["abel" "able" "bale" "bela" "elba" "alger" "glare" "lager" "large" "regal" "angel" "angle" "galen" "glean" "lange" "caret" "carte" "cater" "crate" "trace" "elan" "lane" "lean" "lena" "neal" "evil" "levi" "live" "veil" "vile"]) (def groups {}) (def maxLen 0) (doseq [w words] (do (def k (sortRunes w)) (if (not (in k groups)) (def groups (assoc groups k [w])) (def groups (assoc groups k (conj (nth groups k) w)))) (when (> (count (nth groups k)) maxLen) (def maxLen (count (nth groups k)))))) (def printed {}) (doseq [w words] (do (def k (sortRunes w)) (when (= (count (nth groups k)) maxLen) (when (not (in k printed)) (do (def g (sortStrings (nth groups k))) (def line (str "[" (nth g 0))) (def i 1) (while (< i (count g)) (do (def line (str (str line " ") (nth g i))) (def i (+ i 1)))) (def line (str line "]")) (println line) (def printed (assoc printed k true)))))))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-1.bench
+++ b/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 24659,
+  "memory_bytes": 20573248,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-1.clj
+++ b/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-1.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [angleDiff]))
 
 (require 'clojure.set)
 
@@ -7,19 +7,18 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare angleDiff)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn angleDiff [b1 b2]
+  (try (do (def d (- b2 b1)) (when (< d (- 0 180)) (throw (ex-info "return" {:v (+ d 360)}))) (if (> d 180) (- d 360) d)) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
-(defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+(def testCases [[20 45] [(- 0 45) 45] [(- 0 85) 90] [(- 0 95) 90] [(- 0 45) 125] [(- 0 45) 145] [29.4803 (- 0 88.6381)] [(- 0 78.3251) (- 0 159.036)]])
 
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (main)
+      (doseq [tc testCases] (println (angleDiff (nth tc 0) (nth tc 1))))
       (System/gc)
       (let [end (System/nanoTime)
         end-mem (- (.totalMemory rt) (.freeMemory rt))

--- a/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-2.bench
+++ b/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 22483,
+  "memory_bytes": 20742992,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-2.clj
+++ b/tests/rosetta/transpiler/Clojure/angle-difference-between-two-bearings-2.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [angleDiff]))
 
 (require 'clojure.set)
 
@@ -7,19 +7,18 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare angleDiff)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn angleDiff [b1 b2]
+  (try (do (def diff (- b2 b1)) (throw (ex-info "return" {:v (- (mod (+ (+ (mod diff 360) 360) 180) 360) 180)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
-(defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+(def testCases [[20 45] [(- 0 45) 45] [(- 0 85) 90] [(- 0 95) 90] [(- 0 45) 125] [(- 0 45) 145] [29.4803 (- 0 88.6381)] [(- 0 78.3251) (- 0 159.036)] [(- 0 70099.74233810938) 29840.67437876723] [(- 0 165313.6666297357) 33693.9894517456] [1174.8380510598456 (- 0 154146.66490124757)] [60175.77306795546 42213.07192354373]])
 
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (main)
+      (doseq [tc testCases] (println (angleDiff (nth tc 0) (nth tc 1))))
       (System/gc)
       (let [end (System/nanoTime)
         end-mem (- (.totalMemory rt) (.freeMemory rt))

--- a/tests/rosetta/transpiler/Clojure/angles-geometric-normalization-and-conversion.bench
+++ b/tests/rosetta/transpiler/Clojure/angles-geometric-normalization-and-conversion.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 42981,
+  "memory_bytes": 25159760,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/angles-geometric-normalization-and-conversion.clj
+++ b/tests/rosetta/transpiler/Clojure/angles-geometric-normalization-and-conversion.clj
@@ -1,0 +1,77 @@
+(ns main (:refer-clojure :exclude [d2d g2g m2m r2r d2g d2m d2r g2d g2m g2r m2d m2g m2r r2d r2g r2m main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare d2d g2g m2m r2r d2g d2m d2r g2d g2m g2r m2d m2g m2r r2d r2g r2m main)
+
+(defn d2d [d]
+  (try (throw (ex-info "return" {:v (mod d 360)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn g2g [g]
+  (try (throw (ex-info "return" {:v (mod g 400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn m2m [m]
+  (try (throw (ex-info "return" {:v (mod m 6400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn r2r [r]
+  (try (throw (ex-info "return" {:v (mod r (* 2 3.141592653589793))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn d2g [d]
+  (try (throw (ex-info "return" {:v (/ (* (d2d d) 400) 360)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn d2m [d]
+  (try (throw (ex-info "return" {:v (/ (* (d2d d) 6400) 360)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn d2r [d]
+  (try (throw (ex-info "return" {:v (/ (* (d2d d) 3.141592653589793) 180)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn g2d [g]
+  (try (throw (ex-info "return" {:v (/ (* (g2g g) 360) 400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn g2m [g]
+  (try (throw (ex-info "return" {:v (/ (* (g2g g) 6400) 400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn g2r [g]
+  (try (throw (ex-info "return" {:v (/ (* (g2g g) 3.141592653589793) 200)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn m2d [m]
+  (try (throw (ex-info "return" {:v (/ (* (m2m m) 360) 6400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn m2g [m]
+  (try (throw (ex-info "return" {:v (/ (* (m2m m) 400) 6400)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn m2r [m]
+  (try (throw (ex-info "return" {:v (/ (* (m2m m) 3.141592653589793) 3200)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn r2d [r]
+  (try (throw (ex-info "return" {:v (/ (* (r2r r) 180) 3.141592653589793)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn r2g [r]
+  (try (throw (ex-info "return" {:v (/ (* (r2r r) 200) 3.141592653589793)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn r2m [r]
+  (try (throw (ex-info "return" {:v (/ (* (r2r r) 3200) 3.141592653589793)})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def angles [(- 2) (- 1) 0 1 2 6.2831853 16 57.2957795 359 399 6399 1000000]) (println "degrees normalized_degs gradians mils radians") (doseq [a angles] (println (str (str (str (str (str (str (str (str (str a) " ") (str (d2d a))) " ") (str (d2g a))) " ") (str (d2m a))) " ") (str (d2r a))))) (println "\ngradians normalized_grds degrees mils radians") (doseq [a angles] (println (str (str (str (str (str (str (str (str (str a) " ") (str (g2g a))) " ") (str (g2d a))) " ") (str (g2m a))) " ") (str (g2r a))))) (println "\nmils normalized_mils degrees gradians radians") (doseq [a angles] (println (str (str (str (str (str (str (str (str (str a) " ") (str (m2m a))) " ") (str (m2d a))) " ") (str (m2g a))) " ") (str (m2r a))))) (println "\nradians normalized_rads degrees gradians mils") (doseq [a angles] (println (str (str (str (str (str (str (str (str (str a) " ") (str (r2r a))) " ") (str (r2d a))) " ") (str (r2g a))) " ") (str (r2m a)))))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/animate-a-pendulum.bench
+++ b/tests/rosetta/transpiler/Clojure/animate-a-pendulum.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 21004,
+  "memory_bytes": 21654016,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/animate-a-pendulum.clj
+++ b/tests/rosetta/transpiler/Clojure/animate-a-pendulum.clj
@@ -1,0 +1,49 @@
+(ns main (:refer-clojure :exclude [sinApprox cosApprox sqrtApprox]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare sinApprox cosApprox sqrtApprox)
+
+(def PI 3.141592653589793)
+
+(defn sinApprox [x]
+  (try (do (def term x) (def sum x) (def n 1) (while (<= n 10) (do (def denom (double (* (* 2 n) (+ (* 2 n) 1)))) (def term (/ (* (* (- term) x) x) denom)) (def sum (+ sum term)) (def n (+ n 1)))) (throw (ex-info "return" {:v sum}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn cosApprox [x]
+  (try (do (def term 1) (def sum 1) (def n 1) (while (<= n 10) (do (def denom (double (* (- (* 2 n) 1) (* 2 n)))) (def term (/ (* (* (- term) x) x) denom)) (def sum (+ sum term)) (def n (+ n 1)))) (throw (ex-info "return" {:v sum}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn sqrtApprox [x]
+  (try (do (def guess x) (def i 0) (while (< i 10) (do (def guess (/ (+ guess (/ x guess)) 2)) (def i (+ i 1)))) (throw (ex-info "return" {:v guess}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(def L 10)
+
+(def G 9.81)
+
+(def dt 0.2)
+
+(def phi0 (/ PI 4))
+
+(def omega (sqrtApprox (/ G L)))
+
+(def t 0)
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (dotimes [step 10] (do (def phi (* phi0 (cosApprox (* omega t)))) (def pos (int (+ (* 10 (sinApprox phi)) 0.5))) (println (str pos)) (def t (+ t dt))))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/animation.bench
+++ b/tests/rosetta/transpiler/Clojure/animation.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 25301,
+  "memory_bytes": 19618736,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/animation.clj
+++ b/tests/rosetta/transpiler/Clojure/animation.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main)
 
 (require 'clojure.set)
 
@@ -7,19 +7,21 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(def msg "Hello World! ")
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(def shift 0)
 
-(defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+(def inc 1)
+
+(def clicks 0)
+
+(def frames 0)
 
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (main)
+      (while (< clicks 5) (do (def line "") (def i 0) (while (< i (count msg)) (do (def idx (mod (+ shift i) (count msg))) (def line (str line (subs msg idx (+ idx 1)))) (def i (+ i 1)))) (println line) (def shift (mod (+ shift inc) (count msg))) (def frames (+ frames 1)) (when (= (mod frames (count msg)) 0) (do (def inc (- (count msg) inc)) (def clicks (+ clicks 1))))))
       (System/gc)
       (let [end (System/nanoTime)
         end-mem (- (.totalMemory rt) (.freeMemory rt))

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion-1.bench
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 49151,
+  "memory_bytes": 20231960,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion-1.clj
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion-1.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [fib main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,13 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare fib main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn fib [n]
+  (try (do (when (< n 2) (throw (ex-info "return" {:v n}))) (def a 0) (def b 1) (def i 1) (while (< i n) (do (def t (+ a b)) (def a b) (def b t) (def i (+ i 1)))) (throw (ex-info "return" {:v b}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (doseq [n [0 1 2 3 4 5 10 40 (- 1)]] (if (< n 0) (println "fib undefined for negative numbers") (println (str (str (str "fib " (str n)) " = ") (str (fib n)))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion-2.bench
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 46059,
+  "memory_bytes": 20312416,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion-2.clj
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion-2.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [fib main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,13 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare fib main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn fib [n]
+  (try (do (when (< n 2) (throw (ex-info "return" {:v n}))) (def a 0) (def b 1) (def i 1) (while (< i n) (do (def t (+ a b)) (def a b) (def b t) (def i (+ i 1)))) (throw (ex-info "return" {:v b}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (doseq [i [(- 1) 0 1 2 3 4 5 6 7 8 9 10]] (if (< i 0) (println (str (str "fib(" (str i)) ") returned error: negative n is forbidden")) (println (str (str (str "fib(" (str i)) ") = ") (str (fib i)))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion.bench
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 21672,
+  "memory_bytes": 19662264,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/anonymous-recursion.clj
+++ b/tests/rosetta/transpiler/Clojure/anonymous-recursion.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [fib main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,13 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare fib main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn fib [n]
+  (try (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (do (def i (- 1)) (while (<= i 10) (do (if (< i 0) (println (str (str "fib(" (str i)) ") returned error: negative n is forbidden")) (println (str (str (str "fib(" (str i)) ") = ") (str (fib i))))) (def i (+ i 1))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/anti-primes.bench
+++ b/tests/rosetta/transpiler/Clojure/anti-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 64874,
+  "memory_bytes": 20406224,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/anti-primes.clj
+++ b/tests/rosetta/transpiler/Clojure/anti-primes.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [countDivisors main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,13 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare countDivisors main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn countDivisors [n]
+  (try (do (when (< n 2) (throw (ex-info "return" {:v 1}))) (def count_v 2) (def i 2) (while (<= i (/ n 2)) (do (when (= (mod n i) 0) (def count_v (+ count_v 1))) (def i (+ i 1)))) (throw (ex-info "return" {:v count_v}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (do (println "The first 20 anti-primes are:") (def maxDiv 0) (def count_v 0) (def n 1) (def line "") (while (< count_v 20) (do (def d (countDivisors n)) (when (> d maxDiv) (do (def line (str (str line (str n)) " ")) (def maxDiv d) (def count_v (+ count_v 1)))) (def n (+ n 1)))) (def line (subs line 0 (- (count line) 1))) (println line)))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/append-a-record-to-the-end-of-a-text-file.bench
+++ b/tests/rosetta/transpiler/Clojure/append-a-record-to-the-end-of-a-text-file.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 18961,
+  "memory_bytes": 19618672,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/append-a-record-to-the-end-of-a-text-file.clj
+++ b/tests/rosetta/transpiler/Clojure/append-a-record-to-the-end-of-a-text-file.clj
@@ -1,0 +1,35 @@
+(ns main (:refer-clojure :exclude [writeTwo appendOneMore main]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare writeTwo appendOneMore main)
+
+(defn writeTwo []
+  (try (throw (ex-info "return" {:v ["jsmith:x:1001:1000:Joe Smith,Room 1007,(234)555-8917,(234)555-0077,jsmith@rosettacode.org:/home/jsmith:/bin/bash" "jdoe:x:1002:1000:Jane Doe,Room 1004,(234)555-8914,(234)555-0044,jdoe@rosettacode.org:/home/jsmith:/bin/bash"]})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn appendOneMore [lines]
+  (try (throw (ex-info "return" {:v (conj lines "xyz:x:1003:1000:X Yz,Room 1003,(234)555-8913,(234)555-0033,xyz@rosettacode.org:/home/xyz:/bin/bash")})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(defn main []
+  (do (def lines (writeTwo)) (def lines (appendOneMore lines)) (if (and (>= (count lines) 3) (= (nth lines 2) "xyz:x:1003:1000:X Yz,Room 1003,(234)555-8913,(234)555-0033,xyz@rosettacode.org:/home/xyz:/bin/bash")) (println "append okay") (println "it didn't work"))))
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-1.bench
+++ b/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 42369,
+  "memory_bytes": 19288968,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-1.clj
+++ b/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-1.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main)
 
 (require 'clojure.set)
 
@@ -7,19 +7,11 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
-
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
-
-(defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
-
 (defn -main []
   (let [rt (Runtime/getRuntime)
     start-mem (- (.totalMemory rt) (.freeMemory rt))
     start (System/nanoTime)]
-      (main)
+      (doseq [i [1 2 3 4 5]] (println (str (* i i))))
       (System/gc)
       (let [end (System/nanoTime)
         end-mem (- (.totalMemory rt) (.freeMemory rt))

--- a/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-2.bench
+++ b/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 35862,
+  "memory_bytes": 20520408,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-2.clj
+++ b/tests/rosetta/transpiler/Clojure/apply-a-callback-to-an-array-2.clj
@@ -1,4 +1,4 @@
-(ns main (:refer-clojure :exclude [connect main]))
+(ns main (:refer-clojure :exclude [each Map main]))
 
 (require 'clojure.set)
 
@@ -7,13 +7,16 @@
 
 (def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
 
-(declare connect main)
+(declare each Map main)
 
-(defn connect [client]
-  (try (throw (ex-info "return" {:v (and (not= (:Host client) "") (> (:Port client) 0))})) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+(defn each [xs f]
+  (doseq [x xs] (f x)))
+
+(defn Map [xs f]
+  (try (do (def r []) (doseq [x xs] (def r (conj r (f x)))) (throw (ex-info "return" {:v r}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
 
 (defn main []
-  (do (def client {:Base "dc=example,dc=com" :Host "ldap.example.com" :Port 389 :UseSSL false :BindDN "uid=readonlyuser,ou=People,dc=example,dc=com" :BindPassword "readonlypassword" :UserFilter "(uid=%s)" :GroupFilter "(memberUid=%s)" :Attributes ["givenName" "sn" "mail" "uid"]}) (if (connect client) (println (str "Connected to " (:Host client))) (println "Failed to connect"))))
+  (do (def s [1 2 3 4 5]) (each s (fn [i] (println (str (* i i))))) (println (str (Map s (fn [i] (* i i)))))))
 
 (defn -main []
   (let [rt (Runtime/getRuntime)

--- a/tests/rosetta/transpiler/Clojure/apply-a-digital-filter-direct-form-ii-transposed-.bench
+++ b/tests/rosetta/transpiler/Clojure/apply-a-digital-filter-direct-form-ii-transposed-.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 20222,
+  "memory_bytes": 21375752,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/apply-a-digital-filter-direct-form-ii-transposed-.clj
+++ b/tests/rosetta/transpiler/Clojure/apply-a-digital-filter-direct-form-ii-transposed-.clj
@@ -1,0 +1,39 @@
+(ns main (:refer-clojure :exclude [applyFilter]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare applyFilter)
+
+(defn applyFilter [input a b]
+  (try (do (def out []) (def scale (/ 1 (nth a 0))) (def i 0) (while (< i (count input)) (do (def tmp 0) (def j 0) (while (and (<= j i) (< j (count b))) (do (def tmp (+ tmp (* (nth b j) (nth input (- i j))))) (def j (+ j 1)))) (def j 0) (while (and (< j i) (< (+ j 1) (count a))) (do (def tmp (- tmp (* (nth a (+ j 1)) (nth out (- (- i j) 1))))) (def j (+ j 1)))) (def out (conj out (* tmp scale))) (def i (+ i 1)))) (throw (ex-info "return" {:v out}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(def a [1 (- 0.00000000000000027756) 0.33333333 (- 0.0000000000000000185)])
+
+(def b [0.16666667 0.5 0.5 0.16666667])
+
+(def sig [(- 0.917843918645) 0.141984778794 1.20536903482 0.190286794412 (- 0.662370894973) (- 1.00700480494) (- 0.404707073677) 0.800482325044 0.743500089861 1.01090520172 0.741527555207 0.277841675195 0.400833448236 (- 0.2085993586) (- 0.172842103641) (- 0.134316096293) 0.0259303398477 0.490105989562 0.549391221511 0.9047198589])
+
+(def res (applyFilter sig a b))
+
+(def k 0)
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (while (< k (count res)) (do (println (nth res k)) (def k (+ k 1))))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -108,4 +108,4 @@ Compiled programs: 101/104
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-27 00:51 +0700
+Last updated: 2025-07-27 16:50 +0700

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 20/465
-Last updated: 2025-07-27 16:10 +0700
+Completed: 38/465
+Last updated: 2025-07-27 17:17 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -36,36 +36,36 @@ Last updated: 2025-07-27 16:10 +0700
 | 29 | ackermann-function-2 |   |  |  |
 | 30 | ackermann-function-3 |   |  |  |
 | 31 | ackermann-function |   |  |  |
-| 32 | active-directory-connect | ✓ |  |  |
-| 33 | active-directory-search-for-a-user | ✓ |  |  |
-| 34 | active-object | ✓ |  |  |
-| 35 | add-a-variable-to-a-class-instance-at-runtime |   |  |  |
-| 36 | additive-primes |   |  |  |
-| 37 | address-of-a-variable | ✓ |  |  |
+| 32 | active-directory-connect | ✓ | 18.043ms | 18.7 MB |
+| 33 | active-directory-search-for-a-user | ✓ | 19.549ms | 24.3 MB |
+| 34 | active-object | ✓ | 37.262ms | 20.0 MB |
+| 35 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 15.428ms | 18.8 MB |
+| 36 | additive-primes | ✓ | 76.429ms | 20.4 MB |
+| 37 | address-of-a-variable | ✓ | 14.698ms | 17.9 MB |
 | 38 | adfgvx-cipher |   |  |  |
 | 39 | aks-test-for-primes |   |  |  |
 | 40 | algebraic-data-types |   |  |  |
-| 41 | align-columns |   |  |  |
-| 42 | aliquot-sequence-classifications |   |  |  |
+| 41 | align-columns | ✓ | 26.04ms | 22.4 MB |
+| 42 | aliquot-sequence-classifications | ✓ |  |  |
 | 43 | almkvist-giullera-formula-for-pi |   |  |  |
 | 44 | almost-prime |   |  |  |
 | 45 | amb |   |  |  |
-| 46 | amicable-pairs |   |  |  |
+| 46 | amicable-pairs | ✓ | 19.466429s | 19.4 MB |
 | 47 | anagrams-deranged-anagrams |   |  |  |
 | 48 | anagrams |   |  |  |
-| 49 | angle-difference-between-two-bearings-1 |   |  |  |
-| 50 | angle-difference-between-two-bearings-2 |   |  |  |
-| 51 | angles-geometric-normalization-and-conversion |   |  |  |
-| 52 | animate-a-pendulum |   |  |  |
-| 53 | animation |   |  |  |
-| 54 | anonymous-recursion-1 |   |  |  |
-| 55 | anonymous-recursion-2 |   |  |  |
-| 56 | anonymous-recursion |   |  |  |
-| 57 | anti-primes |   |  |  |
-| 58 | append-a-record-to-the-end-of-a-text-file |   |  |  |
-| 59 | apply-a-callback-to-an-array-1 |   |  |  |
-| 60 | apply-a-callback-to-an-array-2 |   |  |  |
-| 61 | apply-a-digital-filter-direct-form-ii-transposed- |   |  |  |
+| 49 | angle-difference-between-two-bearings-1 | ✓ | 24.659ms | 19.6 MB |
+| 50 | angle-difference-between-two-bearings-2 | ✓ | 22.483ms | 19.8 MB |
+| 51 | angles-geometric-normalization-and-conversion | ✓ | 42.981ms | 24.0 MB |
+| 52 | animate-a-pendulum | ✓ | 21.004ms | 20.7 MB |
+| 53 | animation | ✓ | 25.301ms | 18.7 MB |
+| 54 | anonymous-recursion-1 | ✓ | 49.151ms | 19.3 MB |
+| 55 | anonymous-recursion-2 | ✓ | 46.059ms | 19.4 MB |
+| 56 | anonymous-recursion | ✓ | 21.672ms | 18.8 MB |
+| 57 | anti-primes | ✓ | 64.874ms | 19.5 MB |
+| 58 | append-a-record-to-the-end-of-a-text-file | ✓ | 18.961ms | 18.7 MB |
+| 59 | apply-a-callback-to-an-array-1 | ✓ | 42.369ms | 18.4 MB |
+| 60 | apply-a-callback-to-an-array-2 | ✓ | 35.862ms | 19.6 MB |
+| 61 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 20.222ms | 20.4 MB |
 | 62 | approximate-equality |   |  |  |
 | 63 | arbitrary-precision-integers-included- |   |  |  |
 | 64 | archimedean-spiral |   |  |  |

--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,143 @@
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 16:50 +0700)
+- php: support struct methods
+- Regenerated golden files - 101/104 vm valid programs passing
+
 ## Progress (2025-07-26 19:01 +0700)
 - ex transpiler: handle float mod and module globals
 - Regenerated golden files - 101/104 vm valid programs passing


### PR DESCRIPTION
## Summary
- improve map detection in Clojure transpiler
- regenerate Rosetta transpiler outputs and benchmarks
- add many new Clojure examples for Rosetta

## Testing
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index=35 -count=1`
- `for i in $(seq 36 61); do MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index=$i -count=1; done`


------
https://chatgpt.com/codex/tasks/task_e_6885f92593ac8320b7cac22d465868a0