### PR TITLE
Fix Java transpiler variable scope

### DIFF
--- a/tests/rosetta/transpiler/Java/cuban-primes.java
+++ b/tests/rosetta/transpiler/Java/cuban-primes.java
@@ -27,7 +27,7 @@ public class Main {
         int s = 0;
         while (Math.floorMod(d, 2) == 0) {
             d = d / 2;
-            s = s + String.valueOf(1);
+            s = s + 1;
         }
         for (int a : new int[]{2, 325, 9375, 28178, 450775, 9780504, 1795265022}) {
             if (Math.floorMod(a, n) == 0) {


### PR DESCRIPTION
## Summary
- ensure local variable types are tracked when emitting Java code
- regenerate `cuban-primes.java` with numeric addition

## Testing
- `go test ./transpiler/x/java -tags slow -run Rosetta -index 264 -count=1` *(fails: execution timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68863493fd30832093de7786372cba72