### PR TITLE
Update Kotlin transpiler rosetta outputs

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
@@ -1,0 +1,1 @@
+{"duration_us":8120, "memory_bytes":137320, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.kt
+++ b/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.kt
@@ -1,0 +1,87 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val n: MutableList<Int> = mutableListOf(3, 5, 7)
+val a: MutableList<Int> = mutableListOf(2, 3, 2)
+val res: Int = crt(a, n)
+fun egcd(a: Int, b: Int): MutableList<Int> {
+    if (a == 0) {
+        return mutableListOf(b, 0, 1)
+    }
+    val res: MutableList<Int> = egcd(Math.floorMod(b, a), a)
+    val g: Int = res[0]
+    val x1: Int = res[1]
+    val y1: Int = res[2]
+    return mutableListOf(g, y1 - ((b / a) * x1), x1)
+}
+
+fun modInv(a: Int, m: Int): Int {
+    val r: MutableList<Int> = egcd(a, m)
+    if (r[0] != 1) {
+        return 0
+    }
+    val x: Int = r[1]
+    if (x < 0) {
+        return x + m
+    }
+    return x
+}
+
+fun crt(a: MutableList<Int>, n: MutableList<Int>): Int {
+    var prod: Int = 1
+    var i: Int = 0
+    while (i < n.size) {
+        prod = prod * n[i]
+        i = i + 1
+    }
+    var x: Int = 0
+    i = 0
+    while (i < n.size) {
+        val ni: Int = n[i]
+        val ai: Int = a[i]
+        val p: Int = prod / ni
+        val inv: Int = modInv(Math.floorMod(p, ni), ni)
+        x = x + ((ai * inv) * p)
+        i = i + 1
+    }
+    return Math.floorMod(x, prod)
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println(res.toString() + " <nil>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
@@ -1,0 +1,1 @@
+{"duration_us":10602, "memory_bytes":127112, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
@@ -1,0 +1,60 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+data class Info(var animal: String, var yinYang: String, var element: String, var stemBranch: String, var cycle: Int)
+val animal: MutableList<String> = mutableListOf("Rat", "Ox", "Tiger", "Rabbit", "Dragon", "Snake", "Horse", "Goat", "Monkey", "Rooster", "Dog", "Pig")
+val yinYang: MutableList<String> = mutableListOf("Yang", "Yin")
+val element: MutableList<String> = mutableListOf("Wood", "Fire", "Earth", "Metal", "Water")
+val stemChArr: MutableList<String> = mutableListOf("甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸")
+val branchChArr: MutableList<String> = mutableListOf("子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥")
+fun cz(yr: Int, animal: MutableList<String>, yinYang: MutableList<String>, element: MutableList<String>, sc: MutableList<String>, bc: MutableList<String>): Info {
+    var y: BigInteger = (yr - 4).toBigInteger()
+    val stem: BigInteger = y.remainder(10.toBigInteger())
+    val branch: BigInteger = y.remainder(12.toBigInteger())
+    val sb: String = sc[(stem).toInt()] + bc[(branch).toInt()]
+    return Info(animal = (animal[(branch).toInt()]).toString(), yinYang = (yinYang[(stem.remainder(2.toBigInteger())).toInt()]).toString(), element = (element[(stem.divide(2.toBigInteger())).toInt()]).toString(), stemBranch = sb, cycle = ((y.remainder(60.toBigInteger())).add(1.toBigInteger())).toInt())
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (yr in mutableListOf(1935, 1938, 1968, 1972, 1976)) {
+            val r: Info = cz(yr, animal, yinYang, element, stemChArr, branchChArr)
+            println((((((((((yr.toString() + ": ") + r.element) + " ") + r.animal) + ", ") + r.yinYang) + ", Cycle year ") + r.cycle.toString()) + " ") + r.stemBranch)
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.error
+++ b/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.error
@@ -1,0 +1,35 @@
+OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:53:67: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, ???>.get(key: Int): ??? defined in kotlin.collections
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+                                                                  ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:53:70: error: no get method providing array access
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+                                                                     ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:67:30: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@SinceKotlin @InlineOnly public inline fun Int.toBigInteger(): BigInteger defined in kotlin
+@SinceKotlin @InlineOnly public inline fun Long.toBigInteger(): BigInteger defined in kotlin
+@SinceKotlin @InlineOnly public inline fun String.toBigInteger(): BigInteger defined in kotlin.text
+@SinceKotlin @InlineOnly public inline fun String.toBigInteger(radix: Int): BigInteger defined in kotlin.text
+        while (c.compareTo(n.toBigInteger()) < 0) {
+                             ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:107:67: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, ???>.get(key: Int): ??? defined in kotlin.collections
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+                                                                  ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:107:70: error: no get method providing array access
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+                                                                     ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:126:21: error: unresolved reference: size
+    while (idx < ae.size) {
+                    ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:135:19: error: unresolved reference: size
+    while (i < ae.size) {
+                  ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:136:17: error: unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
+@InlineOnly public inline operator fun <@OnlyInputTypes K, V> Map<out Int, ???>.get(key: Int): ??? defined in kotlin.collections
+        val e = ae[i]
+                ^
+/workspace/mochi/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt:136:19: error: no get method providing array access
+        val e = ae[i]
+                  ^

--- a/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt
+++ b/tests/rosetta/transpiler/Kotlin/cholesky-decomposition-1.kt
@@ -1,0 +1,186 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+fun sqrtApprox(x: Double): Double {
+    var guess: Double = x
+    var i: Int = 0
+    while (i < 20) {
+        guess = (guess + (x / guess)) / 2.0
+        i = i + 1
+    }
+    return guess
+}
+
+fun makeSym(order: Int, elements: MutableList<Double>): MutableMap<String, Any?> {
+    return mutableMapOf<String, Any?>("order" to (order), "ele" to (elements))
+}
+
+fun unpackSym(m: MutableMap<String, Any?>): MutableList<MutableList<Double>> {
+    val n: Any? = (m)["order"] as Any?
+    val ele: Any? = (m)["ele"] as Any?
+    var mat: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>()
+    var idx: Int = 0
+    var r: Int = 0
+    while ((r).toInt() < (n as Number).toDouble()) {
+        var row: MutableList<Double> = mutableListOf<Double>()
+        var c: Int = 0
+        while (c <= r) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+            idx = idx + 1
+            c = c + 1
+        }
+        while ((c).toInt() < (n as Number).toDouble()) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add(0.0); _tmp } as MutableList<Double>
+            c = c + 1
+        }
+        mat = run { val _tmp = mat.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Double>>
+        r = r + 1
+    }
+    r = 0
+    while ((r).toInt() < (n as Number).toDouble()) {
+        var c: BigInteger = (r + 1).toBigInteger()
+        while (c.compareTo(n.toBigInteger()) < 0) {
+            mat[r][(c).toInt()] = mat[(c).toInt()][r]
+            c = c.add(1.toBigInteger())
+        }
+        r = r + 1
+    }
+    return mat
+}
+
+fun printMat(m: MutableList<MutableList<Double>>): Unit {
+    var i: Int = 0
+    while (i < m.size) {
+        var line: String = ""
+        var j: Int = 0
+        while (j < (m[i]).size) {
+            line = line + (m[i][j]).toString()
+            if (j < ((m[i]).size - 1)) {
+                line = line + " "
+            }
+            j = j + 1
+        }
+        println(line)
+        i = i + 1
+    }
+}
+
+fun printSym(m: MutableMap<String, Any?>): Unit {
+    printMat(unpackSym(m))
+}
+
+fun printLower(m: MutableMap<String, Any?>): Unit {
+    val n: Any? = (m)["order"] as Any?
+    val ele: Any? = (m)["ele"] as Any?
+    var mat: MutableList<MutableList<Double>> = mutableListOf<MutableList<Double>>()
+    var idx: Int = 0
+    var r: Int = 0
+    while ((r).toInt() < (n as Number).toDouble()) {
+        var row: MutableList<Double> = mutableListOf<Double>()
+        var c: Int = 0
+        while (c <= r) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add((ele[idx]).toDouble()); _tmp } as MutableList<Double>
+            idx = idx + 1
+            c = c + 1
+        }
+        while ((c).toInt() < (n as Number).toDouble()) {
+            row = run { val _tmp = row.toMutableList(); _tmp.add(0.0); _tmp } as MutableList<Double>
+            c = c + 1
+        }
+        mat = run { val _tmp = mat.toMutableList(); _tmp.add(row); _tmp } as MutableList<MutableList<Double>>
+        r = r + 1
+    }
+    printMat(mat)
+}
+
+fun choleskyLower(a: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    val n: Any? = (a)["order"] as Any?
+    val ae: Any? = (a)["ele"] as Any?
+    var le: MutableList<Double> = mutableListOf<Double>()
+    var idx: Int = 0
+    while (idx < ae.size) {
+        le = run { val _tmp = le.toMutableList(); _tmp.add(0.0); _tmp } as MutableList<Double>
+        idx = idx + 1
+    }
+    var row: Int = 1
+    var col: Int = 1
+    var dr: Int = 0
+    var dc: Int = 0
+    var i: Int = 0
+    while (i < ae.size) {
+        val e = ae[i]
+        if (i < dr) {
+            var d: Double = ((e as Number).toDouble() - le[i]) / le[dc]
+            le[i] = d
+            var ci: Int = col
+            var cx: Int = dc
+            var j: BigInteger = (i + 1).toBigInteger()
+            while (j.compareTo(dr.toBigInteger()) <= 0) {
+                cx = cx + ci
+                ci = ci + 1
+                le[(j).toInt()] = le[(j).toInt()] + (d * le[cx])
+                j = j.add(1.toBigInteger())
+            }
+            col = col + 1
+            dc = dc + col
+        } else {
+            le[i] = sqrtApprox((e as Number).toDouble() - le[i])
+            row = row + 1
+            dr = dr + row
+            col = 1
+            dc = 0
+        }
+        i = i + 1
+    }
+    return mutableMapOf<String, Any?>("order" to (n), "ele" to (le))
+}
+
+fun demo(a: MutableMap<String, Any?>): Unit {
+    println("A:")
+    printSym(a)
+    println("L:")
+    val l: MutableMap<String, Any?> = choleskyLower(a)
+    printLower(l)
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        demo(makeSym(3, mutableListOf(25.0, 15.0, 18.0, 0.0 - 5.0, 0.0, 11.0)))
+        demo(makeSym(4, mutableListOf(18.0, 22.0, 70.0, 54.0, 86.0, 174.0, 42.0, 62.0, 134.0, 106.0)))
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/README.md
+++ b/transpiler/x/kt/README.md
@@ -2,7 +2,7 @@
 
 Generated Kotlin sources for golden tests are stored in `tests/transpiler/x/kt`.
 
-Last updated: 2025-07-28 11:26 +0700
+Last updated: 2025-07-28 11:42 +0700
 
 The transpiler currently supports expression programs with `print`, integer and list literals, mutable variables and built-ins `count`, `sum`, `avg`, `len`, `str`, `append`, `min`, `max`, `substring` and `values`.
 

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-28 11:26 +0700
+Last updated: 2025-07-28 11:42 +0700
 
-Completed tasks: **126/493**
+Completed tasks: **128/493**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -208,8 +208,8 @@ Completed tasks: **126/493**
 | 197 | checkpoint-synchronization-4 |  |  |  |
 | 198 | chernicks-carmichael-numbers |  |  |  |
 | 199 | cheryls-birthday |  |  |  |
-| 200 | chinese-remainder-theorem |  |  |  |
-| 201 | chinese-zodiac |  |  |  |
+| 200 | chinese-remainder-theorem | ✓ | 8.12ms | 134.1 KB |
+| 201 | chinese-zodiac | ✓ | 10.60ms | 124.1 KB |
 | 202 | cholesky-decomposition-1 |  |  |  |
 | 203 | cholesky-decomposition |  |  |  |
 | 204 | chowla-numbers |  |  |  |

--- a/transpiler/x/kt/TASKS.md
+++ b/transpiler/x/kt/TASKS.md
@@ -1,3 +1,21 @@
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
+## VM Golden Progress (2025-07-28 11:42 +0700)
+- Regenerated Kotlin golden files and README
+
 ## VM Golden Progress (2025-07-28 11:26 +0700)
 - Regenerated Kotlin golden files and README
 


### PR DESCRIPTION
## Summary
- update Kotlin transpiler code generation to handle BigInteger casts when building structs
- improve type casting for comparisons with `Any?`
- generate Kotlin sources for `chinese-remainder-theorem` and `chinese-zodiac`
- include failing output for `cholesky-decomposition-1`
- refresh transpiler progress docs

## Testing
- `ROSETTA_INDEX=201 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1`
- `ROSETTA_INDEX=202 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags=slow -count=1` *(fails: program failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886ff9250788320a6089f3285b99260