### PR TITLE
Add Kotlin transpiler features

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/barnsley-fern.bench
+++ b/tests/rosetta/transpiler/Kotlin/barnsley-fern.bench
@@ -1,0 +1,1 @@
+{"duration_us":28582, "memory_bytes":45680, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/barnsley-fern.kt
+++ b/tests/rosetta/transpiler/Kotlin/barnsley-fern.kt
@@ -1,0 +1,122 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val xMin: Double = 0.0 - 2.182
+val xMax: Double = 2.6558
+val yMin: Double = 0.0
+val yMax: Double = 9.9983
+val width: Int = 60
+val nIter: Int = 10000
+val dx: Double = xMax - xMin
+val dy: Double = yMax - yMin
+val height: Int = ((width * dy) / dx).toInt()
+var grid: MutableList<MutableList<String>> = mutableListOf<MutableList<String>>()
+var row: Int = 0
+var seed: Int = 1
+var x: Double = 0.0
+var y: Double = 0.0
+var ix: Int = ((width.toDouble() * (x - xMin)) / dx).toInt()
+var iy: Int = ((height.toDouble() * (yMax - y)) / dy).toInt()
+var i: Int = 0
+fun randInt(s: Int, n: Int): MutableList<Int> {
+    val next: Int = Math.floorMod(((s * 1664525) + 1013904223), 2147483647)
+    return mutableListOf(next, Math.floorMod(next, n))
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        while (row < height) {
+            var line: MutableList<String> = mutableListOf<String>()
+            var col: Int = 0
+            while (col < width) {
+                line = run { val _tmp = line.toMutableList(); _tmp.add(" "); _tmp } as MutableList<String>
+                col = col + 1
+            }
+            grid = run { val _tmp = grid.toMutableList(); _tmp.add(line); _tmp } as MutableList<MutableList<String>>
+            row = row + 1
+        }
+        if ((((((ix >= 0) && (ix < width) as Boolean)) && (iy >= 0) as Boolean)) && (iy < height)) {
+            grid[iy][ix] = "*"
+        }
+        while (i < nIter) {
+            var res: MutableList<Int> = randInt(seed, 100)
+            seed = res[0]
+            val r: Int = res[1]
+            if (r < 85) {
+                val nx: Double = (0.85 * x) + (0.04 * y)
+                val ny: Double = (((0.0 - 0.04) * x) + (0.85 * y)) + 1.6
+                x = nx
+                y = ny
+            } else {
+                if (r < 92) {
+                    val nx: Double = (0.2 * x) - (0.26 * y)
+                    val ny: Double = ((0.23 * x) + (0.22 * y)) + 1.6
+                    x = nx
+                    y = ny
+                } else {
+                    if (r < 99) {
+                        val nx: Double = ((0.0 - 0.15) * x) + (0.28 * y)
+                        val ny: Double = ((0.26 * x) + (0.24 * y)) + 0.44
+                        x = nx
+                        y = ny
+                    } else {
+                        x = 0.0
+                        y = 0.16 * y
+                    }
+                }
+            }
+            ix = ((width.toDouble() * (x - xMin)) / dx).toInt()
+            iy = ((height.toDouble() * (yMax - y)) / dy).toInt()
+            if ((((((ix >= 0) && (ix < width) as Boolean)) && (iy >= 0) as Boolean)) && (iy < height)) {
+                grid[iy][ix] = "*"
+            }
+            i = i + 1
+        }
+        row = 0
+        while (row < height) {
+            var line: String = ""
+            var col: Int = 0
+            while (col < width) {
+                line = line + grid[row][col]
+                col = col + 1
+            }
+            println(line)
+            row = row + 1
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/base64-decode-data.bench
+++ b/tests/rosetta/transpiler/Kotlin/base64-decode-data.bench
@@ -1,0 +1,1 @@
+{"duration_us":7033, "memory_bytes":95328, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/base64-decode-data.kt
+++ b/tests/rosetta/transpiler/Kotlin/base64-decode-data.kt
@@ -1,0 +1,209 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val msg: String = "Rosetta Code Base64 decode data task"
+val enc: String = base64Encode(msg)
+val dec: String = base64Decode(enc)
+fun indexOf(s: String, ch: String): Int {
+    var i: Int = 0
+    while (i < s.length) {
+        if (s[i].toString() == ch) {
+            return i
+        }
+        i = i + 1
+    }
+    return 0 - 1
+}
+
+fun parseIntStr(str: String): Int {
+    var i: Int = 0
+    var neg: Boolean = false
+    if ((str.length > 0) && (str[0].toString() == "-")) {
+        neg = true
+        i = 1
+    }
+    var n: Int = 0
+    val digits: MutableMap<String, Int> = mutableMapOf<String, Int>("0" to (0), "1" to (1), "2" to (2), "3" to (3), "4" to (4), "5" to (5), "6" to (6), "7" to (7), "8" to (8), "9" to (9))
+    while (i < str.length) {
+        n = (n * 10) + (digits)[str[i].toString()] as Int
+        i = i + 1
+    }
+    if (neg as Boolean) {
+        n = 0 - n
+    }
+    return n
+}
+
+fun ord(ch: String): Int {
+    val upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    val lower: String = "abcdefghijklmnopqrstuvwxyz"
+    var idx: Int = indexOf(upper, ch)
+    if (idx >= 0) {
+        return 65 + idx
+    }
+    idx = indexOf(lower, ch)
+    if (idx >= 0) {
+        return 97 + idx
+    }
+    if ((ch >= "0") && (ch <= "9")) {
+        return 48 + parseIntStr(ch)
+    }
+    if (ch == "+") {
+        return 43
+    }
+    if (ch == "/") {
+        return 47
+    }
+    if (ch == " ") {
+        return 32
+    }
+    if (ch == "=") {
+        return 61
+    }
+    return 0
+}
+
+fun chr(n: Int): String {
+    val upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    val lower: String = "abcdefghijklmnopqrstuvwxyz"
+    if ((n >= 65) && (n < 91)) {
+        return upper.substring(n - 65, n - 64)
+    }
+    if ((n >= 97) && (n < 123)) {
+        return lower.substring(n - 97, n - 96)
+    }
+    if ((n >= 48) && (n < 58)) {
+        val digits: String = "0123456789"
+        return digits.substring(n - 48, n - 47)
+    }
+    if (n == 43) {
+        return "+"
+    }
+    if (n == 47) {
+        return "/"
+    }
+    if (n == 32) {
+        return " "
+    }
+    if (n == 61) {
+        return "="
+    }
+    return "?"
+}
+
+fun toBinary(n: Int, bits: Int): String {
+    var b: String = ""
+    var _val: Int = n
+    var i: Int = 0
+    while (i < bits) {
+        b = (Math.floorMod(_val, 2)).toString() + b
+        _val = (_val / 2).toInt()
+        i = i + 1
+    }
+    return b
+}
+
+fun binToInt(bits: String): Int {
+    var n: Int = 0
+    var i: Int = 0
+    while (i < bits.length) {
+        n = (n * 2) + parseIntStr(bits.substring(i, i + 1))
+        i = i + 1
+    }
+    return n
+}
+
+fun base64Encode(text: String): String {
+    val alphabet: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    var bin: String = ""
+    for (_ch in text) {
+        val ch = _ch.toString()
+        bin = bin + toBinary(ord(ch), 8)
+    }
+    while ((Math.floorMod(bin.length, 6)) != 0) {
+        bin = bin + "0"
+    }
+    var out: String = ""
+    var i: Int = 0
+    while (i < bin.length) {
+        val chunk: String = bin.substring(i, i + 6)
+        val _val: Int = binToInt(chunk)
+        out = out + alphabet.substring(_val, _val + 1)
+        i = i + 6
+    }
+    val pad: Int = Math.floorMod((3 - (Math.floorMod(text.length, 3))), 3)
+    if (pad == 1) {
+        out = out.substring(0, out.length - 1) + "="
+    }
+    if (pad == 2) {
+        out = out.substring(0, out.length - 2) + "=="
+    }
+    return out
+}
+
+fun base64Decode(enc: String): String {
+    val alphabet: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    var bin: String = ""
+    var i: Int = 0
+    while (i < enc.length) {
+        val ch: String = enc[i].toString()
+        if (ch == "=") {
+            break
+        }
+        val idx: Int = indexOf(alphabet, ch)
+        bin = bin + toBinary(idx, 6)
+        i = i + 1
+    }
+    var out: String = ""
+    i = 0
+    while ((i + 8) <= bin.length) {
+        val chunk: String = bin.substring(i, i + 8)
+        val _val: Int = binToInt(chunk)
+        out = out + chr(_val)
+        i = i + 8
+    }
+    return out
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println("Original : " + msg)
+        println("\nEncoded  : " + enc)
+        println("\nDecoded  : " + dec)
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/bell-numbers.bench
+++ b/tests/rosetta/transpiler/Kotlin/bell-numbers.bench
@@ -1,0 +1,1 @@
+{"duration_us":20229, "memory_bytes":112024, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/bell-numbers.kt
+++ b/tests/rosetta/transpiler/Kotlin/bell-numbers.kt
@@ -1,0 +1,84 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun bellTriangle(n: Int): MutableList<MutableList<BigInteger>> {
+    var tri: MutableList<MutableList<BigInteger>> = mutableListOf<MutableList<BigInteger>>()
+    var i: Int = 0
+    while (i < n) {
+        var row: MutableList<BigInteger> = mutableListOf<BigInteger>()
+        var j: Int = 0
+        while (j < i) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add(0.toBigInteger()); _tmp } as MutableList<BigInteger>
+            j = j + 1
+        }
+        tri = run { val _tmp = tri.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<BigInteger>>
+        i = i + 1
+    }
+    tri[1][0] = 1.toBigInteger()
+    i = 2
+    while (i < n) {
+        tri[i][0] = tri[i - 1][i - 2]
+        var j: Int = 1
+        while (j < i) {
+            tri[i][j] = tri[i][j - 1].add(tri[i - 1][j - 1])
+            j = j + 1
+        }
+        i = i + 1
+    }
+    return tri
+}
+
+fun user_main(): Unit {
+    val bt: MutableList<MutableList<BigInteger>> = bellTriangle(51)
+    println("First fifteen and fiftieth Bell numbers:")
+    for (i in 1 until 16) {
+        println((("" + (i.toString().padStart(2, " "[0])).toString()) + ": ") + (bt[i][0]).toString())
+    }
+    println("50: " + (bt[50][0]).toString())
+    println("")
+    println("The first ten rows of Bell's triangle:")
+    for (i in 1 until 11) {
+        println(bt[i])
+    }
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/benfords-law.bench
+++ b/tests/rosetta/transpiler/Kotlin/benfords-law.bench
@@ -1,0 +1,1 @@
+{"duration_us":15936, "memory_bytes":67488, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/benfords-law.kt
+++ b/tests/rosetta/transpiler/Kotlin/benfords-law.kt
@@ -1,0 +1,141 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun floorf(x: Double): Double {
+    val y: Int = x.toInt()
+    return y.toDouble()
+}
+
+fun indexOf(s: String, ch: String): Int {
+    var i: Int = 0
+    while (i < s.length) {
+        if (s.substring(i, i + 1) == ch) {
+            return i
+        }
+        i = i + 1
+    }
+    return 0 - 1
+}
+
+fun fmtF3(x: Double): String {
+    var y: Double = floorf((x * 1000.0) + 0.5) / 1000.0
+    var s: String = y.toString()
+    var dot: Int = indexOf(s, ".")
+    if (dot == (0 - 1)) {
+        s = s + ".000"
+    } else {
+        var decs: BigInteger = ((s.length - dot) - 1).toBigInteger()
+        if (decs.compareTo(3.toBigInteger()) > 0) {
+            s = s.substring(0, dot + 4) as String
+        } else {
+            while (decs.compareTo(3.toBigInteger()) < 0) {
+                s = s + "0"
+                decs = decs.add(1.toBigInteger())
+            }
+        }
+    }
+    return s
+}
+
+fun padFloat3(x: Double, width: Int): String {
+    var s: String = fmtF3(x)
+    while (s.length < width) {
+        s = " " + s
+    }
+    return s
+}
+
+fun fib1000(): MutableList<Double> {
+    var a: Double = 0.0
+    var b: Double = 1.0
+    var res: MutableList<Double> = mutableListOf<Double>()
+    var i: Int = 0
+    while (i < 1000) {
+        res = run { val _tmp = res.toMutableList(); _tmp.add(b); _tmp } as MutableList<Double>
+        var t: Double = b
+        b = b + a
+        a = t
+        i = i + 1
+    }
+    return res
+}
+
+fun leadingDigit(x: Double): Int {
+    var x: Double = x
+    if (x < 0.0) {
+        x = 0.0 - x
+    }
+    while (x >= 10.0) {
+        x = x / 10.0
+    }
+    while ((x > 0.0) && (x < 1.0)) {
+        x = x * 10.0
+    }
+    return x.toInt()
+}
+
+fun show(nums: MutableList<Double>, title: String): Unit {
+    var counts: MutableList<Int> = mutableListOf(0, 0, 0, 0, 0, 0, 0, 0, 0)
+    for (n in nums) {
+        val d: Int = leadingDigit(n)
+        if ((d >= 1) && (d <= 9)) {
+            counts[d - 1] = counts[d - 1] + 1
+        }
+    }
+    val preds: MutableList<Double> = mutableListOf(0.301, 0.176, 0.125, 0.097, 0.079, 0.067, 0.058, 0.051, 0.046)
+    val total: Int = nums.size
+    println(title)
+    println("Digit  Observed  Predicted")
+    var i: Int = 0
+    while (i < 9) {
+        val obs: Double = (counts[i]).toDouble() / total.toDouble()
+        var line: String = (((("  " + (i + 1).toString()) + "  ") + padFloat3(obs, 9)) + "  ") + padFloat3(preds[i], 8)
+        println(line)
+        i = i + 1
+    }
+}
+
+fun user_main(): Unit {
+    show(fib1000(), "First 1000 Fibonacci numbers")
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-28 01:22 +0700
+Last updated: 2025-07-28 07:51 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-28 01:22 +0700
+Last updated: 2025-07-28 07:51 +0700
 
-Completed tasks: **89/467**
+Completed tasks: **93/467**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -110,10 +110,10 @@ Completed tasks: **89/467**
 | 99 | babylonian-spiral | ✓ |  |  |
 | 100 | balanced-brackets | ✓ | 11.75ms | 115.2 KB |
 | 101 | balanced-ternary | ✓ | 13.76ms | 111.5 KB |
-| 102 | barnsley-fern |  |  |  |
-| 103 | base64-decode-data |  |  |  |
-| 104 | bell-numbers |  |  |  |
-| 105 | benfords-law |  |  |  |
+| 102 | barnsley-fern | ✓ | 28.58ms | 44.6 KB |
+| 103 | base64-decode-data | ✓ | 7.03ms | 93.1 KB |
+| 104 | bell-numbers | ✓ | 20.23ms | 109.4 KB |
+| 105 | benfords-law | ✓ | 15.94ms | 65.9 KB |
 | 106 | bernoulli-numbers |  |  |  |
 | 107 | best-shuffle |  |  |  |
 | 108 | bifid-cipher |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,42 @@
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 07:51 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-28 01:22 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- handle variable redeclaration in Kotlin transpiler
- add support for indexing strings and iterating over them
- implement padStart builtin
- regenerate Kotlin Rosetta sources for indexes 102‑105

## Testing
- `ROSETTA_INDEX=102 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`
- `ROSETTA_INDEX=103 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`
- `ROSETTA_INDEX=104 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`
- `ROSETTA_INDEX=105 MOCHI_BENCHMARK=true go test -tags slow ./transpiler/x/kt -run TestRosettaKotlin -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6886c99fc6b083209d91527c92bd095d