### PR TITLE
Fix F# function array emission

### DIFF
--- a/tests/rosetta/transpiler/FS/call-an-object-method-2.bench
+++ b/tests/rosetta/transpiler/FS/call-an-object-method-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 9,
+  "memory_bytes": 592,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/call-an-object-method-2.fs
+++ b/tests/rosetta/transpiler/FS/call-an-object-method-2.fs
@@ -1,0 +1,75 @@
+// Generated 2025-07-27 15:42 +0000
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+type Box = {
+    Contents: string
+    secret: int
+}
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let rec Box_TellSecret (self: Box) =
+    let mutable __ret : int = Unchecked.defaultof<int>
+    let mutable self = self
+    try
+        __ret <- self.secret
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let rec newFactory () =
+    let mutable __ret : obj array = Unchecked.defaultof<obj array>
+    try
+        let mutable sn: int = 0
+        let rec New () =
+            let mutable __ret : Box = Unchecked.defaultof<Box>
+            try
+                sn <- sn + 1
+                let mutable b: Box = { Contents = Unchecked.defaultof<string>; secret = sn }
+                if sn = 1 then
+                    b <- { b with Contents = "rabbit" }
+                else
+                    if sn = 2 then
+                        b <- { b with Contents = "rock" }
+                __ret <- b
+                raise Return
+                __ret
+            with
+                | Return -> __ret
+        let rec Count () =
+            let mutable __ret : int = Unchecked.defaultof<int>
+            try
+                __ret <- sn
+                raise Return
+                __ret
+            with
+                | Return -> __ret
+        __ret <- unbox<obj array> [|box New; box Count|]
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let funcs = newFactory()
+let New = funcs.[0]
+let Count = funcs.[1]
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/transpiler/x/fs/README.md
+++ b/transpiler/x/fs/README.md
@@ -111,4 +111,4 @@ The list below tracks Mochi programs under `tests/vm/valid` that should successf
 - [x] var_assignment.mochi
 - [x] while_loop.mochi
 
-Last updated: 2025-07-27 17:18 +0700
+Last updated: 2025-07-27 15:42 +0000

--- a/transpiler/x/fs/ROSETTA.md
+++ b/transpiler/x/fs/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This file is auto-generated from rosetta tests.
 
-## Rosetta Golden Test Checklist (141/465)
+## Rosetta Golden Test Checklist (143/467)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 151µs | 41.3 KB |
@@ -168,13 +168,13 @@ This file is auto-generated from rosetta tests.
 | 161 | call-a-function-8 | ✓ | 21µs | 14.6 KB |
 | 162 | call-a-function-9 | ✓ | 33µs | 15.5 KB |
 | 163 | call-an-object-method-1 | ✓ | 20µs | 12.1 KB |
-| 164 | call-an-object-method-2 |   |  |  |
+| 164 | call-an-object-method-2 | ✓ | 9µs | 592 B |
 | 165 | call-an-object-method-3 |   |  |  |
 | 166 | call-an-object-method |   |  |  |
 | 167 | camel-case-and-snake-case |   |  |  |
 | 168 | canny-edge-detector |   |  |  |
 | 169 | canonicalize-cidr |   |  |  |
-| 170 | cantor-set |   |  |  |
+| 170 | cantor-set | ✓ |  |  |
 | 171 | carmichael-3-strong-pseudoprimes |   |  |  |
 | 172 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
 | 173 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
@@ -413,62 +413,64 @@ This file is auto-generated from rosetta tests.
 | 406 | fibonacci-sequence-2 |   |  |  |
 | 407 | fibonacci-sequence-3 |   |  |  |
 | 408 | fibonacci-sequence-4 |   |  |  |
-| 409 | fibonacci-word-fractal |   |  |  |
-| 410 | fibonacci-word |   |  |  |
-| 411 | file-extension-is-in-extensions-list |   |  |  |
-| 412 | file-input-output-1 |   |  |  |
-| 413 | file-input-output-2 |   |  |  |
-| 414 | file-modification-time |   |  |  |
-| 415 | file-size-distribution |   |  |  |
-| 416 | file-size |   |  |  |
-| 417 | filter |   |  |  |
-| 418 | find-chess960-starting-position-identifier |   |  |  |
-| 419 | find-common-directory-path |   |  |  |
-| 420 | find-duplicate-files |   |  |  |
-| 421 | find-if-a-point-is-within-a-triangle |   |  |  |
-| 422 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
-| 423 | find-limit-of-recursion |   |  |  |
-| 424 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
-| 425 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
-| 426 | find-the-intersection-of-two-lines |   |  |  |
-| 427 | find-the-last-sunday-of-each-month |   |  |  |
-| 428 | find-the-missing-permutation |   |  |  |
-| 429 | fivenum-1 |   |  |  |
-| 430 | fivenum-2 |   |  |  |
-| 431 | fixed-length-records-1 |   |  |  |
-| 432 | fixed-length-records-2 |   |  |  |
-| 433 | fizzbuzz-1 |   |  |  |
-| 434 | fizzbuzz-2 |   |  |  |
-| 435 | flatten-a-list-1 |   |  |  |
-| 436 | flatten-a-list-2 |   |  |  |
-| 437 | flipping-bits-game |   |  |  |
-| 438 | flow-control-structures-1 |   |  |  |
-| 439 | flow-control-structures-2 |   |  |  |
-| 440 | flow-control-structures-3 |   |  |  |
-| 441 | flow-control-structures-4 |   |  |  |
-| 442 | floyd-warshall-algorithm |   |  |  |
-| 443 | floyds-triangle |   |  |  |
-| 444 | forest-fire |   |  |  |
-| 445 | fork |   |  |  |
-| 446 | ftp |   |  |  |
-| 447 | gamma-function |   |  |  |
-| 448 | general-fizzbuzz |   |  |  |
-| 449 | generic-swap |   |  |  |
-| 450 | get-system-command-output |   |  |  |
-| 451 | giuga-numbers |   |  |  |
-| 452 | globally-replace-text-in-several-files |   |  |  |
-| 453 | goldbachs-comet |   |  |  |
-| 454 | golden-ratio-convergence |   |  |  |
-| 455 | graph-colouring |   |  |  |
-| 456 | gray-code |   |  |  |
-| 457 | http |   |  |  |
-| 458 | image-noise |   |  |  |
-| 459 | loops-increment-loop-index-within-loop-body |   |  |  |
-| 460 | md5 |   |  |  |
-| 461 | nim-game |   |  |  |
-| 462 | plasma-effect |   |  |  |
-| 463 | sorting-algorithms-bubble-sort |   |  |  |
-| 464 | window-management |   |  |  |
-| 465 | zumkeller-numbers |   |  |  |
+| 409 | fibonacci-sequence-5 |   |  |  |
+| 410 | fibonacci-word-fractal |   |  |  |
+| 411 | fibonacci-word |   |  |  |
+| 412 | file-extension-is-in-extensions-list |   |  |  |
+| 413 | file-input-output-1 |   |  |  |
+| 414 | file-input-output-2 |   |  |  |
+| 415 | file-input-output-3 |   |  |  |
+| 416 | file-modification-time |   |  |  |
+| 417 | file-size-distribution |   |  |  |
+| 418 | file-size |   |  |  |
+| 419 | filter |   |  |  |
+| 420 | find-chess960-starting-position-identifier |   |  |  |
+| 421 | find-common-directory-path |   |  |  |
+| 422 | find-duplicate-files |   |  |  |
+| 423 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 424 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 425 | find-limit-of-recursion |   |  |  |
+| 426 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 427 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 428 | find-the-intersection-of-two-lines |   |  |  |
+| 429 | find-the-last-sunday-of-each-month |   |  |  |
+| 430 | find-the-missing-permutation |   |  |  |
+| 431 | fivenum-1 |   |  |  |
+| 432 | fivenum-2 |   |  |  |
+| 433 | fixed-length-records-1 |   |  |  |
+| 434 | fixed-length-records-2 |   |  |  |
+| 435 | fizzbuzz-1 |   |  |  |
+| 436 | fizzbuzz-2 |   |  |  |
+| 437 | flatten-a-list-1 |   |  |  |
+| 438 | flatten-a-list-2 |   |  |  |
+| 439 | flipping-bits-game |   |  |  |
+| 440 | flow-control-structures-1 |   |  |  |
+| 441 | flow-control-structures-2 |   |  |  |
+| 442 | flow-control-structures-3 |   |  |  |
+| 443 | flow-control-structures-4 |   |  |  |
+| 444 | floyd-warshall-algorithm |   |  |  |
+| 445 | floyds-triangle |   |  |  |
+| 446 | forest-fire |   |  |  |
+| 447 | fork |   |  |  |
+| 448 | ftp |   |  |  |
+| 449 | gamma-function |   |  |  |
+| 450 | general-fizzbuzz |   |  |  |
+| 451 | generic-swap |   |  |  |
+| 452 | get-system-command-output |   |  |  |
+| 453 | giuga-numbers |   |  |  |
+| 454 | globally-replace-text-in-several-files |   |  |  |
+| 455 | goldbachs-comet |   |  |  |
+| 456 | golden-ratio-convergence |   |  |  |
+| 457 | graph-colouring |   |  |  |
+| 458 | gray-code |   |  |  |
+| 459 | http |   |  |  |
+| 460 | image-noise |   |  |  |
+| 461 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 462 | md5 |   |  |  |
+| 463 | nim-game |   |  |  |
+| 464 | plasma-effect |   |  |  |
+| 465 | sorting-algorithms-bubble-sort |   |  |  |
+| 466 | window-management |   |  |  |
+| 467 | zumkeller-numbers |   |  |  |
 
-Last updated: 2025-07-27 17:18 +0700
+Last updated: 2025-07-27 15:42 +0000

--- a/transpiler/x/fs/TASKS.md
+++ b/transpiler/x/fs/TASKS.md
@@ -1,3 +1,7 @@
+## Progress (2025-07-27 15:42 +0000)
+- Applying previous commit.
+- Generated F# for 103/104 programs (103 passing)
+
 ## Progress (2025-07-27 17:18 +0700)
 - fs transpiler: handle typed lambdas and append elem cast
 - Generated F# for 103/104 programs (103 passing)


### PR DESCRIPTION
## Summary
- ensure list literals box elements when types differ or are unknown
- regenerate F# Rosetta outputs after compiling index 164

## Testing
- `MOCHI_ROSETTA_INDEX=164 MOCHI_BENCHMARK=1 go test -run Rosetta ./transpiler/x/fs -tags=slow -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68863b939b4c83209c3ff156676c1a0f