### PR TITLE
Add Rosetta palindromic numbers example

### DIFF
--- a/tests/rosetta/x/Mochi/find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
+++ b/tests/rosetta/x/Mochi/find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi
@@ -1,4 +1,5 @@
-// Mochi version: find first 7 numbers palindromic in base2 and base3.
+// Mochi implementation of palindromic numbers in both binary and ternary bases
+// Translated from Go version
 
 fun toBase(n: int, b: int): string {
   if n == 0 { return "0" }
@@ -9,6 +10,33 @@ fun toBase(n: int, b: int): string {
     x = (x / b) as int
   }
   return s
+
+fun parseIntStr(str: string): int {
+  var i = 0
+  var neg = false
+  if len(str) > 0 && str[0] == "-" {
+    neg = true
+    i = 1
+  }
+  var n = 0
+  while i < len(str) {
+    n = n * 10 + (str[i:i+1] as int) - ("0" as int)
+    i = i + 1
+  }
+  if neg { n = -n }
+  return n
+}
+
+}
+
+fun parseIntBase(s: string, b: int): int {
+  var n = 0
+  var i = 0
+  while i < len(s) {
+    n = n * b + parseIntStr(s[i:i+1])
+    i = i + 1
+  }
+  return n
 }
 
 fun reverseStr(s: string): string {
@@ -21,20 +49,73 @@ fun reverseStr(s: string): string {
   return out
 }
 
-fun isPal(s: string): bool { return s == reverseStr(s) }
+fun isPalindrome(s: string): bool { return s == reverseStr(s) }
+
+fun isPalindromeBin(n: int): bool {
+  let b = toBase(n, 2)
+  return isPalindrome(b)
+}
+
+fun myMin(a: int, b: int): int { if a < b { return a } return b }
+fun myMax(a: int, b: int): int { if a > b { return a } return b }
+
+fun reverse3(n: int): int {
+  var x = 0
+  var y = n
+  while y != 0 {
+    x = x * 3 + (y % 3)
+    y = (y / 3) as int
+  }
+  return x
+}
+
+fun show(n: int) {
+  print("Decimal : " + str(n))
+  print("Binary  : " + toBase(n,2))
+  print("Ternary : " + toBase(n,3))
+  print("")
+}
 
 fun main() {
-  print("Numbers palindromic in both binary and ternary :\n")
-  var count = 0
-  var n = 0
-  while count < 4 {
-    let b2 = toBase(n,2)
-    let b3 = toBase(n,3)
-    if isPal(b2) && isPal(b3) {
-      print(str(n))
-      count = count + 1
+  print("The first 6 numbers which are palindromic in both binary and ternary are :\n")
+  show(0)
+  var count = 1
+  var lo = 0
+  var hi = 1
+  var pow2 = 1
+  var pow3 = 1
+  while true {
+    var i = lo
+    while i < hi {
+      var n = (i*3 + 1) * pow3 + reverse3(i)
+      if isPalindromeBin(n) {
+        show(n)
+        count = count + 1
+        if count >= 6 { return }
+      }
+      i = i + 1
     }
-    n = n + 1
+    if i == pow3 {
+      pow3 = pow3 * 3
+    } else {
+      pow2 = pow2 * 4
+    }
+    while true {
+      while pow2 <= pow3 { pow2 = pow2 * 4 }
+      var lo2 = ((pow2 / pow3 - 1) / 3) as int
+      var hi2 = ((pow2 * 2 / pow3 - 1) / 3) as int + 1
+      var lo3 = (pow3 / 3) as int
+      var hi3 = pow3
+      if lo2 >= hi3 {
+        pow3 = pow3 * 3
+      } else if lo3 >= hi2 {
+        pow2 = pow2 * 4
+      } else {
+        lo = myMax(lo2, lo3)
+        hi = myMin(hi2, hi3)
+        break
+      }
+    }
   }
 }
 

--- a/tests/rosetta/x/Mochi/find-palindromic-numbers-in-both-binary-and-ternary-bases.out
+++ b/tests/rosetta/x/Mochi/find-palindromic-numbers-in-both-binary-and-ternary-bases.out
@@ -1,6 +1,26 @@
-Numbers palindromic in both binary and ternary :
+The first 6 numbers which are palindromic in both binary and ternary are :
 
-0
-1
-6643
-1422773
+Decimal : 0
+Binary  : 0
+Ternary : 0
+
+Decimal : 1
+Binary  : 1
+Ternary : 1
+
+Decimal : 6643
+Binary  : 1100111110011
+Ternary : 100010001
+
+Decimal : 1422773
+Binary  : 101011011010110110101
+Ternary : 2200021200022
+
+Decimal : 5415589
+Binary  : 10100101010001010100101
+Ternary : 101012010210101
+
+Decimal : 90396755477
+Binary  : 1010100001100000100010000011000010101
+Ternary : 22122022220102222022122
+


### PR DESCRIPTION
## Summary
- add Go solution for palindromic numbers in binary and ternary
- implement equivalent Mochi version with full algorithm
- record expected output from Mochi program

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/find-palindromic-numbers-in-both-binary-and-ternary-bases.mochi`

------
https://chatgpt.com/codex/tasks/task_e_6886ca919a788320bbe3a3adde611e11