### PR TITLE
Update Clojure rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Clojure/arithmetic-complex.bench
+++ b/tests/rosetta/transpiler/Clojure/arithmetic-complex.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 46769,
-  "memory_bytes": 21433768,
+  "duration_us": 19014,
+  "memory_bytes": 21581704,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Clojure/arithmetic-derivative.bench
+++ b/tests/rosetta/transpiler/Clojure/arithmetic-derivative.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 107461,
-  "memory_bytes": 22902072,
+  "duration_us": 42289,
+  "memory_bytes": 23016600,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Clojure/arithmetic-derivative.clj
+++ b/tests/rosetta/transpiler/Clojure/arithmetic-derivative.clj
@@ -25,6 +25,17 @@
   (do (def vals []) (def n (- 99)) (while (< n 101) (do (def vals (conj vals (int (D (double n))))) (def n (+ n 1)))) (def i 0) (while (< i (count vals)) (do (def line "") (def j 0) (while (< j 10) (do (def line (str line (pad (nth vals (+ i j))))) (when (< j 9) (def line (str line " "))) (def j (+ j 1)))) (println line) (def i (+ i 10)))) (def pow 1.0) (def m 1) (while (< m 21) (do (def pow (* pow 10.0)) (def exp (str m)) (when (< (count exp) 2) (def exp (str exp " "))) (def res (str (str m) (repeat "0" (- m 1)))) (println (str (str (str "D(10^" exp) ") / 7 = ") res)) (def m (+ m 1))))))
 
 (defn -main []
-  (main))
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (main)
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
 
 (-main)

--- a/transpiler/x/clj/README.md
+++ b/transpiler/x/clj/README.md
@@ -108,4 +108,4 @@ Compiled programs: 101/104
 - [x] values_builtin
 - [x] var_assignment
 - [x] while_loop
-Last updated: 2025-07-27 21:41 +0700
+Last updated: 2025-07-27 22:27 +0700

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
 Completed: 52/467
-Last updated: 2025-07-27 22:15 +0700
+Last updated: 2025-07-27 22:45 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -70,8 +70,8 @@ Last updated: 2025-07-27 22:15 +0700
 | 63 | arbitrary-precision-integers-included- |   |  |  |
 | 64 | archimedean-spiral |   |  |  |
 | 65 | arena-storage-pool | ✓ | 44.229ms | 20.2 MB |
-| 66 | arithmetic-complex | ✓ | 46.769ms | 20.4 MB |
-| 67 | arithmetic-derivative | ✓ | 107.461ms | 21.8 MB |
+| 66 | arithmetic-complex | ✓ | 19.014ms | 20.6 MB |
+| 67 | arithmetic-derivative | ✓ | 42.289ms | 22.0 MB |
 | 68 | arithmetic-evaluation |   |  |  |
 | 69 | arithmetic-geometric-mean-calculate-pi | ✓ | 44.656ms | 19.9 MB |
 | 70 | arithmetic-geometric-mean | ✓ |  |  |

--- a/transpiler/x/clj/TASKS.md
+++ b/transpiler/x/clj/TASKS.md
@@ -1,3 +1,51 @@
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
+## Progress (2025-07-27 22:27 +0700)
+- Generate Ruby transpiler outputs for tasks 363-379
+- Regenerated golden files - 101/104 vm valid programs passing
+
 ## Progress (2025-07-27 21:41 +0700)
 - remove old error file for deconvolution
 - Regenerated golden files - 101/104 vm valid programs passing


### PR DESCRIPTION
## Summary
- regenerate Clojure transpiler benchmark output for a few arithmetic tasks
- refresh transpiler progress docs

## Testing
- `MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/clj -run TestRosettaClojure -index=66 -count=1`
- `MOCHI_BENCHMARK=1 go test -tags slow ./transpiler/x/clj -run TestRosettaClojure -index=67 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688645d36ee8832083e9ac3dcac1d9f0