### PR TITLE
Fix Java transpiler map index assignment

### DIFF
--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 28435,
+  "duration_us": 43098,
   "memory_bytes": 57528,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-1.java
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-1.java
@@ -65,7 +65,41 @@ counts[s] = counts[s] + 1;
         return tot;
     }
     public static void main(String[] args) {
-        System.out.println(String.valueOf(beatingProbability(4, 9, 6, 6)));
-        System.out.println(String.valueOf(beatingProbability(10, 5, 7, 6)));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(beatingProbability(4, 9, 6, 6)));
+            System.out.println(String.valueOf(beatingProbability(10, 5, 7, 6)));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 16991,
+  "duration_us": 43100,
   "memory_bytes": 10832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-2.java
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-2.java
@@ -22,8 +22,20 @@ public class Main {
         return (((Number)(wins)).doubleValue()) / (((Number)(trials)).doubleValue());
     }
     public static void main(String[] args) {
-        System.out.println(String.valueOf(beats(9, 4, 6, 6, 1000)));
-        System.out.println(String.valueOf(beats(5, 10, 7, 6, 1000)));
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(String.valueOf(beats(9, 4, 6, 6, 1000)));
+            System.out.println(String.valueOf(beats(5, 10, 7, 6, 1000)));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
     }
 
     static boolean _nowSeeded = false;
@@ -40,5 +52,11 @@ public class Main {
             return _nowSeed;
         }
         return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
+++ b/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 75819,
+  "duration_us": 196899,
   "memory_bytes": 123832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.java
+++ b/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.java
@@ -81,7 +81,41 @@ list[mdr] = java.util.stream.IntStream.concat(java.util.Arrays.stream(list[mdr])
         }
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static <T> T[] appendObj(T[] arr, T v) {

--- a/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
+++ b/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 50844,
+  "memory_bytes": 98592,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/dijkstras-algorithm.java
+++ b/tests/rosetta/transpiler/Java/dijkstras-algorithm.java
@@ -1,14 +1,14 @@
 public class Main {
     static int INF = 1000000000;
-    static java.util.Map<String,java.util.Map<String,Integer>> graph = new java.util.LinkedHashMap<String, java.util.Map<String,Integer>>();
+    static java.util.Map<String,java.util.Map<String,Integer>> graph = ((java.util.Map<String,java.util.Map<String,Integer>>)(new java.util.LinkedHashMap<String, java.util.Map<String,Integer>>()));
 
     static void addEdge(String u, String v, int w) {
         if (!(Boolean)(graph.containsKey(u))) {
-graph.put(u, new java.util.LinkedHashMap<String, Object>());
+graph.put(u, new java.util.LinkedHashMap<String, Integer>());
         }
-((Object)graph.get(u))[v] = w;
+((java.util.Map<String,Integer>)(graph).get(u)).put(v, w);
         if (!(Boolean)(graph.containsKey(v))) {
-graph.put(v, new java.util.LinkedHashMap<String, Object>());
+graph.put(v, new java.util.LinkedHashMap<String, Integer>());
         }
     }
 
@@ -25,8 +25,8 @@ graph.put(v, new java.util.LinkedHashMap<String, Object>());
     }
 
     static java.util.Map<String,Object> dijkstra(String source) {
-        java.util.Map<String,Integer> dist = new java.util.LinkedHashMap<String, Integer>();
-        java.util.Map<String,String> prev = new java.util.LinkedHashMap<String, String>();
+        java.util.Map<String,Integer> dist = ((java.util.Map<String,Integer>)(new java.util.LinkedHashMap<String, Integer>()));
+        java.util.Map<String,String> prev = ((java.util.Map<String,String>)(new java.util.LinkedHashMap<String, String>()));
         for (String v : graph.keySet()) {
 dist.put(v, INF);
 prev.put(v, "");
@@ -42,16 +42,16 @@ dist.put(source, 0);
             int i = 1;
             while (i < q.length) {
                 String v = q[i];
-                if ((int)(((int)dist.getOrDefault(v, 0))) < (int)(((int)dist.getOrDefault(u, 0)))) {
+                if ((int)(((int)(dist).getOrDefault(v, 0))) < (int)(((int)(dist).getOrDefault(u, 0)))) {
                     u = v;
                     bestIdx = i;
                 }
                 i = i + 1;
             }
             q = removeAt(q, bestIdx);
-            for (var v : ((java.util.Map<String,Integer)graph.get(u))) {
-                int alt = (int)(((int)dist.getOrDefault(u, 0))) + (int)(((int)((java.util.Map<String,Integer)graph.get(u)).getOrDefault(v, 0)));
-                if (alt < (int)(((int)dist.getOrDefault(v, 0)))) {
+            for (String v : ((java.util.Map<String,Integer>)(graph).get(u)).keySet()) {
+                int alt = (int)(((int)(dist).getOrDefault(u, 0))) + (int)(((int)(((java.util.Map<String,Integer>)(graph).get(u))).getOrDefault(v, 0)));
+                if (alt < (int)(((int)(dist).getOrDefault(v, 0)))) {
 dist.put(v, alt);
 prev.put(v, u);
                 }
@@ -63,8 +63,8 @@ prev.put(v, u);
     static String path(java.util.Map<String,String> prev, String v) {
         String s = v;
         String cur = v;
-        while (!(((String)prev.get(cur)).equals(""))) {
-            cur = ((String)prev.get(cur));
+        while (!(((String)(prev).get(cur)).equals(""))) {
+            cur = ((String)(prev).get(cur));
             s = cur + s;
         }
         return s;
@@ -81,10 +81,10 @@ prev.put(v, u);
         addEdge("d", "e", 6);
         addEdge("e", "f", 9);
         java.util.Map<String,Object> res = dijkstra("a");
-        java.util.Map<String,Integer> dist = (java.util.Map<String,Integer>)(((java.util.Map<String,Integer>)res.get("dist")));
-        java.util.Map<String,String> prev = (java.util.Map<String,String>)(((java.util.Map<String,String>)res.get("prev")));
-        System.out.println("Distance to e: " + String.valueOf(((int)dist.getOrDefault("e", 0))) + ", Path: " + String.valueOf(path(prev, "e")));
-        System.out.println("Distance to f: " + String.valueOf(((int)dist.getOrDefault("f", 0))) + ", Path: " + String.valueOf(path(prev, "f")));
+        java.util.Map<String,Integer> dist = ((java.util.Map<String,Integer>)(((java.util.Map<String,Integer>) (res.get("dist")))));
+        java.util.Map<String,String> prev = ((java.util.Map<String,String>)(((java.util.Map<String,String>) (res.get("prev")))));
+        System.out.println("Distance to e: " + String.valueOf(((int)(dist).getOrDefault("e", 0))) + ", Path: " + String.valueOf(path(prev, "e")));
+        System.out.println("Distance to f: " + String.valueOf(((int)(dist).getOrDefault("f", 0))) + ", Path: " + String.valueOf(path(prev, "f")));
     }
     public static void main(String[] args) {
         {

--- a/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
+++ b/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 31366,
+  "duration_us": 49028,
   "memory_bytes": 96264,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.java
+++ b/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.java
@@ -43,6 +43,40 @@ public class Main {
         System.out.println("No solution found.");
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/104) - updated 2025-07-27 16:08 UTC
+## VM Golden Test Checklist (103/104) - updated 2025-07-28 03:25 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-28 00:54 GMT+7
+Last updated: 2025-07-28 10:25 GMT+7
 
-## Rosetta Checklist (256/467)
+## Rosetta Checklist (284/493)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -22,454 +22,480 @@ Last updated: 2025-07-28 00:54 GMT+7
 | 14 | 99-bottles-of-beer | ✓ | 14.0ms | 0B |
 | 15 | DNS-query | ✓ | 391.0µs | 0B |
 | 16 | Duffinian-numbers |   |  |  |
-| 17 | a+b | ✓ | 1.0ms | 0B |
-| 18 | abbreviations-automatic | ✓ | 44.0ms | 2.96MB |
-| 19 | abbreviations-easy | ✓ | 23.0ms | 491.63KB |
-| 20 | abbreviations-simple | ✓ | 39.0ms | 737.39KB |
-| 21 | abc-problem | ✓ | 22.0ms | 737.38KB |
-| 22 | abelian-sandpile-model-identity | ✓ | 16.0ms | 491.65KB |
-| 23 | abelian-sandpile-model | ✓ | 10.0ms | 245.78KB |
-| 24 | abstract-type | ✓ | 25.0ms | 245.84KB |
-| 25 | abundant-deficient-and-perfect-number-classifications | ✓ | 205.0ms | 245.78KB |
-| 26 | abundant-odd-numbers | ✓ | 554.0ms | 95.51MB |
-| 27 | accumulator-factory | ✓ | 4.0ms | 0B |
-| 28 | achilles-numbers | ✓ | 54.0ms | 10.33MB |
-| 29 | ackermann-function-2 | ✓ | 5.0ms | 0B |
-| 30 | ackermann-function-3 | ✓ | 160.47s | 11.78MB |
-| 31 | ackermann-function | ✓ | 5.0ms | 0B |
-| 32 | active-directory-connect | ✓ | 5.0ms | 0B |
-| 33 | active-directory-search-for-a-user | ✓ | 20.0ms | 246.02KB |
-| 34 | active-object | ✓ | 710.0µs | 0B |
-| 35 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 4.0ms | 0B |
-| 36 | additive-primes | ✓ | 14.0ms | 0B |
-| 37 | address-of-a-variable | ✓ | 11.0ms | 245.78KB |
-| 38 | adfgvx-cipher |   |  |  |
-| 39 | aks-test-for-primes | ✓ | 14.0ms | 245.79KB |
-| 40 | algebraic-data-types | ✓ | 15.0ms | 245.98KB |
-| 41 | align-columns | ✓ | 11.0ms | 491.66KB |
-| 42 | aliquot-sequence-classifications | ✓ | 19.0ms | 491.59KB |
-| 43 | almkvist-giullera-formula-for-pi | ✓ | 227.0ms | 63.45MB |
-| 44 | almost-prime | ✓ | 9.0ms | 0B |
-| 45 | amb | ✓ | 16.0ms | 245.88KB |
-| 46 | amicable-pairs | ✓ | 405.0ms | 80.72MB |
-| 47 | anagrams-deranged-anagrams | ✓ | 9.0ms | 245.78KB |
-| 48 | anagrams | ✓ | 21.0ms | 491.59KB |
-| 49 | angle-difference-between-two-bearings-1 | ✓ | 627.0µs | 0B |
-| 50 | angle-difference-between-two-bearings-2 | ✓ | 802.0µs | 0B |
-| 51 | angles-geometric-normalization-and-conversion | ✓ | 9.0ms | 245.78KB |
-| 52 | animate-a-pendulum | ✓ | 634.0µs | 0B |
-| 53 | animation | ✓ | 11.0ms | 0B |
-| 54 | anonymous-recursion-1 | ✓ | 7.0ms | 0B |
-| 55 | anonymous-recursion-2 | ✓ | 8.0ms | 0B |
-| 56 | anonymous-recursion | ✓ | 10.0ms | 0B |
-| 57 | anti-primes | ✓ | 44.0ms | 0B |
-| 58 | append-a-record-to-the-end-of-a-text-file | ✓ | 9.0ms | 0B |
-| 59 | apply-a-callback-to-an-array-1 | ✓ | 517.0µs | 0B |
-| 60 | apply-a-callback-to-an-array-2 | ✓ | 23.0ms | 0B |
-| 61 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 1.0ms | 0B |
-| 62 | approximate-equality | ✓ | 15.0ms | 48.33KB |
-| 63 | arbitrary-precision-integers-included- | ✓ | 22.0ms | 65.13KB |
-| 64 | archimedean-spiral | ✓ | 23.0ms | 47.97KB |
-| 65 | arena-storage-pool | ✓ | 13.0ms | 46.47KB |
-| 66 | arithmetic-complex | ✓ | 13.0ms | 50.62KB |
-| 67 | arithmetic-derivative | ✓ | 23.0ms | 56.12KB |
-| 68 | arithmetic-evaluation | ✓ | 10.0ms | 38.70KB |
-| 69 | arithmetic-geometric-mean-calculate-pi | ✓ | 6.0ms | 10.35KB |
-| 70 | arithmetic-geometric-mean | ✓ | 6.0ms | 10.35KB |
-| 71 | arithmetic-integer-1 | ✓ | 23.0ms | 40.70KB |
-| 72 | arithmetic-integer-2 | ✓ | 10.0ms | 40.70KB |
-| 73 | arithmetic-numbers | ✓ |  |  |
-| 74 | arithmetic-rational | ✓ | 24.0ms | 39.38KB |
-| 75 | array-concatenation | ✓ | 14.0ms | 47.89KB |
-| 76 | array-length | ✓ | 11.0ms | 39.15KB |
-| 77 | arrays | ✓ | 16.0ms | 58.69KB |
-| 78 | ascending-primes | ✓ | 18.0ms | 55.77KB |
-| 79 | ascii-art-diagram-converter | ✓ | 6.0ms | 3.63KB |
-| 80 | assertions | ✓ | 5.0ms | 504B |
-| 81 | associative-array-creation | ✓ | 19.0ms | 94.27KB |
-| 82 | associative-array-iteration | ✓ | 11.0ms | 39.91KB |
-| 83 | associative-array-merging | ✓ | 6.0ms | 11.35KB |
-| 84 | atomic-updates | ✓ | 14.0ms | 55.44KB |
-| 85 | attractive-numbers | ✓ | 13.0ms | 39.11KB |
-| 86 | average-loop-length | ✓ | 77.0ms | 91.09KB |
-| 87 | averages-arithmetic-mean | ✓ | 12.0ms | 49.51KB |
-| 88 | averages-mean-time-of-day | ✓ | 17.0ms | 77.97KB |
-| 89 | averages-median-1 | ✓ | 6.0ms | 10.35KB |
-| 90 | averages-median-2 | ✓ | 13.0ms | 10.35KB |
-| 91 | averages-median-3 | ✓ | 7.0ms | 10.45KB |
-| 92 | averages-mode | ✓ | 16.0ms | 46.71KB |
-| 93 | averages-pythagorean-means | ✓ | 14.0ms | 49.09KB |
-| 94 | averages-root-mean-square | ✓ | 21.0ms | 448B |
-| 95 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
-| 96 | avl-tree |   |  |  |
-| 97 | b-zier-curves-intersections |   |  |  |
-| 98 | babbage-problem | ✓ | 28.0ms | 38.90KB |
-| 99 | babylonian-spiral | ✓ | 31.0ms | 40.02KB |
-| 100 | balanced-brackets | ✓ | 27.0ms | 54.56KB |
-| 101 | balanced-ternary | ✓ | 19.0ms | 56.83KB |
-| 102 | barnsley-fern | ✓ | 167.0ms | 81.71KB |
-| 103 | base64-decode-data | ✓ | 18.0ms | 5.48KB |
-| 104 | bell-numbers | ✓ | 53.0ms | 64.29KB |
-| 105 | benfords-law | ✓ | 91.0ms | 106.47KB |
-| 106 | bernoulli-numbers | ✓ | 335.0ms | 104.32KB |
-| 107 | best-shuffle | ✓ | 60.0ms | 101.66KB |
-| 108 | bifid-cipher | ✓ | 65.0ms | 100.41KB |
-| 109 | bin-given-limits | ✓ | 68.0ms | 122.30KB |
-| 110 | binary-digits | ✓ | 28.0ms | 32.82KB |
-| 111 | binary-search | ✓ | 48.0ms | 79.30KB |
-| 112 | binary-strings | ✓ | 37.0ms | 47.36KB |
-| 113 | bioinformatics-base-count | ✓ | 50.0ms | 81.38KB |
-| 114 | bioinformatics-global-alignment | ✓ | 770.0ms | 91.08KB |
-| 115 | bioinformatics-sequence-mutation | ✓ | 95.0ms | 125.98KB |
-| 116 | biorhythms | ✓ | 63.0ms | 126.57KB |
-| 117 | bitcoin-address-validation | ✓ | 34.0ms | 252.41KB |
-| 118 | bitmap-b-zier-curves-cubic | ✓ | 23.0ms | -2878472B |
-| 119 | bitmap-b-zier-curves-quadratic | ✓ | 40.0ms | -2878472B |
-| 120 | bitmap-bresenhams-line-algorithm | ✓ | 22.0ms | 92.34KB |
-| 121 | bitmap-flood-fill |   |  |  |
-| 122 | bitmap-histogram |   |  |  |
-| 123 | bitmap-midpoint-circle-algorithm |   |  |  |
-| 124 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
-| 125 | bitmap-read-a-ppm-file |   |  |  |
-| 126 | bitmap-read-an-image-through-a-pipe |   |  |  |
-| 127 | bitmap-write-a-ppm-file |   |  |  |
-| 128 | bitmap | ✓ | 341.0ms | 115.98KB |
-| 129 | bitwise-io-1 | ✓ | 36.0ms | 55.18KB |
-| 130 | bitwise-io-2 | ✓ | 60.0ms | 125.30KB |
-| 131 | bitwise-operations | ✓ | 36.0ms | 40.73KB |
-| 132 | blum-integer | ✓ | 50.0ms | 94.55KB |
-| 133 | boolean-values | ✓ | 30.0ms | 39.56KB |
-| 134 | box-the-compass | ✓ | 46.0ms | 97.79KB |
-| 135 | boyer-moore-string-search | ✓ | 57.0ms | 113.94KB |
-| 136 | brazilian-numbers | ✓ | 3.49s | 72.62KB |
-| 137 | break-oo-privacy | ✓ | 50.0ms | 98.93KB |
-| 138 | brilliant-numbers |   |  |  |
-| 139 | brownian-tree | ✓ | 64.12s | 520.70KB |
-| 140 | bulls-and-cows-player | ✓ | 144.0ms | 67.21KB |
-| 141 | bulls-and-cows |   |  |  |
-| 142 | burrows-wheeler-transform | ✓ | 70.0ms | 104.86KB |
-| 143 | caesar-cipher-1 | ✓ | 51.0ms | 73.05KB |
-| 144 | caesar-cipher-2 | ✓ | 41.0ms | 73.05KB |
-| 145 | calculating-the-value-of-e |   |  |  |
-| 146 | calendar---for-real-programmers-1 | ✓ | 34.0ms | 80.95KB |
-| 147 | calendar---for-real-programmers-2 | ✓ | 30.0ms | 80.95KB |
-| 148 | calendar | ✓ | 40.0ms | 80.95KB |
-| 149 | calkin-wilf-sequence |   |  |  |
-| 150 | call-a-foreign-language-function | ✓ | 24.0ms | 25.62KB |
-| 151 | call-a-function-1 | ✓ | 21.0ms | 0B |
-| 152 | call-a-function-10 | ✓ | 46.0ms | 45.60KB |
-| 153 | call-a-function-11 | ✓ | 32.0ms | 37.83KB |
-| 154 | call-a-function-12 | ✓ | 50.0ms | 88.48KB |
-| 155 | call-a-function-2 | ✓ | 21.0ms | 320B |
-| 156 | call-a-function-3 | ✓ | 20.0ms | 192B |
-| 157 | call-a-function-4 | ✓ | 23.0ms | 280B |
-| 158 | call-a-function-5 | ✓ | 20.0ms | 720B |
-| 159 | call-a-function-6 | ✓ | 51.0ms | 84.13KB |
-| 160 | call-a-function-7 | ✓ | 19.0ms | 0B |
-| 161 | call-a-function-8 | ✓ | 17.0ms | 46.48KB |
-| 162 | call-a-function-9 | ✓ | 18.0ms | 45.91KB |
-| 163 | call-an-object-method-1 | ✓ | 7.0ms | 0B |
-| 164 | call-an-object-method-2 | ✓ | 16.0ms | -320B |
-| 165 | call-an-object-method-3 |   |  |  |
-| 166 | call-an-object-method |   |  |  |
-| 167 | camel-case-and-snake-case |   |  |  |
-| 168 | canny-edge-detector |   |  |  |
-| 169 | canonicalize-cidr |   |  |  |
-| 170 | cantor-set | ✓ | 46.0ms | 101.48KB |
-| 171 | carmichael-3-strong-pseudoprimes | ✓ | 54.0ms | 89.27KB |
-| 172 | cartesian-product-of-two-or-more-lists-1 | ✓ | 32.0ms | 38.78KB |
-| 173 | cartesian-product-of-two-or-more-lists-2 | ✓ | 44.0ms | 55.77KB |
-| 174 | cartesian-product-of-two-or-more-lists-3 | ✓ | 41.0ms | 55.77KB |
-| 175 | cartesian-product-of-two-or-more-lists-4 | ✓ | 43.0ms | 55.77KB |
-| 176 | case-sensitivity-of-identifiers | ✓ | 57.0ms | 106.52KB |
-| 177 | casting-out-nines | ✓ | 68.0ms | 102.78KB |
-| 178 | catalan-numbers-1 | ✓ | 19.0ms | 448B |
-| 179 | catalan-numbers-2 | ✓ | 20.0ms | 448B |
-| 180 | catalan-numbers-pascals-triangle | ✓ | 50.0ms | 93.13KB |
-| 181 | catamorphism | ✓ | 37.0ms | 39.63KB |
-| 182 | catmull-clark-subdivision-surface |   |  |  |
-| 183 | chaocipher |   |  |  |
-| 184 | chaos-game |   |  |  |
-| 185 | character-codes-1 |   |  |  |
-| 186 | character-codes-2 |   |  |  |
-| 187 | character-codes-3 |   |  |  |
-| 188 | character-codes-4 |   |  |  |
-| 189 | character-codes-5 |   |  |  |
-| 190 | chat-server |   |  |  |
-| 191 | check-machin-like-formulas |   |  |  |
-| 192 | check-that-file-exists |   |  |  |
-| 193 | checkpoint-synchronization-1 |   |  |  |
-| 194 | checkpoint-synchronization-2 |   |  |  |
-| 195 | checkpoint-synchronization-3 | ✓ | 42.0ms | 83.76KB |
-| 196 | checkpoint-synchronization-4 | ✓ | 48.0ms | 88.00KB |
-| 197 | chernicks-carmichael-numbers | ✓ | 406.0ms | 93.80KB |
-| 198 | cheryls-birthday | ✓ | 45.0ms | 96.05KB |
-| 199 | chinese-remainder-theorem | ✓ | 25.0ms | 37.30KB |
-| 200 | chinese-zodiac | ✓ | 45.0ms | 99.30KB |
-| 201 | cholesky-decomposition-1 |   |  |  |
-| 202 | cholesky-decomposition | ✓ | 17.0ms | 65.20KB |
-| 203 | chowla-numbers | ✓ | 6.0ms | 3.83KB |
-| 204 | church-numerals-1 |   |  |  |
-| 205 | church-numerals-2 |   |  |  |
-| 206 | circles-of-given-radius-through-two-points |   |  |  |
-| 207 | circular-primes | ✓ | 27.0ms | 89.04KB |
-| 208 | cistercian-numerals |   |  |  |
-| 209 | comma-quibbling | ✓ | 24.0ms | 88.39KB |
-| 210 | compiler-virtual-machine-interpreter |   |  |  |
-| 211 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | ✓ | 11.43s | 94.89KB |
-| 212 | compound-data-type | ✓ | 6.0ms | 0B |
-| 213 | concurrent-computing-1 | ✓ | 8.0ms | 648B |
-| 214 | concurrent-computing-2 | ✓ | 6.0ms | 648B |
-| 215 | concurrent-computing-3 | ✓ | 8.0ms | 648B |
-| 216 | conditional-structures-1 |   |  |  |
-| 217 | conditional-structures-10 | ✓ | 8.0ms | 496B |
-| 218 | conditional-structures-2 |   |  |  |
-| 219 | conditional-structures-3 |   |  |  |
-| 220 | conditional-structures-4 | ✓ | 8.0ms | 0B |
-| 221 | conditional-structures-5 |   |  |  |
-| 222 | conditional-structures-6 |   |  |  |
-| 223 | conditional-structures-7 |   |  |  |
-| 224 | conditional-structures-8 |   |  |  |
-| 225 | conditional-structures-9 | ✓ | 8.0ms | 0B |
-| 226 | consecutive-primes-with-ascending-or-descending-differences | ✓ |  |  |
-| 227 | constrained-genericity-1 | ✓ | 5.0ms | 0B |
-| 228 | constrained-genericity-2 | ✓ | 6.0ms | 0B |
-| 229 | constrained-genericity-3 | ✓ |  |  |
-| 230 | constrained-genericity-4 |   |  |  |
-| 231 | constrained-random-points-on-a-circle-1 | ✓ | 34.0ms | 104.09KB |
-| 232 | constrained-random-points-on-a-circle-2 | ✓ | 67.0ms | 121.77KB |
-| 233 | continued-fraction | ✓ | 31.0ms | 48.12KB |
-| 234 | convert-decimal-number-to-rational | ✓ | 45.0ms | 84.43KB |
-| 235 | convert-seconds-to-compound-duration | ✓ | 44.0ms | 81.18KB |
-| 236 | convex-hull | ✓ | 37.0ms | 49.32KB |
-| 237 | conways-game-of-life | ✓ | 388.0ms | 41.82KB |
-| 238 | copy-a-string-1 | ✓ | 18.0ms | 0B |
-| 239 | copy-a-string-2 | ✓ | 31.0ms | 38.00KB |
-| 240 | copy-stdin-to-stdout-1 | ✓ | 24.0ms | -1640B |
-| 241 | copy-stdin-to-stdout-2 | ✓ | 20.0ms | -1640B |
-| 242 | count-in-factors | ✓ | 49.0ms | 86.81KB |
-| 243 | count-in-octal-1 | ✓ | 30.0ms | 32.87KB |
-| 244 | count-in-octal-2 | ✓ | 221.0ms | 33.13KB |
-| 245 | count-in-octal-3 | ✓ | 25.0ms | 32.87KB |
-| 246 | count-in-octal-4 | ✓ | 38.0ms | 32.87KB |
-| 247 | count-occurrences-of-a-substring | ✓ | 19.0ms | 608B |
-| 248 | count-the-coins-1 | ✓ | 29.0ms | 92.72KB |
-| 249 | count-the-coins-2 | ✓ | 40.0ms | 92.79KB |
-| 250 | cramers-rule | ✓ | 13.0ms | 18.30KB |
-| 251 | crc-32-1 | ✓ | 9.0ms | 656B |
-| 252 | crc-32-2 | ✓ | 8.0ms | 2.30KB |
-| 253 | create-a-file-on-magnetic-tape | ✓ | 6.0ms | 728B |
-| 254 | create-a-file | ✓ | 25.0ms | 70.23KB |
-| 255 | create-a-two-dimensional-array-at-runtime-1 | ✓ | 41.0ms | 102.07KB |
-| 256 | create-an-html-table | ✓ | 27.0ms | 86.33KB |
-| 257 | create-an-object-at-a-given-address | ✓ | 30.0ms | 96.82KB |
-| 258 | csv-data-manipulation | ✓ | 20.0ms | 51.52KB |
-| 259 | csv-to-html-translation-1 | ✓ | 29.0ms | 87.33KB |
-| 260 | csv-to-html-translation-2 | ✓ | 29.0ms | 88.36KB |
-| 261 | csv-to-html-translation-3 | ✓ | 7.0ms | 1.51KB |
-| 262 | csv-to-html-translation-4 | ✓ | 8.0ms | 1.27KB |
-| 263 | csv-to-html-translation-5 | ✓ | 31.0ms | 89.14KB |
-| 264 | cuban-primes | ✓ |  |  |
-| 265 | cullen-and-woodall-numbers | ✓ | 37.0ms | 63.46KB |
-| 266 | cumulative-standard-deviation | ✓ | 19.0ms | 10.59KB |
-| 267 | currency | ✓ | 42.0ms | 80.55KB |
-| 268 | currying | ✓ | 39.0ms | 68.09KB |
-| 269 | curzon-numbers | ✓ |  |  |
-| 270 | cusip | ✓ | 43.0ms | 77.64KB |
-| 271 | cyclops-numbers | ✓ | 16.0ms | 0B |
-| 272 | damm-algorithm | ✓ | 44.0ms | 79.77KB |
-| 273 | date-format | ✓ | 56.0ms | 103.55KB |
-| 274 | date-manipulation |   |  |  |
-| 275 | day-of-the-week | ✓ | 39.0ms | 69.08KB |
-| 276 | de-bruijn-sequences | ✓ | 1.22s | 105.70KB |
-| 277 | deal-cards-for-freecell |   |  |  |
-| 278 | death-star | ✓ | 65.0ms | 39.51KB |
-| 279 | deceptive-numbers | ✓ |  |  |
-| 280 | deconvolution-1d-2 | ✓ | 43.0ms | 65.21KB |
-| 281 | deconvolution-1d-3 | ✓ | 46.0ms | 95.74KB |
-| 282 | deconvolution-1d | ✓ | 35.0ms | 65.21KB |
-| 283 | deepcopy-1 |   |  |  |
-| 284 | define-a-primitive-data-type | ✓ | 29.0ms | 39.78KB |
-| 285 | delegates |   |  |  |
-| 286 | demings-funnel | ✓ | 60.0ms | 109.08KB |
-| 287 | department-numbers | ✓ | 44.0ms | 87.02KB |
-| 288 | descending-primes | ✓ | 39.0ms | 56.60KB |
-| 289 | detect-division-by-zero | ✓ | 41.0ms | 77.66KB |
-| 290 | determine-if-a-string-has-all-the-same-characters | ✓ | 57.0ms | 106.90KB |
-| 291 | determine-if-a-string-has-all-unique-characters | ✓ | 54.0ms | 101.68KB |
-| 292 | determine-if-a-string-is-collapsible |   |  |  |
-| 293 | determine-if-a-string-is-numeric-1 | ✓ | 39.0ms | 77.67KB |
-| 294 | determine-if-a-string-is-numeric-2 | ✓ | 39.0ms | 77.88KB |
-| 295 | determine-if-a-string-is-squeezable | ✓ | 25.0ms | 88.58KB |
-| 296 | determine-if-only-one-instance-is-running | ✓ | 6.0ms | 584B |
-| 297 | determine-if-two-triangles-overlap | ✓ | 26.0ms | 110.55KB |
-| 298 | determine-sentence-type | ✓ | 31.0ms | 52.66KB |
-| 299 | dice-game-probabilities-1 | ✓ | 28.0ms | 56.18KB |
-| 300 | dice-game-probabilities-2 | ✓ | 16.0ms | 10.58KB |
-| 301 | digital-root-multiplicative-digital-root | ✓ | 75.0ms | 120.93KB |
-| 302 | dijkstras-algorithm |   |  |  |
-| 303 | dinesmans-multiple-dwelling-problem | ✓ | 31.0ms | 94.01KB |
-| 304 | dining-philosophers-1 | ✓ | 13.0ms | 38.70KB |
-| 305 | dining-philosophers-2 | ✓ | 14.0ms | 38.70KB |
-| 306 | disarium-numbers | ✓ | 1.58s | 83.91KB |
-| 307 | discordian-date | ✓ | 26.0ms | 101.55KB |
-| 308 | display-a-linear-combination | ✓ | 37.0ms | 101.29KB |
-| 309 | display-an-outline-as-a-nested-table | ✓ | 30.0ms | 110.75KB |
-| 310 | distance-and-bearing |   |  |  |
-| 311 | distributed-programming |   |  |  |
-| 312 | diversity-prediction-theorem |   |  |  |
-| 313 | documentation |   |  |  |
-| 314 | doomsday-rule |   |  |  |
-| 315 | dot-product |   |  |  |
-| 316 | doubly-linked-list-definition-1 |   |  |  |
-| 317 | doubly-linked-list-definition-2 |   |  |  |
-| 318 | doubly-linked-list-element-definition |   |  |  |
-| 319 | doubly-linked-list-traversal |   |  |  |
-| 320 | dragon-curve |   |  |  |
-| 321 | draw-a-clock |   |  |  |
-| 322 | draw-a-cuboid |   |  |  |
-| 323 | draw-a-pixel-1 |   |  |  |
-| 324 | draw-a-rotating-cube |   |  |  |
-| 325 | draw-a-sphere |   |  |  |
-| 326 | dutch-national-flag-problem |   |  |  |
-| 327 | dynamic-variable-names |   |  |  |
-| 328 | earliest-difference-between-prime-gaps |   |  |  |
-| 329 | eban-numbers |   |  |  |
-| 330 | ecdsa-example |   |  |  |
-| 331 | echo-server |   |  |  |
-| 332 | eertree |   |  |  |
-| 333 | egyptian-division |   |  |  |
-| 334 | ekg-sequence-convergence |   |  |  |
-| 335 | element-wise-operations |   |  |  |
-| 336 | elementary-cellular-automaton-infinite-length |   |  |  |
-| 337 | elementary-cellular-automaton-random-number-generator |   |  |  |
-| 338 | elementary-cellular-automaton |   |  |  |
-| 339 | elliptic-curve-arithmetic |   |  |  |
-| 340 | elliptic-curve-digital-signature-algorithm |   |  |  |
-| 341 | emirp-primes |   |  |  |
-| 342 | empty-directory |   |  |  |
-| 343 | empty-program |   |  |  |
-| 344 | empty-string-1 |   |  |  |
-| 345 | empty-string-2 |   |  |  |
-| 346 | enforced-immutability |   |  |  |
-| 347 | entropy-1 |   |  |  |
-| 348 | entropy-2 |   |  |  |
-| 349 | entropy-narcissist |   |  |  |
-| 350 | enumerations-1 |   |  |  |
-| 351 | enumerations-2 |   |  |  |
-| 352 | enumerations-3 |   |  |  |
-| 353 | enumerations-4 |   |  |  |
-| 354 | environment-variables-1 |   |  |  |
-| 355 | environment-variables-2 |   |  |  |
-| 356 | equal-prime-and-composite-sums |   |  |  |
-| 357 | equilibrium-index |   |  |  |
-| 358 | erd-s-nicolas-numbers |   |  |  |
-| 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
-| 360 | esthetic-numbers |   |  |  |
-| 361 | ethiopian-multiplication |   |  |  |
-| 362 | euclid-mullin-sequence |   |  |  |
-| 363 | euler-method |   |  |  |
-| 364 | eulers-constant-0.5772... |   |  |  |
-| 365 | eulers-identity |   |  |  |
-| 366 | eulers-sum-of-powers-conjecture |   |  |  |
-| 367 | evaluate-binomial-coefficients |   |  |  |
-| 368 | even-or-odd |   |  |  |
-| 369 | events |   |  |  |
-| 370 | evolutionary-algorithm |   |  |  |
-| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
-| 372 | exceptions |   |  |  |
-| 373 | executable-library |   |  |  |
-| 374 | execute-a-markov-algorithm |   |  |  |
-| 375 | execute-a-system-command |   |  |  |
-| 376 | execute-brain- |   |  |  |
-| 377 | execute-computer-zero-1 |   |  |  |
-| 378 | execute-computer-zero |   |  |  |
-| 379 | execute-hq9+ |   |  |  |
-| 380 | execute-snusp |   |  |  |
-| 381 | exponentiation-operator-2 |   |  |  |
-| 382 | exponentiation-operator |   |  |  |
-| 383 | exponentiation-order |   |  |  |
-| 384 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
-| 385 | extend-your-language |   |  |  |
-| 386 | extensible-prime-generator |   |  |  |
-| 387 | extreme-floating-point-values |   |  |  |
-| 388 | faces-from-a-mesh-2 |   |  |  |
-| 389 | faces-from-a-mesh |   |  |  |
-| 390 | factorial-base-numbers-indexing-permutations-of-a-collection |   |  |  |
-| 391 | factorial-primes |   |  |  |
-| 392 | factorial |   |  |  |
-| 393 | factorions |   |  |  |
-| 394 | factors-of-a-mersenne-number |   |  |  |
-| 395 | factors-of-an-integer |   |  |  |
-| 396 | fairshare-between-two-and-more |   |  |  |
-| 397 | farey-sequence |   |  |  |
-| 398 | fast-fourier-transform |   |  |  |
-| 399 | fasta-format |   |  |  |
-| 400 | faulhabers-formula |   |  |  |
-| 401 | faulhabers-triangle |   |  |  |
-| 402 | feigenbaum-constant-calculation |   |  |  |
-| 403 | fermat-numbers |   |  |  |
-| 404 | fibonacci-n-step-number-sequences |   |  |  |
-| 405 | fibonacci-sequence-1 |   |  |  |
-| 406 | fibonacci-sequence-2 |   |  |  |
-| 407 | fibonacci-sequence-3 |   |  |  |
-| 408 | fibonacci-sequence-4 |   |  |  |
-| 409 | fibonacci-sequence-5 |   |  |  |
-| 410 | fibonacci-word-fractal |   |  |  |
-| 411 | fibonacci-word |   |  |  |
-| 412 | file-extension-is-in-extensions-list |   |  |  |
-| 413 | file-input-output-1 |   |  |  |
-| 414 | file-input-output-2 |   |  |  |
-| 415 | file-input-output-3 |   |  |  |
-| 416 | file-modification-time |   |  |  |
-| 417 | file-size-distribution |   |  |  |
-| 418 | file-size |   |  |  |
-| 419 | filter |   |  |  |
-| 420 | find-chess960-starting-position-identifier |   |  |  |
-| 421 | find-common-directory-path |   |  |  |
-| 422 | find-duplicate-files |   |  |  |
-| 423 | find-if-a-point-is-within-a-triangle |   |  |  |
-| 424 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
-| 425 | find-limit-of-recursion |   |  |  |
-| 426 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
-| 427 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
-| 428 | find-the-intersection-of-two-lines |   |  |  |
-| 429 | find-the-last-sunday-of-each-month |   |  |  |
-| 430 | find-the-missing-permutation |   |  |  |
-| 431 | fivenum-1 |   |  |  |
-| 432 | fivenum-2 |   |  |  |
-| 433 | fixed-length-records-1 |   |  |  |
-| 434 | fixed-length-records-2 |   |  |  |
-| 435 | fizzbuzz-1 |   |  |  |
-| 436 | fizzbuzz-2 |   |  |  |
-| 437 | flatten-a-list-1 |   |  |  |
-| 438 | flatten-a-list-2 |   |  |  |
-| 439 | flipping-bits-game |   |  |  |
-| 440 | flow-control-structures-1 |   |  |  |
-| 441 | flow-control-structures-2 |   |  |  |
-| 442 | flow-control-structures-3 |   |  |  |
-| 443 | flow-control-structures-4 |   |  |  |
-| 444 | floyd-warshall-algorithm |   |  |  |
-| 445 | floyds-triangle |   |  |  |
-| 446 | forest-fire |   |  |  |
-| 447 | fork |   |  |  |
-| 448 | ftp |   |  |  |
-| 449 | gamma-function |   |  |  |
-| 450 | general-fizzbuzz |   |  |  |
-| 451 | generic-swap |   |  |  |
-| 452 | get-system-command-output |   |  |  |
-| 453 | giuga-numbers |   |  |  |
-| 454 | globally-replace-text-in-several-files |   |  |  |
-| 455 | goldbachs-comet |   |  |  |
-| 456 | golden-ratio-convergence |   |  |  |
-| 457 | graph-colouring |   |  |  |
-| 458 | gray-code |   |  |  |
-| 459 | http |   |  |  |
-| 460 | image-noise |   |  |  |
-| 461 | loops-increment-loop-index-within-loop-body |   |  |  |
-| 462 | md5 |   |  |  |
-| 463 | nim-game |   |  |  |
-| 464 | plasma-effect |   |  |  |
-| 465 | sorting-algorithms-bubble-sort |   |  |  |
-| 466 | window-management |   |  |  |
-| 467 | zumkeller-numbers |   |  |  |
+| 17 | Find-if-a-point-is-within-a-triangle |   |  |  |
+| 18 | a+b | ✓ | 1.0ms | 0B |
+| 19 | abbreviations-automatic | ✓ | 44.0ms | 2.96MB |
+| 20 | abbreviations-easy | ✓ | 23.0ms | 491.63KB |
+| 21 | abbreviations-simple | ✓ | 39.0ms | 737.39KB |
+| 22 | abc-problem | ✓ | 22.0ms | 737.38KB |
+| 23 | abelian-sandpile-model-identity | ✓ | 16.0ms | 491.65KB |
+| 24 | abelian-sandpile-model | ✓ | 10.0ms | 245.78KB |
+| 25 | abstract-type | ✓ | 25.0ms | 245.84KB |
+| 26 | abundant-deficient-and-perfect-number-classifications | ✓ | 205.0ms | 245.78KB |
+| 27 | abundant-odd-numbers | ✓ | 554.0ms | 95.51MB |
+| 28 | accumulator-factory | ✓ | 4.0ms | 0B |
+| 29 | achilles-numbers | ✓ | 54.0ms | 10.33MB |
+| 30 | ackermann-function-2 | ✓ | 5.0ms | 0B |
+| 31 | ackermann-function-3 | ✓ | 160.47s | 11.78MB |
+| 32 | ackermann-function | ✓ | 5.0ms | 0B |
+| 33 | active-directory-connect | ✓ | 5.0ms | 0B |
+| 34 | active-directory-search-for-a-user | ✓ | 20.0ms | 246.02KB |
+| 35 | active-object | ✓ | 710.0µs | 0B |
+| 36 | add-a-variable-to-a-class-instance-at-runtime | ✓ | 4.0ms | 0B |
+| 37 | additive-primes | ✓ | 14.0ms | 0B |
+| 38 | address-of-a-variable | ✓ | 11.0ms | 245.78KB |
+| 39 | adfgvx-cipher |   |  |  |
+| 40 | aks-test-for-primes | ✓ | 14.0ms | 245.79KB |
+| 41 | algebraic-data-types | ✓ | 15.0ms | 245.98KB |
+| 42 | align-columns | ✓ | 11.0ms | 491.66KB |
+| 43 | aliquot-sequence-classifications | ✓ | 19.0ms | 491.59KB |
+| 44 | almkvist-giullera-formula-for-pi | ✓ | 227.0ms | 63.45MB |
+| 45 | almost-prime | ✓ | 9.0ms | 0B |
+| 46 | amb | ✓ | 16.0ms | 245.88KB |
+| 47 | amicable-pairs | ✓ | 405.0ms | 80.72MB |
+| 48 | anagrams-deranged-anagrams | ✓ | 9.0ms | 245.78KB |
+| 49 | anagrams | ✓ | 21.0ms | 491.59KB |
+| 50 | angle-difference-between-two-bearings-1 | ✓ | 627.0µs | 0B |
+| 51 | angle-difference-between-two-bearings-2 | ✓ | 802.0µs | 0B |
+| 52 | angles-geometric-normalization-and-conversion | ✓ | 9.0ms | 245.78KB |
+| 53 | animate-a-pendulum | ✓ | 634.0µs | 0B |
+| 54 | animation | ✓ | 11.0ms | 0B |
+| 55 | anonymous-recursion-1 | ✓ | 7.0ms | 0B |
+| 56 | anonymous-recursion-2 | ✓ | 8.0ms | 0B |
+| 57 | anonymous-recursion | ✓ | 10.0ms | 0B |
+| 58 | anti-primes | ✓ | 44.0ms | 0B |
+| 59 | append-a-record-to-the-end-of-a-text-file | ✓ | 9.0ms | 0B |
+| 60 | apply-a-callback-to-an-array-1 | ✓ | 517.0µs | 0B |
+| 61 | apply-a-callback-to-an-array-2 | ✓ | 23.0ms | 0B |
+| 62 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 1.0ms | 0B |
+| 63 | approximate-equality | ✓ | 15.0ms | 48.33KB |
+| 64 | arbitrary-precision-integers-included- | ✓ | 22.0ms | 65.13KB |
+| 65 | archimedean-spiral | ✓ | 23.0ms | 47.97KB |
+| 66 | arena-storage-pool | ✓ | 13.0ms | 46.47KB |
+| 67 | arithmetic-complex | ✓ | 13.0ms | 50.62KB |
+| 68 | arithmetic-derivative | ✓ | 23.0ms | 56.12KB |
+| 69 | arithmetic-evaluation | ✓ | 10.0ms | 38.70KB |
+| 70 | arithmetic-geometric-mean-calculate-pi | ✓ | 6.0ms | 10.35KB |
+| 71 | arithmetic-geometric-mean | ✓ | 6.0ms | 10.35KB |
+| 72 | arithmetic-integer-1 | ✓ | 23.0ms | 40.70KB |
+| 73 | arithmetic-integer-2 | ✓ | 10.0ms | 40.70KB |
+| 74 | arithmetic-numbers | ✓ |  |  |
+| 75 | arithmetic-rational | ✓ | 24.0ms | 39.38KB |
+| 76 | array-concatenation | ✓ | 14.0ms | 47.89KB |
+| 77 | array-length | ✓ | 11.0ms | 39.15KB |
+| 78 | arrays | ✓ | 16.0ms | 58.69KB |
+| 79 | ascending-primes | ✓ | 18.0ms | 55.77KB |
+| 80 | ascii-art-diagram-converter | ✓ | 6.0ms | 3.63KB |
+| 81 | assertions | ✓ | 5.0ms | 504B |
+| 82 | associative-array-creation | ✓ | 19.0ms | 94.27KB |
+| 83 | associative-array-iteration | ✓ | 11.0ms | 39.91KB |
+| 84 | associative-array-merging | ✓ | 6.0ms | 11.35KB |
+| 85 | atomic-updates | ✓ | 14.0ms | 55.44KB |
+| 86 | attractive-numbers | ✓ | 13.0ms | 39.11KB |
+| 87 | average-loop-length | ✓ | 77.0ms | 91.09KB |
+| 88 | averages-arithmetic-mean | ✓ | 12.0ms | 49.51KB |
+| 89 | averages-mean-time-of-day | ✓ | 17.0ms | 77.97KB |
+| 90 | averages-median-1 | ✓ | 6.0ms | 10.35KB |
+| 91 | averages-median-2 | ✓ | 13.0ms | 10.35KB |
+| 92 | averages-median-3 | ✓ | 7.0ms | 10.45KB |
+| 93 | averages-mode | ✓ | 16.0ms | 46.71KB |
+| 94 | averages-pythagorean-means | ✓ | 14.0ms | 49.09KB |
+| 95 | averages-root-mean-square | ✓ | 21.0ms | 448B |
+| 96 | averages-simple-moving-average | ✓ | 58.0ms | 105.52KB |
+| 97 | avl-tree |   |  |  |
+| 98 | b-zier-curves-intersections |   |  |  |
+| 99 | babbage-problem | ✓ | 28.0ms | 38.90KB |
+| 100 | babylonian-spiral | ✓ | 31.0ms | 40.02KB |
+| 101 | balanced-brackets | ✓ | 27.0ms | 54.56KB |
+| 102 | balanced-ternary | ✓ | 19.0ms | 56.83KB |
+| 103 | barnsley-fern | ✓ | 167.0ms | 81.71KB |
+| 104 | base64-decode-data | ✓ | 18.0ms | 5.48KB |
+| 105 | bell-numbers | ✓ | 53.0ms | 64.29KB |
+| 106 | benfords-law | ✓ | 91.0ms | 106.47KB |
+| 107 | bernoulli-numbers | ✓ | 335.0ms | 104.32KB |
+| 108 | best-shuffle | ✓ | 60.0ms | 101.66KB |
+| 109 | bifid-cipher | ✓ | 65.0ms | 100.41KB |
+| 110 | bin-given-limits | ✓ | 68.0ms | 122.30KB |
+| 111 | binary-digits | ✓ | 28.0ms | 32.82KB |
+| 112 | binary-search | ✓ | 48.0ms | 79.30KB |
+| 113 | binary-strings | ✓ | 37.0ms | 47.36KB |
+| 114 | bioinformatics-base-count | ✓ | 50.0ms | 81.38KB |
+| 115 | bioinformatics-global-alignment | ✓ | 770.0ms | 91.08KB |
+| 116 | bioinformatics-sequence-mutation | ✓ | 95.0ms | 125.98KB |
+| 117 | biorhythms | ✓ | 63.0ms | 126.57KB |
+| 118 | bitcoin-address-validation | ✓ | 34.0ms | 252.41KB |
+| 119 | bitmap-b-zier-curves-cubic | ✓ | 23.0ms | -2878472B |
+| 120 | bitmap-b-zier-curves-quadratic | ✓ | 40.0ms | -2878472B |
+| 121 | bitmap-bresenhams-line-algorithm | ✓ | 22.0ms | 92.34KB |
+| 122 | bitmap-flood-fill |   |  |  |
+| 123 | bitmap-histogram |   |  |  |
+| 124 | bitmap-midpoint-circle-algorithm |   |  |  |
+| 125 | bitmap-ppm-conversion-through-a-pipe |   |  |  |
+| 126 | bitmap-read-a-ppm-file |   |  |  |
+| 127 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 128 | bitmap-write-a-ppm-file |   |  |  |
+| 129 | bitmap | ✓ | 341.0ms | 115.98KB |
+| 130 | bitwise-io-1 | ✓ | 36.0ms | 55.18KB |
+| 131 | bitwise-io-2 | ✓ | 60.0ms | 125.30KB |
+| 132 | bitwise-operations | ✓ | 36.0ms | 40.73KB |
+| 133 | blum-integer | ✓ | 50.0ms | 94.55KB |
+| 134 | boolean-values | ✓ | 30.0ms | 39.56KB |
+| 135 | box-the-compass | ✓ | 46.0ms | 97.79KB |
+| 136 | boyer-moore-string-search | ✓ | 57.0ms | 113.94KB |
+| 137 | brazilian-numbers | ✓ | 3.49s | 72.62KB |
+| 138 | break-oo-privacy | ✓ | 50.0ms | 98.93KB |
+| 139 | brilliant-numbers |   |  |  |
+| 140 | brownian-tree | ✓ | 64.12s | 520.70KB |
+| 141 | bulls-and-cows-player | ✓ | 144.0ms | 67.21KB |
+| 142 | bulls-and-cows |   |  |  |
+| 143 | burrows-wheeler-transform | ✓ | 70.0ms | 104.86KB |
+| 144 | caesar-cipher-1 | ✓ | 51.0ms | 73.05KB |
+| 145 | caesar-cipher-2 | ✓ | 41.0ms | 73.05KB |
+| 146 | calculating-the-value-of-e |   |  |  |
+| 147 | calendar---for-real-programmers-1 | ✓ | 34.0ms | 80.95KB |
+| 148 | calendar---for-real-programmers-2 | ✓ | 30.0ms | 80.95KB |
+| 149 | calendar | ✓ | 40.0ms | 80.95KB |
+| 150 | calkin-wilf-sequence |   |  |  |
+| 151 | call-a-foreign-language-function | ✓ | 24.0ms | 25.62KB |
+| 152 | call-a-function-1 | ✓ | 21.0ms | 0B |
+| 153 | call-a-function-10 | ✓ | 46.0ms | 45.60KB |
+| 154 | call-a-function-11 | ✓ | 32.0ms | 37.83KB |
+| 155 | call-a-function-12 | ✓ | 50.0ms | 88.48KB |
+| 156 | call-a-function-2 | ✓ | 21.0ms | 320B |
+| 157 | call-a-function-3 | ✓ | 20.0ms | 192B |
+| 158 | call-a-function-4 | ✓ | 23.0ms | 280B |
+| 159 | call-a-function-5 | ✓ | 20.0ms | 720B |
+| 160 | call-a-function-6 | ✓ | 51.0ms | 84.13KB |
+| 161 | call-a-function-7 | ✓ | 19.0ms | 0B |
+| 162 | call-a-function-8 | ✓ | 17.0ms | 46.48KB |
+| 163 | call-a-function-9 | ✓ | 18.0ms | 45.91KB |
+| 164 | call-an-object-method-1 | ✓ | 7.0ms | 0B |
+| 165 | call-an-object-method-2 | ✓ | 16.0ms | -320B |
+| 166 | call-an-object-method-3 |   |  |  |
+| 167 | call-an-object-method |   |  |  |
+| 168 | camel-case-and-snake-case |   |  |  |
+| 169 | canny-edge-detector |   |  |  |
+| 170 | canonicalize-cidr |   |  |  |
+| 171 | cantor-set | ✓ | 46.0ms | 101.48KB |
+| 172 | carmichael-3-strong-pseudoprimes | ✓ | 54.0ms | 89.27KB |
+| 173 | cartesian-product-of-two-or-more-lists-1 | ✓ | 32.0ms | 38.78KB |
+| 174 | cartesian-product-of-two-or-more-lists-2 | ✓ | 44.0ms | 55.77KB |
+| 175 | cartesian-product-of-two-or-more-lists-3 | ✓ | 41.0ms | 55.77KB |
+| 176 | cartesian-product-of-two-or-more-lists-4 | ✓ | 43.0ms | 55.77KB |
+| 177 | case-sensitivity-of-identifiers | ✓ | 57.0ms | 106.52KB |
+| 178 | casting-out-nines | ✓ | 68.0ms | 102.78KB |
+| 179 | catalan-numbers-1 | ✓ | 19.0ms | 448B |
+| 180 | catalan-numbers-2 | ✓ | 20.0ms | 448B |
+| 181 | catalan-numbers-pascals-triangle | ✓ | 50.0ms | 93.13KB |
+| 182 | catamorphism | ✓ | 37.0ms | 39.63KB |
+| 183 | catmull-clark-subdivision-surface |   |  |  |
+| 184 | chaocipher |   |  |  |
+| 185 | chaos-game |   |  |  |
+| 186 | character-codes-1 |   |  |  |
+| 187 | character-codes-2 |   |  |  |
+| 188 | character-codes-3 |   |  |  |
+| 189 | character-codes-4 |   |  |  |
+| 190 | character-codes-5 |   |  |  |
+| 191 | chat-server |   |  |  |
+| 192 | check-machin-like-formulas |   |  |  |
+| 193 | check-that-file-exists |   |  |  |
+| 194 | checkpoint-synchronization-1 |   |  |  |
+| 195 | checkpoint-synchronization-2 |   |  |  |
+| 196 | checkpoint-synchronization-3 | ✓ | 42.0ms | 83.76KB |
+| 197 | checkpoint-synchronization-4 | ✓ | 48.0ms | 88.00KB |
+| 198 | chernicks-carmichael-numbers | ✓ | 406.0ms | 93.80KB |
+| 199 | cheryls-birthday | ✓ | 45.0ms | 96.05KB |
+| 200 | chinese-remainder-theorem | ✓ | 25.0ms | 37.30KB |
+| 201 | chinese-zodiac | ✓ | 45.0ms | 99.30KB |
+| 202 | cholesky-decomposition-1 |   |  |  |
+| 203 | cholesky-decomposition | ✓ | 17.0ms | 65.20KB |
+| 204 | chowla-numbers | ✓ | 6.0ms | 3.83KB |
+| 205 | church-numerals-1 |   |  |  |
+| 206 | church-numerals-2 |   |  |  |
+| 207 | circles-of-given-radius-through-two-points |   |  |  |
+| 208 | circular-primes | ✓ | 27.0ms | 89.04KB |
+| 209 | cistercian-numerals |   |  |  |
+| 210 | comma-quibbling | ✓ | 24.0ms | 88.39KB |
+| 211 | compiler-virtual-machine-interpreter |   |  |  |
+| 212 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k | ✓ | 11.43s | 94.89KB |
+| 213 | compound-data-type | ✓ | 6.0ms | 0B |
+| 214 | concurrent-computing-1 | ✓ | 8.0ms | 648B |
+| 215 | concurrent-computing-2 | ✓ | 6.0ms | 648B |
+| 216 | concurrent-computing-3 | ✓ | 8.0ms | 648B |
+| 217 | conditional-structures-1 |   |  |  |
+| 218 | conditional-structures-10 | ✓ | 8.0ms | 496B |
+| 219 | conditional-structures-2 |   |  |  |
+| 220 | conditional-structures-3 |   |  |  |
+| 221 | conditional-structures-4 | ✓ | 8.0ms | 0B |
+| 222 | conditional-structures-5 |   |  |  |
+| 223 | conditional-structures-6 |   |  |  |
+| 224 | conditional-structures-7 |   |  |  |
+| 225 | conditional-structures-8 |   |  |  |
+| 226 | conditional-structures-9 | ✓ | 8.0ms | 0B |
+| 227 | consecutive-primes-with-ascending-or-descending-differences | ✓ |  |  |
+| 228 | constrained-genericity-1 | ✓ | 5.0ms | 0B |
+| 229 | constrained-genericity-2 | ✓ | 6.0ms | 0B |
+| 230 | constrained-genericity-3 | ✓ |  |  |
+| 231 | constrained-genericity-4 |   |  |  |
+| 232 | constrained-random-points-on-a-circle-1 | ✓ | 34.0ms | 104.09KB |
+| 233 | constrained-random-points-on-a-circle-2 | ✓ | 67.0ms | 121.77KB |
+| 234 | continued-fraction | ✓ | 31.0ms | 48.12KB |
+| 235 | convert-decimal-number-to-rational | ✓ | 45.0ms | 84.43KB |
+| 236 | convert-seconds-to-compound-duration | ✓ | 44.0ms | 81.18KB |
+| 237 | convex-hull | ✓ | 37.0ms | 49.32KB |
+| 238 | conways-game-of-life | ✓ | 388.0ms | 41.82KB |
+| 239 | copy-a-string-1 | ✓ | 18.0ms | 0B |
+| 240 | copy-a-string-2 | ✓ | 31.0ms | 38.00KB |
+| 241 | copy-stdin-to-stdout-1 | ✓ | 24.0ms | -1640B |
+| 242 | copy-stdin-to-stdout-2 | ✓ | 20.0ms | -1640B |
+| 243 | count-in-factors | ✓ | 49.0ms | 86.81KB |
+| 244 | count-in-octal-1 | ✓ | 30.0ms | 32.87KB |
+| 245 | count-in-octal-2 | ✓ | 221.0ms | 33.13KB |
+| 246 | count-in-octal-3 | ✓ | 25.0ms | 32.87KB |
+| 247 | count-in-octal-4 | ✓ | 38.0ms | 32.87KB |
+| 248 | count-occurrences-of-a-substring | ✓ | 19.0ms | 608B |
+| 249 | count-the-coins-1 | ✓ | 29.0ms | 92.72KB |
+| 250 | count-the-coins-2 | ✓ | 40.0ms | 92.79KB |
+| 251 | cramers-rule | ✓ | 13.0ms | 18.30KB |
+| 252 | crc-32-1 | ✓ | 9.0ms | 656B |
+| 253 | crc-32-2 | ✓ | 8.0ms | 2.30KB |
+| 254 | create-a-file-on-magnetic-tape | ✓ | 6.0ms | 728B |
+| 255 | create-a-file | ✓ | 25.0ms | 70.23KB |
+| 256 | create-a-two-dimensional-array-at-runtime-1 | ✓ | 41.0ms | 102.07KB |
+| 257 | create-an-html-table | ✓ | 27.0ms | 86.33KB |
+| 258 | create-an-object-at-a-given-address | ✓ | 30.0ms | 96.82KB |
+| 259 | csv-data-manipulation | ✓ | 20.0ms | 51.52KB |
+| 260 | csv-to-html-translation-1 | ✓ | 29.0ms | 87.33KB |
+| 261 | csv-to-html-translation-2 | ✓ | 29.0ms | 88.36KB |
+| 262 | csv-to-html-translation-3 | ✓ | 7.0ms | 1.51KB |
+| 263 | csv-to-html-translation-4 | ✓ | 8.0ms | 1.27KB |
+| 264 | csv-to-html-translation-5 | ✓ | 31.0ms | 89.14KB |
+| 265 | cuban-primes | ✓ |  |  |
+| 266 | cullen-and-woodall-numbers | ✓ | 37.0ms | 63.46KB |
+| 267 | cumulative-standard-deviation | ✓ | 19.0ms | 10.59KB |
+| 268 | currency | ✓ | 42.0ms | 80.55KB |
+| 269 | currying | ✓ | 39.0ms | 68.09KB |
+| 270 | curzon-numbers | ✓ |  |  |
+| 271 | cusip | ✓ | 43.0ms | 77.64KB |
+| 272 | cyclops-numbers | ✓ | 16.0ms | 0B |
+| 273 | damm-algorithm | ✓ | 44.0ms | 79.77KB |
+| 274 | date-format | ✓ | 56.0ms | 103.55KB |
+| 275 | date-manipulation |   |  |  |
+| 276 | day-of-the-week | ✓ | 39.0ms | 69.08KB |
+| 277 | de-bruijn-sequences | ✓ | 1.22s | 105.70KB |
+| 278 | deal-cards-for-freecell |   |  |  |
+| 279 | death-star | ✓ | 65.0ms | 39.51KB |
+| 280 | deceptive-numbers | ✓ |  |  |
+| 281 | deconvolution-1d-2 | ✓ | 43.0ms | 65.21KB |
+| 282 | deconvolution-1d-3 | ✓ | 46.0ms | 95.74KB |
+| 283 | deconvolution-1d | ✓ | 35.0ms | 65.21KB |
+| 284 | deepcopy-1 |   |  |  |
+| 285 | define-a-primitive-data-type | ✓ | 29.0ms | 39.78KB |
+| 286 | delegates |   |  |  |
+| 287 | demings-funnel | ✓ | 60.0ms | 109.08KB |
+| 288 | department-numbers | ✓ | 44.0ms | 87.02KB |
+| 289 | descending-primes | ✓ | 39.0ms | 56.60KB |
+| 290 | detect-division-by-zero | ✓ | 41.0ms | 77.66KB |
+| 291 | determine-if-a-string-has-all-the-same-characters | ✓ | 57.0ms | 106.90KB |
+| 292 | determine-if-a-string-has-all-unique-characters | ✓ | 54.0ms | 101.68KB |
+| 293 | determine-if-a-string-is-collapsible |   |  |  |
+| 294 | determine-if-a-string-is-numeric-1 | ✓ | 39.0ms | 77.67KB |
+| 295 | determine-if-a-string-is-numeric-2 | ✓ | 39.0ms | 77.88KB |
+| 296 | determine-if-a-string-is-squeezable | ✓ | 25.0ms | 88.58KB |
+| 297 | determine-if-only-one-instance-is-running | ✓ | 6.0ms | 584B |
+| 298 | determine-if-two-triangles-overlap | ✓ | 26.0ms | 110.55KB |
+| 299 | determine-sentence-type | ✓ | 31.0ms | 52.66KB |
+| 300 | dice-game-probabilities-1 | ✓ | 43.0ms | 56.18KB |
+| 301 | dice-game-probabilities-2 | ✓ | 43.0ms | 10.58KB |
+| 302 | digital-root-multiplicative-digital-root | ✓ | 196.0ms | 120.93KB |
+| 303 | dijkstras-algorithm | ✓ | 50.0ms | 96.28KB |
+| 304 | dinesmans-multiple-dwelling-problem | ✓ | 49.0ms | 94.01KB |
+| 305 | dining-philosophers-1 | ✓ | 33.0ms | 38.70KB |
+| 306 | dining-philosophers-2 | ✓ | 34.0ms | 38.70KB |
+| 307 | disarium-numbers | ✓ | 3.35s | 83.91KB |
+| 308 | discordian-date | ✓ | 62.0ms | 101.55KB |
+| 309 | display-a-linear-combination | ✓ | 58.0ms | 101.29KB |
+| 310 | display-an-outline-as-a-nested-table | ✓ | 60.0ms | 110.75KB |
+| 311 | distance-and-bearing |   |  |  |
+| 312 | distributed-programming |   |  |  |
+| 313 | diversity-prediction-theorem | ✓ | 47.0ms | 81.02KB |
+| 314 | documentation | ✓ | 17.0ms | 0B |
+| 315 | doomsday-rule | ✓ | 45.0ms | 77.99KB |
+| 316 | dot-product | ✓ | 19.0ms | 792B |
+| 317 | doubly-linked-list-definition-1 | ✓ | 19.0ms | 0B |
+| 318 | doubly-linked-list-definition-2 |   |  |  |
+| 319 | doubly-linked-list-element-definition |   |  |  |
+| 320 | doubly-linked-list-traversal |   |  |  |
+| 321 | dragon-curve | ✓ | 64.0ms | 87.17KB |
+| 322 | draw-a-clock | ✓ | 38.0ms | 37.52KB |
+| 323 | draw-a-cuboid | ✓ | 51.0ms | 88.09KB |
+| 324 | draw-a-pixel-1 | ✓ | 365.0ms | 388.07KB |
+| 325 | draw-a-rotating-cube | ✓ | 98.0ms | 96.24KB |
+| 326 | draw-a-sphere | ✓ | 50.0ms | 38.53KB |
+| 327 | dutch-national-flag-problem |   |  |  |
+| 328 | dynamic-variable-names | ✓ | 42.0ms | 38.10KB |
+| 329 | earliest-difference-between-prime-gaps | ✓ | 62.0ms | 112.08KB |
+| 330 | eban-numbers |   |  |  |
+| 331 | ecdsa-example |   |  |  |
+| 332 | echo-server | ✓ | 35.0ms | 37.62KB |
+| 333 | eertree | ✓ | 53.0ms | 99.79KB |
+| 334 | egyptian-division |   |  |  |
+| 335 | ekg-sequence-convergence | ✓ | 69.0ms | 102.72KB |
+| 336 | element-wise-operations |   |  |  |
+| 337 | elementary-cellular-automaton-infinite-length | ✓ | 69.0ms | 96.68KB |
+| 338 | elementary-cellular-automaton-random-number-generator |   |  |  |
+| 339 | elementary-cellular-automaton | ✓ | 38.0ms | 38.83KB |
+| 340 | elliptic-curve-arithmetic | ✓ | 52.0ms | 97.39KB |
+| 341 | elliptic-curve-digital-signature-algorithm | ✓ | 21.0ms | 1.28KB |
+| 342 | emirp-primes | ✓ | 520.0ms | 103.34KB |
+| 343 | empty-directory |   |  |  |
+| 344 | empty-program | ✓ | 20.0ms | 0B |
+| 345 | empty-string-1 | ✓ | 21.0ms | 448B |
+| 346 | empty-string-2 | ✓ | 18.0ms | 552B |
+| 347 | enforced-immutability | ✓ | 22.0ms | 368B |
+| 348 | entropy-1 | ✓ | 20.0ms | 10.84KB |
+| 349 | entropy-2 | ✓ | 20.0ms | 10.84KB |
+| 350 | entropy-narcissist |   |  |  |
+| 351 | enumerations-1 |   |  |  |
+| 352 | enumerations-2 |   |  |  |
+| 353 | enumerations-3 |   |  |  |
+| 354 | enumerations-4 |   |  |  |
+| 355 | environment-variables-1 |   |  |  |
+| 356 | environment-variables-2 |   |  |  |
+| 357 | equal-prime-and-composite-sums |   |  |  |
+| 358 | equilibrium-index |   |  |  |
+| 359 | erd-s-nicolas-numbers |   |  |  |
+| 360 | erd-s-selfridge-categorization-of-primes |   |  |  |
+| 361 | esthetic-numbers |   |  |  |
+| 362 | ethiopian-multiplication |   |  |  |
+| 363 | euclid-mullin-sequence |   |  |  |
+| 364 | euler-method |   |  |  |
+| 365 | eulers-constant-0.5772... |   |  |  |
+| 366 | eulers-identity |   |  |  |
+| 367 | eulers-sum-of-powers-conjecture |   |  |  |
+| 368 | evaluate-binomial-coefficients |   |  |  |
+| 369 | even-or-odd |   |  |  |
+| 370 | events |   |  |  |
+| 371 | evolutionary-algorithm |   |  |  |
+| 372 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
+| 373 | exceptions |   |  |  |
+| 374 | executable-library |   |  |  |
+| 375 | execute-a-markov-algorithm |   |  |  |
+| 376 | execute-a-system-command |   |  |  |
+| 377 | execute-brain- |   |  |  |
+| 378 | execute-computer-zero-1 |   |  |  |
+| 379 | execute-computer-zero |   |  |  |
+| 380 | execute-hq9+ |   |  |  |
+| 381 | execute-snusp |   |  |  |
+| 382 | exponentiation-operator-2 |   |  |  |
+| 383 | exponentiation-operator |   |  |  |
+| 384 | exponentiation-order |   |  |  |
+| 385 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
+| 386 | extend-your-language |   |  |  |
+| 387 | extensible-prime-generator |   |  |  |
+| 388 | extreme-floating-point-values |   |  |  |
+| 389 | faces-from-a-mesh-2 |   |  |  |
+| 390 | faces-from-a-mesh |   |  |  |
+| 391 | factorial-base-numbers-indexing-permutations-of-a-collection |   |  |  |
+| 392 | factorial-primes |   |  |  |
+| 393 | factorial |   |  |  |
+| 394 | factorions |   |  |  |
+| 395 | factors-of-a-mersenne-number |   |  |  |
+| 396 | factors-of-an-integer |   |  |  |
+| 397 | fairshare-between-two-and-more |   |  |  |
+| 398 | farey-sequence |   |  |  |
+| 399 | fast-fourier-transform |   |  |  |
+| 400 | fasta-format |   |  |  |
+| 401 | faulhabers-formula |   |  |  |
+| 402 | faulhabers-triangle |   |  |  |
+| 403 | feigenbaum-constant-calculation |   |  |  |
+| 404 | fermat-numbers |   |  |  |
+| 405 | fibonacci-n-step-number-sequences |   |  |  |
+| 406 | fibonacci-sequence-1 |   |  |  |
+| 407 | fibonacci-sequence-2 |   |  |  |
+| 408 | fibonacci-sequence-3 |   |  |  |
+| 409 | fibonacci-sequence-4 |   |  |  |
+| 410 | fibonacci-sequence-5 |   |  |  |
+| 411 | fibonacci-word-fractal |   |  |  |
+| 412 | fibonacci-word |   |  |  |
+| 413 | file-extension-is-in-extensions-list |   |  |  |
+| 414 | file-input-output-1 |   |  |  |
+| 415 | file-input-output-2 |   |  |  |
+| 416 | file-input-output-3 |   |  |  |
+| 417 | file-modification-time |   |  |  |
+| 418 | file-size-distribution |   |  |  |
+| 419 | file-size |   |  |  |
+| 420 | filter |   |  |  |
+| 421 | find-chess960-starting-position-identifier-2 |   |  |  |
+| 422 | find-chess960-starting-position-identifier |   |  |  |
+| 423 | find-common-directory-path |   |  |  |
+| 424 | find-duplicate-files |   |  |  |
+| 425 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 426 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 427 | find-limit-of-recursion |   |  |  |
+| 428 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 429 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 430 | find-the-intersection-of-two-lines |   |  |  |
+| 431 | find-the-last-sunday-of-each-month |   |  |  |
+| 432 | find-the-missing-permutation |   |  |  |
+| 433 | first-class-environments |   |  |  |
+| 434 | first-class-functions-use-numbers-analogously |   |  |  |
+| 435 | first-power-of-2-that-has-leading-decimal-digits-of-12 |   |  |  |
+| 436 | five-weekends |   |  |  |
+| 437 | fivenum-1 |   |  |  |
+| 438 | fivenum-2 |   |  |  |
+| 439 | fivenum-3 |   |  |  |
+| 440 | fixed-length-records-1 |   |  |  |
+| 441 | fixed-length-records-2 |   |  |  |
+| 442 | fizzbuzz-1 |   |  |  |
+| 443 | fizzbuzz-2 |   |  |  |
+| 444 | fizzbuzz |   |  |  |
+| 445 | flatten-a-list-1 |   |  |  |
+| 446 | flatten-a-list-2 |   |  |  |
+| 447 | flipping-bits-game |   |  |  |
+| 448 | flow-control-structures-1 |   |  |  |
+| 449 | flow-control-structures-2 |   |  |  |
+| 450 | flow-control-structures-3 |   |  |  |
+| 451 | flow-control-structures-4 |   |  |  |
+| 452 | floyd-warshall-algorithm |   |  |  |
+| 453 | floyd-warshall-algorithm2 |   |  |  |
+| 454 | floyds-triangle |   |  |  |
+| 455 | forest-fire |   |  |  |
+| 456 | fork-2 |   |  |  |
+| 457 | fork |   |  |  |
+| 458 | formal-power-series |   |  |  |
+| 459 | formatted-numeric-output |   |  |  |
+| 460 | forward-difference |   |  |  |
+| 461 | four-bit-adder-1 |   |  |  |
+| 462 | four-is-magic |   |  |  |
+| 463 | four-is-the-number-of-letters-in-the-... |   |  |  |
+| 464 | fractal-tree |   |  |  |
+| 465 | fractran |   |  |  |
+| 466 | french-republican-calendar |   |  |  |
+| 467 | ftp |   |  |  |
+| 468 | function-frequency |   |  |  |
+| 469 | function-prototype |   |  |  |
+| 470 | functional-coverage-tree |   |  |  |
+| 471 | fusc-sequence |   |  |  |
+| 472 | gamma-function |   |  |  |
+| 473 | general-fizzbuzz |   |  |  |
+| 474 | generic-swap |   |  |  |
+| 475 | get-system-command-output |   |  |  |
+| 476 | giuga-numbers |   |  |  |
+| 477 | globally-replace-text-in-several-files |   |  |  |
+| 478 | goldbachs-comet |   |  |  |
+| 479 | golden-ratio-convergence |   |  |  |
+| 480 | graph-colouring |   |  |  |
+| 481 | gray-code |   |  |  |
+| 482 | gui-component-interaction |   |  |  |
+| 483 | gui-enabling-disabling-of-controls |   |  |  |
+| 484 | gui-maximum-window-dimensions |   |  |  |
+| 485 | http |   |  |  |
+| 486 | image-noise |   |  |  |
+| 487 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 488 | md5 |   |  |  |
+| 489 | nim-game |   |  |  |
+| 490 | plasma-effect |   |  |  |
+| 491 | sorting-algorithms-bubble-sort |   |  |  |
+| 492 | window-management |   |  |  |
+| 493 | zumkeller-numbers |   |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,122 @@
-## Progress (2025-07-27 16:08 UTC)
+## Progress (2025-07-28 10:03 +0700)
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
+- chore: sort rosetta index (b04341afb7)
+
 - java: add rosetta benchmark for program 180 (ed2562baf8)
 
 - java: add rosetta benchmark for program 179 (58be251441)


### PR DESCRIPTION
## Summary
- fix Java transpiler to handle nested map index assignments
- regenerate Java outputs for several Rosetta tasks

## Testing
- `MOCHI_BENCHMARK=1 UPDATE=1 go test ./transpiler/x/java -run Rosetta -index 303 -tags slow -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6886e94b02208320b804eab4e43f2dc5