### PR TITLE
Update PHP transpiler output for index 350

### DIFF
--- a/tests/rosetta/transpiler/php/entropy-narcissist.bench
+++ b/tests/rosetta/transpiler/php/entropy-narcissist.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 280,
+  "duration_us": 237,
   "memory_bytes": 128,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/php/entropy-narcissist.out
+++ b/tests/rosetta/transpiler/php/entropy-narcissist.out
@@ -1,6 +1,6 @@
 Source file entropy: 4.5684027372891
 {
-  "duration_us": 280,
+  "duration_us": 237,
   "memory_bytes": 128,
   "name": "main"
 }

--- a/transpiler/x/php/README.md
+++ b/transpiler/x/php/README.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from programs in `tests/vm/valid` lives in `tests/transpiler/x/php`.
 
-Last updated: 2025-07-28 10:20 +0700
+Last updated: 2025-07-28 10:26 +0700
 
 ## VM Golden Test Checklist (103/104)
 - [x] append_builtin

--- a/transpiler/x/php/ROSETTA.md
+++ b/transpiler/x/php/ROSETTA.md
@@ -2,7 +2,7 @@
 
 Generated PHP code from Mochi Rosetta tasks lives in `tests/rosetta/transpiler/php`.
 
-Last updated: 2025-07-28 10:20 +0700
+Last updated: 2025-07-28 10:26 +0700
 
 ## Checklist (461/493)
 | Index | Name | Status | Duration | Memory |
@@ -356,7 +356,7 @@ Last updated: 2025-07-28 10:20 +0700
 | 347 | enforced-immutability | ✓ | 60µs | 136 B |
 | 348 | entropy-1 | ✓ | 121µs | 96 B |
 | 349 | entropy-2 | ✓ | 132µs | 96 B |
-| 350 | entropy-narcissist | ✓ | 280µs | 128 B |
+| 350 | entropy-narcissist | ✓ | 237µs | 128 B |
 | 351 | enumerations-1 | ✓ | 1µs | 64 B |
 | 352 | enumerations-2 | ✓ | 1µs | 64 B |
 | 353 | enumerations-3 | ✓ | 2µs | 64 B |

--- a/transpiler/x/php/TASKS.md
+++ b/transpiler/x/php/TASKS.md
@@ -1,4 +1,4 @@
-## Progress (2025-07-28 10:20 +0700)
+## Progress (2025-07-28 10:26 +0700)
 - Generated PHP for 103/104 programs
 - Updated README checklist and outputs
 - Enhanced printing to match golden format


### PR DESCRIPTION
## Summary
- regenerate PHP output for entropy-narcissist
- update PHP Rosetta docs with new benchmark

## Testing
- `MOCHI_ROSETTA_INDEX=350 MOCHI_BENCHMARK=1 UPDATE=1 go test ./transpiler/x/php -run Rosetta -tags=slow -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6886edeae2fc83209097c6d3705e3112