### PR TITLE
Fix Kotlin transpiler null map handling

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/array-concatenation.bench
+++ b/tests/rosetta/transpiler/Kotlin/array-concatenation.bench
@@ -1,1 +1,1 @@
-{"duration_us":11174, "memory_bytes":135592, "name":"main"}
+{"duration_us":5911, "memory_bytes":135208, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/array-length.bench
+++ b/tests/rosetta/transpiler/Kotlin/array-length.bench
@@ -1,1 +1,1 @@
-{"duration_us":20041, "memory_bytes":126480, "name":"main"}
+{"duration_us":10633, "memory_bytes":126560, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/arrays.bench
+++ b/tests/rosetta/transpiler/Kotlin/arrays.bench
@@ -1,1 +1,1 @@
-{"duration_us":10244, "memory_bytes":135232, "name":"main"}
+{"duration_us":6528, "memory_bytes":134840, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/ascending-primes.bench
+++ b/tests/rosetta/transpiler/Kotlin/ascending-primes.bench
@@ -1,1 +1,1 @@
-{"duration_us":22533, "memory_bytes":124920, "name":"main"}
+{"duration_us":13985, "memory_bytes":123568, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/ascii-art-diagram-converter.bench
+++ b/tests/rosetta/transpiler/Kotlin/ascii-art-diagram-converter.bench
@@ -1,1 +1,1 @@
-{"duration_us":9750, "memory_bytes":134104, "name":"main"}
+{"duration_us":5009, "memory_bytes":134040, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/assertions.bench
+++ b/tests/rosetta/transpiler/Kotlin/assertions.bench
@@ -1,1 +1,1 @@
-{"duration_us":7334, "memory_bytes":137320, "name":"main"}
+{"duration_us":2986, "memory_bytes":137256, "name":"main"}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-27 22:51 +0700
+Last updated: 2025-07-27 23:38 +0700
 
-Completed tasks: **72/467**
+Completed tasks: **74/467**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -83,15 +83,15 @@ Completed tasks: **72/467**
 | 72 | arithmetic-integer-2 | ✓ | 10.42ms | 140.1 KB |
 | 73 | arithmetic-numbers |  |  |  |
 | 74 | arithmetic-rational |  |  |  |
-| 75 | array-concatenation | ✓ | 11.17ms | 132.4 KB |
-| 76 | array-length | ✓ | 20.04ms | 123.5 KB |
-| 77 | arrays | ✓ | 10.24ms | 132.1 KB |
-| 78 | ascending-primes | ✓ | 22.53ms | 122.0 KB |
-| 79 | ascii-art-diagram-converter | ✓ | 9.75ms | 131.0 KB |
-| 80 | assertions | ✓ | 7.33ms | 134.1 KB |
+| 75 | array-concatenation | ✓ | 5.91ms | 132.0 KB |
+| 76 | array-length | ✓ | 10.63ms | 123.6 KB |
+| 77 | arrays | ✓ | 6.53ms | 131.7 KB |
+| 78 | ascending-primes | ✓ | 13.98ms | 120.7 KB |
+| 79 | ascii-art-diagram-converter | ✓ | 5.01ms | 130.9 KB |
+| 80 | assertions | ✓ | 2.99ms | 134.0 KB |
 | 81 | associative-array-creation |  |  |  |
-| 82 | associative-array-iteration |  |  |  |
-| 83 | associative-array-merging |  |  |  |
+| 82 | associative-array-iteration | ✓ | 15.12ms | 118.4 KB |
+| 83 | associative-array-merging | ✓ | 10.43ms | 114.6 KB |
 | 84 | atomic-updates |  |  |  |
 | 85 | attractive-numbers |  |  |  |
 | 86 | average-loop-length |  |  |  |


### PR DESCRIPTION
## Summary
- update Kotlin ROSETTA benchmarks
- handle null initialization for map variables
- allow map indexing to return nullable values

## Testing
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=81 go test ./transpiler/x/kt -tags slow -run Rosetta -count=1 -v` *(fails: program associative-array-creation)*

------
https://chatgpt.com/codex/tasks/task_e_688656958a54832083a6027413acf704