### PR TITLE
Update Java transpiler outputs 300-330

### DIFF
--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 39895,
+  "duration_us": 55678,
   "memory_bytes": 57528,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
+++ b/tests/rosetta/transpiler/Java/dice-game-probabilities-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 38887,
+  "duration_us": 52612,
   "memory_bytes": 10832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
+++ b/tests/rosetta/transpiler/Java/digital-root-multiplicative-digital-root.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 181538,
+  "duration_us": 234549,
   "memory_bytes": 123832,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
+++ b/tests/rosetta/transpiler/Java/dijkstras-algorithm.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 45868,
+  "duration_us": 62164,
   "memory_bytes": 98592,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
+++ b/tests/rosetta/transpiler/Java/dinesmans-multiple-dwelling-problem.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 52035,
+  "duration_us": 58271,
   "memory_bytes": 96264,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dining-philosophers-1.bench
+++ b/tests/rosetta/transpiler/Java/dining-philosophers-1.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 34951,
+  "duration_us": 37909,
   "memory_bytes": 39632,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/dining-philosophers-2.bench
+++ b/tests/rosetta/transpiler/Java/dining-philosophers-2.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 32258,
+  "duration_us": 42771,
   "memory_bytes": 39632,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/disarium-numbers.bench
+++ b/tests/rosetta/transpiler/Java/disarium-numbers.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 3005018,
+  "duration_us": 4504767,
   "memory_bytes": 85928,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/discordian-date.bench
+++ b/tests/rosetta/transpiler/Java/discordian-date.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 53997,
+  "duration_us": 64597,
   "memory_bytes": 103984,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/display-a-linear-combination.bench
+++ b/tests/rosetta/transpiler/Java/display-a-linear-combination.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 51153,
+  "duration_us": 64821,
   "memory_bytes": 103720,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.bench
+++ b/tests/rosetta/transpiler/Java/display-an-outline-as-a-nested-table.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 56475,
+  "duration_us": 83400,
   "memory_bytes": 113408,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/distance-and-bearing.bench
+++ b/tests/rosetta/transpiler/Java/distance-and-bearing.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 54085,
+  "duration_us": 71494,
   "memory_bytes": 106472,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/distributed-programming.bench
+++ b/tests/rosetta/transpiler/Java/distributed-programming.bench
@@ -1,5 +1,5 @@
 {
-  "duration_us": 43487,
+  "duration_us": 55754,
   "memory_bytes": 79264,
   "name": "main"
 }

--- a/tests/rosetta/transpiler/Java/diversity-prediction-theorem.bench
+++ b/tests/rosetta/transpiler/Java/diversity-prediction-theorem.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 54155,
+  "memory_bytes": 82968,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/diversity-prediction-theorem.java
+++ b/tests/rosetta/transpiler/Java/diversity-prediction-theorem.java
@@ -55,7 +55,7 @@ public class Main {
         double avErr = averageSquareDiff(truth, preds);
         double crowdErr = (truth - av) * (truth - av);
         double div = averageSquareDiff(av, preds);
-        return new Object[]{avErr, crowdErr, div};
+        return new double[]{avErr, crowdErr, div};
     }
 
     static void main() {

--- a/tests/rosetta/transpiler/Java/documentation.bench
+++ b/tests/rosetta/transpiler/Java/documentation.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 22789,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/documentation.java
+++ b/tests/rosetta/transpiler/Java/documentation.java
@@ -1,0 +1,48 @@
+public class Main {
+    static int X = 0;
+    static int Y = 0;
+    static int Z = 0;
+    static int MEMEME = 0;
+
+    static void XP() {
+    }
+
+    static void nonXP() {
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/doomsday-rule.bench
+++ b/tests/rosetta/transpiler/Java/doomsday-rule.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 55035,
+  "memory_bytes": 79864,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/doomsday-rule.java
+++ b/tests/rosetta/transpiler/Java/doomsday-rule.java
@@ -1,0 +1,94 @@
+public class Main {
+    static String[] days = new String[]{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+    static int[] firstDaysCommon = new int[]{3, 7, 7, 4, 2, 6, 4, 1, 5, 3, 7, 5};
+    static int[] firstDaysLeap = new int[]{4, 1, 7, 4, 2, 6, 4, 1, 5, 3, 7, 5};
+
+    static int parseIntStr(String str) {
+        int i = 0;
+        boolean neg = false;
+        if (_runeLen(str) > 0 && (str.substring(0, 1).equals("-"))) {
+            neg = true;
+            i = 1;
+        }
+        int n = 0;
+        java.util.Map<String,Integer> digits = ((java.util.Map<String,Integer>)(new java.util.LinkedHashMap<String, Integer>(java.util.Map.ofEntries(java.util.Map.entry("0", 0), java.util.Map.entry("1", 1), java.util.Map.entry("2", 2), java.util.Map.entry("3", 3), java.util.Map.entry("4", 4), java.util.Map.entry("5", 5), java.util.Map.entry("6", 6), java.util.Map.entry("7", 7), java.util.Map.entry("8", 8), java.util.Map.entry("9", 9)))));
+        while (i < _runeLen(str)) {
+            n = n * 10 + (int)(((int)(digits).get(str.substring(i, i + 1))));
+            i = i + 1;
+        }
+        if (neg) {
+            n = -n;
+        }
+        return n;
+    }
+
+    static int anchorDay(int y) {
+        return Math.floorMod((2 + 5 * (Math.floorMod(y, 4)) + 4 * (Math.floorMod(y, 100)) + 6 * (Math.floorMod(y, 400))), 7);
+    }
+
+    static boolean isLeapYear(int y) {
+        return Math.floorMod(y, 4) == 0 && (Math.floorMod(y, 100) != 0 || Math.floorMod(y, 400) == 0);
+    }
+
+    static void main() {
+        String[] dates = new String[]{"1800-01-06", "1875-03-29", "1915-12-07", "1970-12-23", "2043-05-14", "2077-02-12", "2101-04-02"};
+        System.out.println("Days of week given by Doomsday rule:");
+        for (String date : dates) {
+            int y = Integer.parseInt(date.substring(0, 4));
+            int m = Integer.parseInt(date.substring(5, 7)) - 1;
+            int d = Integer.parseInt(date.substring(8, 10));
+            int a = anchorDay(y);
+            int f = firstDaysCommon[m];
+            if (isLeapYear(y)) {
+                f = firstDaysLeap[m];
+            }
+            int w = d - f;
+            if (w < 0) {
+                w = 7 + w;
+            }
+            int dow = Math.floorMod((a + w), 7);
+            System.out.println(date + " -> " + days[dow]);
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+}

--- a/tests/rosetta/transpiler/Java/dot-product.bench
+++ b/tests/rosetta/transpiler/Java/dot-product.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 23470,
+  "memory_bytes": 792,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/dot-product.java
+++ b/tests/rosetta/transpiler/Java/dot-product.java
@@ -1,0 +1,73 @@
+public class Main {
+    static class DotResult {
+        int value;
+        boolean ok;
+        DotResult(int value, boolean ok) {
+            this.value = value;
+            this.ok = ok;
+        }
+        @Override public String toString() {
+            return String.format("{'value': %s, 'ok': %s}", String.valueOf(value), String.valueOf(ok));
+        }
+    }
+
+
+    static DotResult dot(int[] x, int[] y) {
+        if (x.length != y.length) {
+            return new DotResult(0, false);
+        }
+        int sum = 0;
+        int i = 0;
+        while (i < x.length) {
+            sum = sum + x[i] * y[i];
+            i = i + 1;
+        }
+        return new DotResult(sum, true);
+    }
+
+    static void main() {
+        DotResult r = dot(new int[]{1, 3, -5}, new int[]{4, -2, -1});
+        if (!r.ok) {
+            System.out.println("incompatible lengths");
+        } else {
+            System.out.println(String.valueOf(r.value));
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-definition-1.bench
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-definition-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 24745,
+  "memory_bytes": 0,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-definition-1.java
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-definition-1.java
@@ -1,0 +1,67 @@
+public class Main {
+    static class dlNode {
+        int value;
+        Object next;
+        Object prev;
+        dlNode(int value, Object next, Object prev) {
+            this.value = value;
+            this.next = next;
+            this.prev = prev;
+        }
+        @Override public String toString() {
+            return String.format("{'value': %s, 'next': %s, 'prev': %s}", String.valueOf(value), String.valueOf(next), String.valueOf(prev));
+        }
+    }
+
+    static class dlList {
+        java.util.Map<Object,Integer> members;
+        Object head;
+        Object tail;
+        dlList(java.util.Map<Object,Integer> members, Object head, Object tail) {
+            this.members = members;
+            this.head = head;
+            this.tail = tail;
+        }
+        @Override public String toString() {
+            return String.format("{'members': %s, 'head': %s, 'tail': %s}", String.valueOf(members), String.valueOf(head), String.valueOf(tail));
+        }
+    }
+
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-definition-2.bench
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-definition-2.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 26114,
+  "memory_bytes": 816,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-definition-2.java
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-definition-2.java
@@ -1,0 +1,152 @@
+public class Main {
+
+    static java.util.Map<String,Object> newList() {
+        return new java.util.LinkedHashMap<String, Object>(java.util.Map.ofEntries(java.util.Map.entry("nodes", new java.util.LinkedHashMap<String, Object>()), java.util.Map.entry("head", 0), java.util.Map.entry("tail", 0), java.util.Map.entry("nextID", 1)));
+    }
+
+    static java.util.Map<String,Object> newNode(java.util.Map<String,Object> l, Object v) {
+        int id = (int)(((int)(l).getOrDefault("nextID", 0)));
+l.put("nextID", id + 1);
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+        java.util.Map<String,Object> n = ((java.util.Map<String,Object>)(new java.util.LinkedHashMap<String, Object>(java.util.Map.ofEntries(java.util.Map.entry("id", id), java.util.Map.entry("value", v), java.util.Map.entry("next", 0), java.util.Map.entry("prev", 0)))));
+nodes.put(id, n);
+l.put("nodes", nodes);
+        return n;
+    }
+
+    static java.util.Map<String,Object> pushFront(java.util.Map<String,Object> l, Object v) {
+        java.util.Map<String,Object> n = newNode(l, v);
+n.put("next", (Object)(((Object)(l).get("head"))));
+        if ((((int)(l).getOrDefault("head", 0))) != 0) {
+            java.util.Map<Integer,java.util.Map<String,Object>> nodes = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+            java.util.Map<String,Object> h = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(((int)(l).getOrDefault("head", 0)))));
+h.put("prev", (Object)(((int) (n.get("id")))));
+nodes.put(((int)(h).getOrDefault("id", 0)), h);
+l.put("nodes", nodes);
+        } else {
+l.put("tail", (Object)(((int) (n.get("id")))));
+        }
+l.put("head", (Object)(((int) (n.get("id")))));
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes2 = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+nodes2.put(((Number)(((int) (n.get("id"))))).intValue(), n);
+l.put("nodes", nodes2);
+        return n;
+    }
+
+    static java.util.Map<String,Object> pushBack(java.util.Map<String,Object> l, Object v) {
+        java.util.Map<String,Object> n = newNode(l, v);
+n.put("prev", (Object)(((Object)(l).get("tail"))));
+        if ((((int)(l).getOrDefault("tail", 0))) != 0) {
+            java.util.Map<Integer,java.util.Map<String,Object>> nodes = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+            java.util.Map<String,Object> t = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(((int)(l).getOrDefault("tail", 0)))));
+t.put("next", (Object)(((int) (n.get("id")))));
+nodes.put(((int)(t).getOrDefault("id", 0)), t);
+l.put("nodes", nodes);
+        } else {
+l.put("head", (Object)(((int) (n.get("id")))));
+        }
+l.put("tail", (Object)(((int) (n.get("id")))));
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes2 = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+nodes2.put(((Number)(((int) (n.get("id"))))).intValue(), n);
+l.put("nodes", nodes2);
+        return n;
+    }
+
+    static java.util.Map<String,Object> insertBefore(java.util.Map<String,Object> l, int refID, Object v) {
+        if (refID == 0) {
+            return pushFront(l, v);
+        }
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+        java.util.Map<String,Object> ref = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(refID)));
+        java.util.Map<String,Object> n = newNode(l, v);
+n.put("prev", (Object)(((Object)(ref).get("prev"))));
+n.put("next", (Object)(((Object)(ref).get("id"))));
+        if ((((int)(ref).getOrDefault("prev", 0))) != 0) {
+            java.util.Map<String,Object> p = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(((int)(ref).getOrDefault("prev", 0)))));
+p.put("next", (Object)(((int) (n.get("id")))));
+nodes.put(((int)(p).getOrDefault("id", 0)), p);
+        } else {
+l.put("head", (Object)(((int) (n.get("id")))));
+        }
+ref.put("prev", (Object)(((int) (n.get("id")))));
+nodes.put(refID, ref);
+nodes.put(((Number)(((int) (n.get("id"))))).intValue(), n);
+l.put("nodes", nodes);
+        return n;
+    }
+
+    static java.util.Map<String,Object> insertAfter(java.util.Map<String,Object> l, int refID, Object v) {
+        if (refID == 0) {
+            return pushBack(l, v);
+        }
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes = (java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map<Integer,java.util.Map<String,Object>>)(l).get("nodes")));
+        java.util.Map<String,Object> ref = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(refID)));
+        java.util.Map<String,Object> n = newNode(l, v);
+n.put("next", (Object)(((Object)(ref).get("next"))));
+n.put("prev", (Object)(((Object)(ref).get("id"))));
+        if ((((int)(ref).getOrDefault("next", 0))) != 0) {
+            java.util.Map<String,Object> nx = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(((int)(ref).getOrDefault("next", 0)))));
+nx.put("prev", (Object)(((int) (n.get("id")))));
+nodes.put(((int)(nx).getOrDefault("id", 0)), nx);
+        } else {
+l.put("tail", (Object)(((int) (n.get("id")))));
+        }
+ref.put("next", (Object)(((int) (n.get("id")))));
+nodes.put(refID, ref);
+nodes.put(((Number)(((int) (n.get("id"))))).intValue(), n);
+l.put("nodes", nodes);
+        return n;
+    }
+
+    static void main() {
+        java.util.Map<String,Object> l = newList();
+        java.util.Map<String,Object> e4 = pushBack(l, 4);
+        java.util.Map<String,Object> e1 = pushFront(l, 1);
+        insertBefore(l, (int)(((int)(e4).getOrDefault("id", 0))), 3);
+        insertAfter(l, (int)(((int)(e1).getOrDefault("id", 0))), "two");
+        int id = ((Number)(((int) (l.get("head"))))).intValue();
+        java.util.Map<Integer,java.util.Map<String,Object>> nodes = ((java.util.Map<Integer,java.util.Map<String,Object>>)(((java.util.Map) (l.get("nodes")))));
+        while (id != 0) {
+            java.util.Map<String,Object> node = (java.util.Map<String,Object>)(((java.util.Map<String,Object>)(nodes).get(id)));
+            System.out.println(String.valueOf(((Object)(node).get("value"))));
+            id = (int)(((int)(node).getOrDefault("next", 0)));
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-element-definition.bench
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-element-definition.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 38567,
+  "memory_bytes": 39672,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-element-definition.java
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-element-definition.java
@@ -1,0 +1,71 @@
+public class Main {
+
+    static java.util.Map<String,Object> Node(String value, Object next, Object prev) {
+        return new java.util.LinkedHashMap<String, Object>() {{ put("value", value); put("next", next); put("prev", prev); }};
+    }
+
+    static void main() {
+        java.util.Map<String,Object> a = Node("A", null, null);
+        java.util.Map<String,Object> b = Node("B", null, a);
+a.put("next", b);
+        java.util.Map<String,Object> c = Node("C", null, b);
+b.put("next", c);
+        java.util.Map<String,Object> p = a;
+        String line = "";
+        while (!(p == null)) {
+            line = line + String.valueOf((((String)(p).get("value"))));
+            p = (java.util.Map<String,Object>)(((Object)(p).get("next")));
+            if (!(p == null)) {
+                line = line + " ";
+            }
+        }
+        System.out.println(line);
+        p = c;
+        line = "";
+        while (!(p == null)) {
+            line = line + String.valueOf((((String)(p).get("value"))));
+            p = (java.util.Map<String,Object>)(((Object)(p).get("prev")));
+            if (!(p == null)) {
+                line = line + " ";
+            }
+        }
+        System.out.println(line);
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-traversal.bench
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-traversal.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 59286,
+  "memory_bytes": 84232,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/doubly-linked-list-traversal.java
+++ b/tests/rosetta/transpiler/Java/doubly-linked-list-traversal.java
@@ -1,0 +1,74 @@
+public class Main {
+    static java.util.Map<Integer,java.util.Map<String,Object>> nodes = ((java.util.Map<Integer,java.util.Map<String,Object>>)(new java.util.LinkedHashMap<Integer, java.util.Map<String,Object>>()));
+    static int head = 0 - 1;
+    static int tail = 0 - 1;
+    static String out = "From tail:";
+    static int id = tail;
+
+    static String listString() {
+        if (head == 0 - 1) {
+            return "<nil>";
+        }
+        String r = "[" + (String)(((Object)(((java.util.Map<String,Object>)(nodes).get(head))).get("value")));
+        int id = (int)(((int)(((java.util.Map<String,Object>)(nodes).get(head))).getOrDefault("next", 0)));
+        while (id != 0 - 1) {
+            r = r + " " + (String)(((Object)(((java.util.Map<String,Object>)(nodes).get(id))).get("value")));
+            id = (int)(((int)(((java.util.Map<String,Object>)(nodes).get(id))).getOrDefault("next", 0)));
+        }
+        r = r + "]";
+        return r;
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(listString());
+nodes.put(0, new java.util.LinkedHashMap<String, Object>() {{ put("value", "A"); put("next", 0 - 1); put("prev", 0 - 1); }});
+            head = 0;
+            tail = 0;
+nodes.put(1, new java.util.LinkedHashMap<String, Object>() {{ put("value", "B"); put("next", 0 - 1); put("prev", 0); }});
+((java.util.Map<String,Object>)(nodes).get(0)).put("next", 1);
+            tail = 1;
+            System.out.println(listString());
+nodes.put(2, new java.util.LinkedHashMap<String, Object>() {{ put("value", "C"); put("next", 1); put("prev", 0); }});
+((java.util.Map<String,Object>)(nodes).get(1)).put("prev", 2);
+((java.util.Map<String,Object>)(nodes).get(0)).put("next", 2);
+            System.out.println(listString());
+            while (id != 0 - 1) {
+                out = out + " " + (String)(((Object)(((java.util.Map<String,Object>)(nodes).get(id))).get("value")));
+                id = (int)(((int)(((java.util.Map<String,Object>)(nodes).get(id))).getOrDefault("prev", 0)));
+            }
+            System.out.println(out);
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/dragon-curve.bench
+++ b/tests/rosetta/transpiler/Java/dragon-curve.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 73056,
+  "memory_bytes": 89264,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/dragon-curve.java
+++ b/tests/rosetta/transpiler/Java/dragon-curve.java
@@ -1,0 +1,70 @@
+public class Main {
+    static int depth = 10;
+    static String seq = "F";
+    static int i = 0;
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            while (i < depth) {
+                String rev = "";
+                int j = _runeLen(seq) - 1;
+                while (j >= 0) {
+                    String c = _substr(seq, j, j + 1);
+                    if ((c.equals("L"))) {
+                        rev = rev + "R";
+                    } else                     if ((c.equals("R"))) {
+                        rev = rev + "L";
+                    } else {
+                        rev = rev + c;
+                    }
+                    j = j - 1;
+                }
+                seq = seq + "L" + rev;
+                i = i + 1;
+            }
+            System.out.println(seq);
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+}

--- a/tests/rosetta/transpiler/Java/draw-a-clock.bench
+++ b/tests/rosetta/transpiler/Java/draw-a-clock.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 41621,
+  "memory_bytes": 39320,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/draw-a-clock.java
+++ b/tests/rosetta/transpiler/Java/draw-a-clock.java
@@ -1,0 +1,102 @@
+public class Main {
+    static int t = _now() / 1000000000;
+    static int sec = Math.floorMod(t, 60);
+    static int mins = t / 60;
+    static int min = Math.floorMod(mins, 60);
+    static int hour = Math.floorMod((mins / 60), 24);
+    static String xs = "";
+    static int i = 0;
+    static String out = "";
+    static int j = 0;
+
+    static int pow2(int exp) {
+        int r = 1;
+        int i = 0;
+        while (i < exp) {
+            r = r * 2;
+            i = i + 1;
+        }
+        return r;
+    }
+
+    static String bin(int n, int digits) {
+        String s = "";
+        int i = digits - 1;
+        while (i >= 0) {
+            int p = pow2(i);
+            if (n >= p) {
+                s = s + "x";
+                n = n - p;
+            } else {
+                s = s + " ";
+            }
+            if (i > 0) {
+                s = s + "|";
+            }
+            i = i - 1;
+        }
+        return s;
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println(bin(hour, 8));
+            System.out.println("");
+            System.out.println(bin(min, 8));
+            System.out.println("");
+            while (i < sec) {
+                xs = xs + "x";
+                i = i + 1;
+            }
+            while (j < _runeLen(xs)) {
+                out = out + _substr(xs, j, j + 1);
+                if (Math.floorMod((j + 1), 5) == 0 && j + 1 < _runeLen(xs)) {
+                    out = out + "|";
+                }
+                j = j + 1;
+            }
+            System.out.println(out);
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+}

--- a/tests/rosetta/transpiler/Java/draw-a-cuboid.bench
+++ b/tests/rosetta/transpiler/Java/draw-a-cuboid.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 65480,
+  "memory_bytes": 90200,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/draw-a-cuboid.java
+++ b/tests/rosetta/transpiler/Java/draw-a-cuboid.java
@@ -1,0 +1,92 @@
+public class Main {
+
+    static String repeat(String ch, int n) {
+        String s = "";
+        int i = 0;
+        while (i < n) {
+            s = s + ch;
+            i = i + 1;
+        }
+        return s;
+    }
+
+    static void cubLine(int n, int dx, int dy, String cde) {
+        String line = String.valueOf(repeat(" ", n + 1)) + cde.substring(0, 1);
+        int d = 9 * dx - 1;
+        while (d > 0) {
+            line = line + cde.substring(1, 2);
+            d = d - 1;
+        }
+        line = line + cde.substring(0, 1);
+        line = line + String.valueOf(repeat(" ", dy)) + cde.substring(2, _runeLen(cde));
+        System.out.println(line);
+    }
+
+    static void cuboid(int dx, int dy, int dz) {
+        System.out.println("cuboid " + String.valueOf(dx) + " " + String.valueOf(dy) + " " + String.valueOf(dz) + ":");
+        cubLine(dy + 1, dx, 0, "+-");
+        int i = 1;
+        while (i <= dy) {
+            cubLine(dy - i + 1, dx, i - 1, "/ |");
+            i = i + 1;
+        }
+        cubLine(0, dx, dy, "+-|");
+        int j = 4 * dz - dy - 2;
+        while (j > 0) {
+            cubLine(0, dx, dy, "| |");
+            j = j - 1;
+        }
+        cubLine(0, dx, dy, "| +");
+        i = 1;
+        while (i <= dy) {
+            cubLine(0, dx, dy - i, "| /");
+            i = i + 1;
+        }
+        cubLine(0, dx, 0, "+-\n");
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            cuboid(2, 3, 4);
+            System.out.println("");
+            cuboid(1, 1, 1);
+            System.out.println("");
+            cuboid(6, 2, 1);
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+}

--- a/tests/rosetta/transpiler/Java/draw-a-pixel-1.bench
+++ b/tests/rosetta/transpiler/Java/draw-a-pixel-1.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 438090,
+  "memory_bytes": 397384,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/draw-a-pixel-1.java
+++ b/tests/rosetta/transpiler/Java/draw-a-pixel-1.java
@@ -1,0 +1,62 @@
+public class Main {
+    static int width = 320;
+    static int height = 240;
+    static String[][] img = new String[][]{};
+    static int y = 0;
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            while (y < height) {
+                String[] row = new String[]{};
+                int x = 0;
+                while (x < width) {
+                    row = java.util.stream.Stream.concat(java.util.Arrays.stream(row), java.util.stream.Stream.of("green")).toArray(String[]::new);
+                    x = x + 1;
+                }
+                img = appendObj(img, row);
+                y = y + 1;
+            }
+img[100][100] = "red";
+            System.out.println("The color of the pixel at (  0,   0) is " + img[0][0] + ".");
+            System.out.println("The color of the pixel at (100, 100) is " + img[100][100] + ".");
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static <T> T[] appendObj(T[] arr, T v) {
+        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/tests/rosetta/transpiler/Java/draw-a-rotating-cube.bench
+++ b/tests/rosetta/transpiler/Java/draw-a-rotating-cube.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 120531,
+  "memory_bytes": 98552,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/draw-a-rotating-cube.java
+++ b/tests/rosetta/transpiler/Java/draw-a-rotating-cube.java
@@ -1,0 +1,222 @@
+public class Main {
+    static double PI = 3.141592653589793;
+    static double TWO_PI = 6.283185307179586;
+    static class Point3 {
+        double x;
+        double y;
+        double z;
+        Point3(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+        @Override public String toString() {
+            return String.format("{'x': %s, 'y': %s, 'z': %s}", String.valueOf(x), String.valueOf(y), String.valueOf(z));
+        }
+    }
+
+    static class Point2 {
+        int x;
+        int y;
+        Point2(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+        @Override public String toString() {
+            return String.format("{'x': %s, 'y': %s}", String.valueOf(x), String.valueOf(y));
+        }
+    }
+
+    static Point3[] nodes = new Point3[]{new Point3(-1.0, -1.0, -1.0), new Point3(-1.0, -1.0, 1.0), new Point3(-1.0, 1.0, -1.0), new Point3(-1.0, 1.0, 1.0), new Point3(1.0, -1.0, -1.0), new Point3(1.0, -1.0, 1.0), new Point3(1.0, 1.0, -1.0), new Point3(1.0, 1.0, 1.0)};
+    static int[][] edges = new int[][]{new int[]{0, 1}, new int[]{1, 3}, new int[]{3, 2}, new int[]{2, 0}, new int[]{4, 5}, new int[]{5, 7}, new int[]{7, 6}, new int[]{6, 4}, new int[]{0, 4}, new int[]{1, 5}, new int[]{2, 6}, new int[]{3, 7}};
+    static int width = 40;
+    static int height = 20;
+    static double distance = 3.0;
+    static double scale = 8.0;
+
+    static double _mod(double x, double m) {
+        return x - (((Number)(((Number)((x / m))).intValue())).doubleValue()) * m;
+    }
+
+    static double _sin(double x) {
+        double y = _mod(x + PI, TWO_PI) - PI;
+        double y2 = y * y;
+        double y3 = y2 * y;
+        double y5 = y3 * y2;
+        double y7 = y5 * y2;
+        return y - y3 / 6.0 + y5 / 120.0 - y7 / 5040.0;
+    }
+
+    static double _cos(double x) {
+        double y = _mod(x + PI, TWO_PI) - PI;
+        double y2 = y * y;
+        double y4 = y2 * y2;
+        double y6 = y4 * y2;
+        return 1.0 - y2 / 2.0 + y4 / 24.0 - y6 / 720.0;
+    }
+
+    static Point3 rotate(Point3 p, double ax, double ay) {
+        double sinx = _sin(ax);
+        double cosx = _cos(ax);
+        double siny = _sin(ay);
+        double cosy = _cos(ay);
+        double x1 = p.x;
+        double y1 = p.y * cosx - p.z * sinx;
+        double z1 = p.y * sinx + p.z * cosx;
+        double x2 = x1 * cosy + z1 * siny;
+        double z2 = -x1 * siny + z1 * cosy;
+        return new Point3(x2, y1, z2);
+    }
+
+    static Point2 project(Point3 p) {
+        double factor = scale / (p.z + distance);
+        int x = ((Number)((p.x * factor))).intValue() + width / 2;
+        int y = ((Number)((-p.y * factor))).intValue() + height / 2;
+        return new Point2(x, y);
+    }
+
+    static String[][] clearGrid() {
+        String[][] g = new String[][]{};
+        int y = 0;
+        while (y < height) {
+            String[] row = new String[]{};
+            int x = 0;
+            while (x < width) {
+                row = java.util.stream.Stream.concat(java.util.Arrays.stream(row), java.util.stream.Stream.of(" ")).toArray(String[]::new);
+                x = x + 1;
+            }
+            g = appendObj(g, row);
+            y = y + 1;
+        }
+        return g;
+    }
+
+    static void drawPoint(String[][] g, int x, int y, String ch) {
+        if (x >= 0 && x < width && y >= 0 && y < height) {
+            String[] row = g[y];
+row[x] = ch;
+g[y] = row;
+        }
+    }
+
+    static void bresenham(int x0, int y0, int x1, int y1, String[][] g, String ch) {
+        int dx = x1 - x0;
+        if (dx < 0) {
+            dx = -dx;
+        }
+        int dy = y1 - y0;
+        if (dy < 0) {
+            dy = -dy;
+        }
+        int sx = -1;
+        if (x0 < x1) {
+            sx = 1;
+        }
+        int sy = -1;
+        if (y0 < y1) {
+            sy = 1;
+        }
+        int err = dx - dy;
+        while (true) {
+            drawPoint(g, x0, y0, ch);
+            if (x0 == x1 && y0 == y1) {
+                break;
+            }
+            int e2 = 2 * err;
+            if (e2 > (-dy)) {
+                err = err - dy;
+                x0 = x0 + sx;
+            }
+            if (e2 < dx) {
+                err = err + dx;
+                y0 = y0 + sy;
+            }
+        }
+    }
+
+    static String render(String[][] g) {
+        String out = "";
+        int y = 0;
+        while (y < height) {
+            String line = "";
+            int x = 0;
+            while (x < width) {
+                line = line + g[y][x];
+                x = x + 1;
+            }
+            out = out + line + "\n";
+            y = y + 1;
+        }
+        return out;
+    }
+
+    static void main() {
+        int f = 0;
+        while (f < 10) {
+            String[][] grid = clearGrid();
+            Point2[] rot = new Point2[]{};
+            int i = 0;
+            double ay = (PI / 4.0) + (((Number)(f)).doubleValue()) * PI / 10.0;
+            while (i < nodes.length) {
+                Point3 p = rotate(nodes[i], PI / 4.0, ay);
+                Point2 pp = project(p);
+                rot = java.util.stream.Stream.concat(java.util.Arrays.stream(rot), java.util.stream.Stream.of(pp)).toArray(Point2[]::new);
+                i = i + 1;
+            }
+            int e = 0;
+            while (e < edges.length) {
+                int a = edges[e][0];
+                int b = edges[e][1];
+                Point2 p1 = rot[a];
+                Point2 p2 = rot[b];
+                bresenham(p1.x, p1.y, p2.x, p2.y, grid, "#");
+                e = e + 1;
+            }
+            System.out.println(render(grid));
+            f = f + 1;
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static <T> T[] appendObj(T[] arr, T v) {
+        T[] out = java.util.Arrays.copyOf(arr, arr.length + 1);
+        out[arr.length] = v;
+        return out;
+    }
+}

--- a/tests/rosetta/transpiler/Java/draw-a-sphere.bench
+++ b/tests/rosetta/transpiler/Java/draw-a-sphere.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 55438,
+  "memory_bytes": 39456,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/draw-a-sphere.java
+++ b/tests/rosetta/transpiler/Java/draw-a-sphere.java
@@ -1,0 +1,136 @@
+public class Main {
+    static class V3 {
+        double x;
+        double y;
+        double z;
+        V3(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+        @Override public String toString() {
+            return String.format("{'x': %s, 'y': %s, 'z': %s}", String.valueOf(x), String.valueOf(y), String.valueOf(z));
+        }
+    }
+
+
+    static double sqrtApprox(double x) {
+        if (x <= 0.0) {
+            return 0.0;
+        }
+        double guess = x;
+        int i = 0;
+        while (i < 20) {
+            guess = (guess + x / guess) / 2.0;
+            i = i + 1;
+        }
+        return guess;
+    }
+
+    static double powf(double base, int exp) {
+        double result = 1.0;
+        int i = 0;
+        while (i < exp) {
+            result = result * base;
+            i = i + 1;
+        }
+        return result;
+    }
+
+    static V3 normalize(V3 v) {
+        double len = sqrtApprox(v.x * v.x + v.y * v.y + v.z * v.z);
+        return new V3(v.x / len, v.y / len, v.z / len);
+    }
+
+    static double dot(V3 a, V3 b) {
+        double d = a.x * b.x + a.y * b.y + a.z * b.z;
+        if (d < 0.0) {
+            return -d;
+        }
+        return 0.0;
+    }
+
+    static void drawSphere(int r, int k, double ambient, V3 light, String shades) {
+        int i = -r;
+        while (i <= r) {
+            double x = (((Number)(i)).doubleValue()) + 0.5;
+            String line = "";
+            int j = -(2 * r);
+            while (j <= 2 * r) {
+                double y = (((Number)(j)).doubleValue()) / 2.0 + 0.5;
+                if (x * x + y * y <= (((Number)(r)).doubleValue()) * (((Number)(r)).doubleValue())) {
+                    double zsq = (((Number)(r)).doubleValue()) * (((Number)(r)).doubleValue()) - x * x - y * y;
+                    V3 vec = normalize(new V3(x, y, sqrtApprox(zsq)));
+                    double b = powf(dot(light, vec), k) + ambient;
+                    int intensity = ((Number)(((1.0 - b) * ((((Number)(_runeLen(shades))).doubleValue()) - 1.0)))).intValue();
+                    if (intensity < 0) {
+                        intensity = 0;
+                    }
+                    if (intensity >= _runeLen(shades)) {
+                        intensity = _runeLen(shades) - 1;
+                    }
+                    line = line + _substr(shades, intensity, intensity + 1);
+                } else {
+                    line = line + " ";
+                }
+                j = j + 1;
+            }
+            System.out.println(line);
+            i = i + 1;
+        }
+    }
+
+    static void main() {
+        String shades = ".:!*oe&#%@";
+        V3 light = normalize(new V3(30.0, 30.0, -50.0));
+        drawSphere(20, 4, 0.1, light, shades);
+        drawSphere(10, 2, 0.4, light, shades);
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+}

--- a/tests/rosetta/transpiler/Java/dutch-national-flag-problem.bench
+++ b/tests/rosetta/transpiler/Java/dutch-national-flag-problem.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 42762,
+  "memory_bytes": 56056,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/dutch-national-flag-problem.java
+++ b/tests/rosetta/transpiler/Java/dutch-national-flag-problem.java
@@ -1,0 +1,119 @@
+public class Main {
+
+    static String listStr(int[] xs) {
+        String s = "[";
+        int i = 0;
+        while (i < xs.length) {
+            s = s + String.valueOf(xs[i]);
+            if (i < xs.length - 1) {
+                s = s + " ";
+            }
+            i = i + 1;
+        }
+        s = s + "]";
+        return s;
+    }
+
+    static boolean ordered(int[] xs) {
+        if (xs.length == 0) {
+            return true;
+        }
+        int prev = xs[0];
+        int i = 1;
+        while (i < xs.length) {
+            if (xs[i] < prev) {
+                return false;
+            }
+            prev = xs[i];
+            i = i + 1;
+        }
+        return true;
+    }
+
+    static int[] outOfOrder(int n) {
+        if (n < 2) {
+            return new int[]{};
+        }
+        int[] r = new int[]{};
+        while (true) {
+            r = new int[]{};
+            int i = 0;
+            while (i < n) {
+                r = java.util.stream.IntStream.concat(java.util.Arrays.stream(r), java.util.stream.IntStream.of(Math.floorMod(_now(), 3))).toArray();
+                i = i + 1;
+            }
+            if (!(Boolean)ordered(r)) {
+                break;
+            }
+        }
+        return r;
+    }
+
+    static int[] sort3(int[] a) {
+        int lo = 0;
+        int mid = 0;
+        int hi = a.length - 1;
+        while (mid <= hi) {
+            int v = a[mid];
+            if (v == 0) {
+                int tmp = a[lo];
+a[lo] = a[mid];
+a[mid] = tmp;
+                lo = lo + 1;
+                mid = mid + 1;
+            } else             if (v == 1) {
+                mid = mid + 1;
+            } else {
+                int tmp = a[mid];
+a[mid] = a[hi];
+a[hi] = tmp;
+                hi = hi - 1;
+            }
+        }
+        return a;
+    }
+
+    static void main() {
+        int[] f = outOfOrder(12);
+        System.out.println(listStr(f));
+        f = sort3(f);
+        System.out.println(listStr(f));
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/tests/rosetta/transpiler/Java/dynamic-variable-names.bench
+++ b/tests/rosetta/transpiler/Java/dynamic-variable-names.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 41135,
+  "memory_bytes": 39016,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/dynamic-variable-names.java
+++ b/tests/rosetta/transpiler/Java/dynamic-variable-names.java
@@ -1,0 +1,132 @@
+public class Main {
+
+    static java.util.Scanner _scanner = new java.util.Scanner(System.in);
+
+    static int parseIntStr(String str) {
+        int i = 0;
+        boolean neg = false;
+        if (_runeLen(str) > 0 && (str.substring(0, 1).equals("-"))) {
+            neg = true;
+            i = 1;
+        }
+        int n = 0;
+        java.util.Map<String,Integer> digits = ((java.util.Map<String,Integer>)(new java.util.LinkedHashMap<String, Integer>(java.util.Map.ofEntries(java.util.Map.entry("0", 0), java.util.Map.entry("1", 1), java.util.Map.entry("2", 2), java.util.Map.entry("3", 3), java.util.Map.entry("4", 4), java.util.Map.entry("5", 5), java.util.Map.entry("6", 6), java.util.Map.entry("7", 7), java.util.Map.entry("8", 8), java.util.Map.entry("9", 9)))));
+        while (i < _runeLen(str)) {
+            n = n * 10 + (int)(((int)(digits).get(str.substring(i, i + 1))));
+            i = i + 1;
+        }
+        if (neg) {
+            n = -n;
+        }
+        return n;
+    }
+
+    static void main() {
+        int n = 0;
+        while (n < 1 || n > 5) {
+            System.out.println("How many integer variables do you want to create (max 5) : ");
+            String line = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            if (_runeLen(line) > 0) {
+                n = Integer.parseInt(line);
+            }
+        }
+        java.util.Map<String,Integer> vars = ((java.util.Map<String,Integer>)(new java.util.LinkedHashMap<String, Integer>()));
+        System.out.println("OK, enter the variable names and their values, below\n");
+        int i = 1;
+        while (i <= n) {
+            System.out.println("\n  Variable " + String.valueOf(i) + "\n");
+            System.out.println("    Name  : ");
+            String name = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            if (vars.containsKey(name)) {
+                System.out.println("  Sorry, you've already created a variable of that name, try again");
+                continue;
+            }
+            int value = 0;
+            while (true) {
+                System.out.println("    Value : ");
+                String valstr = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+                if (_runeLen(valstr) == 0) {
+                    System.out.println("  Not a valid integer, try again");
+                    continue;
+                }
+                boolean ok = true;
+                int j = 0;
+                boolean neg = false;
+                if ((valstr.substring(0, 1).equals("-"))) {
+                    neg = true;
+                    j = 1;
+                }
+                while (j < _runeLen(valstr)) {
+                    String ch = valstr.substring(j, j + 1);
+                    if ((ch.compareTo("0") < 0) || (ch.compareTo("9") > 0)) {
+                        ok = false;
+                        break;
+                    }
+                    j = j + 1;
+                }
+                if (!ok) {
+                    System.out.println("  Not a valid integer, try again");
+                    continue;
+                }
+                value = Integer.parseInt(valstr);
+                break;
+            }
+vars.put(name, value);
+            i = i + 1;
+        }
+        System.out.println("\nEnter q to quit");
+        while (true) {
+            System.out.println("\nWhich variable do you want to inspect : ");
+            String name = (_scanner.hasNextLine() ? _scanner.nextLine() : "");
+            if ((name.toLowerCase().equals("q"))) {
+                return;
+            }
+            if (vars.containsKey(name)) {
+                System.out.println("It's value is " + String.valueOf(((int)(vars).getOrDefault(name, 0))));
+            } else {
+                System.out.println("Sorry there's no variable of that name, try again");
+            }
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+}

--- a/tests/rosetta/transpiler/Java/earliest-difference-between-prime-gaps.bench
+++ b/tests/rosetta/transpiler/Java/earliest-difference-between-prime-gaps.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 71233,
+  "memory_bytes": 114768,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/earliest-difference-between-prime-gaps.java
+++ b/tests/rosetta/transpiler/Java/earliest-difference-between-prime-gaps.java
@@ -1,0 +1,85 @@
+public class Main {
+    static class Data1 {
+        int pm;
+        int g1;
+        int s1;
+        int g2;
+        int s2;
+        int d;
+        Data1(int pm, int g1, int s1, int g2, int s2, int d) {
+            this.pm = pm;
+            this.g1 = g1;
+            this.s1 = s1;
+            this.g2 = g2;
+            this.s2 = s2;
+            this.d = d;
+        }
+        @Override public String toString() {
+            return String.format("{'pm': %s, 'g1': %s, 's1': %s, 'g2': %s, 's2': %s, 'd': %s}", String.valueOf(pm), String.valueOf(g1), String.valueOf(s1), String.valueOf(g2), String.valueOf(s2), String.valueOf(d));
+        }
+    }
+
+
+    static String commatize(int n) {
+        String s = String.valueOf(n);
+        int i = _runeLen(s) - 3;
+        while (i > 0) {
+            s = s.substring(0, i) + "," + s.substring(i, _runeLen(s));
+            i = i - 3;
+        }
+        return s;
+    }
+
+    static void main() {
+        Data1[] data = new Data1[]{new Data1(10, 4, 7, 6, 23, 16), new Data1(100, 14, 113, 16, 1831, 1718), new Data1(1000, 14, 113, 16, 1831, 1718), new Data1(10000, 36, 9551, 38, 30593, 21042), new Data1(100000, 70, 173359, 72, 31397, 141962), new Data1(1000000, 100, 396733, 102, 1444309, 1047576), new Data1(10000000, 148, 2010733, 150, 13626257, 11615524), new Data1(100000000, 198, 46006769, 200, 378043979, 332037210), new Data1(1000000000, 276, 649580171, 278, (int)4260928601L, (int)3611348430L), new Data1((int)10000000000L, 332, (int)5893180121L, 334, (int)30827138509L, (int)24933958388L), new Data1((int)100000000000L, 386, (int)35238645587L, 388, (int)156798792223L, (int)121560146636L)};
+        for (Data1 entry : data) {
+            String pm = String.valueOf(commatize(entry.pm));
+            String line1 = "Earliest difference > " + pm + " between adjacent prime gap starting primes:";
+            System.out.println(line1);
+            String line2 = "Gap " + String.valueOf(entry.g1) + " starts at " + String.valueOf(commatize(entry.s1)) + ", gap " + String.valueOf(entry.g2) + " starts at " + String.valueOf(commatize(entry.s2)) + ", difference is " + String.valueOf(commatize(entry.d)) + ".";
+            System.out.println(line2);
+            System.out.println("");
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+}

--- a/tests/rosetta/transpiler/Java/eban-numbers.bench
+++ b/tests/rosetta/transpiler/Java/eban-numbers.bench
@@ -1,0 +1,5 @@
+{
+  "duration_us": 79640,
+  "memory_bytes": 105256,
+  "name": "main"
+}

--- a/tests/rosetta/transpiler/Java/eban-numbers.java
+++ b/tests/rosetta/transpiler/Java/eban-numbers.java
@@ -1,0 +1,113 @@
+public class Main {
+    static int[] vals = new int[]{0, 2, 4, 6, 30, 32, 34, 36, 40, 42, 44, 46, 50, 52, 54, 56, 60, 62, 64, 66};
+    static int[] billions = new int[]{0, 2, 4, 6};
+
+    static int[] ebanNumbers(int start, int stop) {
+        int[] nums = new int[]{};
+        for (int b : billions) {
+            for (int m : vals) {
+                for (int t : vals) {
+                    for (int r : vals) {
+                        int n = b * 1000000000 + m * 1000000 + t * 1000 + r;
+                        if ((n >= start) && (n <= stop)) {
+                            nums = java.util.stream.IntStream.concat(java.util.Arrays.stream(nums), java.util.stream.IntStream.of(n)).toArray();
+                        }
+                    }
+                }
+            }
+        }
+        return nums;
+    }
+
+    static int countEban(int start, int stop) {
+        int count = 0;
+        for (int b : billions) {
+            for (int m : vals) {
+                for (int t : vals) {
+                    for (int r : vals) {
+                        int n = b * 1000000000 + m * 1000000 + t * 1000 + r;
+                        if ((n >= start) && (n <= stop)) {
+                            count = count + 1;
+                        }
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    static void main() {
+        Object[][] ranges = new Object[][]{new Object[]{2, 1000, true}, new Object[]{1000, 4000, true}, new Object[]{2, 10000, false}, new Object[]{2, 100000, false}, new Object[]{2, 1000000, false}, new Object[]{2, 10000000, false}, new Object[]{2, 100000000, false}, new Object[]{2, 1000000000, false}};
+        for (Object[] rg : ranges) {
+            int start = ((int)(rg[0]));
+            int stop = ((int)(rg[1]));
+            boolean show = ((boolean)(rg[2]));
+            if (start == 2) {
+                System.out.println("eban numbers up to and including " + String.valueOf(stop) + ":");
+            } else {
+                System.out.println("eban numbers between " + String.valueOf(start) + " and " + String.valueOf(stop) + " (inclusive):");
+            }
+            if (show) {
+                int[] nums = ebanNumbers(start, stop);
+                String line = "";
+                int i = 0;
+                while (i < nums.length) {
+                    line = line + String.valueOf(nums[i]) + " ";
+                    i = i + 1;
+                }
+                if (_runeLen(line) > 0) {
+                    System.out.println(_substr(line, 0, _runeLen(line) - 1));
+                }
+            }
+            int c = countEban(start, stop);
+            System.out.println("count = " + String.valueOf(c) + "\n");
+        }
+    }
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            main();
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+
+    static int _runeLen(String s) {
+        return s.codePointCount(0, s.length());
+    }
+
+    static String _substr(String s, int i, int j) {
+        int start = s.offsetByCodePoints(0, i);
+        int end = s.offsetByCodePoints(0, j);
+        return s.substring(start, end);
+    }
+}

--- a/tests/rosetta/transpiler/Java/ecdsa-example.java
+++ b/tests/rosetta/transpiler/Java/ecdsa-example.java
@@ -1,0 +1,50 @@
+public class Main {
+    static Object res = testpkg.ECDSAExample();
+
+    public static void main(String[] args) {
+        {
+            long _benchStart = _now();
+            long _benchMem = _mem();
+            System.out.println("Private key:\nD: " + (String)(res.D));
+            System.out.println("\nPublic key:");
+            System.out.println("X: " + (String)(res.X));
+            System.out.println("Y: " + (String)(res.Y));
+            System.out.println("\nMessage: Rosetta Code");
+            System.out.println("Hash   : " + (String)(res.Hash));
+            System.out.println("\nSignature:");
+            System.out.println("R: " + (String)(res.R));
+            System.out.println("S: " + (String)(res.S));
+            System.out.println("\nSignature verified: " + String.valueOf(res.Valid));
+            long _benchDuration = _now() - _benchStart;
+            long _benchMemory = _mem() - _benchMem;
+            System.out.println("{");
+            System.out.println("  \"duration_us\": " + _benchDuration + ",");
+            System.out.println("  \"memory_bytes\": " + _benchMemory + ",");
+            System.out.println("  \"name\": \"main\"");
+            System.out.println("}");
+            return;
+        }
+    }
+
+    static boolean _nowSeeded = false;
+    static int _nowSeed;
+    static int _now() {
+        if (!_nowSeeded) {
+            String s = System.getenv("MOCHI_NOW_SEED");
+            if (s != null && !s.isEmpty()) {
+                try { _nowSeed = Integer.parseInt(s); _nowSeeded = true; } catch (Exception e) {}
+            }
+        }
+        if (_nowSeeded) {
+            _nowSeed = (int)((_nowSeed * 1664525L + 1013904223) % 2147483647);
+            return _nowSeed;
+        }
+        return (int)(System.nanoTime() / 1000);
+    }
+
+    static long _mem() {
+        Runtime rt = Runtime.getRuntime();
+        rt.gc();
+        return rt.totalMemory() - rt.freeMemory();
+    }
+}

--- a/transpiler/x/java/README.md
+++ b/transpiler/x/java/README.md
@@ -2,7 +2,7 @@
 
 Generated Java code for programs in `tests/vm/valid`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
 
-## VM Golden Test Checklist (103/104) - updated 2025-07-28 04:43 UTC
+## VM Golden Test Checklist (103/104) - updated 2025-07-28 05:07 UTC
 - [x] append_builtin.mochi
 - [x] avg_builtin.mochi
 - [x] basic_compare.mochi

--- a/transpiler/x/java/ROSETTA.md
+++ b/transpiler/x/java/ROSETTA.md
@@ -1,9 +1,9 @@
 # Java Rosetta Transpiler Output
 
 Generated Java code for programs in `tests/rosetta/x/Mochi`. Each program has a `.java` file produced by the transpiler and a `.out` file with its runtime output. Compilation or execution errors are captured in `.error` files.
-Last updated: 2025-07-28 11:43 GMT+7
+Last updated: 2025-07-28 12:07 GMT+7
 
-## Rosetta Checklist (263/493)
+## Rosetta Checklist (280/493)
 | Index | Name | Status | Duration | Memory |
 |------:|------|:-----:|---------:|-------:|
 | 1 | 100-doors-2 | ✓ | 23.0ms | 245.84KB |
@@ -305,37 +305,37 @@ Last updated: 2025-07-28 11:43 GMT+7
 | 297 | determine-if-only-one-instance-is-running | ✓ | 6.0ms | 584B |
 | 298 | determine-if-two-triangles-overlap | ✓ | 26.0ms | 110.55KB |
 | 299 | determine-sentence-type | ✓ | 31.0ms | 52.66KB |
-| 300 | dice-game-probabilities-1 | ✓ | 39.0ms | 56.18KB |
-| 301 | dice-game-probabilities-2 | ✓ | 38.0ms | 10.58KB |
-| 302 | digital-root-multiplicative-digital-root | ✓ | 181.0ms | 120.93KB |
-| 303 | dijkstras-algorithm | ✓ | 45.0ms | 96.28KB |
-| 304 | dinesmans-multiple-dwelling-problem | ✓ | 52.0ms | 94.01KB |
-| 305 | dining-philosophers-1 | ✓ | 34.0ms | 38.70KB |
-| 306 | dining-philosophers-2 | ✓ | 32.0ms | 38.70KB |
-| 307 | disarium-numbers | ✓ | 3.01s | 83.91KB |
-| 308 | discordian-date | ✓ | 53.0ms | 101.55KB |
-| 309 | display-a-linear-combination | ✓ | 51.0ms | 101.29KB |
-| 310 | display-an-outline-as-a-nested-table | ✓ | 56.0ms | 110.75KB |
-| 311 | distance-and-bearing | ✓ | 54.0ms | 103.98KB |
-| 312 | distributed-programming | ✓ | 43.0ms | 77.41KB |
-| 313 | diversity-prediction-theorem | ✓ |  |  |
-| 314 | documentation |   |  |  |
-| 315 | doomsday-rule |   |  |  |
-| 316 | dot-product |   |  |  |
-| 317 | doubly-linked-list-definition-1 |   |  |  |
-| 318 | doubly-linked-list-definition-2 |   |  |  |
-| 319 | doubly-linked-list-element-definition |   |  |  |
-| 320 | doubly-linked-list-traversal |   |  |  |
-| 321 | dragon-curve |   |  |  |
-| 322 | draw-a-clock |   |  |  |
-| 323 | draw-a-cuboid |   |  |  |
-| 324 | draw-a-pixel-1 |   |  |  |
-| 325 | draw-a-rotating-cube |   |  |  |
-| 326 | draw-a-sphere |   |  |  |
-| 327 | dutch-national-flag-problem |   |  |  |
-| 328 | dynamic-variable-names |   |  |  |
-| 329 | earliest-difference-between-prime-gaps |   |  |  |
-| 330 | eban-numbers |   |  |  |
+| 300 | dice-game-probabilities-1 | ✓ | 55.0ms | 56.18KB |
+| 301 | dice-game-probabilities-2 | ✓ | 52.0ms | 10.58KB |
+| 302 | digital-root-multiplicative-digital-root | ✓ | 234.0ms | 120.93KB |
+| 303 | dijkstras-algorithm | ✓ | 62.0ms | 96.28KB |
+| 304 | dinesmans-multiple-dwelling-problem | ✓ | 58.0ms | 94.01KB |
+| 305 | dining-philosophers-1 | ✓ | 37.0ms | 38.70KB |
+| 306 | dining-philosophers-2 | ✓ | 42.0ms | 38.70KB |
+| 307 | disarium-numbers | ✓ | 4.50s | 83.91KB |
+| 308 | discordian-date | ✓ | 64.0ms | 101.55KB |
+| 309 | display-a-linear-combination | ✓ | 64.0ms | 101.29KB |
+| 310 | display-an-outline-as-a-nested-table | ✓ | 83.0ms | 110.75KB |
+| 311 | distance-and-bearing | ✓ | 71.0ms | 103.98KB |
+| 312 | distributed-programming | ✓ | 55.0ms | 77.41KB |
+| 313 | diversity-prediction-theorem | ✓ | 54.0ms | 81.02KB |
+| 314 | documentation | ✓ | 22.0ms | 0B |
+| 315 | doomsday-rule | ✓ | 55.0ms | 77.99KB |
+| 316 | dot-product | ✓ | 23.0ms | 792B |
+| 317 | doubly-linked-list-definition-1 | ✓ | 24.0ms | 0B |
+| 318 | doubly-linked-list-definition-2 | ✓ | 26.0ms | 816B |
+| 319 | doubly-linked-list-element-definition | ✓ | 38.0ms | 38.74KB |
+| 320 | doubly-linked-list-traversal | ✓ | 59.0ms | 82.26KB |
+| 321 | dragon-curve | ✓ | 73.0ms | 87.17KB |
+| 322 | draw-a-clock | ✓ | 41.0ms | 38.40KB |
+| 323 | draw-a-cuboid | ✓ | 65.0ms | 88.09KB |
+| 324 | draw-a-pixel-1 | ✓ | 438.0ms | 388.07KB |
+| 325 | draw-a-rotating-cube | ✓ | 120.0ms | 96.24KB |
+| 326 | draw-a-sphere | ✓ | 55.0ms | 38.53KB |
+| 327 | dutch-national-flag-problem | ✓ | 42.0ms | 54.74KB |
+| 328 | dynamic-variable-names | ✓ | 41.0ms | 38.10KB |
+| 329 | earliest-difference-between-prime-gaps | ✓ | 71.0ms | 112.08KB |
+| 330 | eban-numbers | ✓ | 79.0ms | 102.79KB |
 | 331 | ecdsa-example |   |  |  |
 | 332 | echo-server |   |  |  |
 | 333 | eertree |   |  |  |

--- a/transpiler/x/java/TASKS.md
+++ b/transpiler/x/java/TASKS.md
@@ -1,4 +1,88 @@
-## Progress (2025-07-28 11:14 +0700)
+## Progress (2025-07-28 11:48 +0700)
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
+- hs transpiler: add dice probabilities case (0f6b7a3ff7)
+
 - pascal transpiler: add failing dijkstra case (07c40fc178)
 
 - pascal transpiler: add failing dijkstra case (07c40fc178)


### PR DESCRIPTION
## Summary
- regenerate Java transpiler outputs for Rosetta tasks 300-330
- handle empty list/array casts and heterogeneous map literals
- avoid Java `Map.ofEntries` when null values present
- update ROSETTA checklist

## Testing
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -count=1 -tags slow ./transpiler/x/java -run Rosetta -index 313`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -count=1 -tags slow ./transpiler/x/java -run Rosetta -index 318`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -count=1 -tags slow ./transpiler/x/java -run Rosetta -index 320`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -count=1 -tags slow ./transpiler/x/java -run Rosetta -index 327`
- `UPDATE=1 MOCHI_BENCHMARK=1 go test -count=1 -tags slow ./transpiler/x/java -run Rosetta -index 330`

------
https://chatgpt.com/codex/tasks/task_e_688700e7b3b8832099c81ee36031ba17