### PR TITLE
Add function value support in VM

### DIFF
--- a/runtime/vm/ROSETTA.md
+++ b/runtime/vm/ROSETTA.md
@@ -2,9 +2,9 @@
 
 This checklist is auto-generated.
 Generated IR and outputs from programs in `tests/rosetta/x/Mochi` lives in `tests/rosetta/ir`.
-Last updated: 2025-07-27 15:57 UTC
+Last updated: 2025-07-27 16:58 UTC
 
-## Rosetta Golden Test Checklist (450/467)
+## Rosetta Golden Test Checklist (452/467)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 216µs | 34.2 KB |
@@ -207,27 +207,27 @@ Last updated: 2025-07-27 15:57 UTC
 | 198 | cheryls-birthday | ✓ | 1.966ms | 425.7 KB |
 | 199 | chinese-remainder-theorem | ✓ | 826µs | 48.3 KB |
 | 200 | chinese-zodiac | ✓ | 254µs | 57.9 KB |
-| 201 | cholesky-decomposition-1 | ✓ | 329µs | 188.6 KB |
-| 202 | cholesky-decomposition | ✓ | 315µs | 100.8 KB |
-| 203 | chowla-numbers | ✓ | 30µs | 1.1 KB |
+| 201 | cholesky-decomposition-1 | ✓ | 416µs | 188.2 KB |
+| 202 | cholesky-decomposition | ✓ | 282µs | 100.8 KB |
+| 203 | chowla-numbers | ✓ | 32µs | 1.1 KB |
 | 204 | church-numerals-1 |   |  |  |
-| 205 | church-numerals-2 | ✓ | 54µs | 136 B |
-| 206 | circles-of-given-radius-through-two-points | ✓ | 280µs | 195.5 KB |
-| 207 | circular-primes | ✓ | 5.346ms |  |
+| 205 | church-numerals-2 | ✓ | 17µs | 136 B |
+| 206 | circles-of-given-radius-through-two-points | ✓ | 276µs | 195.5 KB |
+| 207 | circular-primes | ✓ | 6.237ms |  |
 | 208 | cistercian-numerals | ✓ |  |  |
-| 209 | comma-quibbling | ✓ | 677µs | 22.5 KB |
-| 210 | compiler-virtual-machine-interpreter | ✓ | 4.182ms | 1.5 MB |
+| 209 | comma-quibbling | ✓ | 225µs | 22.5 KB |
+| 210 | compiler-virtual-machine-interpreter | ✓ | 1.829ms | 897.5 KB |
 | 211 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | ✓ |  |  |
-| 212 | compound-data-type | ✓ | 30µs | 136 B |
-| 213 | concurrent-computing-1 | ✓ | 32µs | 3.5 KB |
-| 214 | concurrent-computing-2 | ✓ | 30µs | 3.5 KB |
-| 215 | concurrent-computing-3 | ✓ | 55µs | 8.7 KB |
-| 216 | conditional-structures-1 | ✓ | 31µs | 136 B |
-| 217 | conditional-structures-10 | ✓ | 34µs | 552 B |
-| 218 | conditional-structures-2 | ✓ | 29µs | 136 B |
-| 219 | conditional-structures-3 | ✓ | 28µs | 136 B |
-| 220 | conditional-structures-4 |   |  |  |
-| 221 | conditional-structures-5 |   |  |  |
+| 212 | compound-data-type | ✓ | 28µs | 136 B |
+| 213 | concurrent-computing-1 | ✓ | 82µs |  |
+| 214 | concurrent-computing-2 | ✓ | 50µs | 4.9 KB |
+| 215 | concurrent-computing-3 | ✓ | 46µs | 13.1 KB |
+| 216 | conditional-structures-1 | ✓ | 74µs | 136 B |
+| 217 | conditional-structures-10 | ✓ | 33µs | 552 B |
+| 218 | conditional-structures-2 | ✓ | 57µs | 136 B |
+| 219 | conditional-structures-3 | ✓ | 29µs | 136 B |
+| 220 | conditional-structures-4 | ✓ | 27µs | 136 B |
+| 221 | conditional-structures-5 | ✓ | 47µs | 136 B |
 | 222 | conditional-structures-6 |   |  |  |
 | 223 | conditional-structures-7 |   |  |  |
 | 224 | conditional-structures-8 |   |  |  |

--- a/runtime/vm/vm.go
+++ b/runtime/vm/vm.go
@@ -3730,6 +3730,10 @@ func (fc *funcCompiler) compilePrimary(p *parser.Primary) int {
 				r = fc.newReg()
 				fc.emit(p.Pos, Instr{Op: OpGetGlobal, A: r, B: gidx})
 				fc.tags[r] = tagUnknown
+			} else if fnIdx, fok := fc.comp.fnIndex[p.Selector.Root]; fok && len(p.Selector.Tail) == 0 {
+				r = fc.newReg()
+				fc.emit(p.Pos, Instr{Op: OpMakeClosure, A: r, B: fnIdx, C: 0})
+				fc.tags[r] = tagUnknown
 			} else {
 				if len(p.Selector.Tail) == 0 {
 					if st, ok := fc.comp.env.GetStruct(p.Selector.Root); ok && len(st.Order) == 0 {

--- a/tests/rosetta/ir/cholesky-decomposition-1.bench
+++ b/tests/rosetta/ir/cholesky-decomposition-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 329,
-  "memory_bytes": 193104,
+  "duration_us": 416,
+  "memory_bytes": 192736,
   "name": "main"
 }

--- a/tests/rosetta/ir/cholesky-decomposition.bench
+++ b/tests/rosetta/ir/cholesky-decomposition.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 315,
+  "duration_us": 282,
   "memory_bytes": 103216,
   "name": "main"
 }

--- a/tests/rosetta/ir/chowla-numbers.bench
+++ b/tests/rosetta/ir/chowla-numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 30,
+  "duration_us": 32,
   "memory_bytes": 1176,
   "name": "main"
 }

--- a/tests/rosetta/ir/church-numerals-1.ir
+++ b/tests/rosetta/ir/church-numerals-1.ir
@@ -1,5 +1,6 @@
 func main (regs=58)
   // let z: Church = zero
+  MakeClosure  r3, zero, 0, r0
   Move         r0, r3
   SetGlobal    0,0,0,0
   // let three = succ(succ(succ(z)))
@@ -149,6 +150,7 @@ func incr (regs=7)
   // fun toInt(c: Church): int { return c(incr)(0) as int }
 func toInt (regs=11)
   // fun toInt(c: Church): int { return c(incr)(0) as int }
+  MakeClosure  r5, incr, 0, r0
   Move         r4, r5
   CallV        r6, r3, 1, r4
   Const        r8, 0
@@ -163,6 +165,7 @@ func intToChurch (regs=13)
   Const        r4, 0
   Equal        r5, r3, r4
   JumpIfFalse  r5, L0
+  MakeClosure  r6, zero, 0, r0
   Return       r6
 L0:
   // return succ(intToChurch(i - 1))

--- a/tests/rosetta/ir/church-numerals-2.ir
+++ b/tests/rosetta/ir/church-numerals-2.ir
@@ -23,6 +23,7 @@ func zero (regs=1)
   // fun one(): Church { return id }
 func one (regs=1)
   // fun one(): Church { return id }
+  MakeClosure  r0, id, 0, r0
   Return       r0
 
   // fun succ(n: Church): Church {
@@ -67,6 +68,7 @@ func toInt (regs=11)
   // x(fCounter)(id)
   Move         r6, r5
   CallV        r7, r0, 1, r6
+  MakeClosure  r9, id, 0, r0
   Move         r8, r9
   CallV        r10, r7, 1, r8
   // return counter
@@ -84,6 +86,7 @@ func toStr (regs=11)
   // x(fCounter)(id)
   Move         r6, r5
   CallV        r7, r0, 1, r6
+  MakeClosure  r9, id, 0, r0
   Move         r8, r9
   CallV        r10, r7, 1, r8
   // return s
@@ -179,6 +182,7 @@ func fn12 (regs=7)
   // fun zero(): Church { return fun(f: Church): Church { return id } }
 func fn13 (regs=2)
   // fun zero(): Church { return fun(f: Church): Church { return id } }
+  MakeClosure  r1, id, 0, r0
   Return       r1
 
   // return fun(f: Church): Church { return compose(f, n(f)) }

--- a/tests/rosetta/ir/circles-of-given-radius-through-two-points.bench
+++ b/tests/rosetta/ir/circles-of-given-radius-through-two-points.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 280,
+  "duration_us": 276,
   "memory_bytes": 200216,
   "name": "main"
 }

--- a/tests/rosetta/ir/circular-primes.bench
+++ b/tests/rosetta/ir/circular-primes.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 5346,
-  "memory_bytes": -453080,
+  "duration_us": 6237,
+  "memory_bytes": -244800,
   "name": "main"
 }

--- a/tests/rosetta/ir/comma-quibbling.bench
+++ b/tests/rosetta/ir/comma-quibbling.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 677,
+  "duration_us": 225,
   "memory_bytes": 23008,
   "name": "main"
 }

--- a/tests/rosetta/ir/compiler-virtual-machine-interpreter.bench
+++ b/tests/rosetta/ir/compiler-virtual-machine-interpreter.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 4182,
-  "memory_bytes": 1609336,
+  "duration_us": 1829,
+  "memory_bytes": 919064,
   "name": "main"
 }

--- a/tests/rosetta/ir/compound-data-type.bench
+++ b/tests/rosetta/ir/compound-data-type.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 30,
+  "duration_us": 28,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/concurrent-computing-1.bench
+++ b/tests/rosetta/ir/concurrent-computing-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 32,
-  "memory_bytes": 3624,
+  "duration_us": 82,
+  "memory_bytes": -242232,
   "name": "main"
 }

--- a/tests/rosetta/ir/concurrent-computing-2.bench
+++ b/tests/rosetta/ir/concurrent-computing-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 30,
-  "memory_bytes": 3624,
+  "duration_us": 50,
+  "memory_bytes": 4984,
   "name": "main"
 }

--- a/tests/rosetta/ir/concurrent-computing-3.bench
+++ b/tests/rosetta/ir/concurrent-computing-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 55,
-  "memory_bytes": 8904,
+  "duration_us": 46,
+  "memory_bytes": 13416,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-1.bench
+++ b/tests/rosetta/ir/conditional-structures-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 31,
+  "duration_us": 74,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-10.bench
+++ b/tests/rosetta/ir/conditional-structures-10.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 34,
+  "duration_us": 33,
   "memory_bytes": 552,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-2.bench
+++ b/tests/rosetta/ir/conditional-structures-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 29,
+  "duration_us": 57,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-3.bench
+++ b/tests/rosetta/ir/conditional-structures-3.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 28,
+  "duration_us": 29,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-4.bench
+++ b/tests/rosetta/ir/conditional-structures-4.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 17,
+  "duration_us": 27,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-4.ir
+++ b/tests/rosetta/ir/conditional-structures-4.ir
@@ -1,0 +1,37 @@
+func main (regs=1)
+  Return       r0
+
+  // fun fetchSomething(): int { return 0 }
+func fetchSomething (regs=1)
+  // fun fetchSomething(): int { return 0 }
+  Const        r0, 0
+  Return       r0
+
+  // fun doPos(x: int) {}
+func doPos (regs=1)
+  Return       r0
+
+  // fun doNeg(x: int) {}
+func doNeg (regs=1)
+  Return       r0
+
+  // fun example4() {
+func example4 (regs=7)
+  // let x = fetchSomething()
+  Const        r0, 0
+  Move         r1, r0
+  // if x > 0 {
+  Const        r0, 0
+  LessInt      r2, r0, r1
+  JumpIfFalse  r2, L0
+  // doPos(x)
+  Move         r3, r1
+  Call         r4, doPos, r3
+  // if x > 0 {
+  Jump         L1
+L0:
+  // doNeg(x)
+  Move         r5, r1
+  Call         r6, doNeg, r5
+L1:
+  Return       r0

--- a/tests/rosetta/ir/conditional-structures-5.bench
+++ b/tests/rosetta/ir/conditional-structures-5.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 17,
+  "duration_us": 47,
   "memory_bytes": 136,
   "name": "main"
 }

--- a/tests/rosetta/ir/conditional-structures-5.ir
+++ b/tests/rosetta/ir/conditional-structures-5.ir
@@ -1,0 +1,23 @@
+func main (regs=1)
+  Return       r0
+
+  // fun example5(b1: bool, b2: bool) {
+func example5 (regs=3)
+  // if b1 {
+  JumpIfFalse  r0, L0
+  // null
+  Const        r2, nil
+  // if b1 {
+  Jump         L1
+L0:
+  // } else if b2 {
+  JumpIfFalse  r1, L2
+  // null
+  Const        r2, nil
+  // } else if b2 {
+  Jump         L1
+L2:
+  // null
+  Const        r2, nil
+L1:
+  Return       r0


### PR DESCRIPTION
## Summary
- support referring to functions as values in the VM compiler
- regenerate Rosetta IR/benchmarks for several programs

## Testing
- `MOCHI_ROSETTA_INDEX=201 MOCHI_BENCHMARK=1 go test ./runtime/vm -tags slow -run TestVM_Rosetta_Golden -count=1`
- `for i in 202 203 205 206 207; do MOCHI_ROSETTA_INDEX=$i MOCHI_BENCHMARK=1 go test ./runtime/vm -tags slow -run TestVM_Rosetta_Golden -count=1; done`

------
https://chatgpt.com/codex/tasks/task_e_6886551906ac8320af248723e3e307f0