### PR TITLE
Add Mochi solution for Rosetta task 387

### DIFF
--- a/tests/rosetta/x/Mochi/first-class-functions-use-numbers-analogously.mochi
+++ b/tests/rosetta/x/Mochi/first-class-functions-use-numbers-analogously.mochi
@@ -1,0 +1,26 @@
+fun multiplier(n1: float, n2: float): fun(float): float {
+  let n1n2 = n1 * n2
+  return fun(m: float): float => n1n2 * m
+}
+
+fun main() {
+  let x = 2.0
+  let xi = 0.5
+  let y = 4.0
+  let yi = 0.25
+  let z = x + y
+  let zi = 1.0 / (x + y)
+  let numbers = [x, y, z]
+  let inverses = [xi, yi, zi]
+  var mfs: list<fun(float): float> = []
+  var i = 0
+  while i < len(numbers) {
+    mfs = append(mfs, multiplier(numbers[i], inverses[i]))
+    i = i + 1
+  }
+  for mf in mfs {
+    print(str(mf(1.0)))
+  }
+}
+
+main()

--- a/tests/rosetta/x/Mochi/first-class-functions-use-numbers-analogously.out
+++ b/tests/rosetta/x/Mochi/first-class-functions-use-numbers-analogously.out
@@ -1,0 +1,8 @@
+1
+1
+1
+{
+  "duration_us": 546,
+  "memory_bytes": 19544,
+  "name": "main"
+}


### PR DESCRIPTION
## Summary
- download Rosetta task 387 (First-class functions: use numbers analogously) for Go via tools
- implement the same logic in Mochi
- provide example output from running the program with vm

## Testing
- `MOCHI_ROSETTA_ONLY=first-class-functions-use-numbers-analogously go test -tags slow ./runtime/vm -run TestVM_Rosetta_Golden -count=1 -v`
- `MOCHI_ROSETTA_ONLY=first-class-functions-use-numbers-analogously MOCHI_BENCHMARK=1 go test -tags slow ./runtime/vm -run TestVM_Rosetta_Golden -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_6886d1e2d6d883209d5e5c3981271d6c