### PR TITLE
Add French Republican calendar example in Mochi

### DIFF
--- a/tests/rosetta/x/Mochi/french-republican-calendar.mochi
+++ b/tests/rosetta/x/Mochi/french-republican-calendar.mochi
@@ -1,0 +1,111 @@
+let gregorianStr = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+let gregorian = [31,28,31,30,31,30,31,31,30,31,30,31]
+let republicanStr = ["Vendemiaire", "Brumaire", "Frimaire", "Nivose", "Pluviose", "Ventose", "Germinal", "Floreal", "Prairial", "Messidor", "Thermidor", "Fructidor"]
+let sansculotidesStr = ["Fete de la vertu", "Fete du genie", "Fete du travail", "Fete de l'opinion", "Fete des recompenses", "Fete de la Revolution"]
+
+fun greLeap(year: int): bool {
+  let a = (year % 4) as int
+  let b = (year % 100) as int
+  let c = (year % 400) as int
+  return a == 0 && (b != 0 || c == 0)
+}
+
+fun repLeap(year: int): bool {
+  let a = ((year + 1) % 4) as int
+  let b = ((year + 1) % 100) as int
+  let c = ((year + 1) % 400) as int
+  return a == 0 && (b != 0 || c == 0)
+}
+
+fun greToDay(d: int, m: int, y: int): int {
+  var yy = y
+  var mm = m
+  if mm < 3 {
+    yy = yy - 1
+    mm = mm + 12
+  }
+  return yy * 36525 / 100 - yy / 100 + yy / 400 + 306 * (mm + 1) / 10 + d - 654842
+}
+
+fun repToDay(d: int, m: int, y: int): int {
+  var dd = d
+  var mm = m
+  if mm == 13 {
+    mm = mm - 1
+    dd = dd + 30
+  }
+  if repLeap(y) {
+    dd = dd - 1
+  }
+  return 365 * y + (y + 1) / 4 - (y + 1) / 100 + (y + 1) / 400 + 30 * mm + dd - 395
+}
+
+fun dayToGre(day: int): list<int> {
+  var y = day * 100 / 36525
+  var d = day - y * 36525 / 100 + 21
+  y = y + 1792
+  d = d + y / 100 - y / 400 - 13
+  var m = 8
+  while d > gregorian[m] {
+    d = d - gregorian[m]
+    m = m + 1
+    if m == 12 {
+      m = 0
+      y = y + 1
+      if greLeap(y) {
+        gregorian[1] = 29
+      } else {
+        gregorian[1] = 28
+      }
+    }
+  }
+  m = m + 1
+  return [d, m, y]
+}
+
+fun dayToRep(day: int): list<int> {
+  var y = (day - 1) * 100 / 36525
+  if repLeap(y) {
+    y = y - 1
+  }
+  var d = day - (y + 1) * 36525 / 100 + 365 + (y + 1) / 100 - (y + 1) / 400
+  y = y + 1
+  var m = 1
+  var sc = 5
+  if repLeap(y) {
+    sc = 6
+  }
+  while d > 30 {
+    d = d - 30
+    m = m + 1
+    if m == 13 {
+      if d > sc {
+        d = d - sc
+        m = 1
+        y = y + 1
+        sc = 5
+        if repLeap(y) {
+          sc = 6
+        }
+      }
+    }
+  }
+  return [d, m, y]
+}
+
+fun formatRep(d: int, m: int, y: int): string {
+  if m == 13 {
+    return sansculotidesStr[d - 1] + " " + str(y)
+  }
+  return str(d) + " " + republicanStr[m - 1] + " " + str(y)
+}
+
+fun formatGre(d: int, m: int, y: int): string {
+  return str(d) + " " + gregorianStr[m - 1] + " " + str(y)
+}
+
+// Example conversions
+let rep = dayToRep(greToDay(20, 5, 1795))
+print(formatRep(rep[0], rep[1], rep[2]))
+let gre = dayToGre(repToDay(1, 9, 3))
+print(formatGre(gre[0], gre[1], gre[2]))

--- a/tests/rosetta/x/Mochi/french-republican-calendar.out
+++ b/tests/rosetta/x/Mochi/french-republican-calendar.out
@@ -1,0 +1,2 @@
+1 Prairial 3
+20 May 1795


### PR DESCRIPTION
## Summary
- add Rosetta Code example `french-republican-calendar` in Mochi
- include output generated by runtime/vm

## Testing
- `make test STAGE=runtime/vm`

------
https://chatgpt.com/codex/tasks/task_e_6886d98ef89883209b27d9d1071864e2