### PR TITLE
Enhance F# transpiler for Rosetta tasks

### DIFF
--- a/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.bench
+++ b/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 270,
+  "memory_bytes": 44040,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.fs
+++ b/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.fs
@@ -1,0 +1,114 @@
+// Generated 2025-07-28 01:10 +0700
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+type Point = {
+    x: float
+    y: float
+}
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let rec sqrtApprox (x: float) =
+    let mutable __ret : float = Unchecked.defaultof<float>
+    let mutable x = x
+    try
+        let mutable g: float = x
+        let mutable i: int = 0
+        while i < 40 do
+            g <- (g + (x / g)) / 2.0
+            i <- i + 1
+        __ret <- g
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let rec hypot (x: float) (y: float) =
+    let mutable __ret : float = Unchecked.defaultof<float>
+    let mutable x = x
+    let mutable y = y
+    try
+        __ret <- sqrtApprox ((x * x) + (y * y))
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let Two: string = "Two circles."
+let R0: string = "R==0.0 does not describe circles."
+let Co: string = "Coincident points describe an infinite number of circles."
+let CoR0: string = "Coincident points with r==0.0 describe a degenerate circle."
+let Diam: string = "Points form a diameter and describe only a single circle."
+let Far: string = "Points too far apart to form circles."
+let rec circles (p1: Point) (p2: Point) (r: float) =
+    let mutable __ret : obj array = Unchecked.defaultof<obj array>
+    let mutable p1 = p1
+    let mutable p2 = p2
+    let mutable r = r
+    try
+        if ((p1.x) = (p2.x)) && ((p1.y) = (p2.y)) then
+            if r = 0.0 then
+                __ret <- [|box p1; box p1; box "Coincident points with r==0.0 describe a degenerate circle."|]
+                raise Return
+            __ret <- [|box p1; box p2; box "Coincident points describe an infinite number of circles."|]
+            raise Return
+        if r = 0.0 then
+            __ret <- [|box p1; box p2; box "R==0.0 does not describe circles."|]
+            raise Return
+        let dx: float = (p2.x) - (p1.x)
+        let dy: float = (p2.y) - (p1.y)
+        let q: float = hypot dx dy
+        if q > (2.0 * r) then
+            __ret <- [|box p1; box p2; box "Points too far apart to form circles."|]
+            raise Return
+        let m: Point = { x = ((p1.x) + (p2.x)) / 2.0; y = ((p1.y) + (p2.y)) / 2.0 }
+        if q = (2.0 * r) then
+            __ret <- [|box m; box m; box "Points form a diameter and describe only a single circle."|]
+            raise Return
+        let d: float = sqrtApprox ((r * r) - ((q * q) / 4.0))
+        let ox: float = (d * dx) / q
+        let oy: float = (d * dy) / q
+        __ret <- [|box { x = (m.x) - oy; y = (m.y) + ox }; box { x = (m.x) + oy; y = (m.y) - ox }; box "Two circles."|]
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let mutable td = [|[|box { x = 0.1234; y = 0.9876 }; box { x = 0.8765; y = 0.2345 }; box 2.0|]; [|box { x = 0.0; y = 2.0 }; box { x = 0.0; y = 0.0 }; box 1.0|]; [|box { x = 0.1234; y = 0.9876 }; box { x = 0.1234; y = 0.9876 }; box 2.0|]; [|box { x = 0.1234; y = 0.9876 }; box { x = 0.8765; y = 0.2345 }; box 0.5|]; [|box { x = 0.1234; y = 0.9876 }; box { x = 0.1234; y = 0.9876 }; box 0.0|]|]
+for tc in td do
+    let p1: obj = box (tc.[0])
+    let p2: obj = box (tc.[1])
+    let r: obj = box (tc.[2])
+    printfn "%s" (((("p1:  {" + (string (((p1 :?> Point).x)))) + " ") + (string (((p1 :?> Point).y)))) + "}")
+    printfn "%s" (((("p2:  {" + (string (((p2 :?> Point).x)))) + " ") + (string (((p2 :?> Point).y)))) + "}")
+    printfn "%s" ("r:  " + (string r))
+    let res: obj array = circles (unbox<Point> p1) (unbox<Point> p2) (unbox<float> r)
+    let c1: obj = res.[0]
+    let c2: obj = res.[1]
+    let caseStr: obj = res.[2]
+    printfn "%s" ("   " + (unbox<string> caseStr))
+    if ((unbox<string> caseStr) = "Points form a diameter and describe only a single circle.") || ((unbox<string> caseStr) = "Coincident points with r==0.0 describe a degenerate circle.") then
+        printfn "%s" (((("   Center:  {" + (string (((c1 :?> Point).x)))) + " ") + (string (((c1 :?> Point).y)))) + "}")
+    else
+        if (unbox<string> caseStr) = "Two circles." then
+            printfn "%s" (((("   Center 1:  {" + (string (((c1 :?> Point).x)))) + " ") + (string (((c1 :?> Point).y)))) + "}")
+            printfn "%s" (((("   Center 2:  {" + (string (((c2 :?> Point).x)))) + " ") + (string (((c2 :?> Point).y)))) + "}")
+    printfn "%s" ""
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.out
+++ b/tests/rosetta/transpiler/FS/circles-of-given-radius-through-two-points.out
@@ -1,0 +1,28 @@
+p1:  {0.1234 0.9876}
+p2:  {0.8765 0.2345}
+r:  2
+   Two circles.
+   Center 1:  {1.86311180165819 1.97421180165819}
+   Center 2:  {-0.863211801658189 -0.752111801658189}
+
+p1:  {0 2}
+p2:  {0 0}
+r:  1
+   Points form a diameter and describe only a single circle.
+   Center:  {0 1}
+
+p1:  {0.1234 0.9876}
+p2:  {0.1234 0.9876}
+r:  2
+   Coincident points describe an infinite number of circles.
+
+p1:  {0.1234 0.9876}
+p2:  {0.8765 0.2345}
+r:  0.5
+   Points too far apart to form circles.
+
+p1:  {0.1234 0.9876}
+p2:  {0.1234 0.9876}
+r:  0
+   Coincident points with r==0.0 describe a degenerate circle.
+   Center:  {0.1234 0.9876}

--- a/tests/rosetta/transpiler/FS/circular-primes.bench
+++ b/tests/rosetta/transpiler/FS/circular-primes.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 237,
+  "memory_bytes": 48480,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/circular-primes.fs
+++ b/tests/rosetta/transpiler/FS/circular-primes.fs
@@ -1,0 +1,140 @@
+// Generated 2025-07-28 01:10 +0700
+
+exception Break
+exception Continue
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let rec isPrime (n: int) =
+    let mutable __ret : bool = Unchecked.defaultof<bool>
+    let mutable n = n
+    try
+        if n < 2 then
+            __ret <- false
+            raise Return
+        if (((n % 2 + 2) % 2)) = 0 then
+            __ret <- n = 2
+            raise Return
+        if (((n % 3 + 3) % 3)) = 0 then
+            __ret <- n = 3
+            raise Return
+        let mutable d: int = 5
+        while (d * d) <= n do
+            if (((n % d + d) % d)) = 0 then
+                __ret <- false
+                raise Return
+            d <- d + 2
+            if (((n % d + d) % d)) = 0 then
+                __ret <- false
+                raise Return
+            d <- d + 4
+        __ret <- true
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+let mutable circs: int array = [||]
+let rec isCircular (n: int) =
+    let mutable __ret : bool = Unchecked.defaultof<bool>
+    let mutable n = n
+    try
+        let mutable nn: int = n
+        let mutable pow: int = 1
+        while nn > 0 do
+            pow <- pow * 10
+            nn <- nn / 10
+        nn <- n
+        try
+            while true do
+                try
+                    nn <- nn * 10
+                    let f: int = nn / pow
+                    nn <- nn + (f * (1 - pow))
+                    if nn = n then
+                        raise Break
+                    if not (isPrime nn) then
+                        __ret <- false
+                        raise Return
+                with
+                | Continue -> ()
+                | Break -> raise Break
+        with
+        | Break -> ()
+        | Continue -> ()
+        __ret <- true
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+printfn "%s" "The first 19 circular primes are:"
+let mutable digits: int array = [|1; 3; 7; 9|]
+let mutable q: int array = [|1; 2; 3; 5; 7; 9|]
+let mutable fq: int array = [|1; 2; 3; 5; 7; 9|]
+let mutable count: int = 0
+try
+    while true do
+        try
+            let f: int = q.[0]
+            let fd: int = fq.[0]
+            if (isPrime f) && (isCircular f) then
+                circs <- Array.append circs [|f|]
+                count <- count + 1
+                if count = 19 then
+                    raise Break
+            q <- Array.sub q 1 ((int (Array.length q)) - 1)
+            fq <- Array.sub fq 1 ((int (Array.length fq)) - 1)
+            if (f <> 2) && (f <> 5) then
+                for d in digits do
+                    q <- Array.append q [|(f * 10) + d|]
+                    fq <- Array.append fq [|fd|]
+        with
+        | Continue -> ()
+        | Break -> raise Break
+with
+| Break -> ()
+| Continue -> ()
+let rec showList (xs: int array) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable xs = xs
+    try
+        let mutable out: string = "["
+        let mutable i: int = 0
+        while i < (Seq.length xs) do
+            out <- out + (string (xs.[i]))
+            if i < ((Seq.length xs) - 1) then
+                out <- out + ", "
+            i <- i + 1
+        __ret <- out + "]"
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+printfn "%s" (showList circs)
+printfn "%s" "\nThe next 4 circular primes, in repunit format, are:"
+printfn "%s" "[R(19) R(23) R(317) R(1031)]"
+printfn "%s" "\nThe following repunits are probably circular primes:"
+for i in [|5003; 9887; 15073; 25031; 35317; 49081|] do
+    printfn "%s" (("R(" + (string i)) + ") : true")
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/circular-primes.out
+++ b/tests/rosetta/transpiler/FS/circular-primes.out
@@ -1,0 +1,13 @@
+The first 19 circular primes are:
+[2, 3, 5, 7, 11, 13, 17, 31, 37, 71, 73, 79, 97, 113, 131, 197, 199, 311, 337]
+
+The next 4 circular primes, in repunit format, are:
+[R(19) R(23) R(317) R(1031)]
+
+The following repunits are probably circular primes:
+R(5003) : true
+R(9887) : true
+R(15073) : true
+R(25031) : true
+R(35317) : true
+R(49081) : true

--- a/tests/rosetta/transpiler/FS/cistercian-numerals.bench
+++ b/tests/rosetta/transpiler/FS/cistercian-numerals.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 368,
+  "memory_bytes": 77296,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/cistercian-numerals.fs
+++ b/tests/rosetta/transpiler/FS/cistercian-numerals.fs
@@ -1,0 +1,226 @@
+// Generated 2025-07-28 01:10 +0700
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let __bench_start = _now()
+let __mem_start = System.GC.GetTotalMemory(true)
+let mutable n: string array array = [||]
+let rec initN () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let mutable i: int = 0
+        while i < 15 do
+            let mutable row: string array = [||]
+            let mutable j: int = 0
+            while j < 11 do
+                row <- Array.append row [|" "|]
+                j <- j + 1
+            row.[5] <- "x"
+            n <- Array.append n [|row|]
+            i <- i + 1
+        __ret
+    with
+        | Return -> __ret
+let rec horiz (c1: int) (c2: int) (r: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable c1 = c1
+    let mutable c2 = c2
+    let mutable r = r
+    try
+        let mutable c: int = c1
+        while c <= c2 do
+            (n.[r]).[c] <- "x"
+            c <- c + 1
+        __ret
+    with
+        | Return -> __ret
+let rec verti (r1: int) (r2: int) (c: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable r1 = r1
+    let mutable r2 = r2
+    let mutable c = c
+    try
+        let mutable r: int = r1
+        while r <= r2 do
+            (n.[r]).[c] <- "x"
+            r <- r + 1
+        __ret
+    with
+        | Return -> __ret
+let rec diagd (c1: int) (c2: int) (r: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable c1 = c1
+    let mutable c2 = c2
+    let mutable r = r
+    try
+        let mutable c: int = c1
+        while c <= c2 do
+            (n.[(r + c) - c1]).[c] <- "x"
+            c <- c + 1
+        __ret
+    with
+        | Return -> __ret
+let rec diagu (c1: int) (c2: int) (r: int) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable c1 = c1
+    let mutable c2 = c2
+    let mutable r = r
+    try
+        let mutable c: int = c1
+        while c <= c2 do
+            (n.[(r - c) + c1]).[c] <- "x"
+            c <- c + 1
+        __ret
+    with
+        | Return -> __ret
+let mutable draw: Map<int, unit -> unit> = Map.ofList []
+let rec initDraw () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        draw <- Map.add 1 (        fun () -> 
+            horiz 6 10 0) draw
+        draw <- Map.add 2 (        fun () -> 
+            horiz 6 10 4) draw
+        draw <- Map.add 3 (        fun () -> 
+            diagd 6 10 0) draw
+        draw <- Map.add 4 (        fun () -> 
+            diagu 6 10 4) draw
+        draw <- Map.add 5 (        fun () -> 
+            (draw.[1] |> unbox<unit -> unit>) ()
+            (draw.[4] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 6 (        fun () -> 
+            verti 0 4 10) draw
+        draw <- Map.add 7 (        fun () -> 
+            (draw.[1] |> unbox<unit -> unit>) ()
+            (draw.[6] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 8 (        fun () -> 
+            (draw.[2] |> unbox<unit -> unit>) ()
+            (draw.[6] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 9 (        fun () -> 
+            (draw.[1] |> unbox<unit -> unit>) ()
+            (draw.[8] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 10 (        fun () -> 
+            horiz 0 4 0) draw
+        draw <- Map.add 20 (        fun () -> 
+            horiz 0 4 4) draw
+        draw <- Map.add 30 (        fun () -> 
+            diagu 0 4 4) draw
+        draw <- Map.add 40 (        fun () -> 
+            diagd 0 4 0) draw
+        draw <- Map.add 50 (        fun () -> 
+            (draw.[10] |> unbox<unit -> unit>) ()
+            (draw.[40] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 60 (        fun () -> 
+            verti 0 4 0) draw
+        draw <- Map.add 70 (        fun () -> 
+            (draw.[10] |> unbox<unit -> unit>) ()
+            (draw.[60] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 80 (        fun () -> 
+            (draw.[20] |> unbox<unit -> unit>) ()
+            (draw.[60] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 90 (        fun () -> 
+            (draw.[10] |> unbox<unit -> unit>) ()
+            (draw.[80] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 100 (        fun () -> 
+            horiz 6 10 14) draw
+        draw <- Map.add 200 (        fun () -> 
+            horiz 6 10 10) draw
+        draw <- Map.add 300 (        fun () -> 
+            diagu 6 10 14) draw
+        draw <- Map.add 400 (        fun () -> 
+            diagd 6 10 10) draw
+        draw <- Map.add 500 (        fun () -> 
+            (draw.[100] |> unbox<unit -> unit>) ()
+            (draw.[400] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 600 (        fun () -> 
+            verti 10 14 10) draw
+        draw <- Map.add 700 (        fun () -> 
+            (draw.[100] |> unbox<unit -> unit>) ()
+            (draw.[600] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 800 (        fun () -> 
+            (draw.[200] |> unbox<unit -> unit>) ()
+            (draw.[600] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 900 (        fun () -> 
+            (draw.[100] |> unbox<unit -> unit>) ()
+            (draw.[800] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 1000 (        fun () -> 
+            horiz 0 4 14) draw
+        draw <- Map.add 2000 (        fun () -> 
+            horiz 0 4 10) draw
+        draw <- Map.add 3000 (        fun () -> 
+            diagd 0 4 10) draw
+        draw <- Map.add 4000 (        fun () -> 
+            diagu 0 4 14) draw
+        draw <- Map.add 5000 (        fun () -> 
+            (draw.[1000] |> unbox<unit -> unit>) ()
+            (draw.[4000] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 6000 (        fun () -> 
+            verti 10 14 0) draw
+        draw <- Map.add 7000 (        fun () -> 
+            (draw.[1000] |> unbox<unit -> unit>) ()
+            (draw.[6000] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 8000 (        fun () -> 
+            (draw.[2000] |> unbox<unit -> unit>) ()
+            (draw.[6000] |> unbox<unit -> unit>) ()) draw
+        draw <- Map.add 9000 (        fun () -> 
+            (draw.[1000] |> unbox<unit -> unit>) ()
+            (draw.[8000] |> unbox<unit -> unit>) ()) draw
+        __ret
+    with
+        | Return -> __ret
+let rec printNumeral () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let mutable i: int = 0
+        while i < 15 do
+            let mutable line: string = ""
+            let mutable j: int = 0
+            while j < 11 do
+                line <- (line + ((n.[i]).[j])) + " "
+                j <- j + 1
+            printfn "%s" line
+            i <- i + 1
+        printfn "%s" ""
+        __ret
+    with
+        | Return -> __ret
+initDraw()
+let numbers: int array = [|0; 1; 20; 300; 4000; 5555; 6789; 9999|]
+for number in numbers do
+    initN()
+    printfn "%s" ((string number) + ":")
+    let mutable num: int = number
+    let thousands: int = num / 1000
+    num <- ((num % 1000 + 1000) % 1000)
+    let hundreds: int = num / 100
+    num <- ((num % 100 + 100) % 100)
+    let tens: int = num / 10
+    let ones: int = ((num % 10 + 10) % 10)
+    if thousands > 0 then
+        (draw.[(thousands * 1000)] |> unbox<unit -> unit>) ()
+    if hundreds > 0 then
+        (draw.[(hundreds * 100)] |> unbox<unit -> unit>) ()
+    if tens > 0 then
+        (draw.[(tens * 10)] |> unbox<unit -> unit>) ()
+    if ones > 0 then
+        (draw.[ones] |> unbox<unit -> unit>) ()
+    printNumeral()
+let __bench_end = _now()
+let __mem_end = System.GC.GetTotalMemory(true)
+printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)

--- a/tests/rosetta/transpiler/FS/cistercian-numerals.out
+++ b/tests/rosetta/transpiler/FS/cistercian-numerals.out
@@ -1,0 +1,135 @@
+0:
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+
+1:
+          x x x x x x 
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+
+20:
+          x x x x x x 
+          x           
+          x           
+          x           
+x x x x x x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x           
+
+300:
+          x x x x x x 
+          x           
+          x           
+          x           
+x x x x x x           
+          x           
+          x           
+          x           
+          x           
+          x           
+          x         x 
+          x       x   
+          x     x     
+          x   x       
+          x x         
+
+4000:
+          x x x x x x 
+          x           
+          x           
+          x           
+x x x x x x           
+          x           
+          x           
+          x           
+          x           
+          x           
+        x x         x 
+      x   x       x   
+    x     x     x     
+  x       x   x       
+x         x x         
+
+5555:
+x x x x x x x x x x x 
+  x       x       x   
+    x     x     x     
+      x   x   x       
+x x x x x x x         
+          x           
+          x           
+          x           
+          x           
+          x           
+        x x x       x 
+      x   x   x   x   
+    x     x     x     
+  x       x   x   x   
+x x x x x x x x x x x 
+
+6789:
+x x x x x x x x x x x 
+x x       x       x x 
+x   x     x     x   x 
+x     x   x   x     x 
+x x x x x x x x x x x 
+          x           
+          x           
+          x           
+          x           
+          x           
+x       x x x       x 
+x     x   x   x   x x 
+x   x     x     x   x 
+x x       x   x   x x 
+x x x x x x x x x x x 
+
+9999:
+x x x x x x x x x x x 
+x x       x       x x 
+x   x     x     x   x 
+x     x   x   x     x 
+x x x x x x x x x x x 
+          x           
+          x           
+          x           
+          x           
+          x           
+x x x x x x x x x x x 
+x     x   x   x   x x 
+x   x     x     x   x 
+x x       x   x   x x 
+x x x x x x x x x x x

--- a/tests/rosetta/transpiler/FS/comma-quibbling.bench
+++ b/tests/rosetta/transpiler/FS/comma-quibbling.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 221,
+  "memory_bytes": 43200,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/FS/comma-quibbling.fs
+++ b/tests/rosetta/transpiler/FS/comma-quibbling.fs
@@ -1,0 +1,79 @@
+// Generated 2025-07-28 01:10 +0700
+
+exception Break
+exception Continue
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let rec quibble (items: string array) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable items = items
+    try
+        let n: int = Seq.length items
+        if n = 0 then
+            __ret <- "{}"
+            raise Return
+        else
+            if n = 1 then
+                __ret <- ("{" + (items.[0])) + "}"
+                raise Return
+            else
+                if n = 2 then
+                    __ret <- ((("{" + (items.[0])) + " and ") + (items.[1])) + "}"
+                    raise Return
+                else
+                    let mutable prefix: string = ""
+                    try
+                        for i in 0 .. ((n - 1) - 1) do
+                            try
+                                if i = (n - 1) then
+                                    raise Break
+                                if i > 0 then
+                                    prefix <- prefix + ", "
+                                prefix <- prefix + (items.[i])
+                            with
+                            | Continue -> ()
+                            | Break -> raise Break
+                    with
+                    | Break -> ()
+                    | Continue -> ()
+                    __ret <- ((("{" + prefix) + " and ") + (items.[n - 1])) + "}"
+                    raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        printfn "%s" (quibble [||])
+        printfn "%s" (quibble [|"ABC"|])
+        printfn "%s" (quibble [|"ABC"; "DEF"|])
+        printfn "%s" (quibble [|"ABC"; "DEF"; "G"; "H"|])
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()

--- a/tests/rosetta/transpiler/FS/comma-quibbling.out
+++ b/tests/rosetta/transpiler/FS/comma-quibbling.out
@@ -1,0 +1,4 @@
+{}
+{ABC}
+{ABC and DEF}
+{ABC, DEF, G and H}

--- a/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.error
+++ b/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.error
@@ -1,0 +1,33 @@
+compile: exit status 1
+F# Compiler for F# 4.0 (Open Source Edition)
+Freely distributed under the Apache 2.0 Open Source License
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(3,1): warning FS0221: The declarations in this file will be placed in an implicit module 'Compiler-virtual-machine-interpreter' based on the file name 'compiler-virtual-machine-interpreter.fs'. However this is not a valid F# identifier, so the contents will not be accessible from other files. Consider renaming the file or adding a 'module' or 'namespace' declaration at the top of the file.
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(168,25): error FS0001: The type 'obj' does not support a conversion to the type 'int'
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(188,31): error FS0001: This expression was expected to have type
+    int    
+but here has type
+    obj    
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(189,52): error FS0039: The value or constructor 'slice' is not defined
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(193,61): error FS0001: This expression was expected to have type
+    int    
+but here has type
+    obj    
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(198,52): error FS0039: The value or constructor 'slice' is not defined
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(206,52): error FS0039: The value or constructor 'slice' is not defined
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(211,52): error FS0039: The value or constructor 'slice' is not defined
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(213,41): error FS0001: The type 'obj' does not support a conversion to the type 'int'
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(218,37): error FS0001: The type 'obj' does not support a conversion to the type 'int'
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(222,52): error FS0039: The value or constructor 'slice' is not defined
+
+/workspace/mochi/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs(231,52): error FS0039: The value or constructor 'slice' is not defined

--- a/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs
+++ b/tests/rosetta/transpiler/FS/compiler-virtual-machine-interpreter.fs
@@ -1,0 +1,298 @@
+// Generated 2025-07-28 01:10 +0700
+
+exception Break
+exception Continue
+
+exception Return
+
+let mutable _nowSeed:int64 = 0L
+let mutable _nowSeeded = false
+let _initNow () =
+    let s = System.Environment.GetEnvironmentVariable("MOCHI_NOW_SEED")
+    if System.String.IsNullOrEmpty(s) |> not then
+        match System.Int32.TryParse(s) with
+        | true, v ->
+            _nowSeed <- int64 v
+            _nowSeeded <- true
+        | _ -> ()
+let _now () =
+    if _nowSeeded then
+        _nowSeed <- (_nowSeed * 1664525L + 1013904223L) % 2147483647L
+        int _nowSeed
+    else
+        int (System.DateTime.UtcNow.Ticks % 2147483647L)
+
+_initNow()
+let _substring (s:string) (start:int) (finish:int) =
+    let len = String.length s
+    let mutable st = if start < 0 then len + start else start
+    let mutable en = if finish < 0 then len + finish else finish
+    if st < 0 then st <- 0
+    if st > len then st <- len
+    if en > len then en <- len
+    if st > en then st <- en
+    s.Substring(st, en - st)
+
+let rec parseIntStr (str: string) =
+    let mutable __ret : int = Unchecked.defaultof<int>
+    let mutable str = str
+    try
+        let mutable i: int = 0
+        let mutable neg: bool = false
+        if ((String.length str) > 0) && ((str.Substring(0, 1 - 0)) = "-") then
+            neg <- true
+            i <- 1
+        let mutable n: int = 0
+        let digits: Map<string, int> = Map.ofList [("0", 0); ("1", 1); ("2", 2); ("3", 3); ("4", 4); ("5", 5); ("6", 6); ("7", 7); ("8", 8); ("9", 9)]
+        while i < (String.length str) do
+            n <- int ((n * 10) + (int (digits.[(str.Substring(i, (i + 1) - i))] |> unbox<int>)))
+            i <- i + 1
+        if neg then
+            n <- -n
+        __ret <- n
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and fields (s: string) =
+    let mutable __ret : string array = Unchecked.defaultof<string array>
+    let mutable s = s
+    try
+        let mutable words: string array = [||]
+        let mutable cur: string = ""
+        let mutable i: int = 0
+        while i < (String.length s) do
+            let ch: string = _substring s i (i + 1)
+            if ((ch = " ") || (ch = "\t")) || (ch = "\n") then
+                if (String.length cur) > 0 then
+                    words <- Array.append words [|cur|]
+                    cur <- ""
+            else
+                cur <- cur + ch
+            i <- i + 1
+        if (String.length cur) > 0 then
+            words <- Array.append words [|cur|]
+        __ret <- words
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and unescape (s: string) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable s = s
+    try
+        let mutable out: string = ""
+        let mutable i: int = 0
+        try
+            while i < (String.length s) do
+                try
+                    if ((s.Substring(i, (i + 1) - i)) = "\\") && ((i + 1) < (String.length s)) then
+                        let c: string = s.Substring(i + 1, (i + 2) - (i + 1))
+                        if c = "n" then
+                            out <- out + "\n"
+                            i <- i + 2
+                            raise Continue
+                        else
+                            if c = "\\" then
+                                out <- out + "\\"
+                                i <- i + 2
+                                raise Continue
+                    out <- out + (s.Substring(i, (i + 1) - i))
+                    i <- i + 1
+                with
+                | Continue -> ()
+                | Break -> raise Break
+        with
+        | Break -> ()
+        | Continue -> ()
+        __ret <- out
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and parseProgram (src: string) =
+    let mutable __ret : Map<string, obj> = Unchecked.defaultof<Map<string, obj>>
+    let mutable src = src
+    try
+        let lines: string array = split src "\n"
+        let header: string array = fields (lines.[0])
+        let dataSize: int = parseIntStr (header.[1])
+        let nStrings: int = parseIntStr (header.[3])
+        let mutable stringPool: string array = [||]
+        let mutable i: int = 1
+        while i <= nStrings do
+            let s: string = lines.[i]
+            if (String.length s) > 0 then
+                stringPool <- Array.append stringPool [|unbox<string> (unescape (s.Substring(1, ((String.length s) - 1) - 1)))|]
+            i <- i + 1
+        let mutable code: Map<string, obj> array = [||]
+        let mutable addrMap: Map<int, int> = Map.ofList []
+        try
+            while i < (Seq.length lines) do
+                try
+                    let line: string = trim (lines.[i])
+                    if (String.length line) = 0 then
+                        raise Break
+                    let parts: string array = fields line
+                    let addr: int = parseIntStr (parts.[0])
+                    let op: string = parts.[1]
+                    let mutable arg: int = 0
+                    if op = "push" then
+                        arg <- parseIntStr (parts.[2])
+                    else
+                        if (op = "fetch") || (op = "store") then
+                            arg <- parseIntStr (parts.[2].Substring(1, ((String.length (parts.[2])) - 1) - 1))
+                        else
+                            if (op = "jmp") || (op = "jz") then
+                                arg <- parseIntStr (parts.[3])
+                    code <- Array.append code [|Map.ofList [("addr", box addr); ("op", box op); ("arg", box arg)]|]
+                    addrMap <- Map.add addr ((Seq.length code) - 1) addrMap
+                    i <- i + 1
+                with
+                | Continue -> ()
+                | Break -> raise Break
+        with
+        | Break -> ()
+        | Continue -> ()
+        __ret <- unbox<Map<string, obj>> (Map.ofList [("dataSize", box dataSize); ("strings", box stringPool); ("code", box code); ("addrMap", box addrMap)])
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and runVM (prog: Map<string, obj>) =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    let mutable prog = prog
+    try
+        let mutable data: int array = [||]
+        let mutable i: int = 0
+        while i < (int (prog.["dataSize"])) do
+            data <- Array.append data [|0|]
+            i <- i + 1
+        let mutable stack: int array = [||]
+        let mutable pc: int = 0
+        let code: obj = box (prog.["code"])
+        let addrMap: obj = box (prog.["addrMap"])
+        let pool: obj = box (prog.["strings"])
+        let mutable line: string = ""
+        try
+            while pc < (int ((unbox<System.Array> code).Length)) do
+                try
+                    let inst: obj = box (((code :?> System.Array).GetValue(pc)))
+                    let op: obj = box (((inst :?> Map<string, obj>).["op"]))
+                    let arg: obj = box (((inst :?> Map<string, obj>).["arg"]))
+                    if (unbox<string> op) = "push" then
+                        stack <- Array.append stack [|unbox<int> arg|]
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "store" then
+                        data.[arg] <- stack.[(Seq.length stack) - 1]
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "fetch" then
+                        stack <- Array.append stack [|data.[arg]|]
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "add" then
+                        stack.[(Seq.length stack) - 2] <- (stack.[(Seq.length stack) - 2]) + (stack.[(Seq.length stack) - 1])
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "lt" then
+                        let mutable v: int = 0
+                        if (stack.[(Seq.length stack) - 2]) < (stack.[(Seq.length stack) - 1]) then
+                            v <- 1
+                        stack.[(Seq.length stack) - 2] <- v
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "jz" then
+                        let v: int = stack.[(Seq.length stack) - 1]
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        if v = 0 then
+                            pc <- int (((addrMap :?> Map<string, obj>).[arg]))
+                        else
+                            pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "jmp" then
+                        pc <- int (((addrMap :?> Map<string, obj>).[arg]))
+                        raise Continue
+                    if (unbox<string> op) = "prts" then
+                        let s: obj = box (((pool :?> System.Array).GetValue((stack.[(Seq.length stack) - 1]))))
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        if (unbox<string> s) <> "\n" then
+                            line <- line + (unbox<string> s)
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "prti" then
+                        line <- line + (string (stack.[(Seq.length stack) - 1]))
+                        printfn "%s" line
+                        line <- ""
+                        stack <- unbox<int array> (slice stack 0 ((Seq.length stack) - 1))
+                        pc <- pc + 1
+                        raise Continue
+                    if (unbox<string> op) = "halt" then
+                        raise Break
+                    pc <- pc + 1
+                with
+                | Continue -> ()
+                | Break -> raise Break
+        with
+        | Break -> ()
+        | Continue -> ()
+        __ret
+    with
+        | Return -> __ret
+and trim (s: string) =
+    let mutable __ret : string = Unchecked.defaultof<string>
+    let mutable s = s
+    try
+        let mutable start: int = 0
+        while (start < (String.length s)) && (((s.Substring(start, (start + 1) - start)) = " ") || ((s.Substring(start, (start + 1) - start)) = "\t")) do
+            start <- start + 1
+        let mutable ``end``: int = String.length s
+        while (``end`` > start) && (((s.Substring(``end`` - 1, ``end`` - (``end`` - 1))) = " ") || ((s.Substring(``end`` - 1, ``end`` - (``end`` - 1))) = "\t")) do
+            ``end`` <- ``end`` - 1
+        __ret <- _substring s start ``end``
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and split (s: string) (sep: string) =
+    let mutable __ret : string array = Unchecked.defaultof<string array>
+    let mutable s = s
+    let mutable sep = sep
+    try
+        let mutable parts: string array = [||]
+        let mutable cur: string = ""
+        let mutable i: int = 0
+        while i < (String.length s) do
+            if (((String.length sep) > 0) && ((i + (String.length sep)) <= (String.length s))) && ((_substring s i (i + (String.length sep))) = sep) then
+                parts <- Array.append parts [|cur|]
+                cur <- ""
+                i <- i + (String.length sep)
+            else
+                cur <- cur + (_substring s i (i + 1))
+                i <- i + 1
+        parts <- Array.append parts [|cur|]
+        __ret <- parts
+        raise Return
+        __ret
+    with
+        | Return -> __ret
+and main () =
+    let mutable __ret : unit = Unchecked.defaultof<unit>
+    try
+        let __bench_start = _now()
+        let __mem_start = System.GC.GetTotalMemory(true)
+        let programText: string = ((((((((((((((((((("Datasize: 1 Strings: 2\n" + "\"count is: \"\n") + "\"\\n\"\n") + "    0 push  1\n") + "    5 store [0]\n") + "   10 fetch [0]\n") + "   15 push  10\n") + "   20 lt\n") + "   21 jz     (43) 65\n") + "   26 push  0\n") + "   31 prts\n") + "   32 fetch [0]\n") + "   37 prti\n") + "   38 push  1\n") + "   43 prts\n") + "   44 fetch [0]\n") + "   49 push  1\n") + "   54 add\n") + "   55 store [0]\n") + "   60 jmp    (-51) 10\n") + "   65 halt\n"
+        let prog: Map<string, obj> = parseProgram programText
+        runVM prog
+        let __bench_end = _now()
+        let __mem_end = System.GC.GetTotalMemory(true)
+        printfn "{\n  \"duration_us\": %d,\n  \"memory_bytes\": %d,\n  \"name\": \"main\"\n}" ((__bench_end - __bench_start) / 1000) (__mem_end - __mem_start)
+
+        __ret
+    with
+        | Return -> __ret
+main()


### PR DESCRIPTION
## Summary
- improve F# transpiler: handle zero‑arg function types, invoke arbitrary expressions
- add heuristic for struct field access and outer loop try blocks
- generate outputs for several Rosetta programs

## Testing
- `MOCHI_ROSETTA_INDEX=206 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=208 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=209 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta -count=1`
- `MOCHI_ROSETTA_INDEX=210 MOCHI_BENCHMARK=1 go test ./transpiler/x/fs -tags slow -run Rosetta -count=1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68866b15b1e0832090608ad67cb11824