### PR TITLE
Add Rosetta 'Fork' example for Go and Mochi

### DIFF
--- a/tests/rosetta/x/Go/fork.go
+++ b/tests/rosetta/x/Go/fork.go
@@ -4,26 +4,26 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 )
 
 func main() {
-	fmt.Printf("PID: %v\n", os.Getpid())
-	if len(os.Args) < 2 {
-		fmt.Println("Done.")
-		return
-	}
-	cp, err := os.StartProcess(os.Args[0], nil,
-		&os.ProcAttr{Files: []*os.File{nil, os.Stdout}},
-	)
-	if err != nil {
-		fmt.Println(err)
-	}
-	// Child process running independently at this point.
-	// We have its PID and can print it.
-	fmt.Printf("Child's PID: %v\n", cp.Pid)
-	if _, err = cp.Wait(); err != nil {
-		fmt.Println(err)
-	}
+    fmt.Printf("PID: %v\n", os.Getpid())
+    if len(os.Args) < 2 {
+        fmt.Println("Done.")
+        return
+    }
+    cp, err := os.StartProcess(os.Args[0], nil,
+        &os.ProcAttr{Files: []*os.File{nil, os.Stdout}},
+    )
+    if err != nil {
+        fmt.Println(err)
+    }
+    // Child process running independently at this point.
+    // We have its PID and can print it.
+    fmt.Printf("Child's PID: %v\n", cp.Pid)
+    if _, err = cp.Wait(); err != nil {
+        fmt.Println(err)
+    }
 }

--- a/tests/rosetta/x/Mochi/fork-2.mochi
+++ b/tests/rosetta/x/Mochi/fork-2.mochi
@@ -1,0 +1,20 @@
+// Another Mochi implementation of the Rosetta "Fork" task
+// Simulates process forking by recursively invoking the program logic.
+var nextPID = 1
+
+fun fork(hasChild: bool) {
+  let pid = nextPID
+  nextPID = nextPID + 1
+  print("PID: " + str(pid))
+
+  if !hasChild {
+    print("Done.")
+    return
+  }
+
+  let childPID = nextPID
+  print("Child's PID: " + str(childPID))
+  fork(false)
+}
+
+fork(true)

--- a/tests/rosetta/x/Mochi/fork-2.out
+++ b/tests/rosetta/x/Mochi/fork-2.out
@@ -1,0 +1,4 @@
+PID: 1
+Child's PID: 2
+PID: 2
+Done.


### PR DESCRIPTION
## Summary
- refresh Rosetta `Fork` task in Go using `DownloadTaskByNumber`
- implement a second Mochi version of `Fork`
- add golden output for new Mochi program

## Testing
- `go run ./cmd/mochi run tests/rosetta/x/Mochi/fork-2.mochi`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6886d670bf388320ac03a0b73e950c6f