### PR TITLE
Fix go tests by updating golden IR

### DIFF
--- a/tests/vm_extended/valid/bigint_ops.ir.out
+++ b/tests/vm_extended/valid/bigint_ops.ir.out
@@ -1,4 +1,4 @@
-func main (regs=11)
+func __main (regs=11)
   // let a: bigint = 10
   Const        r2, 10
   Cast         r3, r2, bigint


### PR DESCRIPTION
## Summary
- update BigInt IR golden file to match current assembly output

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6886f933ff788320ae780160005f7ed5