### PR TITLE
Add release notes for v0.10.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 📦 CHANGELOG.md
 
+## [0.10.43] – 2025-07-28T11:11:30+07:00
+
+### Added
+
+* Environment variable helpers and OS FFI across multiple transpilers
+* BigRat math, union operations and typed maps
+* Dynamic function calls, typed lambdas and improved indexing
+* Hundreds of new Rosetta programs with updated benchmarks
+
+### Changed
+
+* Progress indexes and examples refreshed across languages
+* Map handling and type inference enhanced in various backends
+
+### Fixed
+
+* Numerous bugs with map iteration, globals and casting
 ## [0.10.42] – 2025-07-27T09:00:51+00:00
 
 ### Added

--- a/releases/v0.10.43.md
+++ b/releases/v0.10.43.md
@@ -1,0 +1,17 @@
+# Jul 2025 (v0.10.43)
+
+Released on Mon Jul 28 11:11:30 2025 +0700.
+
+Mochi v0.10.43 expands Rosetta coverage and enhances many transpilers with new features and bug fixes.
+
+## Compilers
+
+- Environment variable helpers and OS FFI added across Dart, Scheme and Rust
+- BigRat math, union operations and typed maps for several languages
+- Dynamic function calls, typed lambdas and improved indexing in C, C++, Java and others
+- Hundreds of new Rosetta programs with refreshed outputs and benchmarks
+
+## Documentation
+
+- Progress tables regenerated for updated tasks
+- Various examples and READMEs improved


### PR DESCRIPTION
## Summary
- document the v0.10.43 release
- update CHANGELOG with entries for v0.10.43

## Testing
- `make test` *(fails: TestVM_BigInt_IR)*

------
https://chatgpt.com/codex/tasks/task_e_6886f9845da08320be3de6658297524e