### PR TITLE
Add comments for Feigenbaum constant task

### DIFF
--- a/tests/rosetta/x/Go/feigenbaum-constant-calculation.go
+++ b/tests/rosetta/x/Go/feigenbaum-constant-calculation.go
@@ -3,28 +3,30 @@
 
 package main
 
+// Implementation of the Rosetta Code "Feigenbaum constant calculation" task
+
 import "fmt"
 
 func feigenbaum() {
-    maxIt, maxItJ := 13, 10
-    a1, a2, d1 := 1.0, 0.0, 3.2
-    fmt.Println(" i       d")
-    for i := 2; i <= maxIt; i++ {
-        a := a1 + (a1-a2)/d1
-        for j := 1; j <= maxItJ; j++ {
-            x, y := 0.0, 0.0
-            for k := 1; k <= 1<<uint(i); k++ {
-                y = 1.0 - 2.0*y*x
-                x = a - x*x
-            }
-            a -= x / y
-        }
-        d := (a1 - a2) / (a - a1)
-        fmt.Printf("%2d    %.8f\n", i, d)
-        d1, a2, a1 = d, a1, a
-    }
+	maxIt, maxItJ := 13, 10
+	a1, a2, d1 := 1.0, 0.0, 3.2
+	fmt.Println(" i       d")
+	for i := 2; i <= maxIt; i++ {
+		a := a1 + (a1-a2)/d1
+		for j := 1; j <= maxItJ; j++ {
+			x, y := 0.0, 0.0
+			for k := 1; k <= 1<<uint(i); k++ {
+				y = 1.0 - 2.0*y*x
+				x = a - x*x
+			}
+			a -= x / y
+		}
+		d := (a1 - a2) / (a - a1)
+		fmt.Printf("%2d    %.8f\n", i, d)
+		d1, a2, a1 = d, a1, a
+	}
 }
 
 func main() {
-    feigenbaum()
+	feigenbaum()
 }

--- a/tests/rosetta/x/Mochi/feigenbaum-constant-calculation.mochi
+++ b/tests/rosetta/x/Mochi/feigenbaum-constant-calculation.mochi
@@ -1,3 +1,6 @@
+// Mochi translation of Rosetta "Feigenbaum constant calculation" task
+// Based on Go version in tests/rosetta/x/Go/feigenbaum-constant-calculation.go
+
 fun floorf(x: float): float { let y = x as int; return y as float }
 fun indexOf(s: string, ch: string): int { var i=0; while i < len(s) { if substring(s,i,i+1)==ch { return i } i=i+1 } return 0 - 1 }
 fun fmt8(x: float): string {


### PR DESCRIPTION
## Summary
- clarify Go Feigenbaum constant example
- add header comment to Mochi translation

## Testing
- `MOCHI_ROSETTA_ONLY=feigenbaum-constant-calculation go test ./runtime/vm -run Rosetta_Golden -tags slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6885fc1b732083208c5c473c4f94c023