### PR TITLE
Add alternative Chess960 SP-ID implementation

### DIFF
--- a/tests/rosetta/x/Go/find-chess960-starting-position-identifier-2.go
+++ b/tests/rosetta/x/Go/find-chess960-starting-position-identifier-2.go
@@ -1,0 +1,95 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+    "fmt"
+    "log"
+    "strings"
+)
+
+var glyphs = []rune("♜♞♝♛♚♖♘♗♕♔")
+var names = map[rune]string{'R': "rook", 'N': "knight", 'B': "bishop", 'Q': "queen", 'K': "king"}
+var g2lMap = map[rune]string{
+    '♜': "R", '♞': "N", '♝': "B", '♛': "Q", '♚': "K",
+    '♖': "R", '♘': "N", '♗': "B", '♕': "Q", '♔': "K",
+}
+
+var ntable = map[string]int{"01": 0, "02": 1, "03": 2, "04": 3, "12": 4, "13": 5, "14": 6, "23": 7, "24": 8, "34": 9}
+
+func g2l(pieces string) string {
+    lets := ""
+    for _, p := range pieces {
+        lets += g2lMap[p]
+    }
+    return lets
+}
+
+func spid(pieces string) int {
+    pieces = g2l(pieces) // convert glyphs to letters
+
+    /* check for errors */
+    if len(pieces) != 8 {
+        log.Fatal("There must be exactly 8 pieces.")
+    }
+    for _, one := range "KQ" {
+        count := 0
+        for _, p := range pieces {
+            if p == one {
+                count++
+            }
+        }
+        if count != 1 {
+            log.Fatalf("There must be one %s.", names[one])
+        }
+    }
+    for _, two := range "RNB" {
+        count := 0
+        for _, p := range pieces {
+            if p == two {
+                count++
+            }
+        }
+        if count != 2 {
+            log.Fatalf("There must be two %s.", names[two])
+        }
+    }
+    r1 := strings.Index(pieces, "R")
+    r2 := strings.Index(pieces[r1+1:], "R") + r1 + 1
+    k := strings.Index(pieces, "K")
+    if k < r1 || k > r2 {
+        log.Fatal("The king must be between the rooks.")
+    }
+    b1 := strings.Index(pieces, "B")
+    b2 := strings.Index(pieces[b1+1:], "B") + b1 + 1
+    if (b2-b1)%2 == 0 {
+        log.Fatal("The bishops must be on opposite color squares.")
+    }
+
+    /* compute SP_ID */
+    piecesN := strings.ReplaceAll(pieces, "Q", "")
+    piecesN = strings.ReplaceAll(piecesN, "B", "")
+    n1 := strings.Index(piecesN, "N")
+    n2 := strings.Index(piecesN[n1+1:], "N") + n1 + 1
+    np := fmt.Sprintf("%d%d", n1, n2)
+    N := ntable[np]
+
+    piecesQ := strings.ReplaceAll(pieces, "B", "")
+    Q := strings.Index(piecesQ, "Q")
+
+    D := strings.Index("0246", fmt.Sprintf("%d", b1))
+    L := strings.Index("1357", fmt.Sprintf("%d", b2))
+    if D == -1 {
+        D = strings.Index("0246", fmt.Sprintf("%d", b2))
+        L = strings.Index("1357", fmt.Sprintf("%d", b1))
+    }
+
+    return 96*N + 16*Q + 4*D + L
+}
+
+func main() {
+    for _, pieces := range []string{"♕♘♖♗♗♘♔♖", "♖♘♗♕♔♗♘♖", "♖♕♘♗♗♔♖♘", "♖♘♕♗♗♔♖♘"} {
+        fmt.Printf("%s or %s has SP-ID of %d\n", pieces, g2l(pieces), spid(pieces))
+    }
+}

--- a/tests/rosetta/x/Mochi/find-chess960-starting-position-identifier-2.mochi
+++ b/tests/rosetta/x/Mochi/find-chess960-starting-position-identifier-2.mochi
@@ -1,0 +1,94 @@
+// Alternative Mochi implementation of finding Chess960 starting position identifier
+var g2lMap: map<string, string> = {
+  "♜": "R", "♞": "N", "♝": "B", "♛": "Q", "♚": "K",
+  "♖": "R", "♘": "N", "♗": "B", "♕": "Q", "♔": "K"
+}
+var names: map<string, string> = {"R": "rook", "N": "knight", "B": "bishop", "Q": "queen", "K": "king"}
+var ntable: map<string, int> = {"01":0, "02":1, "03":2, "04":3, "12":4, "13":5, "14":6, "23":7, "24":8, "34":9}
+
+fun indexOf(s: string, sub: string): int {
+  var i = 0
+  while i <= len(s) - len(sub) {
+    if substring(s, i, i + len(sub)) == sub { return i }
+    i = i + 1
+  }
+  return -1
+}
+
+fun removeChar(s: string, ch: string): string {
+  var res = ""
+  var i = 0
+  while i < len(s) {
+    let c = substring(s, i, i+1)
+    if c != ch { res = res + c }
+    i = i + 1
+  }
+  return res
+}
+
+fun g2l(pieces: string): string {
+  var res = ""
+  var i = 0
+  while i < len(pieces) {
+    let ch = substring(pieces, i, i+1)
+    res = res + g2lMap[ch]
+    i = i + 1
+  }
+  return res
+}
+
+fun countChar(s: string, ch: string): int {
+  var c = 0
+  var i = 0
+  while i < len(s) {
+    if substring(s, i, i+1) == ch { c = c + 1 }
+    i = i + 1
+  }
+  return c
+}
+
+fun spid(pieces: string): int {
+  pieces = g2l(pieces)
+  if len(pieces) != 8 { return -1 }
+
+  for one in ["K", "Q"] {
+    if countChar(pieces, one) != 1 { return -1 }
+  }
+  for two in ["R", "N", "B"] {
+    if countChar(pieces, two) != 2 { return -1 }
+  }
+
+  let r1 = indexOf(pieces, "R")
+  let r2 = indexOf(substring(pieces, r1+1, len(pieces)), "R") + r1 + 1
+  let k  = indexOf(pieces, "K")
+  if k < r1 || k > r2 { return -1 }
+
+  let b1 = indexOf(pieces, "B")
+  let b2 = indexOf(substring(pieces, b1+1, len(pieces)), "B") + b1 + 1
+  if (b2 - b1) % 2 == 0 { return -1 }
+
+  var piecesN = removeChar(removeChar(pieces, "Q"), "B")
+  let n1 = indexOf(piecesN, "N")
+  let n2 = indexOf(substring(piecesN, n1+1, len(piecesN)), "N") + n1 + 1
+  let N = ntable[str(n1) + str(n2)]
+
+  var piecesQ = removeChar(pieces, "B")
+  let Q = indexOf(piecesQ, "Q")
+
+  var D = indexOf("0246", str(b1))
+  var L = indexOf("1357", str(b2))
+  if D == (0 - 1) {
+    D = indexOf("0246", str(b2))
+    L = indexOf("1357", str(b1))
+  }
+
+  return 96*N + 16*Q + 4*D + L
+}
+
+fun main() {
+  for pieces in ["♕♘♖♗♗♘♔♖", "♖♘♗♕♔♗♘♖", "♖♕♘♗♗♔♖♘", "♖♘♕♗♗♔♖♘"] {
+    print(pieces + " or " + g2l(pieces) + " has SP-ID of " + str(spid(pieces)))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/find-chess960-starting-position-identifier-2.out
+++ b/tests/rosetta/x/Mochi/find-chess960-starting-position-identifier-2.out
@@ -1,0 +1,4 @@
+♕♘♖♗♗♘♔♖ or QNRBBNKR has SP-ID of 105
+♖♘♗♕♔♗♘♖ or RNBQKBNR has SP-ID of 518
+♖♕♘♗♗♔♖♘ or RQNBBKRN has SP-ID of 601
+♖♘♕♗♗♔♖♘ or RNQBBKRN has SP-ID of 617


### PR DESCRIPTION
## Summary
- download task 374 via rosetta tool
- add Go solution copy as `find-chess960-starting-position-identifier-2.go`
- create alternative Mochi solution implementing the same logic
- include output from running the program with `mochi run`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886ca5bcee483208525c2a64d73640b