### PR TITLE
Add GUI maximum window dimensions example

### DIFF
--- a/tests/rosetta/x/Mochi/gui-maximum-window-dimensions.mochi
+++ b/tests/rosetta/x/Mochi/gui-maximum-window-dimensions.mochi
@@ -1,0 +1,29 @@
+// Mochi translation of Rosetta "GUI Maximum window dimensions" task
+// Simulates maximizing a window to screen size.
+
+type Screen { w: int, h: int }
+
+type Window {
+  x: int
+  y: int
+  w: int
+  h: int
+  maximized: bool
+}
+
+fun maximize(s: Screen, win: Window): Window {
+  win.w = s.w
+  win.h = s.h
+  win.maximized = true
+  return win
+}
+
+fun main() {
+  let screen = Screen{ w: 1920, h: 1080 }
+  print("Screen size: " + str(screen.w) + " x " + str(screen.h))
+  var win = Window{ x: 50, y: 50, w: 800, h: 600, maximized: false }
+  win = maximize(screen, win)
+  print("Max usable : " + str(win.w) + " x " + str(win.h))
+}
+
+main()

--- a/tests/rosetta/x/Mochi/gui-maximum-window-dimensions.out
+++ b/tests/rosetta/x/Mochi/gui-maximum-window-dimensions.out
@@ -1,0 +1,2 @@
+Screen size: 1920 x 1080
+Max usable : 1920 x 1080


### PR DESCRIPTION
## Summary
- download Rosetta task #418 and add Mochi implementation
- provide reference output

## Testing
- `MOCHI_ROSETTA_ONLY=gui-maximum-window-dimensions go test ./runtime/vm -run Rosetta -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6886d9d38e708320888c36900ccea7eb