### PR TITLE
Improve Java transpiler handling of lists and panic

### DIFF
--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 43098,
+  "duration_us": 39895,
   "memory_bytes": 57528,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 43100,
+  "duration_us": 38887,
   "memory_bytes": 10832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
+++ b/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 196899,
+  "duration_us": 181538,
   "memory_bytes": 123832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
+++ b/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 50844,
+  "duration_us": 45868,
   "memory_bytes": 98592,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dijkstras-algorithm.error
+++ b/tests/rosetta/transpiler/Java/dijkstras-algorithm.error
@@ -1,8 +1,0 @@
-compile: exit status 1
-/tmp/TestJavaTranspiler_Rosetta_Goldendijkstras-algorithm3108875227/001/Main.java:52: error: > or ',' expected
-            for (var v : ((java.util.Map<String,Integer)graph.get(u))) {
-                                                       ^
-/tmp/TestJavaTranspiler_Rosetta_Goldendijkstras-algorithm3108875227/001/Main.java:53: error: > or ',' expected
-                int alt = (int)(((int)dist.getOrDefault(u, 0))) + (int)(((int)((java.util.Map<String,Integer)graph.get(u)).getOrDefault(v, 0)));
-                                                                                                            ^
-2 errors

--- a/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
+++ b/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 49028,
+  "duration_us": 52035,
   "memory_bytes": 96264,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dining-philosophers-1.bench
+++ b/tests/rosetta/transpiler/Java/dining-philosophers-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 13989,
+  "duration_us": 34951,
   "memory_bytes": 39632,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dining-philosophers-1.java
+++ b/tests/rosetta/transpiler/Java/dining-philosophers-1.java
@@ -24,6 +24,40 @@ public class Main {
         System.out.println("table empty");
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/dining-philosophers-2.bench
+++ b/tests/rosetta/transpiler/Java/dining-philosophers-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 14670,
+  "duration_us": 32258,
   "memory_bytes": 39632,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/disarium-numbers.bench
+++ b/tests/rosetta/transpiler/Java/disarium-numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 1581553,
+  "duration_us": 3005018,
   "memory_bytes": 85928,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/disarium-numbers.java
+++ b/tests/rosetta/transpiler/Java/disarium-numbers.java
@@ -44,6 +44,40 @@ public class Main {
         System.out.println("\nFound the first " + String.valueOf(count) + " Disarium numbers.");
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/discordian-date.bench
+++ b/tests/rosetta/transpiler/Java/discordian-date.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 26085,
+  "duration_us": 53997,
   "memory_bytes": 103984,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/discordian-date.java
+++ b/tests/rosetta/transpiler/Java/discordian-date.java
@@ -69,6 +69,40 @@ public class Main {
         }
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 }

--- a/tests/rosetta/transpiler/Java/display-a-linear-combination.bench
+++ b/tests/rosetta/transpiler/Java/display-a-linear-combination.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 37038,
+  "duration_us": 51153,
   "memory_bytes": 103720,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/display-a-linear-combination.java
+++ b/tests/rosetta/transpiler/Java/display-a-linear-combination.java
@@ -63,7 +63,41 @@ public class Main {
         }
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static int _runeLen(String s) {

--- a/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.bench
+++ b/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 30823,
+  "duration_us": 56475,
   "memory_bytes": 113408,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.java
+++ b/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.java
@@ -52,7 +52,7 @@ public class Main {
 
     static void toNest(java.util.Map<String,Object>[] nodes, int start, int level, java.util.Map<String,Object> n) {
         if (level == 0) {
-n.put("name", (Object)(((Object)(nodes[0]).get("name"))));
+n.put("name", (Object)(((Object)(((java.util.Map)nodes[0])).get("name"))));
         }
         int i = start + 1;
         while (i < nodes.length) {
@@ -163,7 +163,41 @@ n.put("children", cs);
         System.out.println(toMarkup(n2, cols2, 4));
     }
     public static void main(String[] args) {
-        main();
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
     }
 
     static <T> T[] appendObj(T[] arr, T v) {

--- a/tests/rosetta/transpiler/Java/distance-and-bearing.bench
+++ b/tests/rosetta/transpiler/Java/distance-and-bearing.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 54085,
+  "memory_bytes": 106472,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/distance-and-bearing.java
+++ b/tests/rosetta/transpiler/Java/distance-and-bearing.java
@@ -1,0 +1,227 @@
+public class Main {
+    static double PI = 3.141592653589793;
+    static class Airport {
+        String name;
+        String country;
+        String icao;
+        double lat;
+        double lon;
+        Airport(String name, String country, String icao, double lat, double lon) {
+            this.name = name;
+            this.country = country;
+            this.icao = icao;
+            this.lat = lat;
+            this.lon = lon;
+        }
+        @Override public String toString() {
+            return String.format("{'name': '%s', 'country': '%s', 'icao': '%s', 'lat': %s, 'lon': %s}", String.valueOf(name), String.valueOf(country), String.valueOf(icao), String.valueOf(lat), String.valueOf(lon));
+        }
+    }
+
+    static Airport[] airports = new Airport[]{new Airport("Koksijde Air Base", "Belgium", "EBFN", 51.090301513671875, 2.652780055999756), new Airport("Ostend-Bruges International Airport", "Belgium", "EBOS", 51.198898315399994, 2.8622200489), new Airport("Kent International Airport", "United Kingdom", "EGMH", 51.342201, 1.34611), new Airport("Calais-Dunkerque Airport", "France", "LFAC", 50.962100982666016, 1.954759955406189), new Airport("Westkapelle heliport", "Belgium", "EBKW", 51.32222366333, 3.2930560112), new Airport("Lympne Airport", "United Kingdom", "EGMK", 51.08, 1.013), new Airport("Ursel Air Base", "Belgium", "EBUL", 51.14419937133789, 3.475559949874878), new Airport("Southend Airport", "United Kingdom", "EGMC", 51.5713996887207, 0.6955559849739075), new Airport("Merville-Calonne Airport", "France", "LFQT", 50.61840057373047, 2.642240047454834), new Airport("Wevelgem Airport", "Belgium", "EBKT", 50.817199707, 3.20472002029), new Airport("Midden-Zeeland Airport", "Netherlands", "EHMZ", 51.5121994019, 3.73111009598), new Airport("Lydd Airport", "United Kingdom", "EGMD", 50.95610046386719, 0.9391670227050781), new Airport("RAF Wattisham", "United Kingdom", "EGUW", 52.1273002625, 0.956264019012), new Airport("Beccles Airport", "United Kingdom", "EGSM", 52.435298919699996, 1.6183300018300002), new Airport("Lille/Marcq-en-Baroeul Airport", "France", "LFQO", 50.687198638916016, 3.0755600929260254), new Airport("Lashenden (Headcorn) Airfield", "United Kingdom", "EGKH", 51.156898, 0.641667), new Airport("Le Touquet-Côte d'Opale Airport", "France", "LFAT", 50.517398834228516, 1.6205899715423584), new Airport("Rochester Airport", "United Kingdom", "EGTO", 51.351898193359375, 0.5033329725265503), new Airport("Lille-Lesquin Airport", "France", "LFQQ", 50.563332, 3.086886), new Airport("Thurrock Airfield", "United Kingdom", "EGMT", 51.537505, 0.367634)};
+
+    static double sinApprox(double x) {
+        double term = x;
+        double sum = x;
+        int n = 1;
+        while (n <= 8) {
+            double denom = ((Number)(((2 * n) * (2 * n + 1)))).doubleValue();
+            term = -term * x * x / denom;
+            sum = sum + term;
+            n = n + 1;
+        }
+        return sum;
+    }
+
+    static double cosApprox(double x) {
+        double term = 1.0;
+        double sum = 1.0;
+        int n = 1;
+        while (n <= 8) {
+            double denom = ((Number)(((2 * n - 1) * (2 * n)))).doubleValue();
+            term = -term * x * x / denom;
+            sum = sum + term;
+            n = n + 1;
+        }
+        return sum;
+    }
+
+    static double atanApprox(double x) {
+        if (x > 1.0) {
+            return PI / 2.0 - x / (x * x + 0.28);
+        }
+        if (x < (-1.0)) {
+            return -PI / 2.0 - x / (x * x + 0.28);
+        }
+        return x / (1.0 + 0.28 * x * x);
+    }
+
+    static double atan2Approx(double y, double x) {
+        if (x > 0.0) {
+            double r = atanApprox(y / x);
+            return r;
+        }
+        if (x < 0.0) {
+            if (y >= 0.0) {
+                return atanApprox(y / x) + PI;
+            }
+            return atanApprox(y / x) - PI;
+        }
+        if (y > 0.0) {
+            return PI / 2.0;
+        }
+        if (y < 0.0) {
+            return -PI / 2.0;
+        }
+        return 0.0;
+    }
+
+    static double sqrtApprox(double x) {
+        double guess = x;
+        int i = 0;
+        while (i < 10) {
+            guess = (guess + x / guess) / 2.0;
+            i = i + 1;
+        }
+        return guess;
+    }
+
+    static double rad(double x) {
+        return x * PI / 180.0;
+    }
+
+    static double deg(double x) {
+        return x * 180.0 / PI;
+    }
+
+    static double distance(double lat1, double lon1, double lat2, double lon2) {
+        double phi1 = rad(lat1);
+        double phi2 = rad(lat2);
+        double dphi = rad(lat2 - lat1);
+        double dlambda = rad(lon2 - lon1);
+        double sdphi = sinApprox(dphi / 2);
+        double sdlambda = sinApprox(dlambda / 2);
+        double a = sdphi * sdphi + cosApprox(phi1) * cosApprox(phi2) * sdlambda * sdlambda;
+        double c = 2 * atan2Approx(sqrtApprox(a), sqrtApprox(1 - a));
+        return (6371.0 / 1.852) * c;
+    }
+
+    static double bearing(double lat1, double lon1, double lat2, double lon2) {
+        double phi1 = rad(lat1);
+        double phi2 = rad(lat2);
+        double dl = rad(lon2 - lon1);
+        double y = sinApprox(dl) * cosApprox(phi2);
+        double x = cosApprox(phi1) * sinApprox(phi2) - sinApprox(phi1) * cosApprox(phi2) * cosApprox(dl);
+        double br = deg(atan2Approx(y, x));
+        if (br < 0) {
+            br = br + 360;
+        }
+        return br;
+    }
+
+    static double floor(double x) {
+        int i = ((Number)(x)).intValue();
+        if ((((Number)(i)).doubleValue()) > x) {
+            i = i - 1;
+        }
+        return ((Number)(i)).doubleValue();
+    }
+
+    static double pow10(int n) {
+        double p = 1.0;
+        int i = 0;
+        while (i < n) {
+            p = p * 10.0;
+            i = i + 1;
+        }
+        return p;
+    }
+
+    static double round(double x, int n) {
+        double m = pow10(n);
+        return floor(x * m + 0.5) / m;
+    }
+
+    static Object[][] sortByDistance(Object[][] xs) {
+        Object[][] arr = xs;
+        int i = 1;
+        while (i < arr.length) {
+            int j = i;
+            while (j > 0 && ((Number)(arr[j - 1][0])).intValue() > ((Number)(arr[j][0])).intValue()) {
+                Object[] tmp = arr[j - 1];
+arr[j - 1] = arr[j];
+arr[j] = tmp;
+                j = j - 1;
+            }
+            i = i + 1;
+        }
+        return arr;
+    }
+
+    static void main() {
+        double planeLat = 51.514669;
+        double planeLon = 2.198581;
+        Object[][] results = new Object[][]{};
+        for (Airport ap : airports) {
+            double d = distance(planeLat, planeLon, ap.lat, ap.lon);
+            double b = bearing(planeLat, planeLon, ap.lat, ap.lon);
+            results = appendObj(results, new Object[]{d, b, ap});
+        }
+        results = sortByDistance(results);
+        System.out.println("Distance Bearing ICAO Country               Airport");
+        System.out.println("--------------------------------------------------------------");
+        int i = 0;
+        while (i < results.length) {
+            Object[] r = results[i];
+            Object ap = r[2];
+            Object dist = r[0];
+            Object bear = r[1];
+            String line = String.valueOf(round(((Number)(dist)).doubleValue(), 1)) + "\t" + String.valueOf(round(((Number)(bear)).doubleValue(), 0)) + "\t" + ((Airport)ap).icao + "\t" + ((Airport)ap).country + " " + ((Airport)ap).name;
+            System.out.println(line);
+            i = i + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static <T> T[] appendObj(T[] arr, T v) {
+        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/tests/rosetta/transpiler/Java/distributed-programming.bench
+++ b/tests/rosetta/transpiler/Java/distributed-programming.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 43487,
+  "memory_bytes": 79264,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/distributed-programming.java
+++ b/tests/rosetta/transpiler/Java/distributed-programming.java
@@ -1,33 +1,18 @@
 public class Main {
+    static int amount = 300;
+    static int result = tax(amount);
 
-    static void main() {
-        String[] philosophers = new String[]{"Aristotle", "Kant", "Spinoza", "Marx", "Russell"};
-        int hunger = 3;
-        System.out.println("table empty");
-        for (String p : philosophers) {
-            System.out.println(p + " seated");
+    static int tax(int cents) {
+        if (cents < 0) {
+            throw new RuntimeException(String.valueOf("Negative amounts not allowed"));
         }
-        int i = 0;
-        while (i < philosophers.length) {
-            String name = philosophers[i];
-            int h = 0;
-            while (h < hunger) {
-                System.out.println(name + " hungry");
-                System.out.println(name + " eating");
-                System.out.println(name + " thinking");
-                h = h + 1;
-            }
-            System.out.println(name + " satisfied");
-            System.out.println(name + " left the table");
-            i = i + 1;
-        }
-        System.out.println("table empty");
+        return (cents * 5 + 50) / 100;
     }
     public static void main(String[] args) {
         {
             long _benchStart = _now();
             long _benchMem = _mem();
-            main();
+            System.out.println("tax on " + String.valueOf(amount) + " cents is " + String.valueOf(result) + " cents");
             long _benchDuration = _now() - _benchStart;
             long _benchMemory = _mem() - _benchMem;
             System.out.println("{");

--- a/tests/rosetta/transpiler/Java/diversity-prediction-theorem.java
+++ b/tests/rosetta/transpiler/Java/diversity-prediction-theorem.java
@@ -1,0 +1,122 @@
+public class Main {
+
+    static double pow10(int n) {
+        double r = 1.0;
+        int i = 0;
+        while (i < n) {
+            r = r * 10.0;
+            i = i + 1;
+        }
+        return r;
+    }
+
+    static String formatFloat(double f, int prec) {
+        double scale = pow10(prec);
+        double scaled = (f * scale) + 0.5;
+        int n = (((Number)(scaled)).intValue());
+        String digits = String.valueOf(n);
+        while (_runeLen(digits) <= prec) {
+            digits = "0" + digits;
+        }
+        String intPart = _substr(digits, 0, _runeLen(digits) - prec);
+        String fracPart = _substr(digits, _runeLen(digits) - prec, _runeLen(digits));
+        return intPart + "." + fracPart;
+    }
+
+    static String padLeft(String s, int w) {
+        String res = "";
+        int n = w - _runeLen(s);
+        while (n > 0) {
+            res = res + " ";
+            n = n - 1;
+        }
+        return res + s;
+    }
+
+    static double averageSquareDiff(double f, double[] preds) {
+        double av = 0.0;
+        int i = 0;
+        while (i < preds.length) {
+            av = av + (preds[i] - f) * (preds[i] - f);
+            i = i + 1;
+        }
+        av = av / (((Number)(preds.length)).doubleValue());
+        return av;
+    }
+
+    static double[] diversityTheorem(double truth, double[] preds) {
+        double av = 0.0;
+        int i = 0;
+        while (i < preds.length) {
+            av = av + preds[i];
+            i = i + 1;
+        }
+        av = av / (((Number)(preds.length)).doubleValue());
+        double avErr = averageSquareDiff(truth, preds);
+        double crowdErr = (truth - av) * (truth - av);
+        double div = averageSquareDiff(av, preds);
+        return new Object[]{avErr, crowdErr, div};
+    }
+
+    static void main() {
+        double[][] predsArray = new double[][]{new double[]{48.0, 47.0, 51.0}, new double[]{48.0, 47.0, 51.0, 42.0}};
+        double truth = 49.0;
+        int i = 0;
+        while (i < predsArray.length) {
+            double[] preds = predsArray[i];
+            double[] res = diversityTheorem(truth, preds);
+            System.out.println("Average-error : " + String.valueOf(padLeft(String.valueOf(formatFloat(res[0], 3)), 6)));
+            System.out.println("Crowd-error   : " + String.valueOf(padLeft(String.valueOf(formatFloat(res[1], 3)), 6)));
+            System.out.println("Diversity     : " + String.valueOf(padLeft(String.valueOf(formatFloat(res[2], 3)), 6)));
+            System.out.println("");
+            i = i + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+}

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/104) - updated 2025-07-28 03:25 UTC
+## VM Golden Test Checklist (103/104) - updated 2025-07-28 03:50 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-28 10:25 GMT+7
+Last updated: 2025-07-28 10:50 GMT+7
 
-## Rosetta Checklist (284/493)
+## Rosetta Checklist (259/493)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -305,56 +305,56 @@ Last updated: 2025-07-28 10:25 GMT+7
 | 297 | determine-if-only-one-instance-is-running | ✓ | 6.0ms | 584B |
 | 298 | determine-if-two-triangles-overlap | ✓ | 26.0ms | 110.55KB |
 | 299 | determine-sentence-type | ✓ | 31.0ms | 52.66KB |
-| 300 | dice-game-probabilities-1 | ✓ | 43.0ms | 56.18KB |
-| 301 | dice-game-probabilities-2 | ✓ | 43.0ms | 10.58KB |
-| 302 | digital-root-multiplicative-digital-root | ✓ | 196.0ms | 120.93KB |
-| 303 | dijkstras-algorithm | ✓ | 50.0ms | 96.28KB |
-| 304 | dinesmans-multiple-dwelling-problem | ✓ | 49.0ms | 94.01KB |
-| 305 | dining-philosophers-1 | ✓ | 33.0ms | 38.70KB |
-| 306 | dining-philosophers-2 | ✓ | 34.0ms | 38.70KB |
-| 307 | disarium-numbers | ✓ | 3.35s | 83.91KB |
-| 308 | discordian-date | ✓ | 62.0ms | 101.55KB |
-| 309 | display-a-linear-combination | ✓ | 58.0ms | 101.29KB |
-| 310 | display-an-outline-as-a-nested-table | ✓ | 60.0ms | 110.75KB |
-| 311 | distance-and-bearing |   |  |  |
-| 312 | distributed-programming |   |  |  |
-| 313 | diversity-prediction-theorem | ✓ | 47.0ms | 81.02KB |
-| 314 | documentation | ✓ | 17.0ms | 0B |
-| 315 | doomsday-rule | ✓ | 45.0ms | 77.99KB |
-| 316 | dot-product | ✓ | 19.0ms | 792B |
-| 317 | doubly-linked-list-definition-1 | ✓ | 19.0ms | 0B |
+| 300 | dice-game-probabilities-1 | ✓ | 39.0ms | 56.18KB |
+| 301 | dice-game-probabilities-2 | ✓ | 38.0ms | 10.58KB |
+| 302 | digital-root-multiplicative-digital-root | ✓ | 181.0ms | 120.93KB |
+| 303 | dijkstras-algorithm | ✓ | 45.0ms | 96.28KB |
+| 304 | dinesmans-multiple-dwelling-problem | ✓ | 52.0ms | 94.01KB |
+| 305 | dining-philosophers-1 | ✓ | 34.0ms | 38.70KB |
+| 306 | dining-philosophers-2 | ✓ | 32.0ms | 38.70KB |
+| 307 | disarium-numbers | ✓ | 3.01s | 83.91KB |
+| 308 | discordian-date | ✓ | 53.0ms | 101.55KB |
+| 309 | display-a-linear-combination | ✓ | 51.0ms | 101.29KB |
+| 310 | display-an-outline-as-a-nested-table | ✓ | 56.0ms | 110.75KB |
+| 311 | distance-and-bearing | ✓ | 54.0ms | 103.98KB |
+| 312 | distributed-programming | ✓ | 43.0ms | 77.41KB |
+| 313 | diversity-prediction-theorem |   |  |  |
+| 314 | documentation |   |  |  |
+| 315 | doomsday-rule |   |  |  |
+| 316 | dot-product |   |  |  |
+| 317 | doubly-linked-list-definition-1 |   |  |  |
 | 318 | doubly-linked-list-definition-2 |   |  |  |
 | 319 | doubly-linked-list-element-definition |   |  |  |
 | 320 | doubly-linked-list-traversal |   |  |  |
-| 321 | dragon-curve | ✓ | 64.0ms | 87.17KB |
-| 322 | draw-a-clock | ✓ | 38.0ms | 37.52KB |
-| 323 | draw-a-cuboid | ✓ | 51.0ms | 88.09KB |
-| 324 | draw-a-pixel-1 | ✓ | 365.0ms | 388.07KB |
-| 325 | draw-a-rotating-cube | ✓ | 98.0ms | 96.24KB |
-| 326 | draw-a-sphere | ✓ | 50.0ms | 38.53KB |
+| 321 | dragon-curve |   |  |  |
+| 322 | draw-a-clock |   |  |  |
+| 323 | draw-a-cuboid |   |  |  |
+| 324 | draw-a-pixel-1 |   |  |  |
+| 325 | draw-a-rotating-cube |   |  |  |
+| 326 | draw-a-sphere |   |  |  |
 | 327 | dutch-national-flag-problem |   |  |  |
-| 328 | dynamic-variable-names | ✓ | 42.0ms | 38.10KB |
-| 329 | earliest-difference-between-prime-gaps | ✓ | 62.0ms | 112.08KB |
+| 328 | dynamic-variable-names |   |  |  |
+| 329 | earliest-difference-between-prime-gaps |   |  |  |
 | 330 | eban-numbers |   |  |  |
 | 331 | ecdsa-example |   |  |  |
-| 332 | echo-server | ✓ | 35.0ms | 37.62KB |
-| 333 | eertree | ✓ | 53.0ms | 99.79KB |
+| 332 | echo-server |   |  |  |
+| 333 | eertree |   |  |  |
 | 334 | egyptian-division |   |  |  |
-| 335 | ekg-sequence-convergence | ✓ | 69.0ms | 102.72KB |
+| 335 | ekg-sequence-convergence |   |  |  |
 | 336 | element-wise-operations |   |  |  |
-| 337 | elementary-cellular-automaton-infinite-length | ✓ | 69.0ms | 96.68KB |
+| 337 | elementary-cellular-automaton-infinite-length |   |  |  |
 | 338 | elementary-cellular-automaton-random-number-generator |   |  |  |
-| 339 | elementary-cellular-automaton | ✓ | 38.0ms | 38.83KB |
-| 340 | elliptic-curve-arithmetic | ✓ | 52.0ms | 97.39KB |
-| 341 | elliptic-curve-digital-signature-algorithm | ✓ | 21.0ms | 1.28KB |
-| 342 | emirp-primes | ✓ | 520.0ms | 103.34KB |
+| 339 | elementary-cellular-automaton |   |  |  |
+| 340 | elliptic-curve-arithmetic |   |  |  |
+| 341 | elliptic-curve-digital-signature-algorithm |   |  |  |
+| 342 | emirp-primes |   |  |  |
 | 343 | empty-directory |   |  |  |
-| 344 | empty-program | ✓ | 20.0ms | 0B |
-| 345 | empty-string-1 | ✓ | 21.0ms | 448B |
-| 346 | empty-string-2 | ✓ | 18.0ms | 552B |
-| 347 | enforced-immutability | ✓ | 22.0ms | 368B |
-| 348 | entropy-1 | ✓ | 20.0ms | 10.84KB |
-| 349 | entropy-2 | ✓ | 20.0ms | 10.84KB |
+| 344 | empty-program |   |  |  |
+| 345 | empty-string-1 |   |  |  |
+| 346 | empty-string-2 |   |  |  |
+| 347 | enforced-immutability |   |  |  |
+| 348 | entropy-1 |   |  |  |
+| 349 | entropy-2 |   |  |  |
 | 350 | entropy-narcissist |   |  |  |
 | 351 | enumerations-1 |   |  |  |
 | 352 | enumerations-2 |   |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,46 @@
-## Progress (2025-07-28 10:03 +0700)
+## Progress (2025-07-28 10:37 +0700)
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
+- java transpiler: fix map index assignment (da56f4ceaa)
+
 - chore: sort rosetta index (b04341afb7)
 
 - chore: sort rosetta index (b04341afb7)

--- a/transpiler/x/java/transpiler.go
+++ b/transpiler/x/java/transpiler.go
@@ -434,19 +434,34 @@ func fieldTypeFromVar(target Expr, name string) (string, bool) {
 				return "", false
 			}
 		}
-		base := strings.TrimSuffix(tname, "[]")
-		if topEnv != nil {
-			if st, ok := topEnv.GetStruct(base); ok {
-				if ft, ok2 := st.Fields[name]; ok2 {
-					return toJavaTypeFromType(ft), true
-				}
-			}
-		}
-		if structDefs != nil {
-			if f, ok := structDefs[base][name]; ok {
-				return f, true
-			}
-		}
+               base := strings.TrimSuffix(tname, "[]")
+               if topEnv != nil {
+                       if st, ok := topEnv.GetStruct(base); ok {
+                               if ft, ok2 := st.Fields[name]; ok2 {
+                                       return toJavaTypeFromType(ft), true
+                               }
+                       }
+               }
+               if structDefs != nil {
+                       if f, ok := structDefs[base][name]; ok {
+                               return f, true
+                       }
+                       if tname == "Object" {
+                               var found string
+                               for sn, fields := range structDefs {
+                                       if _, ok := fields[name]; ok {
+                                               if found != "" {
+                                                       found = "" // ambiguous
+                                                       break
+                                               }
+                                               found = sn
+                                       }
+                               }
+                               if found != "" {
+                                       return structDefs[found][name], true
+                               }
+                       }
+               }
 	case *FieldExpr:
 		if typ, ok := fieldTypeFromVar(v.Target, v.Name); ok {
 			base := strings.TrimSuffix(typ, "[]")
@@ -507,31 +522,39 @@ func inferType(e Expr) string {
 		if ex.ElemType != "" {
 			return ex.ElemType + "[]"
 		}
-		if len(ex.Elems) > 0 {
-			t := inferType(ex.Elems[0])
-			if t == "" {
-				for _, el := range ex.Elems[1:] {
-					t = inferType(el)
-					if t != "" {
-						break
-					}
-				}
-			}
-			if t != "" {
-				if strings.HasSuffix(t, "[]") {
-					return t + "[]"
-				}
-				switch t {
-				case "string":
-					return "string[]"
-				case "boolean":
-					return "bool[]"
-				default:
-					return t + "[]"
-				}
-			}
-		}
-		return ""
+               if len(ex.Elems) > 0 {
+                       t := inferType(ex.Elems[0])
+                       same := true
+                       for _, el := range ex.Elems[1:] {
+                               et := inferType(el)
+                               if et == "" {
+                                       continue
+                               }
+                               if t == "" {
+                                       t = et
+                               } else if et != t {
+                                       same = false
+                                       break
+                               }
+                       }
+                       if same && t != "" {
+                               if strings.HasSuffix(t, "[]") {
+                                       return t + "[]"
+                               }
+                               switch t {
+                               case "string":
+                                       return "string[]"
+                               case "boolean":
+                                       return "bool[]"
+                               default:
+                                       return t + "[]"
+                               }
+                       }
+                       if !same {
+                               return "Object[]"
+                       }
+               }
+               return ""
 	case *StructLit:
 		if ex.Name != "" {
 			return ex.Name
@@ -1166,9 +1189,17 @@ func (s *IfStmt) emit(w io.Writer, indent string) {
 type ExprStmt struct{ Expr Expr }
 
 func (s *ExprStmt) emit(w io.Writer, indent string) {
-	fmt.Fprint(w, indent)
-	s.Expr.emit(w)
-	fmt.Fprint(w, ";\n")
+        if call, ok := s.Expr.(*CallExpr); ok && call.Func == "panic" && len(call.Args) == 1 {
+                fmt.Fprint(w, indent)
+                fmt.Fprint(w, "throw new RuntimeException(String.valueOf(")
+                call.Args[0].emit(w)
+                fmt.Fprint(w, "));")
+                fmt.Fprint(w, "\n")
+                return
+        }
+        fmt.Fprint(w, indent)
+        s.Expr.emit(w)
+        fmt.Fprint(w, ";\n")
 }
 
 type LetStmt struct {
@@ -1558,8 +1589,8 @@ type ListLit struct {
 }
 
 func (l *ListLit) emit(w io.Writer) {
-	arrType := l.ElemType
-	if arrType == "" {
+        arrType := l.ElemType
+        if arrType == "" {
 		if len(l.Elems) > 0 {
 			t := inferType(l.Elems[0])
 			same := true
@@ -1569,35 +1600,55 @@ func (l *ListLit) emit(w io.Writer) {
 					break
 				}
 			}
-			if same && t != "" {
-				if strings.HasSuffix(t, "[]") {
-					arrType = t
-				} else {
-					arrType = t
-					if arrType == "" {
-						arrType = "Object"
-					}
-					switch arrType {
-					case "string":
-						arrType = "String"
-					case "boolean":
-						arrType = "boolean"
-					}
-				}
-			} else {
-				arrType = "Object"
-			}
-		} else {
-			arrType = "Object"
-		}
-		arrType = javaType(arrType)
-	} else {
-		jt := javaType(arrType)
-		if jt != "" {
-			arrType = jt
-		}
-	}
-	raw := arrType
+                        if same && t != "" {
+                                if strings.HasSuffix(t, "[]") {
+                                        arrType = t
+                                } else {
+                                        arrType = t
+                                        if arrType == "" {
+                                                arrType = "Object"
+                                        }
+                                        switch arrType {
+                                        case "string":
+                                                arrType = "String"
+                                        case "boolean":
+                                                arrType = "boolean"
+                                        }
+                                }
+                        } else {
+                                arrType = "Object"
+                        }
+                } else {
+                        arrType = "Object"
+                }
+                arrType = javaType(arrType)
+        } else {
+                jt := javaType(arrType)
+                if jt != "" {
+                        arrType = jt
+                }
+        }
+       if arrType == "Object" {
+               t := ""
+               same := true
+               for _, el := range l.Elems {
+                       et := inferType(el)
+                       if et == "" {
+                               same = false
+                               break
+                       }
+                       if t == "" {
+                               t = et
+                       } else if et != t {
+                               same = false
+                               break
+                       }
+               }
+               if same && t != "" {
+                       arrType = javaType(t)
+               }
+       }
+        raw := arrType
 	dims := 0
 	for strings.HasSuffix(raw, "[]") {
 		raw = strings.TrimSuffix(raw, "[]")
@@ -1951,13 +2002,33 @@ type FieldExpr struct {
 }
 
 func (f *FieldExpr) emit(w io.Writer) {
-	if v, ok := f.Target.(*VarExpr); ok {
-		if t, ok2 := varTypes[v.Name]; ok2 && t != "map" && !strings.Contains(t, "Map") {
-			f.Target.emit(w)
-			fmt.Fprint(w, "."+f.Name)
-			return
-		}
-	}
+        if v, ok := f.Target.(*VarExpr); ok {
+                if t, ok2 := varTypes[v.Name]; ok2 && t != "map" && !strings.Contains(t, "Map") {
+                        if t != "Object" {
+                                f.Target.emit(w)
+                                fmt.Fprint(w, "."+f.Name)
+                                return
+                        }
+                        if structDefs != nil {
+                                var found string
+                                for sn, fields := range structDefs {
+                                        if _, ok := fields[f.Name]; ok {
+                                                if found != "" {
+                                                        found = ""
+                                                        break
+                                                }
+                                                found = sn
+                                        }
+                                }
+                                if found != "" {
+                                        fmt.Fprintf(w, "((%s)", found)
+                                        f.Target.emit(w)
+                                        fmt.Fprintf(w, ").%s", f.Name)
+                                        return
+                                }
+                        }
+                }
+        }
 	if isMapExpr(f.Target) {
 		castType := "Object"
 		if fields := mapFieldsForExpr(f.Target); fields != nil {
@@ -4573,23 +4644,32 @@ func compilePrimary(p *parser.Primary) (Expr, error) {
 			}
 			elems[i] = ex
 		}
-		lt := ""
-		for _, el := range elems {
-			t := inferType(el)
-			if t != "" {
-				lt = t
-				break
-			}
-		}
-		if strings.HasSuffix(lt, "[]") {
-			inner := strings.TrimSuffix(lt, "[]")
-			for _, el := range elems {
-				if ll, ok := el.(*ListLit); ok && ll.ElemType == "" {
-					ll.ElemType = inner
-				}
-			}
-		}
-		return &ListLit{ElemType: lt, Elems: elems}, nil
+               lt := ""
+               same := true
+               for i, el := range elems {
+                       t := inferType(el)
+                       if t == "" {
+                               continue
+                       }
+                       if i == 0 || lt == "" {
+                               lt = t
+                       } else if t != lt {
+                               same = false
+                               break
+                       }
+               }
+               if !same {
+                       lt = "Object"
+               }
+               if strings.HasSuffix(lt, "[]") {
+                       inner := strings.TrimSuffix(lt, "[]")
+                       for _, el := range elems {
+                               if ll, ok := el.(*ListLit); ok && ll.ElemType == "" {
+                                       ll.ElemType = inner
+                               }
+                       }
+               }
+               return &ListLit{ElemType: lt, Elems: elems}, nil
 	case p.Map != nil:
 		ml := p.Map
 		keys := make([]Expr, len(ml.Items))


### PR DESCRIPTION
## Summary
- support `panic` statements in Java output
- infer list literal element types better and handle mixed lists
- cast fields from `Object` when struct can be determined
- regenerate Rosetta Java outputs for several programs

## Testing
- `go clean -testcache`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run Rosetta -index 311 -tags=slow -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run Rosetta -index 312 -tags=slow -count=1`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test ./transpiler/x/java -run Rosetta -index 313 -tags=slow -count=1` (fails)

------
https://chatgpt.com/codex/tasks/task_e_6886f07cd9b48320ba3cd6cb811791c3