### PR TITLE
Add Mochi implementation for 'Five-weekends' Rosetta task

### DIFF
--- a/tests/rosetta/x/Mochi/five-weekends.mochi
+++ b/tests/rosetta/x/Mochi/five-weekends.mochi
@@ -1,0 +1,69 @@
+fun weekday(y: int, m: int, d: int): int {
+  var yy = y
+  var mm = m
+  if mm < 3 {
+    mm = mm + 12
+    yy = yy - 1
+  }
+  let k = yy % 100
+  let j = (yy / 100) as int
+  let a = ((13 * (mm + 1)) / 5) as int
+  let b = (k / 4) as int
+  let c = (j / 4) as int
+  return (d + a + k + b + c + 5 * j) % 7
+}
+
+fun main() {
+  let months31 = [1, 3, 5, 7, 8, 10, 12]
+  let names = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+
+  var count = 0
+  var firstY = 0
+  var firstM = 0
+  var lastY = 0
+  var lastM = 0
+  var haveNone: list<int> = []
+
+  print("Months with five weekends:")
+  for year in 1900..2101 {
+    var hasOne = false
+    for m in months31 {
+      if weekday(year, m, 1) == 6 {
+        print("  " + str(year) + " " + names[m-1])
+        count = count + 1
+        hasOne = true
+        lastY = year
+        lastM = m
+        if firstY == 0 {
+          firstY = year
+          firstM = m
+        }
+      }
+    }
+    if !hasOne {
+      haveNone = append(haveNone, year)
+    }
+  }
+  print(str(count) + " total")
+  print("")
+
+  print("First five dates of weekends:")
+  for i in 0..5 {
+    let day = 1 + 7 * i
+    print("  Friday, " + names[firstM-1] + " " + str(day) + ", " + str(firstY))
+  }
+  print("Last five dates of weekends:")
+  for i in 0..5 {
+    let day = 1 + 7 * i
+    print("  Friday, " + names[lastM-1] + " " + str(day) + ", " + str(lastY))
+  }
+  print("")
+
+  print("Years with no months with five weekends:")
+  for y in haveNone {
+    print("  " + str(y))
+  }
+  print(str(len(haveNone)) + " total")
+}
+
+main()

--- a/tests/rosetta/x/Mochi/five-weekends.out
+++ b/tests/rosetta/x/Mochi/five-weekends.out
@@ -1,0 +1,253 @@
+Months with five weekends:
+  1901 March
+  1902 August
+  1903 May
+  1904 January
+  1904 July
+  1905 December
+  1907 March
+  1908 May
+  1909 January
+  1909 October
+  1910 July
+  1911 December
+  1912 March
+  1913 August
+  1914 May
+  1915 January
+  1915 October
+  1916 December
+  1918 March
+  1919 August
+  1920 October
+  1921 July
+  1922 December
+  1924 August
+  1925 May
+  1926 January
+  1926 October
+  1927 July
+  1929 March
+  1930 August
+  1931 May
+  1932 January
+  1932 July
+  1933 December
+  1935 March
+  1936 May
+  1937 January
+  1937 October
+  1938 July
+  1939 December
+  1940 March
+  1941 August
+  1942 May
+  1943 January
+  1943 October
+  1944 December
+  1946 March
+  1947 August
+  1948 October
+  1949 July
+  1950 December
+  1952 August
+  1953 May
+  1954 January
+  1954 October
+  1955 July
+  1957 March
+  1958 August
+  1959 May
+  1960 January
+  1960 July
+  1961 December
+  1963 March
+  1964 May
+  1965 January
+  1965 October
+  1966 July
+  1967 December
+  1968 March
+  1969 August
+  1970 May
+  1971 January
+  1971 October
+  1972 December
+  1974 March
+  1975 August
+  1976 October
+  1977 July
+  1978 December
+  1980 August
+  1981 May
+  1982 January
+  1982 October
+  1983 July
+  1985 March
+  1986 August
+  1987 May
+  1988 January
+  1988 July
+  1989 December
+  1991 March
+  1992 May
+  1993 January
+  1993 October
+  1994 July
+  1995 December
+  1996 March
+  1997 August
+  1998 May
+  1999 January
+  1999 October
+  2000 December
+  2002 March
+  2003 August
+  2004 October
+  2005 July
+  2006 December
+  2008 August
+  2009 May
+  2010 January
+  2010 October
+  2011 July
+  2013 March
+  2014 August
+  2015 May
+  2016 January
+  2016 July
+  2017 December
+  2019 March
+  2020 May
+  2021 January
+  2021 October
+  2022 July
+  2023 December
+  2024 March
+  2025 August
+  2026 May
+  2027 January
+  2027 October
+  2028 December
+  2030 March
+  2031 August
+  2032 October
+  2033 July
+  2034 December
+  2036 August
+  2037 May
+  2038 January
+  2038 October
+  2039 July
+  2041 March
+  2042 August
+  2043 May
+  2044 January
+  2044 July
+  2045 December
+  2047 March
+  2048 May
+  2049 January
+  2049 October
+  2050 July
+  2051 December
+  2052 March
+  2053 August
+  2054 May
+  2055 January
+  2055 October
+  2056 December
+  2058 March
+  2059 August
+  2060 October
+  2061 July
+  2062 December
+  2064 August
+  2065 May
+  2066 January
+  2066 October
+  2067 July
+  2069 March
+  2070 August
+  2071 May
+  2072 January
+  2072 July
+  2073 December
+  2075 March
+  2076 May
+  2077 January
+  2077 October
+  2078 July
+  2079 December
+  2080 March
+  2081 August
+  2082 May
+  2083 January
+  2083 October
+  2084 December
+  2086 March
+  2087 August
+  2088 October
+  2089 July
+  2090 December
+  2092 August
+  2093 May
+  2094 January
+  2094 October
+  2095 July
+  2097 March
+  2098 August
+  2099 May
+  2100 January
+  2100 October
+201 total
+
+First five dates of weekends:
+  Friday, March 1, 1901
+  Friday, March 8, 1901
+  Friday, March 15, 1901
+  Friday, March 22, 1901
+  Friday, March 29, 1901
+Last five dates of weekends:
+  Friday, October 1, 2100
+  Friday, October 8, 2100
+  Friday, October 15, 2100
+  Friday, October 22, 2100
+  Friday, October 29, 2100
+
+Years with no months with five weekends:
+  1900
+  1906
+  1917
+  1923
+  1928
+  1934
+  1945
+  1951
+  1956
+  1962
+  1973
+  1979
+  1984
+  1990
+  2001
+  2007
+  2012
+  2018
+  2029
+  2035
+  2040
+  2046
+  2057
+  2063
+  2068
+  2074
+  2085
+  2091
+  2096
+29 total
+{
+  "duration_us": 10660,
+  "memory_bytes": -2230352,
+  "name": "main"
+}


### PR DESCRIPTION
## Summary
- add Mochi program for `Five-weekends`
- include VM output for the example

## Testing
- `MOCHI_ROSETTA_ONLY=five-weekends go test -tags slow ./runtime/vm -run Rosetta -count=1` *(fails: golden mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6886d204c5e083208939eda9fd78c845