### PR TITLE
Update kotlin transpiler and add rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/count-the-coins-2.bench
+++ b/tests/rosetta/transpiler/Kotlin/count-the-coins-2.bench
@@ -1,0 +1,1 @@
+{"duration_us":38639, "memory_bytes":94704, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/count-the-coins-2.kt
+++ b/tests/rosetta/transpiler/Kotlin/count-the-coins-2.kt
@@ -1,0 +1,60 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val amount: Int = 1000
+fun countChange(amount: Int): Int {
+    var ways: MutableList<Int> = mutableListOf<Int>()
+    var i: Int = 0
+    while (i <= amount) {
+        ways = run { val _tmp = ways.toMutableList(); _tmp.add(0); _tmp } as MutableList<Int>
+        i = i + 1
+    }
+    ways[0] = 1
+    for (coin in mutableListOf(100, 50, 25, 10, 5, 1)) {
+        var j: Int = coin
+        while (j <= amount) {
+            ways[j] = ways[j] + ways[j - coin]
+            j = j + 1
+        }
+    }
+    return ways[amount]
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println((("amount, ways to make change: " + amount.toString()) + " ") + countChange(amount).toString())
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/count-the-coins-2.out
+++ b/tests/rosetta/transpiler/Kotlin/count-the-coins-2.out
@@ -1,0 +1,1 @@
+amount, ways to make change: 1000 2103596

--- a/tests/rosetta/transpiler/Kotlin/cramers-rule.bench
+++ b/tests/rosetta/transpiler/Kotlin/cramers-rule.bench
@@ -1,0 +1,1 @@
+{"duration_us":10094, "memory_bytes":133944, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/cramers-rule.kt
+++ b/tests/rosetta/transpiler/Kotlin/cramers-rule.kt
@@ -1,0 +1,111 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val m: MutableList<MutableList<Double>> = mutableListOf(mutableListOf(2.0, 0.0 - 1.0, 5.0, 1.0), mutableListOf(3.0, 2.0, 2.0, 0.0 - 6.0), mutableListOf(1.0, 3.0, 3.0, 0.0 - 1.0), mutableListOf(5.0, 0.0 - 2.0, 0.0 - 3.0, 3.0))
+val v: MutableList<Double> = mutableListOf(0.0 - 3.0, 0.0 - 32.0, 0.0 - 47.0, 49.0)
+val d: Double = det(m)
+var x: MutableList<Double> = mutableListOf<Double>()
+var i: Int = 0
+var s: String = "["
+var j: Int = 0
+fun det(m: MutableList<MutableList<Double>>): Double {
+    val n: Int = m.size
+    if (n == 1) {
+        return m[0][0]
+    }
+    var total: Double = 0.0
+    var sign: Double = 1.0
+    var c: Int = 0
+    while (c < n) {
+        var sub: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>()
+        var r: Int = 1
+        while (r < n) {
+            var row: MutableList<Double> = mutableListOf<Double>()
+            var cc: Int = 0
+            while (cc < n) {
+                if (cc != c) {
+                    row = run { val _tmp = row.toMutableList(); _tmp.add(m[r][cc]); _tmp } as MutableList<Double>
+                }
+                cc = cc + 1
+            }
+            sub = run { val _tmp = sub.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Double>>
+            r = r + 1
+        }
+        total = total + ((sign * m[0][c]) * det(sub))
+        sign = sign * (0.0 - 1.0)
+        c = c + 1
+    }
+    return total
+}
+
+fun replaceCol(m: MutableList<MutableList<Double>>, col: Int, v: MutableList<Double>): MutableList<MutableList<Double>> {
+    var res: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>()
+    var r: Int = 0
+    while (r < m.size) {
+        var row: MutableList<Double> = mutableListOf<Double>()
+        var c: Int = 0
+        while (c < (m[r]).size) {
+            if (c == col) {
+                row = run { val _tmp = row.toMutableList(); _tmp.add(v[r]); _tmp } as MutableList<Double>
+            } else {
+                row = run { val _tmp = row.toMutableList(); _tmp.add(m[r][c]); _tmp } as MutableList<Double>
+            }
+            c = c + 1
+        }
+        res = run { val _tmp = res.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Double>>
+        r = r + 1
+    }
+    return res
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        while (i < v.size) {
+            val mc: MutableList<MutableList<Double>> = replaceCol(m, i, v)
+            x = run { val _tmp = x.toMutableList(); _tmp.add(det(mc) / d); _tmp } as MutableList<Double>
+            i = i + 1
+        }
+        while (j < x.size) {
+            s = s + (x[j]).toString()
+            if (j < (x.size - 1)) {
+                s = s + " "
+            }
+            j = j + 1
+        }
+        s = s + "]"
+        println(s)
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/crc-32-1.error
+++ b/tests/rosetta/transpiler/Kotlin/crc-32-1.error
@@ -1,0 +1,7 @@
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/crc-32-1.kt:65:11: error: type mismatch: inferred type is Any? but Int was expected
+    idx = lower.indexOf(ch) as Any?
+          ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/crc-32-1.kt:119:12: error: type mismatch: inferred type is Long but Int was expected
+    return 4294967295L - crc
+           ^

--- a/tests/rosetta/transpiler/Kotlin/crc-32-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/crc-32-1.kt
@@ -1,0 +1,143 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val table: MutableList<Int> = crc32Table()
+fun xor(a: Int, b: Int): Int {
+    var res: Int = 0
+    var bit: Int = 1
+    var x: Int = a
+    var y: Int = b
+    while ((x > 0) || (y > 0)) {
+        val abit: BigInteger = (Math.floorMod(x, 2)).toBigInteger()
+        val bbit: BigInteger = (Math.floorMod(y, 2)).toBigInteger()
+        if (abit.compareTo(bbit) != 0) {
+            res = res + bit
+        }
+        x = x / 2
+        y = y / 2
+        bit = bit * 2
+    }
+    return res
+}
+
+fun rshift(x: Int, n: Int): Int {
+    var v: Int = x
+    var i: Int = 0
+    while (i < n) {
+        v = v / 2
+        i = i + 1
+    }
+    return v
+}
+
+fun ord(ch: String): Int {
+    val upper: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    val lower: String = "abcdefghijklmnopqrstuvwxyz"
+    var idx = upper.indexOf(ch)
+    if (idx >= 0) {
+        return 65 + (idx).toInt()
+    }
+    idx = lower.indexOf(ch) as Any?
+    if (idx >= 0) {
+        return 97 + (idx).toInt()
+    }
+    if (ch == " ") {
+        return 32
+    }
+    return 0
+}
+
+fun toHex(n: Int): String {
+    val digits: String = "0123456789ABCDEF"
+    if (n == 0) {
+        return "0"
+    }
+    var v: Int = n
+    var out: String = ""
+    while (v > 0) {
+        val d: BigInteger = (Math.floorMod(v, 16)).toBigInteger()
+        out = digits.substring((d).toInt(), (d.add(1.toBigInteger())).toInt()) + out
+        v = v / 16
+    }
+    return out
+}
+
+fun crc32Table(): MutableList<Int> {
+    var table: MutableList<Int> = mutableListOf<Int>()
+    var i: Int = 0
+    while (i < 256) {
+        var word: Int = i
+        var j: Int = 0
+        while (j < 8) {
+            if ((Math.floorMod(word, 2)) == 1) {
+                word = xor(rshift(word, 1), 3988292384L.toInt())
+            } else {
+                word = rshift(word, 1)
+            }
+            j = j + 1
+        }
+        table = run { val _tmp = table.toMutableList(); _tmp.add(word); _tmp } as MutableList<Int>
+        i = i + 1
+    }
+    return table
+}
+
+fun crc32(s: String): Int {
+    var crc: Long = 4294967295L
+    var i: Int = 0
+    while (i < s.length) {
+        val c: Int = ord(s.substring(i, i + 1))
+        val idx: Int = xor(Math.floorMod(crc, (256).toLong()).toInt(), c)
+        crc = (xor(table[idx], rshift(crc.toInt(), 8))) as Long
+        i = i + 1
+    }
+    return 4294967295L - crc
+}
+
+fun user_main(): Unit {
+    val s: String = "The quick brown fox jumps over the lazy dog"
+    val result: Int = crc32(s)
+    val hex: String = toHex(result)
+    println(hex)
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        user_main()
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-28 10:03 +0700
+Last updated: 2025-07-28 11:26 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-28 10:03 +0700
+Last updated: 2025-07-28 11:26 +0700
 
-Completed tasks: **124/493**
+Completed tasks: **126/493**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -258,8 +258,8 @@ Completed tasks: **124/493**
 | 247 | count-in-octal-4 |  |  |  |
 | 248 | count-occurrences-of-a-substring |  |  |  |
 | 249 | count-the-coins-1 |  |  |  |
-| 250 | count-the-coins-2 |  |  |  |
-| 251 | cramers-rule |  |  |  |
+| 250 | count-the-coins-2 | ✓ | 38.64ms | 92.5 KB |
+| 251 | cramers-rule | ✓ | 10.09ms | 130.8 KB |
 | 252 | crc-32-1 |  |  |  |
 | 253 | crc-32-2 |  |  |  |
 | 254 | create-a-file-on-magnetic-tape |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,30 @@
+## VM Golden Progress (2025-07-28 11:26 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:26 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:26 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:26 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:26 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:14 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:14 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:14 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:14 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-28 10:03 +0700)
 - Regenerated Kotlin golden files and README
 

--- a/transpiler/x/kt/transpiler.go
+++ b/transpiler/x/kt/transpiler.go
@@ -202,6 +202,7 @@ fun _div(a: BigRat, b: BigRat): BigRat = a.div(b)`,
 		"_sub":            "BigRat",
 		"_mul":            "BigRat",
 		"_div":            "BigRat",
+		"indexOf":         "Int",
 	}
 }
 
@@ -4751,6 +4752,19 @@ func convertPrimary(env *types.Env, p *parser.Primary) (Expr, error) {
 				return nil, err
 			}
 			return &PadStartExpr{Value: str, Width: width, Pad: pad}, nil
+		case "indexOf":
+			if len(p.Call.Args) != 2 {
+				return nil, fmt.Errorf("indexOf expects 2 args")
+			}
+			target, err := convertExpr(env, p.Call.Args[0])
+			if err != nil {
+				return nil, err
+			}
+			needle, err := convertExpr(env, p.Call.Args[1])
+			if err != nil {
+				return nil, err
+			}
+			return &InvokeExpr{Callee: &FieldExpr{Receiver: target, Name: "indexOf"}, Args: []Expr{needle}}, nil
 		default:
 			args := make([]Expr, len(p.Call.Args))
 			for i, a := range p.Call.Args {


### PR DESCRIPTION
## Summary
- update Kotlin transpiler with `indexOf` builtin support
- regenerate Kotlin Rosetta outputs for `count-the-coins-2` and `cramers-rule`
- add failing output for `crc-32-1`
- refresh Kotlin README, TASKS and ROSETTA progress

## Testing
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=250 go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1`
- `MOCHI_BENCHMARK=true ROSETTA_INDEX=252 go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1` *(fails as expected)*

------
https://chatgpt.com/codex/tasks/task_e_6886fabc26608320b9c63995b856286c