### PR TITLE
Add Rosetta File-modification-time update

### DIFF
--- a/tests/rosetta/x/Go/file-modification-time.go
+++ b/tests/rosetta/x/Go/file-modification-time.go
@@ -4,27 +4,27 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "syscall"
-    "time"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
 )
 
 var filename = "input.txt"
 
 func main() {
-    foo, err := os.Stat(filename)
-    if err != nil {
-        fmt.Println(err)
-        return
-    }
-    fmt.Println("mod time was:", foo.ModTime())
-    mtime := time.Now()
-    atime := mtime // a default, because os.Chtimes has an atime parameter.
-    // but see if there's a real atime that we can preserve.
-    if ss, ok := foo.Sys().(*syscall.Stat_t); ok {
-        atime = time.Unix(ss.Atim.Sec, ss.Atim.Nsec)
-    }
-    os.Chtimes(filename, atime, mtime)
-    fmt.Println("mod time now:", mtime)
+	foo, err := os.Stat(filename)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("mod time was:", foo.ModTime())
+	mtime := time.Now()
+	atime := mtime // a default, because os.Chtimes has an atime parameter.
+	// but see if there's a real atime that we can preserve.
+	if ss, ok := foo.Sys().(*syscall.Stat_t); ok {
+		atime = time.Unix(ss.Atim.Sec, ss.Atim.Nsec)
+	}
+	os.Chtimes(filename, atime, mtime)
+	fmt.Println("mod time now:", mtime)
 }

--- a/tests/rosetta/x/Mochi/file-modification-time.out
+++ b/tests/rosetta/x/Mochi/file-modification-time.out
@@ -1,2 +1,3 @@
 mod time was: 0
-mod time now: 1753553953102146673
+mod time now: 1586792639
+


### PR DESCRIPTION
## Summary
- format Go solution for `File-modification-time`
- regenerate VM output for the Mochi version of the task

## Testing
- `go test ./tools/rosetta -run "RosettaVMGolden/file-modification-time" -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6885fc23db1c8320949b83d324fcf903