### PR TITLE
Update FS transpiler outputs

### DIFF
--- a/tests/rosetta/transpiler/FS/call-an-object-method-3.bench
+++ b/tests/rosetta/transpiler/FS/call-an-object-method-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 7,
-  "memory_bytes": 328,
+  "duration_us": 27,
+  "memory_bytes": 16848,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/call-an-object-method-3.fs
+++ b/tests/rosetta/transpiler/FS/call-an-object-method-3.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 23:30 +0700
 
 exception Return
 

--- a/tests/rosetta/transpiler/FS/call-an-object-method.bench
+++ b/tests/rosetta/transpiler/FS/call-an-object-method.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 7,
-  "memory_bytes": 328,
+  "duration_us": 27,
+  "memory_bytes": 2904,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/call-an-object-method.fs
+++ b/tests/rosetta/transpiler/FS/call-an-object-method.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:38 +0000
 
 exception Return
 

--- a/tests/rosetta/transpiler/FS/camel-case-and-snake-case.bench
+++ b/tests/rosetta/transpiler/FS/camel-case-and-snake-case.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 230,
+  "duration_us": 453,
   "memory_bytes": 58768,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/camel-case-and-snake-case.fs
+++ b/tests/rosetta/transpiler/FS/camel-case-and-snake-case.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:39 +0000
 
 exception Break
 exception Continue

--- a/tests/rosetta/transpiler/FS/canny-edge-detector.bench
+++ b/tests/rosetta/transpiler/FS/canny-edge-detector.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 175,
-  "memory_bytes": 50384,
+  "duration_us": 385,
+  "memory_bytes": 43824,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/canny-edge-detector.fs
+++ b/tests/rosetta/transpiler/FS/canny-edge-detector.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:39 +0000
 
 exception Return
 

--- a/tests/rosetta/transpiler/FS/canonicalize-cidr.bench
+++ b/tests/rosetta/transpiler/FS/canonicalize-cidr.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 255,
-  "memory_bytes": 54592,
+  "duration_us": 493,
+  "memory_bytes": 68944,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/canonicalize-cidr.fs
+++ b/tests/rosetta/transpiler/FS/canonicalize-cidr.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:40 +0000
 
 exception Return
 

--- a/tests/rosetta/transpiler/FS/cantor-set.bench
+++ b/tests/rosetta/transpiler/FS/cantor-set.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 383,
-  "memory_bytes": 65456,
+  "duration_us": 811,
+  "memory_bytes": 77600,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/cantor-set.fs
+++ b/tests/rosetta/transpiler/FS/cantor-set.fs
@@ -1,10 +1,28 @@
-// Generated 2025-07-27 22:00 +0700
+// Generated 2025-07-27 16:40 +0000
 
 exception Break
 exception Continue
 
 exception Return
 
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
 let _substring (s:string) (start:int) (finish:int) =
     let len = String.length s
     let mutable st = if start < 0 then len + start else start
@@ -20,6 +38,8 @@ type Anon1 = {
     len: int
     index: int
 }
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
 let width: int = 81
 let height: int = 5
 let mutable lines: string array = [||]
@@ -66,3 +86,6 @@ with
 | Continue -> ()
 for line in lines do
     printfn "%A" line
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/carmichael-3-strong-pseudoprimes.bench
+++ b/tests/rosetta/transpiler/FS/carmichael-3-strong-pseudoprimes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 264,
-  "memory_bytes": 43104,
+  "duration_us": 518,
+  "memory_bytes": 47184,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/carmichael-3-strong-pseudoprimes.fs
+++ b/tests/rosetta/transpiler/FS/carmichael-3-strong-pseudoprimes.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:41 +0000
 
 exception Break
 exception Continue

--- a/tests/rosetta/transpiler/FS/cartesian-product-of-two-or-more-lists-1.bench
+++ b/tests/rosetta/transpiler/FS/cartesian-product-of-two-or-more-lists-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 161,
-  "memory_bytes": 43080,
+  "duration_us": 325,
+  "memory_bytes": 49152,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/FS/cartesian-product-of-two-or-more-lists-1.fs
+++ b/tests/rosetta/transpiler/FS/cartesian-product-of-two-or-more-lists-1.fs
@@ -1,4 +1,4 @@
-// Generated 2025-07-27 22:23 +0700
+// Generated 2025-07-27 16:41 +0000
 
 exception Return
 


### PR DESCRIPTION
## Summary
- regenerate F# transpiler output files for several Rosetta programs
- update bench files accordingly

## Testing
- `MOCHI_BENCHMARK=1 MOCHI_ROSETTA_INDEX=170 go test -tags slow ./transpiler/x/fs -run TestFSTranspiler_Rosetta_Golden -v`


------
https://chatgpt.com/codex/tasks/task_e_688654dbca64832094658cc80950152a