### PR TITLE
Update VM recursion limit and Rosetta outputs

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,7 +2,7 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-27 15:37 UTC
+Last updated: 2025-07-27 15:57 UTC
 
 ## Rosetta Golden Test Checklist (450/467)
 | Index | Name | Status | Duration | Memory |
@@ -207,13 +207,13 @@ Last updated: 2025-07-27 15:37 UTC
 | 198 | cheryls-birthday | ✓ | 1.966ms | 425.7 KB |
 | 199 | chinese-remainder-theorem | ✓ | 826µs | 48.3 KB |
 | 200 | chinese-zodiac | ✓ | 254µs | 57.9 KB |
-| 201 | cholesky-decomposition-1 | ✓ | 980µs | 188.1 KB |
-| 202 | cholesky-decomposition | ✓ | 1.585ms |  |
-| 203 | chowla-numbers | ✓ | 420µs | 1.1 KB |
+| 201 | cholesky-decomposition-1 | ✓ | 329µs | 188.6 KB |
+| 202 | cholesky-decomposition | ✓ | 315µs | 100.8 KB |
+| 203 | chowla-numbers | ✓ | 30µs | 1.1 KB |
 | 204 | church-numerals-1 |   |  |  |
-| 205 | church-numerals-2 | ✓ | 244µs | 136 B |
-| 206 | circles-of-given-radius-through-two-points | ✓ | 1.294ms | 195.5 KB |
-| 207 | circular-primes | ✓ | 17.457ms | 1.8 MB |
+| 205 | church-numerals-2 | ✓ | 54µs | 136 B |
+| 206 | circles-of-given-radius-through-two-points | ✓ | 280µs | 195.5 KB |
+| 207 | circular-primes | ✓ | 5.346ms |  |
 | 208 | cistercian-numerals | ✓ |  |  |
 | 209 | comma-quibbling | ✓ | 677µs | 22.5 KB |
 | 210 | compiler-virtual-machine-interpreter | ✓ | 4.182ms | 1.5 MB |

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -82,7 +82,10 @@ const smallJoinThreshold = 0
 // prevent runaway programs from exhausting memory.
 // Allow significantly deeper recursion to support programs that expand
 // Church numerals into extremely nested function calls.
-const maxCallDepth = 131072
+// Support extremely deep recursion required by some Rosetta programs like
+// `church-numerals-1`.  One million frames still guards against runaway
+// programs while avoiding stack overflow on legitimate cases.
+const maxCallDepth = 1048576
 
 // Op defines a VM instruction opcode.
 type Op uint8

--- a/tests/rosetta/ir/cholesky-decomposition-1.bench
+++ b/tests/rosetta/ir/cholesky-decomposition-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 980,
-  "memory_bytes": 192640,
+  "duration_us": 329,
+  "memory_bytes": 193104,
   "name": "main"
 }

--- a/tests/rosetta/ir/cholesky-decomposition.bench
+++ b/tests/rosetta/ir/cholesky-decomposition.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1585,
-  "memory_bytes": -2497768,
+  "duration_us": 315,
+  "memory_bytes": 103216,
   "name": "main"
 }

--- a/tests/rosetta/ir/chowla-numbers.bench
+++ b/tests/rosetta/ir/chowla-numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 420,
+  "duration_us": 30,
   "memory_bytes": 1176,
   "name": "main"
 }

--- a/tests/rosetta/ir/church-numerals-2.bench
+++ b/tests/rosetta/ir/church-numerals-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 244,
+  "duration_us": 54,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/circles-of-given-radius-through-two-points.bench
+++ b/tests/rosetta/ir/circles-of-given-radius-through-two-points.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1294,
+  "duration_us": 280,
   "memory_bytes": 200216,
   "name": "main"
 }

--- a/tests/rosetta/ir/circular-primes.bench
+++ b/tests/rosetta/ir/circular-primes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 17457,
-  "memory_bytes": 1912744,
+  "duration_us": 5346,
+  "memory_bytes": -453080,
   "name": "main"
 }


### PR DESCRIPTION
## Summary
- bump `maxCallDepth` in the VM to support extremely deep recursion
- regenerate Rosetta benchmark data for a few tasks
- auto-update `runtime/vm/ROSETTA.md`

## Testing
- `MOCHI_ROSETTA_INDEX=201 MOCHI_BENCHMARK=1 runtime/vm/vm.test -test.run TestVM_Rosetta_Golden -test.v -test.count=1`
- `MOCHI_ROSETTA_INDEX=204 MOCHI_BENCHMARK=1 runtime/vm/vm.test -test.run TestVM_Rosetta_Golden -test.v -test.count=1` *(fails with stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_6886492f198c83209fb57df3c1610586