### PR TITLE
Add Rosetta File Input Output variant

### DIFF
--- a/tests/rosetta/x/Go/file-input-output-3.go
+++ b/tests/rosetta/x/Go/file-input-output-3.go
@@ -1,0 +1,41 @@
+// variant 3
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+)
+
+func CopyFile(out, in string) (err error) {
+	var inf, outf *os.File
+	inf, err = os.Open(in)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cErr := inf.Close()
+		if err == nil {
+			err = cErr
+		}
+	}()
+	outf, err = os.Create(out)
+	if err != nil {
+		return
+	}
+	_, err = io.Copy(outf, inf)
+	cErr := outf.Close()
+	if err == nil {
+		err = cErr
+	}
+	return
+}
+
+func main() {
+	if err := CopyFile("output.txt", "input.txt"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tests/rosetta/x/Mochi/file-input-output-3.mochi
+++ b/tests/rosetta/x/Mochi/file-input-output-3.mochi
@@ -1,0 +1,13 @@
+var fs: map<string,string> = {"input.txt": "example"}
+fun copyFile(out: string, inp: string) {
+  var s = ""
+  for ch in fs[inp] {
+    s = s + ch
+  }
+  fs[out] = s
+}
+fun main() {
+  copyFile("output.txt", "input.txt")
+  print(fs["output.txt"])
+}
+main()

--- a/tests/rosetta/x/Mochi/file-input-output-3.out
+++ b/tests/rosetta/x/Mochi/file-input-output-3.out
@@ -1,0 +1,1 @@
+example


### PR DESCRIPTION
## Summary
- download and add Go sources for `File-input-output`
- implement `File-input-output` in Mochi
- add runtime output for the Mochi program

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6885fc21fd6c8320b2c2f026570023ff