### PR TITLE
Add Clojure output for count-the-coins-2

### DIFF
--- a/tests/rosetta/transpiler/Clojure/count-the-coins-2.bench
+++ b/tests/rosetta/transpiler/Clojure/count-the-coins-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 58829,
+  "memory_bytes": 20555232,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Clojure/count-the-coins-2.clj
+++ b/tests/rosetta/transpiler/Clojure/count-the-coins-2.clj
@@ -1,0 +1,31 @@
+(ns main (:refer-clojure :exclude [countChange]))
+
+(require 'clojure.set)
+
+(defn in [x coll]
+  (cond (string? coll) (clojure.string/includes? coll x) (map? coll) (contains? coll x) (sequential? coll) (some (fn [e] (= e x)) coll) :else false))
+
+(def nowSeed (atom (let [s (System/getenv "MOCHI_NOW_SEED")] (if (and s (not (= s ""))) (Integer/parseInt s) 0))))
+
+(declare countChange)
+
+(defn countChange [amount]
+  (try (do (def ways []) (def i 0) (while (<= i amount) (do (def ways (conj ways 0)) (def i (+ i 1)))) (def ways (assoc ways 0 1)) (doseq [coin [100 50 25 10 5 1]] (do (def j coin) (while (<= j amount) (do (def ways (assoc ways j (+ (nth ways j) (nth ways (- j coin))))) (def j (+ j 1)))))) (throw (ex-info "return" {:v (nth ways amount)}))) (catch clojure.lang.ExceptionInfo e (if (= (ex-message e) "return") (get (ex-data e) :v) (throw e)))))
+
+(def amount 1000)
+
+(defn -main []
+  (let [rt (Runtime/getRuntime)
+    start-mem (- (.totalMemory rt) (.freeMemory rt))
+    start (System/nanoTime)]
+      (println (str (str (str "amount, ways to make change: " (str amount)) " ") (str (countChange amount))))
+      (System/gc)
+      (let [end (System/nanoTime)
+        end-mem (- (.totalMemory rt) (.freeMemory rt))
+        duration-us (quot (- end start) 1000)
+        memory-bytes (Math/abs ^long (- end-mem start-mem))]
+        (println (str "{\n  \"duration_us\": " duration-us ",\n  \"memory_bytes\": " memory-bytes ",\n  \"name\": \"main\"\n}"))
+      )
+    ))
+
+(-main)

--- a/tests/rosetta/transpiler/Clojure/count-the-coins-2.out
+++ b/tests/rosetta/transpiler/Clojure/count-the-coins-2.out
@@ -1,0 +1,1 @@
+amount, ways to make change: 1000 2103596

--- a/transpiler/x/clj/ROSETTA.md
+++ b/transpiler/x/clj/ROSETTA.md
@@ -1,7 +1,7 @@
 # Clojure Rosetta Transpiler
 
-Completed: 84/467
-Last updated: 2025-07-27 23:56 +0700
+Completed: 97/493
+Last updated: 2025-07-28 11:42 +0700
 
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
@@ -21,454 +21,480 @@ Last updated: 2025-07-27 23:56 +0700
 | 14 | 99-bottles-of-beer | ✓ | 31.158ms | 18.5 MB |
 | 15 | DNS-query | ✓ | 21.781ms | 18.1 MB |
 | 16 | Duffinian-numbers |   |  |  |
-| 17 | a+b | ✓ | 13.848ms | 18.3 MB |
-| 18 | abbreviations-automatic |   |  |  |
-| 19 | abbreviations-easy | ✓ | 48.779ms | 22.1 MB |
-| 20 | abbreviations-simple |   |  |  |
-| 21 | abc-problem | ✓ | 46.947ms | 20.6 MB |
-| 22 | abelian-sandpile-model-identity | ✓ |  |  |
-| 23 | abelian-sandpile-model |   |  |  |
-| 24 | abstract-type | ✓ | 24.271ms | 20.0 MB |
-| 25 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
-| 26 | abundant-odd-numbers |   |  |  |
-| 27 | accumulator-factory |   |  |  |
-| 28 | achilles-numbers |   |  |  |
-| 29 | ackermann-function-2 |   |  |  |
-| 30 | ackermann-function-3 |   |  |  |
-| 31 | ackermann-function |   |  |  |
-| 32 | active-directory-connect | ✓ | 18.043ms | 18.7 MB |
-| 33 | active-directory-search-for-a-user | ✓ | 19.549ms | 24.3 MB |
-| 34 | active-object | ✓ | 37.262ms | 20.0 MB |
-| 35 | add-a-variable-to-a-class-instance-at-runtime |   | 15.428ms | 18.8 MB |
-| 36 | additive-primes |   | 76.429ms | 20.4 MB |
-| 37 | address-of-a-variable | ✓ | 14.698ms | 17.9 MB |
-| 38 | adfgvx-cipher |   |  |  |
-| 39 | aks-test-for-primes | ✓ |  |  |
-| 40 | algebraic-data-types |   |  |  |
-| 41 | align-columns | ✓ | 26.04ms | 22.4 MB |
-| 42 | aliquot-sequence-classifications | ✓ |  |  |
-| 43 | almkvist-giullera-formula-for-pi | ✓ |  |  |
-| 44 | almost-prime | ✓ |  |  |
-| 45 | amb | ✓ |  |  |
-| 46 | amicable-pairs | ✓ | 19.466429s | 19.4 MB |
-| 47 | anagrams-deranged-anagrams | ✓ |  |  |
-| 48 | anagrams | ✓ |  |  |
-| 49 | angle-difference-between-two-bearings-1 | ✓ | 24.659ms | 19.6 MB |
-| 50 | angle-difference-between-two-bearings-2 | ✓ | 22.483ms | 19.8 MB |
-| 51 | angles-geometric-normalization-and-conversion | ✓ | 42.981ms | 24.0 MB |
-| 52 | animate-a-pendulum | ✓ | 21.004ms | 20.7 MB |
-| 53 | animation | ✓ | 25.301ms | 18.7 MB |
-| 54 | anonymous-recursion-1 | ✓ | 49.151ms | 19.3 MB |
-| 55 | anonymous-recursion-2 | ✓ | 46.059ms | 19.4 MB |
-| 56 | anonymous-recursion | ✓ | 21.672ms | 18.8 MB |
-| 57 | anti-primes | ✓ | 64.874ms | 19.5 MB |
-| 58 | append-a-record-to-the-end-of-a-text-file | ✓ | 18.961ms | 18.7 MB |
-| 59 | apply-a-callback-to-an-array-1 | ✓ | 42.369ms | 18.4 MB |
-| 60 | apply-a-callback-to-an-array-2 | ✓ | 35.862ms | 19.6 MB |
-| 61 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 20.222ms | 20.4 MB |
-| 62 | approximate-equality | ✓ | 61.528ms | 20.8 MB |
-| 63 | arbitrary-precision-integers-included- |   |  |  |
-| 64 | archimedean-spiral |   |  |  |
-| 65 | arena-storage-pool | ✓ | 44.229ms | 20.2 MB |
-| 66 | arithmetic-complex | ✓ | 46.769ms | 20.4 MB |
-| 67 | arithmetic-derivative | ✓ | 107.461ms | 21.8 MB |
-| 68 | arithmetic-evaluation |   |  |  |
-| 69 | arithmetic-geometric-mean-calculate-pi | ✓ | 44.656ms | 19.9 MB |
-| 70 | arithmetic-geometric-mean | ✓ |  |  |
-| 71 | arithmetic-integer-1 | ✓ | 46.082ms | 18.8 MB |
-| 72 | arithmetic-integer-2 | ✓ | 45.211ms | 18.7 MB |
-| 73 | arithmetic-numbers | ✓ | 13.288406s | 15.6 MB |
-| 74 | arithmetic-rational | ✓ | 64.993ms | 20.5 MB |
-| 75 | array-concatenation | ✓ | 77.149ms | 20.5 MB |
-| 76 | array-length | ✓ | 83.717ms | 18.3 MB |
-| 77 | arrays | ✓ | 22.914ms | 19.6 MB |
-| 78 | ascending-primes | ✓ | 19.607ms | 20.2 MB |
-| 79 | ascii-art-diagram-converter | ✓ | 15.277ms | 18.3 MB |
-| 80 | assertions | ✓ | 17.88ms | 18.1 MB |
-| 81 | associative-array-creation |   |  |  |
-| 82 | associative-array-iteration |   |  |  |
-| 83 | associative-array-merging |   |  |  |
-| 84 | atomic-updates | ✓ | 35.355ms | 21.9 MB |
-| 85 | attractive-numbers |   |  |  |
-| 86 | average-loop-length | ✓ | 1.388492s | 22.7 MB |
-| 87 | averages-arithmetic-mean | ✓ | 35.275ms | 19.5 MB |
-| 88 | averages-mean-time-of-day |   | 48.938ms | 24.4 MB |
-| 89 | averages-median-1 | ✓ | 20.46ms | 19.8 MB |
-| 90 | averages-median-2 | ✓ | 20.305ms | 19.4 MB |
-| 91 | averages-median-3 | ✓ | 21.63ms | 20.2 MB |
-| 92 | averages-mode | ✓ | 26.757ms | 19.9 MB |
-| 93 | averages-pythagorean-means | ✓ |  |  |
-| 94 | averages-root-mean-square | ✓ | 25.824ms | 18.8 MB |
-| 95 | averages-simple-moving-average | ✓ |  |  |
-| 96 | avl-tree | ✓ | 46.738ms | 25.6 MB |
-| 97 | b-zier-curves-intersections | ✓ | 279.112ms | 28.2 MB |
-| 98 | babbage-problem | ✓ | 155.667ms | 18.2 MB |
-| 99 | babylonian-spiral | ✓ |  |  |
-| 100 | balanced-brackets | ✓ | 47.871ms | 20.7 MB |
-| 101 | balanced-ternary | ✓ | 48.758ms | 22.7 MB |
-| 102 | barnsley-fern |   |  |  |
-| 103 | base64-decode-data |   |  |  |
-| 104 | bell-numbers |   |  |  |
-| 105 | benfords-law | ✓ |  |  |
-| 106 | bernoulli-numbers |   |  |  |
-| 107 | best-shuffle |   |  |  |
-| 108 | bifid-cipher |   |  |  |
-| 109 | bin-given-limits |   |  |  |
-| 110 | binary-digits | ✓ | 40.119ms | 18.8 MB |
-| 111 | binary-search | ✓ | 43.13ms | 19.8 MB |
-| 112 | binary-strings | ✓ | 58.888ms | 20.1 MB |
-| 113 | bioinformatics-base-count | ✓ | 51.718ms | 19.5 MB |
-| 114 | bioinformatics-global-alignment |   |  |  |
-| 115 | bioinformatics-sequence-mutation | ✓ | 70.13ms | 23.8 MB |
-| 116 | biorhythms |   |  |  |
-| 117 | bitcoin-address-validation |   |  |  |
-| 118 | bitmap-b-zier-curves-cubic |   |  |  |
-| 119 | bitmap-b-zier-curves-quadratic |   |  |  |
-| 120 | bitmap-bresenhams-line-algorithm | ✓ |  |  |
-| 121 | bitmap-flood-fill |   |  |  |
-| 122 | bitmap-histogram | ✓ | 65.616ms | 22.0 MB |
-| 123 | bitmap-midpoint-circle-algorithm | ✓ | 48.451ms | 21.7 MB |
-| 124 | bitmap-ppm-conversion-through-a-pipe | ✓ | 1.140733s | 21.7 MB |
-| 125 | bitmap-read-a-ppm-file |   |  |  |
-| 126 | bitmap-read-an-image-through-a-pipe |   |  |  |
-| 127 | bitmap-write-a-ppm-file |   |  |  |
-| 128 | bitmap |   |  |  |
-| 129 | bitwise-io-1 |   |  |  |
-| 130 | bitwise-io-2 |   |  |  |
-| 131 | bitwise-operations |   |  |  |
-| 132 | blum-integer |   |  |  |
-| 133 | boolean-values |   |  |  |
-| 134 | box-the-compass |   |  |  |
-| 135 | boyer-moore-string-search |   |  |  |
-| 136 | brazilian-numbers |   |  |  |
-| 137 | break-oo-privacy |   |  |  |
-| 138 | brilliant-numbers |   |  |  |
-| 139 | brownian-tree |   |  |  |
-| 140 | bulls-and-cows-player |   |  |  |
-| 141 | bulls-and-cows |   |  |  |
-| 142 | burrows-wheeler-transform |   |  |  |
-| 143 | caesar-cipher-1 |   |  |  |
-| 144 | caesar-cipher-2 |   |  |  |
-| 145 | calculating-the-value-of-e |   |  |  |
-| 146 | calendar---for-real-programmers-1 |   |  |  |
-| 147 | calendar---for-real-programmers-2 |   |  |  |
-| 148 | calendar |   |  |  |
-| 149 | calkin-wilf-sequence |   |  |  |
-| 150 | call-a-foreign-language-function |   |  |  |
-| 151 | call-a-function-1 |   |  |  |
-| 152 | call-a-function-10 |   |  |  |
-| 153 | call-a-function-11 |   |  |  |
-| 154 | call-a-function-12 |   |  |  |
-| 155 | call-a-function-2 |   |  |  |
-| 156 | call-a-function-3 |   |  |  |
-| 157 | call-a-function-4 |   |  |  |
-| 158 | call-a-function-5 |   |  |  |
-| 159 | call-a-function-6 |   |  |  |
-| 160 | call-a-function-7 |   |  |  |
-| 161 | call-a-function-8 |   |  |  |
-| 162 | call-a-function-9 |   |  |  |
-| 163 | call-an-object-method-1 |   |  |  |
-| 164 | call-an-object-method-2 |   |  |  |
-| 165 | call-an-object-method-3 |   |  |  |
-| 166 | call-an-object-method |   |  |  |
-| 167 | camel-case-and-snake-case |   |  |  |
-| 168 | canny-edge-detector |   |  |  |
-| 169 | canonicalize-cidr |   |  |  |
-| 170 | cantor-set |   |  |  |
-| 171 | carmichael-3-strong-pseudoprimes |   |  |  |
-| 172 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
-| 173 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
-| 174 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
-| 175 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
-| 176 | case-sensitivity-of-identifiers |   |  |  |
-| 177 | casting-out-nines |   |  |  |
-| 178 | catalan-numbers-1 |   |  |  |
-| 179 | catalan-numbers-2 |   |  |  |
-| 180 | catalan-numbers-pascals-triangle |   |  |  |
-| 181 | catamorphism |   |  |  |
-| 182 | catmull-clark-subdivision-surface |   |  |  |
-| 183 | chaocipher |   |  |  |
-| 184 | chaos-game |   |  |  |
-| 185 | character-codes-1 |   |  |  |
-| 186 | character-codes-2 |   |  |  |
-| 187 | character-codes-3 |   |  |  |
-| 188 | character-codes-4 |   |  |  |
-| 189 | character-codes-5 |   |  |  |
-| 190 | chat-server |   |  |  |
-| 191 | check-machin-like-formulas |   |  |  |
-| 192 | check-that-file-exists |   |  |  |
-| 193 | checkpoint-synchronization-1 |   |  |  |
-| 194 | checkpoint-synchronization-2 |   |  |  |
-| 195 | checkpoint-synchronization-3 |   |  |  |
-| 196 | checkpoint-synchronization-4 |   |  |  |
-| 197 | chernicks-carmichael-numbers |   |  |  |
-| 198 | cheryls-birthday |   |  |  |
-| 199 | chinese-remainder-theorem |   |  |  |
-| 200 | chinese-zodiac |   |  |  |
-| 201 | cholesky-decomposition-1 |   |  |  |
-| 202 | cholesky-decomposition |   |  |  |
-| 203 | chowla-numbers |   |  |  |
-| 204 | church-numerals-1 |   |  |  |
-| 205 | church-numerals-2 |   |  |  |
-| 206 | circles-of-given-radius-through-two-points |   |  |  |
-| 207 | circular-primes |   |  |  |
-| 208 | cistercian-numerals |   |  |  |
-| 209 | comma-quibbling |   |  |  |
-| 210 | compiler-virtual-machine-interpreter |   |  |  |
-| 211 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
-| 212 | compound-data-type |   |  |  |
-| 213 | concurrent-computing-1 |   |  |  |
-| 214 | concurrent-computing-2 |   |  |  |
-| 215 | concurrent-computing-3 |   |  |  |
-| 216 | conditional-structures-1 |   |  |  |
-| 217 | conditional-structures-10 |   |  |  |
-| 218 | conditional-structures-2 |   |  |  |
-| 219 | conditional-structures-3 |   |  |  |
-| 220 | conditional-structures-4 |   |  |  |
-| 221 | conditional-structures-5 |   |  |  |
-| 222 | conditional-structures-6 |   |  |  |
-| 223 | conditional-structures-7 |   |  |  |
-| 224 | conditional-structures-8 |   |  |  |
-| 225 | conditional-structures-9 |   |  |  |
-| 226 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
-| 227 | constrained-genericity-1 |   |  |  |
-| 228 | constrained-genericity-2 |   |  |  |
-| 229 | constrained-genericity-3 |   |  |  |
-| 230 | constrained-genericity-4 |   |  |  |
-| 231 | constrained-random-points-on-a-circle-1 |   |  |  |
-| 232 | constrained-random-points-on-a-circle-2 |   |  |  |
-| 233 | continued-fraction |   |  |  |
-| 234 | convert-decimal-number-to-rational |   |  |  |
-| 235 | convert-seconds-to-compound-duration |   |  |  |
-| 236 | convex-hull |   |  |  |
-| 237 | conways-game-of-life |   |  |  |
-| 238 | copy-a-string-1 |   |  |  |
-| 239 | copy-a-string-2 |   |  |  |
-| 240 | copy-stdin-to-stdout-1 |   |  |  |
-| 241 | copy-stdin-to-stdout-2 |   |  |  |
-| 242 | count-in-factors |   |  |  |
-| 243 | count-in-octal-1 |   |  |  |
-| 244 | count-in-octal-2 |   |  |  |
-| 245 | count-in-octal-3 |   |  |  |
-| 246 | count-in-octal-4 |   |  |  |
-| 247 | count-occurrences-of-a-substring |   |  |  |
-| 248 | count-the-coins-1 |   |  |  |
-| 249 | count-the-coins-2 |   |  |  |
-| 250 | cramers-rule |   |  |  |
-| 251 | crc-32-1 |   |  |  |
-| 252 | crc-32-2 |   |  |  |
-| 253 | create-a-file-on-magnetic-tape |   |  |  |
-| 254 | create-a-file |   |  |  |
-| 255 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
-| 256 | create-an-html-table |   |  |  |
-| 257 | create-an-object-at-a-given-address |   |  |  |
-| 258 | csv-data-manipulation |   |  |  |
-| 259 | csv-to-html-translation-1 |   |  |  |
-| 260 | csv-to-html-translation-2 |   |  |  |
-| 261 | csv-to-html-translation-3 |   |  |  |
-| 262 | csv-to-html-translation-4 |   |  |  |
-| 263 | csv-to-html-translation-5 |   |  |  |
-| 264 | cuban-primes |   |  |  |
-| 265 | cullen-and-woodall-numbers |   |  |  |
-| 266 | cumulative-standard-deviation |   |  |  |
-| 267 | currency |   |  |  |
-| 268 | currying |   |  |  |
-| 269 | curzon-numbers |   |  |  |
-| 270 | cusip |   |  |  |
-| 271 | cyclops-numbers |   |  |  |
-| 272 | damm-algorithm |   |  |  |
-| 273 | date-format |   |  |  |
-| 274 | date-manipulation |   |  |  |
-| 275 | day-of-the-week |   |  |  |
-| 276 | de-bruijn-sequences |   |  |  |
-| 277 | deal-cards-for-freecell |   |  |  |
-| 278 | death-star |   |  |  |
-| 279 | deceptive-numbers |   |  |  |
-| 280 | deconvolution-1d-2 |   |  |  |
-| 281 | deconvolution-1d-3 |   |  |  |
-| 282 | deconvolution-1d |   |  |  |
-| 283 | deepcopy-1 |   |  |  |
-| 284 | define-a-primitive-data-type |   |  |  |
-| 285 | delegates |   |  |  |
-| 286 | demings-funnel |   |  |  |
-| 287 | department-numbers |   |  |  |
-| 288 | descending-primes |   |  |  |
-| 289 | detect-division-by-zero |   |  |  |
-| 290 | determine-if-a-string-has-all-the-same-characters |   |  |  |
-| 291 | determine-if-a-string-has-all-unique-characters |   |  |  |
-| 292 | determine-if-a-string-is-collapsible |   |  |  |
-| 293 | determine-if-a-string-is-numeric-1 |   |  |  |
-| 294 | determine-if-a-string-is-numeric-2 |   |  |  |
-| 295 | determine-if-a-string-is-squeezable |   |  |  |
-| 296 | determine-if-only-one-instance-is-running |   |  |  |
-| 297 | determine-if-two-triangles-overlap |   |  |  |
-| 298 | determine-sentence-type |   |  |  |
-| 299 | dice-game-probabilities-1 |   |  |  |
-| 300 | dice-game-probabilities-2 |   |  |  |
-| 301 | digital-root-multiplicative-digital-root |   |  |  |
-| 302 | dijkstras-algorithm |   |  |  |
-| 303 | dinesmans-multiple-dwelling-problem |   |  |  |
-| 304 | dining-philosophers-1 |   |  |  |
-| 305 | dining-philosophers-2 |   |  |  |
-| 306 | disarium-numbers |   |  |  |
-| 307 | discordian-date |   |  |  |
-| 308 | display-a-linear-combination |   |  |  |
-| 309 | display-an-outline-as-a-nested-table |   |  |  |
-| 310 | distance-and-bearing |   |  |  |
-| 311 | distributed-programming |   |  |  |
-| 312 | diversity-prediction-theorem |   |  |  |
-| 313 | documentation |   |  |  |
-| 314 | doomsday-rule |   |  |  |
-| 315 | dot-product |   |  |  |
-| 316 | doubly-linked-list-definition-1 |   |  |  |
-| 317 | doubly-linked-list-definition-2 |   |  |  |
-| 318 | doubly-linked-list-element-definition |   |  |  |
-| 319 | doubly-linked-list-traversal |   |  |  |
-| 320 | dragon-curve |   |  |  |
-| 321 | draw-a-clock |   |  |  |
-| 322 | draw-a-cuboid |   |  |  |
-| 323 | draw-a-pixel-1 |   |  |  |
-| 324 | draw-a-rotating-cube |   |  |  |
-| 325 | draw-a-sphere |   |  |  |
-| 326 | dutch-national-flag-problem |   |  |  |
-| 327 | dynamic-variable-names |   |  |  |
-| 328 | earliest-difference-between-prime-gaps |   |  |  |
-| 329 | eban-numbers |   |  |  |
-| 330 | ecdsa-example |   |  |  |
-| 331 | echo-server |   |  |  |
-| 332 | eertree |   |  |  |
-| 333 | egyptian-division |   |  |  |
-| 334 | ekg-sequence-convergence |   |  |  |
-| 335 | element-wise-operations |   |  |  |
-| 336 | elementary-cellular-automaton-infinite-length |   |  |  |
-| 337 | elementary-cellular-automaton-random-number-generator |   |  |  |
-| 338 | elementary-cellular-automaton |   |  |  |
-| 339 | elliptic-curve-arithmetic |   |  |  |
-| 340 | elliptic-curve-digital-signature-algorithm |   |  |  |
-| 341 | emirp-primes |   |  |  |
-| 342 | empty-directory |   |  |  |
-| 343 | empty-program |   |  |  |
-| 344 | empty-string-1 |   |  |  |
-| 345 | empty-string-2 |   |  |  |
-| 346 | enforced-immutability |   |  |  |
-| 347 | entropy-1 |   |  |  |
-| 348 | entropy-2 |   |  |  |
-| 349 | entropy-narcissist |   |  |  |
-| 350 | enumerations-1 |   |  |  |
-| 351 | enumerations-2 |   |  |  |
-| 352 | enumerations-3 |   |  |  |
-| 353 | enumerations-4 |   |  |  |
-| 354 | environment-variables-1 |   |  |  |
-| 355 | environment-variables-2 |   |  |  |
-| 356 | equal-prime-and-composite-sums |   |  |  |
-| 357 | equilibrium-index |   |  |  |
-| 358 | erd-s-nicolas-numbers |   |  |  |
-| 359 | erd-s-selfridge-categorization-of-primes |   |  |  |
-| 360 | esthetic-numbers |   |  |  |
-| 361 | ethiopian-multiplication |   |  |  |
-| 362 | euclid-mullin-sequence |   |  |  |
-| 363 | euler-method |   |  |  |
-| 364 | eulers-constant-0.5772... |   |  |  |
-| 365 | eulers-identity |   |  |  |
-| 366 | eulers-sum-of-powers-conjecture |   |  |  |
-| 367 | evaluate-binomial-coefficients |   |  |  |
-| 368 | even-or-odd |   |  |  |
-| 369 | events |   |  |  |
-| 370 | evolutionary-algorithm |   |  |  |
-| 371 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
-| 372 | exceptions |   |  |  |
-| 373 | executable-library |   |  |  |
-| 374 | execute-a-markov-algorithm |   |  |  |
-| 375 | execute-a-system-command |   |  |  |
-| 376 | execute-brain- |   |  |  |
-| 377 | execute-computer-zero-1 |   |  |  |
-| 378 | execute-computer-zero |   |  |  |
-| 379 | execute-hq9+ |   |  |  |
-| 380 | execute-snusp |   |  |  |
-| 381 | exponentiation-operator-2 |   |  |  |
-| 382 | exponentiation-operator |   |  |  |
-| 383 | exponentiation-order |   |  |  |
-| 384 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
-| 385 | extend-your-language |   |  |  |
-| 386 | extensible-prime-generator |   |  |  |
-| 387 | extreme-floating-point-values |   |  |  |
-| 388 | faces-from-a-mesh-2 |   |  |  |
-| 389 | faces-from-a-mesh |   |  |  |
-| 390 | factorial-base-numbers-indexing-permutations-of-a-collection |   |  |  |
-| 391 | factorial-primes |   |  |  |
-| 392 | factorial |   |  |  |
-| 393 | factorions |   |  |  |
-| 394 | factors-of-a-mersenne-number |   |  |  |
-| 395 | factors-of-an-integer |   |  |  |
-| 396 | fairshare-between-two-and-more |   |  |  |
-| 397 | farey-sequence |   |  |  |
-| 398 | fast-fourier-transform |   |  |  |
-| 399 | fasta-format |   |  |  |
-| 400 | faulhabers-formula |   |  |  |
-| 401 | faulhabers-triangle |   |  |  |
-| 402 | feigenbaum-constant-calculation |   |  |  |
-| 403 | fermat-numbers |   |  |  |
-| 404 | fibonacci-n-step-number-sequences |   |  |  |
-| 405 | fibonacci-sequence-1 |   |  |  |
-| 406 | fibonacci-sequence-2 |   |  |  |
-| 407 | fibonacci-sequence-3 |   |  |  |
-| 408 | fibonacci-sequence-4 |   |  |  |
-| 409 | fibonacci-sequence-5 |   |  |  |
-| 410 | fibonacci-word-fractal |   |  |  |
-| 411 | fibonacci-word |   |  |  |
-| 412 | file-extension-is-in-extensions-list |   |  |  |
-| 413 | file-input-output-1 |   |  |  |
-| 414 | file-input-output-2 |   |  |  |
-| 415 | file-input-output-3 |   |  |  |
-| 416 | file-modification-time |   |  |  |
-| 417 | file-size-distribution |   |  |  |
-| 418 | file-size |   |  |  |
-| 419 | filter |   |  |  |
-| 420 | find-chess960-starting-position-identifier |   |  |  |
-| 421 | find-common-directory-path |   |  |  |
-| 422 | find-duplicate-files |   |  |  |
-| 423 | find-if-a-point-is-within-a-triangle |   |  |  |
-| 424 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
-| 425 | find-limit-of-recursion |   |  |  |
-| 426 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
-| 427 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
-| 428 | find-the-intersection-of-two-lines |   |  |  |
-| 429 | find-the-last-sunday-of-each-month |   |  |  |
-| 430 | find-the-missing-permutation |   |  |  |
-| 431 | fivenum-1 |   |  |  |
-| 432 | fivenum-2 |   |  |  |
-| 433 | fixed-length-records-1 |   |  |  |
-| 434 | fixed-length-records-2 |   |  |  |
-| 435 | fizzbuzz-1 |   |  |  |
-| 436 | fizzbuzz-2 |   |  |  |
-| 437 | flatten-a-list-1 |   |  |  |
-| 438 | flatten-a-list-2 |   |  |  |
-| 439 | flipping-bits-game |   |  |  |
-| 440 | flow-control-structures-1 |   |  |  |
-| 441 | flow-control-structures-2 |   |  |  |
-| 442 | flow-control-structures-3 |   |  |  |
-| 443 | flow-control-structures-4 |   |  |  |
-| 444 | floyd-warshall-algorithm |   |  |  |
-| 445 | floyds-triangle |   |  |  |
-| 446 | forest-fire |   |  |  |
-| 447 | fork |   |  |  |
-| 448 | ftp |   |  |  |
-| 449 | gamma-function |   |  |  |
-| 450 | general-fizzbuzz |   |  |  |
-| 451 | generic-swap |   |  |  |
-| 452 | get-system-command-output |   |  |  |
-| 453 | giuga-numbers |   |  |  |
-| 454 | globally-replace-text-in-several-files |   |  |  |
-| 455 | goldbachs-comet |   |  |  |
-| 456 | golden-ratio-convergence |   |  |  |
-| 457 | graph-colouring |   |  |  |
-| 458 | gray-code |   |  |  |
-| 459 | http |   |  |  |
-| 460 | image-noise |   |  |  |
-| 461 | loops-increment-loop-index-within-loop-body |   |  |  |
-| 462 | md5 |   |  |  |
-| 463 | nim-game |   |  |  |
-| 464 | plasma-effect |   |  |  |
-| 465 | sorting-algorithms-bubble-sort |   |  |  |
-| 466 | window-management |   |  |  |
-| 467 | zumkeller-numbers |   |  |  |
+| 17 | Find-if-a-point-is-within-a-triangle |   |  |  |
+| 18 | a+b | ✓ | 13.848ms | 18.3 MB |
+| 19 | abbreviations-automatic |   |  |  |
+| 20 | abbreviations-easy | ✓ | 48.779ms | 22.1 MB |
+| 21 | abbreviations-simple |   |  |  |
+| 22 | abc-problem | ✓ | 46.947ms | 20.6 MB |
+| 23 | abelian-sandpile-model-identity | ✓ |  |  |
+| 24 | abelian-sandpile-model |   |  |  |
+| 25 | abstract-type | ✓ | 24.271ms | 20.0 MB |
+| 26 | abundant-deficient-and-perfect-number-classifications | ✓ |  |  |
+| 27 | abundant-odd-numbers |   |  |  |
+| 28 | accumulator-factory |   |  |  |
+| 29 | achilles-numbers |   |  |  |
+| 30 | ackermann-function-2 |   |  |  |
+| 31 | ackermann-function-3 |   |  |  |
+| 32 | ackermann-function |   |  |  |
+| 33 | active-directory-connect | ✓ | 18.043ms | 18.7 MB |
+| 34 | active-directory-search-for-a-user | ✓ | 19.549ms | 24.3 MB |
+| 35 | active-object | ✓ | 37.262ms | 20.0 MB |
+| 36 | add-a-variable-to-a-class-instance-at-runtime |   | 15.428ms | 18.8 MB |
+| 37 | additive-primes |   | 76.429ms | 20.4 MB |
+| 38 | address-of-a-variable | ✓ | 14.698ms | 17.9 MB |
+| 39 | adfgvx-cipher |   |  |  |
+| 40 | aks-test-for-primes | ✓ |  |  |
+| 41 | algebraic-data-types |   |  |  |
+| 42 | align-columns | ✓ | 26.04ms | 22.4 MB |
+| 43 | aliquot-sequence-classifications | ✓ |  |  |
+| 44 | almkvist-giullera-formula-for-pi | ✓ |  |  |
+| 45 | almost-prime | ✓ |  |  |
+| 46 | amb | ✓ |  |  |
+| 47 | amicable-pairs | ✓ | 19.466429s | 19.4 MB |
+| 48 | anagrams-deranged-anagrams | ✓ |  |  |
+| 49 | anagrams | ✓ |  |  |
+| 50 | angle-difference-between-two-bearings-1 | ✓ | 24.659ms | 19.6 MB |
+| 51 | angle-difference-between-two-bearings-2 | ✓ | 22.483ms | 19.8 MB |
+| 52 | angles-geometric-normalization-and-conversion | ✓ | 42.981ms | 24.0 MB |
+| 53 | animate-a-pendulum | ✓ | 21.004ms | 20.7 MB |
+| 54 | animation | ✓ | 25.301ms | 18.7 MB |
+| 55 | anonymous-recursion-1 | ✓ | 49.151ms | 19.3 MB |
+| 56 | anonymous-recursion-2 | ✓ | 46.059ms | 19.4 MB |
+| 57 | anonymous-recursion | ✓ | 21.672ms | 18.8 MB |
+| 58 | anti-primes | ✓ | 64.874ms | 19.5 MB |
+| 59 | append-a-record-to-the-end-of-a-text-file | ✓ | 18.961ms | 18.7 MB |
+| 60 | apply-a-callback-to-an-array-1 | ✓ | 42.369ms | 18.4 MB |
+| 61 | apply-a-callback-to-an-array-2 | ✓ | 35.862ms | 19.6 MB |
+| 62 | apply-a-digital-filter-direct-form-ii-transposed- | ✓ | 20.222ms | 20.4 MB |
+| 63 | approximate-equality | ✓ | 61.528ms | 20.8 MB |
+| 64 | arbitrary-precision-integers-included- |   |  |  |
+| 65 | archimedean-spiral |   |  |  |
+| 66 | arena-storage-pool | ✓ | 44.229ms | 20.2 MB |
+| 67 | arithmetic-complex | ✓ | 46.769ms | 20.4 MB |
+| 68 | arithmetic-derivative | ✓ | 107.461ms | 21.8 MB |
+| 69 | arithmetic-evaluation |   |  |  |
+| 70 | arithmetic-geometric-mean-calculate-pi | ✓ | 44.656ms | 19.9 MB |
+| 71 | arithmetic-geometric-mean | ✓ |  |  |
+| 72 | arithmetic-integer-1 | ✓ | 46.082ms | 18.8 MB |
+| 73 | arithmetic-integer-2 | ✓ | 45.211ms | 18.7 MB |
+| 74 | arithmetic-numbers | ✓ | 13.288406s | 15.6 MB |
+| 75 | arithmetic-rational | ✓ | 64.993ms | 20.5 MB |
+| 76 | array-concatenation | ✓ | 77.149ms | 20.5 MB |
+| 77 | array-length | ✓ | 83.717ms | 18.3 MB |
+| 78 | arrays | ✓ | 22.914ms | 19.6 MB |
+| 79 | ascending-primes | ✓ | 19.607ms | 20.2 MB |
+| 80 | ascii-art-diagram-converter | ✓ | 15.277ms | 18.3 MB |
+| 81 | assertions | ✓ | 17.88ms | 18.1 MB |
+| 82 | associative-array-creation |   |  |  |
+| 83 | associative-array-iteration |   |  |  |
+| 84 | associative-array-merging |   |  |  |
+| 85 | atomic-updates | ✓ | 35.355ms | 21.9 MB |
+| 86 | attractive-numbers |   |  |  |
+| 87 | average-loop-length | ✓ | 1.388492s | 22.7 MB |
+| 88 | averages-arithmetic-mean | ✓ | 35.275ms | 19.5 MB |
+| 89 | averages-mean-time-of-day |   | 48.938ms | 24.4 MB |
+| 90 | averages-median-1 | ✓ | 20.46ms | 19.8 MB |
+| 91 | averages-median-2 | ✓ | 20.305ms | 19.4 MB |
+| 92 | averages-median-3 | ✓ | 21.63ms | 20.2 MB |
+| 93 | averages-mode | ✓ | 26.757ms | 19.9 MB |
+| 94 | averages-pythagorean-means | ✓ |  |  |
+| 95 | averages-root-mean-square | ✓ | 25.824ms | 18.8 MB |
+| 96 | averages-simple-moving-average | ✓ |  |  |
+| 97 | avl-tree | ✓ | 46.738ms | 25.6 MB |
+| 98 | b-zier-curves-intersections | ✓ | 279.112ms | 28.2 MB |
+| 99 | babbage-problem | ✓ | 155.667ms | 18.2 MB |
+| 100 | babylonian-spiral | ✓ | 415.891ms | 25.1 MB |
+| 101 | balanced-brackets | ✓ | 47.871ms | 20.7 MB |
+| 102 | balanced-ternary | ✓ | 48.758ms | 22.7 MB |
+| 103 | barnsley-fern | ✓ | 229.379ms | 22.3 MB |
+| 104 | base64-decode-data | ✓ |  |  |
+| 105 | bell-numbers |   |  |  |
+| 106 | benfords-law | ✓ |  |  |
+| 107 | bernoulli-numbers |   |  |  |
+| 108 | best-shuffle | ✓ |  |  |
+| 109 | bifid-cipher | ✓ |  |  |
+| 110 | bin-given-limits | ✓ |  |  |
+| 111 | binary-digits | ✓ | 40.119ms | 18.8 MB |
+| 112 | binary-search | ✓ | 43.13ms | 19.8 MB |
+| 113 | binary-strings | ✓ | 58.888ms | 20.1 MB |
+| 114 | bioinformatics-base-count | ✓ | 51.718ms | 19.5 MB |
+| 115 | bioinformatics-global-alignment | ✓ |  |  |
+| 116 | bioinformatics-sequence-mutation | ✓ | 70.13ms | 23.8 MB |
+| 117 | biorhythms | ✓ |  |  |
+| 118 | bitcoin-address-validation | ✓ |  |  |
+| 119 | bitmap-b-zier-curves-cubic | ✓ |  |  |
+| 120 | bitmap-b-zier-curves-quadratic | ✓ |  |  |
+| 121 | bitmap-bresenhams-line-algorithm | ✓ |  |  |
+| 122 | bitmap-flood-fill | ✓ |  |  |
+| 123 | bitmap-histogram | ✓ | 65.616ms | 22.0 MB |
+| 124 | bitmap-midpoint-circle-algorithm | ✓ | 48.451ms | 21.7 MB |
+| 125 | bitmap-ppm-conversion-through-a-pipe | ✓ | 1.140733s | 21.7 MB |
+| 126 | bitmap-read-a-ppm-file | ✓ |  |  |
+| 127 | bitmap-read-an-image-through-a-pipe |   |  |  |
+| 128 | bitmap-write-a-ppm-file |   |  |  |
+| 129 | bitmap |   |  |  |
+| 130 | bitwise-io-1 |   |  |  |
+| 131 | bitwise-io-2 |   |  |  |
+| 132 | bitwise-operations |   |  |  |
+| 133 | blum-integer |   |  |  |
+| 134 | boolean-values |   |  |  |
+| 135 | box-the-compass |   |  |  |
+| 136 | boyer-moore-string-search |   |  |  |
+| 137 | brazilian-numbers |   |  |  |
+| 138 | break-oo-privacy |   |  |  |
+| 139 | brilliant-numbers |   |  |  |
+| 140 | brownian-tree |   |  |  |
+| 141 | bulls-and-cows-player |   |  |  |
+| 142 | bulls-and-cows |   |  |  |
+| 143 | burrows-wheeler-transform |   |  |  |
+| 144 | caesar-cipher-1 |   |  |  |
+| 145 | caesar-cipher-2 |   |  |  |
+| 146 | calculating-the-value-of-e |   |  |  |
+| 147 | calendar---for-real-programmers-1 |   |  |  |
+| 148 | calendar---for-real-programmers-2 |   |  |  |
+| 149 | calendar |   |  |  |
+| 150 | calkin-wilf-sequence |   |  |  |
+| 151 | call-a-foreign-language-function |   |  |  |
+| 152 | call-a-function-1 |   |  |  |
+| 153 | call-a-function-10 |   |  |  |
+| 154 | call-a-function-11 |   |  |  |
+| 155 | call-a-function-12 |   |  |  |
+| 156 | call-a-function-2 |   |  |  |
+| 157 | call-a-function-3 |   |  |  |
+| 158 | call-a-function-4 |   |  |  |
+| 159 | call-a-function-5 |   |  |  |
+| 160 | call-a-function-6 |   |  |  |
+| 161 | call-a-function-7 |   |  |  |
+| 162 | call-a-function-8 |   |  |  |
+| 163 | call-a-function-9 |   |  |  |
+| 164 | call-an-object-method-1 |   |  |  |
+| 165 | call-an-object-method-2 |   |  |  |
+| 166 | call-an-object-method-3 |   |  |  |
+| 167 | call-an-object-method |   |  |  |
+| 168 | camel-case-and-snake-case |   |  |  |
+| 169 | canny-edge-detector |   |  |  |
+| 170 | canonicalize-cidr |   |  |  |
+| 171 | cantor-set |   |  |  |
+| 172 | carmichael-3-strong-pseudoprimes |   |  |  |
+| 173 | cartesian-product-of-two-or-more-lists-1 |   |  |  |
+| 174 | cartesian-product-of-two-or-more-lists-2 |   |  |  |
+| 175 | cartesian-product-of-two-or-more-lists-3 |   |  |  |
+| 176 | cartesian-product-of-two-or-more-lists-4 |   |  |  |
+| 177 | case-sensitivity-of-identifiers |   |  |  |
+| 178 | casting-out-nines |   |  |  |
+| 179 | catalan-numbers-1 |   |  |  |
+| 180 | catalan-numbers-2 |   |  |  |
+| 181 | catalan-numbers-pascals-triangle |   |  |  |
+| 182 | catamorphism |   |  |  |
+| 183 | catmull-clark-subdivision-surface |   |  |  |
+| 184 | chaocipher |   |  |  |
+| 185 | chaos-game |   |  |  |
+| 186 | character-codes-1 |   |  |  |
+| 187 | character-codes-2 |   |  |  |
+| 188 | character-codes-3 |   |  |  |
+| 189 | character-codes-4 |   |  |  |
+| 190 | character-codes-5 |   |  |  |
+| 191 | chat-server |   |  |  |
+| 192 | check-machin-like-formulas |   |  |  |
+| 193 | check-that-file-exists |   |  |  |
+| 194 | checkpoint-synchronization-1 |   |  |  |
+| 195 | checkpoint-synchronization-2 |   |  |  |
+| 196 | checkpoint-synchronization-3 |   |  |  |
+| 197 | checkpoint-synchronization-4 |   |  |  |
+| 198 | chernicks-carmichael-numbers |   |  |  |
+| 199 | cheryls-birthday |   |  |  |
+| 200 | chinese-remainder-theorem |   |  |  |
+| 201 | chinese-zodiac |   |  |  |
+| 202 | cholesky-decomposition-1 |   |  |  |
+| 203 | cholesky-decomposition |   |  |  |
+| 204 | chowla-numbers |   |  |  |
+| 205 | church-numerals-1 |   |  |  |
+| 206 | church-numerals-2 |   |  |  |
+| 207 | circles-of-given-radius-through-two-points |   |  |  |
+| 208 | circular-primes |   |  |  |
+| 209 | cistercian-numerals |   |  |  |
+| 210 | comma-quibbling |   |  |  |
+| 211 | compiler-virtual-machine-interpreter |   |  |  |
+| 212 | composite-numbers-k-with-no-single-digit-factors-whose-factors-are-all-substrings-of-k |   |  |  |
+| 213 | compound-data-type |   |  |  |
+| 214 | concurrent-computing-1 |   |  |  |
+| 215 | concurrent-computing-2 |   |  |  |
+| 216 | concurrent-computing-3 |   |  |  |
+| 217 | conditional-structures-1 |   |  |  |
+| 218 | conditional-structures-10 |   |  |  |
+| 219 | conditional-structures-2 |   |  |  |
+| 220 | conditional-structures-3 |   |  |  |
+| 221 | conditional-structures-4 |   |  |  |
+| 222 | conditional-structures-5 |   |  |  |
+| 223 | conditional-structures-6 |   |  |  |
+| 224 | conditional-structures-7 |   |  |  |
+| 225 | conditional-structures-8 |   |  |  |
+| 226 | conditional-structures-9 |   |  |  |
+| 227 | consecutive-primes-with-ascending-or-descending-differences |   |  |  |
+| 228 | constrained-genericity-1 |   |  |  |
+| 229 | constrained-genericity-2 |   |  |  |
+| 230 | constrained-genericity-3 |   |  |  |
+| 231 | constrained-genericity-4 |   |  |  |
+| 232 | constrained-random-points-on-a-circle-1 |   |  |  |
+| 233 | constrained-random-points-on-a-circle-2 |   |  |  |
+| 234 | continued-fraction |   |  |  |
+| 235 | convert-decimal-number-to-rational |   |  |  |
+| 236 | convert-seconds-to-compound-duration |   |  |  |
+| 237 | convex-hull |   |  |  |
+| 238 | conways-game-of-life |   |  |  |
+| 239 | copy-a-string-1 |   |  |  |
+| 240 | copy-a-string-2 |   |  |  |
+| 241 | copy-stdin-to-stdout-1 |   |  |  |
+| 242 | copy-stdin-to-stdout-2 |   |  |  |
+| 243 | count-in-factors |   |  |  |
+| 244 | count-in-octal-1 |   |  |  |
+| 245 | count-in-octal-2 |   |  |  |
+| 246 | count-in-octal-3 |   |  |  |
+| 247 | count-in-octal-4 |   |  |  |
+| 248 | count-occurrences-of-a-substring |   |  |  |
+| 249 | count-the-coins-1 |   |  |  |
+| 250 | count-the-coins-2 | ✓ | 58.829ms | 19.6 MB |
+| 251 | cramers-rule |   |  |  |
+| 252 | crc-32-1 |   |  |  |
+| 253 | crc-32-2 |   |  |  |
+| 254 | create-a-file-on-magnetic-tape |   |  |  |
+| 255 | create-a-file |   |  |  |
+| 256 | create-a-two-dimensional-array-at-runtime-1 |   |  |  |
+| 257 | create-an-html-table |   |  |  |
+| 258 | create-an-object-at-a-given-address |   |  |  |
+| 259 | csv-data-manipulation |   |  |  |
+| 260 | csv-to-html-translation-1 |   |  |  |
+| 261 | csv-to-html-translation-2 |   |  |  |
+| 262 | csv-to-html-translation-3 |   |  |  |
+| 263 | csv-to-html-translation-4 |   |  |  |
+| 264 | csv-to-html-translation-5 |   |  |  |
+| 265 | cuban-primes |   |  |  |
+| 266 | cullen-and-woodall-numbers |   |  |  |
+| 267 | cumulative-standard-deviation |   |  |  |
+| 268 | currency |   |  |  |
+| 269 | currying |   |  |  |
+| 270 | curzon-numbers |   |  |  |
+| 271 | cusip |   |  |  |
+| 272 | cyclops-numbers |   |  |  |
+| 273 | damm-algorithm |   |  |  |
+| 274 | date-format |   |  |  |
+| 275 | date-manipulation |   |  |  |
+| 276 | day-of-the-week |   |  |  |
+| 277 | de-bruijn-sequences |   |  |  |
+| 278 | deal-cards-for-freecell |   |  |  |
+| 279 | death-star |   |  |  |
+| 280 | deceptive-numbers |   |  |  |
+| 281 | deconvolution-1d-2 |   |  |  |
+| 282 | deconvolution-1d-3 |   |  |  |
+| 283 | deconvolution-1d |   |  |  |
+| 284 | deepcopy-1 |   |  |  |
+| 285 | define-a-primitive-data-type |   |  |  |
+| 286 | delegates |   |  |  |
+| 287 | demings-funnel |   |  |  |
+| 288 | department-numbers |   |  |  |
+| 289 | descending-primes |   |  |  |
+| 290 | detect-division-by-zero |   |  |  |
+| 291 | determine-if-a-string-has-all-the-same-characters |   |  |  |
+| 292 | determine-if-a-string-has-all-unique-characters |   |  |  |
+| 293 | determine-if-a-string-is-collapsible |   |  |  |
+| 294 | determine-if-a-string-is-numeric-1 |   |  |  |
+| 295 | determine-if-a-string-is-numeric-2 |   |  |  |
+| 296 | determine-if-a-string-is-squeezable |   |  |  |
+| 297 | determine-if-only-one-instance-is-running |   |  |  |
+| 298 | determine-if-two-triangles-overlap |   |  |  |
+| 299 | determine-sentence-type |   |  |  |
+| 300 | dice-game-probabilities-1 |   |  |  |
+| 301 | dice-game-probabilities-2 |   |  |  |
+| 302 | digital-root-multiplicative-digital-root |   |  |  |
+| 303 | dijkstras-algorithm |   |  |  |
+| 304 | dinesmans-multiple-dwelling-problem |   |  |  |
+| 305 | dining-philosophers-1 |   |  |  |
+| 306 | dining-philosophers-2 |   |  |  |
+| 307 | disarium-numbers |   |  |  |
+| 308 | discordian-date |   |  |  |
+| 309 | display-a-linear-combination |   |  |  |
+| 310 | display-an-outline-as-a-nested-table |   |  |  |
+| 311 | distance-and-bearing |   |  |  |
+| 312 | distributed-programming |   |  |  |
+| 313 | diversity-prediction-theorem |   |  |  |
+| 314 | documentation |   |  |  |
+| 315 | doomsday-rule |   |  |  |
+| 316 | dot-product |   |  |  |
+| 317 | doubly-linked-list-definition-1 |   |  |  |
+| 318 | doubly-linked-list-definition-2 |   |  |  |
+| 319 | doubly-linked-list-element-definition |   |  |  |
+| 320 | doubly-linked-list-traversal |   |  |  |
+| 321 | dragon-curve |   |  |  |
+| 322 | draw-a-clock |   |  |  |
+| 323 | draw-a-cuboid |   |  |  |
+| 324 | draw-a-pixel-1 |   |  |  |
+| 325 | draw-a-rotating-cube |   |  |  |
+| 326 | draw-a-sphere |   |  |  |
+| 327 | dutch-national-flag-problem |   |  |  |
+| 328 | dynamic-variable-names |   |  |  |
+| 329 | earliest-difference-between-prime-gaps |   |  |  |
+| 330 | eban-numbers |   |  |  |
+| 331 | ecdsa-example |   |  |  |
+| 332 | echo-server |   |  |  |
+| 333 | eertree |   |  |  |
+| 334 | egyptian-division |   |  |  |
+| 335 | ekg-sequence-convergence |   |  |  |
+| 336 | element-wise-operations |   |  |  |
+| 337 | elementary-cellular-automaton-infinite-length |   |  |  |
+| 338 | elementary-cellular-automaton-random-number-generator |   |  |  |
+| 339 | elementary-cellular-automaton |   |  |  |
+| 340 | elliptic-curve-arithmetic |   |  |  |
+| 341 | elliptic-curve-digital-signature-algorithm |   |  |  |
+| 342 | emirp-primes |   |  |  |
+| 343 | empty-directory |   |  |  |
+| 344 | empty-program |   |  |  |
+| 345 | empty-string-1 |   |  |  |
+| 346 | empty-string-2 |   |  |  |
+| 347 | enforced-immutability |   |  |  |
+| 348 | entropy-1 |   |  |  |
+| 349 | entropy-2 |   |  |  |
+| 350 | entropy-narcissist |   |  |  |
+| 351 | enumerations-1 |   |  |  |
+| 352 | enumerations-2 |   |  |  |
+| 353 | enumerations-3 |   |  |  |
+| 354 | enumerations-4 |   |  |  |
+| 355 | environment-variables-1 |   |  |  |
+| 356 | environment-variables-2 |   |  |  |
+| 357 | equal-prime-and-composite-sums |   |  |  |
+| 358 | equilibrium-index |   |  |  |
+| 359 | erd-s-nicolas-numbers |   |  |  |
+| 360 | erd-s-selfridge-categorization-of-primes |   |  |  |
+| 361 | esthetic-numbers |   |  |  |
+| 362 | ethiopian-multiplication |   |  |  |
+| 363 | euclid-mullin-sequence |   |  |  |
+| 364 | euler-method |   |  |  |
+| 365 | eulers-constant-0.5772... |   |  |  |
+| 366 | eulers-identity |   |  |  |
+| 367 | eulers-sum-of-powers-conjecture |   |  |  |
+| 368 | evaluate-binomial-coefficients |   |  |  |
+| 369 | even-or-odd |   |  |  |
+| 370 | events |   |  |  |
+| 371 | evolutionary-algorithm |   |  |  |
+| 372 | exceptions-catch-an-exception-thrown-in-a-nested-call |   |  |  |
+| 373 | exceptions |   |  |  |
+| 374 | executable-library |   |  |  |
+| 375 | execute-a-markov-algorithm |   |  |  |
+| 376 | execute-a-system-command |   |  |  |
+| 377 | execute-brain- |   |  |  |
+| 378 | execute-computer-zero-1 |   |  |  |
+| 379 | execute-computer-zero |   |  |  |
+| 380 | execute-hq9+ |   |  |  |
+| 381 | execute-snusp |   |  |  |
+| 382 | exponentiation-operator-2 |   |  |  |
+| 383 | exponentiation-operator |   |  |  |
+| 384 | exponentiation-order |   |  |  |
+| 385 | exponentiation-with-infix-operators-in-or-operating-on-the-base |   |  |  |
+| 386 | extend-your-language |   |  |  |
+| 387 | extensible-prime-generator |   |  |  |
+| 388 | extreme-floating-point-values |   |  |  |
+| 389 | faces-from-a-mesh-2 |   |  |  |
+| 390 | faces-from-a-mesh |   |  |  |
+| 391 | factorial-base-numbers-indexing-permutations-of-a-collection |   |  |  |
+| 392 | factorial-primes |   |  |  |
+| 393 | factorial |   |  |  |
+| 394 | factorions |   |  |  |
+| 395 | factors-of-a-mersenne-number |   |  |  |
+| 396 | factors-of-an-integer |   |  |  |
+| 397 | fairshare-between-two-and-more |   |  |  |
+| 398 | farey-sequence |   |  |  |
+| 399 | fast-fourier-transform |   |  |  |
+| 400 | fasta-format |   |  |  |
+| 401 | faulhabers-formula |   |  |  |
+| 402 | faulhabers-triangle |   |  |  |
+| 403 | feigenbaum-constant-calculation |   |  |  |
+| 404 | fermat-numbers |   |  |  |
+| 405 | fibonacci-n-step-number-sequences |   |  |  |
+| 406 | fibonacci-sequence-1 |   |  |  |
+| 407 | fibonacci-sequence-2 |   |  |  |
+| 408 | fibonacci-sequence-3 |   |  |  |
+| 409 | fibonacci-sequence-4 |   |  |  |
+| 410 | fibonacci-sequence-5 |   |  |  |
+| 411 | fibonacci-word-fractal |   |  |  |
+| 412 | fibonacci-word |   |  |  |
+| 413 | file-extension-is-in-extensions-list |   |  |  |
+| 414 | file-input-output-1 |   |  |  |
+| 415 | file-input-output-2 |   |  |  |
+| 416 | file-input-output-3 |   |  |  |
+| 417 | file-modification-time |   |  |  |
+| 418 | file-size-distribution |   |  |  |
+| 419 | file-size |   |  |  |
+| 420 | filter |   |  |  |
+| 421 | find-chess960-starting-position-identifier-2 |   |  |  |
+| 422 | find-chess960-starting-position-identifier |   |  |  |
+| 423 | find-common-directory-path |   |  |  |
+| 424 | find-duplicate-files |   |  |  |
+| 425 | find-if-a-point-is-within-a-triangle |   |  |  |
+| 426 | find-largest-left-truncatable-prime-in-a-given-base |   |  |  |
+| 427 | find-limit-of-recursion |   |  |  |
+| 428 | find-palindromic-numbers-in-both-binary-and-ternary-bases |   |  |  |
+| 429 | find-the-intersection-of-a-line-with-a-plane |   |  |  |
+| 430 | find-the-intersection-of-two-lines |   |  |  |
+| 431 | find-the-last-sunday-of-each-month |   |  |  |
+| 432 | find-the-missing-permutation |   |  |  |
+| 433 | first-class-environments |   |  |  |
+| 434 | first-class-functions-use-numbers-analogously |   |  |  |
+| 435 | first-power-of-2-that-has-leading-decimal-digits-of-12 |   |  |  |
+| 436 | five-weekends |   |  |  |
+| 437 | fivenum-1 |   |  |  |
+| 438 | fivenum-2 |   |  |  |
+| 439 | fivenum-3 |   |  |  |
+| 440 | fixed-length-records-1 |   |  |  |
+| 441 | fixed-length-records-2 |   |  |  |
+| 442 | fizzbuzz-1 |   |  |  |
+| 443 | fizzbuzz-2 |   |  |  |
+| 444 | fizzbuzz |   |  |  |
+| 445 | flatten-a-list-1 |   |  |  |
+| 446 | flatten-a-list-2 |   |  |  |
+| 447 | flipping-bits-game |   |  |  |
+| 448 | flow-control-structures-1 |   |  |  |
+| 449 | flow-control-structures-2 |   |  |  |
+| 450 | flow-control-structures-3 |   |  |  |
+| 451 | flow-control-structures-4 |   |  |  |
+| 452 | floyd-warshall-algorithm |   |  |  |
+| 453 | floyd-warshall-algorithm2 |   |  |  |
+| 454 | floyds-triangle |   |  |  |
+| 455 | forest-fire |   |  |  |
+| 456 | fork-2 |   |  |  |
+| 457 | fork |   |  |  |
+| 458 | formal-power-series |   |  |  |
+| 459 | formatted-numeric-output |   |  |  |
+| 460 | forward-difference |   |  |  |
+| 461 | four-bit-adder-1 |   |  |  |
+| 462 | four-is-magic |   |  |  |
+| 463 | four-is-the-number-of-letters-in-the-... |   |  |  |
+| 464 | fractal-tree |   |  |  |
+| 465 | fractran |   |  |  |
+| 466 | french-republican-calendar |   |  |  |
+| 467 | ftp |   |  |  |
+| 468 | function-frequency |   |  |  |
+| 469 | function-prototype |   |  |  |
+| 470 | functional-coverage-tree |   |  |  |
+| 471 | fusc-sequence |   |  |  |
+| 472 | gamma-function |   |  |  |
+| 473 | general-fizzbuzz |   |  |  |
+| 474 | generic-swap |   |  |  |
+| 475 | get-system-command-output |   |  |  |
+| 476 | giuga-numbers |   |  |  |
+| 477 | globally-replace-text-in-several-files |   |  |  |
+| 478 | goldbachs-comet |   |  |  |
+| 479 | golden-ratio-convergence |   |  |  |
+| 480 | graph-colouring |   |  |  |
+| 481 | gray-code |   |  |  |
+| 482 | gui-component-interaction |   |  |  |
+| 483 | gui-enabling-disabling-of-controls |   |  |  |
+| 484 | gui-maximum-window-dimensions |   |  |  |
+| 485 | http |   |  |  |
+| 486 | image-noise |   |  |  |
+| 487 | loops-increment-loop-index-within-loop-body |   |  |  |
+| 488 | md5 |   |  |  |
+| 489 | nim-game |   |  |  |
+| 490 | plasma-effect |   |  |  |
+| 491 | sorting-algorithms-bubble-sort |   |  |  |
+| 492 | window-management |   |  |  |
+| 493 | zumkeller-numbers |   |  |  |


### PR DESCRIPTION
## Summary
- generate `count-the-coins-2.clj` using the Clojure transpiler
- add expected output and benchmark result
- update Rosetta progress table

## Testing
- `go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index 250 -count=1`
- `MOCHI_BENCHMARK=1 go test ./transpiler/x/clj -tags slow -run TestRosettaClojure -index 250 -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6886faacb4d48320aa1b3ba9258ca311