### PR TITLE
Fix PHP substring output

### DIFF
--- a/tests/rosetta/transpiler/php/eban-numbers.bench
+++ b/tests/rosetta/transpiler/php/eban-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 11691,
+  "memory_bytes": 160,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/eban-numbers.out
+++ b/tests/rosetta/transpiler/php/eban-numbers.out
@@ -1,0 +1,23 @@
+eban numbers up to and including 1000:
+2 4 6 30 32 34 36 40 42 44 46 50 52 54 56 60 62 64 66
+count = 19
+eban numbers between 1000 and 4000 (inclusive):
+2000 2002 2004 2006 2030 2032 2034 2036 2040 2042 2044 2046 2050 2052 2054 2056 2060 2062 2064 2066 4000
+count = 21
+eban numbers up to and including 10000:
+count = 79
+eban numbers up to and including 100000:
+count = 399
+eban numbers up to and including 1000000:
+count = 399
+eban numbers up to and including 10000000:
+count = 1599
+eban numbers up to and including 100000000:
+count = 7999
+eban numbers up to and including 1000000000:
+count = 7999
+{
+  "duration_us": 11691,
+  "memory_bytes": 160,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/php/eban-numbers.php
+++ b/tests/rosetta/transpiler/php/eban-numbers.php
@@ -1,0 +1,109 @@
+<?php
+ini_set('memory_limit', '-1');
+$now_seed = 0;
+$now_seeded = false;
+$s = getenv('MOCHI_NOW_SEED');
+if ($s !== false && $s !== '') {
+    $now_seed = intval($s);
+    $now_seeded = true;
+}
+function _now() {
+    global $now_seed, $now_seeded;
+    if ($now_seeded) {
+        $now_seed = ($now_seed * 1664525 + 1013904223) % 2147483647;
+        return $now_seed;
+    }
+    return hrtime(true);
+}
+function _str($x) {
+    if (is_array($x)) {
+        $isList = array_keys($x) === range(0, count($x) - 1);
+        if ($isList) {
+            $parts = [];
+            foreach ($x as $v) { $parts[] = _str($v); }
+            return '[' . implode(' ', $parts) . ']';
+        }
+        $parts = [];
+        foreach ($x as $k => $v) { $parts[] = _str($k) . ':' . _str($v); }
+        return 'map[' . implode(' ', $parts) . ']';
+    }
+    if (is_bool($x)) return $x ? 'true' : 'false';
+    if ($x === null) return 'null';
+    return strval($x);
+}
+$__start_mem = memory_get_usage();
+$__start = _now();
+  $vals = [0, 2, 4, 6, 30, 32, 34, 36, 40, 42, 44, 46, 50, 52, 54, 56, 60, 62, 64, 66];
+  $billions = [0, 2, 4, 6];
+  function ebanNumbers($start, $stop) {
+  global $vals, $billions;
+  $nums = [];
+  foreach ($billions as $b) {
+  foreach ($vals as $m) {
+  foreach ($vals as $t) {
+  foreach ($vals as $r) {
+  $n = $b * 1000000000 + $m * 1000000 + $t * 1000 + $r;
+  if (($n >= $start) && ($n <= $stop)) {
+  $nums = array_merge($nums, [$n]);
+}
+};
+};
+};
+};
+  return $nums;
+};
+  function countEban($start, $stop) {
+  global $vals, $billions;
+  $count = 0;
+  foreach ($billions as $b) {
+  foreach ($vals as $m) {
+  foreach ($vals as $t) {
+  foreach ($vals as $r) {
+  $n = $b * 1000000000 + $m * 1000000 + $t * 1000 + $r;
+  if (($n >= $start) && ($n <= $stop)) {
+  $count = $count + 1;
+}
+};
+};
+};
+};
+  return $count;
+};
+  function main() {
+  global $vals, $billions;
+  $ranges = [[2, 1000, true], [1000, 4000, true], [2, 10000, false], [2, 100000, false], [2, 1000000, false], [2, 10000000, false], [2, 100000000, false], [2, 1000000000, false]];
+  foreach ($ranges as $rg) {
+  $start = intval($rg[0]);
+  $stop = intval($rg[1]);
+  $show = boolval($rg[2]);
+  if ($start == 2) {
+  echo rtrim('eban numbers up to and including ' . _str($stop) . ':'), PHP_EOL;
+} else {
+  echo rtrim('eban numbers between ' . _str($start) . ' and ' . _str($stop) . ' (inclusive):'), PHP_EOL;
+}
+  if ($show) {
+  $nums = ebanNumbers($start, $stop);
+  $line = '';
+  $i = 0;
+  while ($i < count($nums)) {
+  $line = $line . _str($nums[$i]) . ' ';
+  $i = $i + 1;
+};
+  if (strlen($line) > 0) {
+  echo rtrim(substr($line, 0, strlen($line) - 1 - 0)), PHP_EOL;
+};
+}
+  $c = countEban($start, $stop);
+  echo rtrim('count = ' . _str($c) . '
+'), PHP_EOL;
+};
+};
+  main();
+$__end = _now();
+$__end_mem = memory_get_usage();
+$__duration = intdiv($__end - $__start, 1000);
+$__mem_diff = max(0, $__end_mem - $__start_mem);
+$__bench = ["duration_us" => $__duration, "memory_bytes" => $__mem_diff, "name" => "main"];
+$__j = json_encode($__bench, 128);
+$__j = str_replace("    ", "  ", $__j);
+echo $__j, PHP_EOL;;

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-27 21:41 +0700
+Last updated: 2025-07-27 21:58 +0700
 
 ## VM Golden Test Checklist (103/104)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-27 21:41 +0700
+Last updated: 2025-07-27 21:58 +0700
 
-## Checklist (323/467)
+## Checklist (324/467)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 154µs | 136 B |
@@ -335,7 +335,7 @@ Last updated: 2025-07-27 21:41 +0700
 | 326 | dutch-national-flag-problem | ✓ | 46µs | 96 B |
 | 327 | dynamic-variable-names | ✓ | 60µs | 8.1 KB |
 | 328 | earliest-difference-between-prime-gaps | ✓ | 50µs | 96 B |
-| 329 | eban-numbers |   |  |  |
+| 329 | eban-numbers | ✓ | 11.691ms | 160 B |
 | 330 | ecdsa-example |   |  |  |
 | 331 | echo-server |   |  |  |
 | 332 | eertree |   |  |  |

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-27 21:41 +0700)
+## Progress (2025-07-27 21:58 +0700)
 - Generated PHP for 103/104 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format

--- a/transpiler/x/php/transpiler.go
+++ b/transpiler/x/php/transpiler.go
@@ -4234,6 +4234,10 @@ func isStringExpr(e Expr) bool {
 		if isStringExpr(v.X) {
 			return true
 		}
+	case *SubstringExpr:
+		if isStringExpr(v.Str) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- treat substring expressions as strings
- regenerate PHP output for eban-numbers with benchmark data

## Testing
- `UPDATE=1 MOCHI_ROSETTA_INDEX=329 MOCHI_BENCHMARK=1 go test -run Rosetta -tags slow -count=1 -failfast`

------
https://chatgpt.com/codex/tasks/task_e_68863e8896dc8320983f002f0dbfa334