### PR TITLE
Improve scala transpiler map value casting

### DIFF
--- a/transpiler/x/scala/transpiler.go
+++ b/transpiler/x/scala/transpiler.go
@@ -1754,9 +1754,18 @@ func convertStmt(st *parser.Statement, env *types.Env) (Stmt, error) {
 				t = types.ExprType(st.Let.Value, env)
 			}
 			env.SetVar(st.Let.Name, t, false)
+			if typ == "" {
+				typ = toScalaTypeFromType(t)
+			}
 		}
 		if typ != "" {
 			localVarTypes[st.Let.Name] = typ
+			if e != nil {
+				et := inferTypeWithEnv(e, env)
+				if et == "" || et == "Any" || et != typ {
+					e = &CastExpr{Value: e, Type: typ}
+				}
+			}
 		}
 		return &LetStmt{Name: st.Let.Name, Type: typ, Value: e}, nil
 	case st.Var != nil:
@@ -1842,9 +1851,18 @@ func convertStmt(st *parser.Statement, env *types.Env) (Stmt, error) {
 				t = types.ExprType(st.Var.Value, env)
 			}
 			env.SetVar(st.Var.Name, t, true)
+			if typ == "" {
+				typ = toScalaTypeFromType(t)
+			}
 		}
 		if typ != "" {
 			localVarTypes[st.Var.Name] = typ
+			if e != nil {
+				et := inferTypeWithEnv(e, env)
+				if et == "" || et == "Any" || et != typ {
+					e = &CastExpr{Value: e, Type: typ}
+				}
+			}
 		}
 		return &VarStmt{Name: st.Var.Name, Type: typ, Value: e}, nil
 	case st.Type != nil:


### PR DESCRIPTION
## Summary
- enhance Scala transpiler to infer type for let/var from `types.Env`
- automatically cast assigned map values to the declared variable type

## Testing
- `go test -run Rosetta -tags=slow -count=1 -v` *(fails: compile: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6886c7aa41348320b24e4b316ac465e4