### PR TITLE
Add int cast for struct literals in Kotlin transpiler

### DIFF
--- a/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.bench
@@ -1,0 +1,1 @@
+{"duration_us":6844, "memory_bytes":137320, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.kt
+++ b/tests/rosetta/transpiler/Kotlin/chinese-remainder-theorem.kt
@@ -1,0 +1,87 @@
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+val n: MutableList<Int> = mutableListOf(3, 5, 7)
+val a: MutableList<Int> = mutableListOf(2, 3, 2)
+val res: Int = crt(a, n)
+fun egcd(a: Int, b: Int): MutableList<Int> {
+    if (a == 0) {
+        return mutableListOf(b, 0, 1)
+    }
+    val res: MutableList<Int> = egcd(Math.floorMod(b, a), a)
+    val g: Int = res[0]
+    val x1: Int = res[1]
+    val y1: Int = res[2]
+    return mutableListOf(g, y1 - ((b / a) * x1), x1)
+}
+
+fun modInv(a: Int, m: Int): Int {
+    val r: MutableList<Int> = egcd(a, m)
+    if (r[0] != 1) {
+        return 0
+    }
+    val x: Int = r[1]
+    if (x < 0) {
+        return x + m
+    }
+    return x
+}
+
+fun crt(a: MutableList<Int>, n: MutableList<Int>): Int {
+    var prod: Int = 1
+    var i: Int = 0
+    while (i < n.size) {
+        prod = prod * n[i]
+        i = i + 1
+    }
+    var x: Int = 0
+    i = 0
+    while (i < n.size) {
+        val ni: Int = n[i]
+        val ai: Int = a[i]
+        val p: Int = prod / ni
+        val inv: Int = modInv(Math.floorMod(p, ni), ni)
+        x = x + ((ai * inv) * p)
+        i = i + 1
+    }
+    return Math.floorMod(x, prod)
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        println(res.toString() + " <nil>")
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.bench
@@ -1,0 +1,1 @@
+{"duration_us":8944, "memory_bytes":127112, "name":"main"}

--- a/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
+++ b/tests/rosetta/transpiler/Kotlin/chinese-zodiac.kt
@@ -1,0 +1,60 @@
+import java.math.BigInteger
+
+var _nowSeed = 0L
+var _nowSeeded = false
+fun _now(): Long {
+    if (!_nowSeeded) {
+        System.getenv("MOCHI_NOW_SEED")?.toLongOrNull()?.let {
+            _nowSeed = it
+            _nowSeeded = true
+        }
+    }
+    return if (_nowSeeded) {
+        _nowSeed = (_nowSeed * 1664525 + 1013904223) % 2147483647
+        kotlin.math.abs(_nowSeed)
+    } else {
+        kotlin.math.abs(System.nanoTime())
+    }
+}
+
+fun toJson(v: Any?): String = when (v) {
+    null -> "null"
+    is String -> "\"" + v.replace("\"", "\\\"") + "\""
+    is Boolean, is Number -> v.toString()
+    is Map<*, *> -> v.entries.joinToString(prefix = "{", postfix = "}") { toJson(it.key.toString()) + ":" + toJson(it.value) }
+    is Iterable<*> -> v.joinToString(prefix = "[", postfix = "]") { toJson(it) }
+    else -> toJson(v.toString())
+}
+
+data class Info(var animal: String, var yinYang: String, var element: String, var stemBranch: String, var cycle: Int)
+val animal: MutableList<String> = mutableListOf("Rat", "Ox", "Tiger", "Rabbit", "Dragon", "Snake", "Horse", "Goat", "Monkey", "Rooster", "Dog", "Pig")
+val yinYang: MutableList<String> = mutableListOf("Yang", "Yin")
+val element: MutableList<String> = mutableListOf("Wood", "Fire", "Earth", "Metal", "Water")
+val stemChArr: MutableList<String> = mutableListOf("甲", "乙", "丙", "丁", "戊", "己", "庚", "辛", "壬", "癸")
+val branchChArr: MutableList<String> = mutableListOf("子", "丑", "寅", "卯", "辰", "巳", "午", "未", "申", "酉", "戌", "亥")
+fun cz(yr: Int, animal: MutableList<String>, yinYang: MutableList<String>, element: MutableList<String>, sc: MutableList<String>, bc: MutableList<String>): Info {
+    var y: BigInteger = (yr - 4).toBigInteger()
+    val stem: BigInteger = y.remainder(10.toBigInteger())
+    val branch: BigInteger = y.remainder(12.toBigInteger())
+    val sb: String = sc[(stem).toInt()] + bc[(branch).toInt()]
+    return Info(animal = (animal[(branch).toInt()]).toString(), yinYang = (yinYang[(stem.remainder(2.toBigInteger())).toInt()]).toString(), element = (element[(stem.divide(2.toBigInteger())).toInt()]).toString(), stemBranch = sb, cycle = ((y.remainder(60.toBigInteger())).add(1.toBigInteger())).toInt())
+}
+
+fun main() {
+    run {
+        System.gc()
+        val _startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _start = _now()
+        for (yr in mutableListOf(1935, 1938, 1968, 1972, 1976)) {
+            val r: Info = cz(yr, animal, yinYang, element, stemChArr, branchChArr)
+            println((((((((((yr.toString() + ": ") + r.element) + " ") + r.animal) + ", ") + r.yinYang) + ", Cycle year ") + r.cycle.toString()) + " ") + r.stemBranch)
+        }
+        System.gc()
+        val _end = _now()
+        val _endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+        val _durationUs = (_end - _start) / 1000
+        val _memDiff = kotlin.math.abs(_endMem - _startMem)
+        val _res = mapOf("duration_us" to _durationUs, "memory_bytes" to _memDiff, "name" to "main")
+        println(toJson(_res))
+    }
+}

--- a/transpiler/x/kt/ROSETTA.md
+++ b/transpiler/x/kt/ROSETTA.md
@@ -2,9 +2,9 @@
 
 Generated Kotlin sources for Rosetta Code tests are stored in `tests/rosetta/transpiler/Kotlin`.
 
-Last updated: 2025-07-28 11:26 +0700
+Last updated: 2025-07-28 11:43 +0700
 
-Completed tasks: **126/493**
+Completed tasks: **128/493**
 
 ### Checklist
 | Index | Name | Status | Duration | Memory |
@@ -208,8 +208,8 @@ Completed tasks: **126/493**
 | 197 | checkpoint-synchronization-4 |  |  |  |
 | 198 | chernicks-carmichael-numbers |  |  |  |
 | 199 | cheryls-birthday |  |  |  |
-| 200 | chinese-remainder-theorem |  |  |  |
-| 201 | chinese-zodiac |  |  |  |
+| 200 | chinese-remainder-theorem | ✓ | 6.84ms | 134.1 KB |
+| 201 | chinese-zodiac | ✓ | 8.94ms | 124.1 KB |
 | 202 | cholesky-decomposition-1 |  |  |  |
 | 203 | cholesky-decomposition |  |  |  |
 | 204 | chowla-numbers |  |  |  |


### PR DESCRIPTION
## Summary
- extend Kotlin transpiler to cast BigInteger fields to Int in struct literals
- handle comparisons where left side is `Any?` and right side numeric
- update Rosetta Kotlin checklist for new programs
- add generated Kotlin sources and bench data for `chinese-remainder-theorem` and `chinese-zodiac`

## Testing
- `ROSETTA_INDEX=201 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1`
- `ROSETTA_INDEX=202 MOCHI_BENCHMARK=true go test ./transpiler/x/kt -run TestRosettaKotlin -tags slow -count=1` *(fails: kotlinc exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_6886ffbc6b3c832091eecbb634c8ea7b