### PR TITLE
Add experimental C++ support to a2mochi

### DIFF
--- a/tools/a2mochi/x/cpp/README.md
+++ b/tools/a2mochi/x/cpp/README.md
@@ -1,0 +1,9 @@
+# a2mochi C++ Converter
+
+This directory contains helpers and golden files for converting C++ programs under
+`tests/transpiler/x/cpp` back into Mochi AST form using `clang++`.
+
+Completed programs: 0/104
+
+The converter is experimental and only understands a very small subset of the
+C++ code emitted by the Mochi transpiler.

--- a/tools/a2mochi/x/cpp/convert.go
+++ b/tools/a2mochi/x/cpp/convert.go
@@ -1,0 +1,411 @@
+package cpp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"mochi/ast"
+	"mochi/parser"
+)
+
+// Node represents the parsed structure of a C++ source file.
+type Node struct {
+	Funcs   []Func
+	Enums   []Enum
+	Structs []Struct
+}
+
+type Func struct {
+	Name   string
+	Params []Param
+	Ret    string
+	Body   string
+}
+
+type Param struct {
+	Name string
+	Typ  string
+}
+
+type Enum struct {
+	Name     string
+	Variants []string
+}
+
+type Struct struct {
+	Name   string
+	Fields []Field
+}
+
+type Field struct {
+	Name string
+	Typ  string
+}
+
+// Parse parses C++ source code using clang++'s JSON AST output.
+func Parse(src string) (*Node, error) {
+	funcs, enums, structs, err := parseAST(src)
+	if err != nil {
+		return nil, err
+	}
+	return &Node{Funcs: funcs, Enums: enums, Structs: structs}, nil
+}
+
+// ConvertSource converts a parsed C++ Node into Mochi source code.
+func ConvertSource(n *Node) (string, error) {
+	var b strings.Builder
+	for _, st := range n.Structs {
+		b.WriteString("type ")
+		b.WriteString(st.Name)
+		b.WriteString(" {\n")
+		for _, f := range st.Fields {
+			b.WriteString("  ")
+			b.WriteString(f.Name)
+			if f.Typ != "" {
+				b.WriteString(": ")
+				b.WriteString(f.Typ)
+			}
+			b.WriteByte('\n')
+		}
+		b.WriteString("}\n")
+	}
+	for _, e := range n.Enums {
+		b.WriteString("type ")
+		b.WriteString(e.Name)
+		b.WriteString(" {\n")
+		for _, v := range e.Variants {
+			b.WriteString("  ")
+			b.WriteString(v)
+			b.WriteByte('\n')
+		}
+		b.WriteString("}\n")
+	}
+	for _, f := range n.Funcs {
+		b.WriteString("fun ")
+		b.WriteString(f.Name)
+		b.WriteByte('(')
+		for i, p := range f.Params {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(p.Name)
+			if p.Typ != "" {
+				b.WriteString(": ")
+				b.WriteString(p.Typ)
+			}
+		}
+		b.WriteByte(')')
+		if f.Ret != "" && f.Ret != "void" {
+			b.WriteString(": ")
+			b.WriteString(f.Ret)
+		}
+		body := convertBodyString(f.Body)
+		if len(body) == 0 {
+			b.WriteString(" {}\n")
+		} else {
+			b.WriteString(" {\n")
+			for _, line := range body {
+				b.WriteString("  ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+			b.WriteString("}\n")
+		}
+	}
+	return b.String(), nil
+}
+
+// Convert parses C++ source and returns the corresponding Mochi AST node.
+func Convert(src string) (*ast.Node, error) {
+	n, err := Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	code, err := ConvertSource(n)
+	if err != nil {
+		return nil, err
+	}
+	prog, err := parser.ParseString(code)
+	if err != nil {
+		return nil, err
+	}
+	return ast.FromProgram(prog), nil
+}
+
+// --- Parsing helpers below (adapted from archived any2mochi) ---
+
+type astNode struct {
+	Kind string `json:"kind"`
+	Name string `json:"name,omitempty"`
+	Type *struct {
+		QualType string `json:"qualType"`
+	} `json:"type,omitempty"`
+	Inner []astNode `json:"inner,omitempty"`
+	Range *struct {
+		Begin struct {
+			Offset int `json:"offset"`
+		} `json:"begin"`
+		End struct {
+			Offset int `json:"offset"`
+		} `json:"end"`
+	} `json:"range,omitempty"`
+}
+
+func parseAST(src string) ([]Func, []Enum, []Struct, error) {
+	cmd := exec.Command("clang++", "-x", "c++", "-std=c++20", "-fsyntax-only", "-Xclang", "-ast-dump=json", "-")
+	cmd.Stdin = strings.NewReader(src)
+	var buf bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &errBuf
+	runErr := cmd.Run()
+	if runErr != nil && buf.Len() == 0 {
+		return nil, nil, nil, fmt.Errorf("clang++: %w: %s", runErr, errBuf.String())
+	}
+	var root astNode
+	if err := json.Unmarshal(buf.Bytes(), &root); err != nil {
+		if runErr != nil {
+			return nil, nil, nil, fmt.Errorf("%v: %w", runErr, err)
+		}
+		return nil, nil, nil, err
+	}
+	var funcs []Func
+	var enums []Enum
+	var structs []Struct
+	collectAST(&root, src, &funcs, &enums, &structs, "")
+	if runErr != nil {
+		return funcs, enums, structs, fmt.Errorf("clang++: %w: %s", runErr, errBuf.String())
+	}
+	return funcs, enums, structs, nil
+}
+
+func collectAST(n *astNode, src string, funcs *[]Func, enums *[]Enum, structs *[]Struct, parent string) {
+	switch n.Kind {
+	case "FunctionDecl":
+		if n.Range == nil || n.Range.Begin.Offset < 0 || n.Range.End.Offset > len(src) {
+			break
+		}
+		var params []Param
+		var body string
+		for i := range n.Inner {
+			c := &n.Inner[i]
+			switch c.Kind {
+			case "ParmVarDecl":
+				typ := ""
+				if c.Type != nil {
+					typ = mapType(c.Type.QualType)
+				}
+				params = append(params, Param{Name: c.Name, Typ: typ})
+			case "CompoundStmt":
+				if c.Range != nil {
+					b := c.Range.Begin.Offset
+					e := c.Range.End.Offset
+					if b >= 0 && e >= b && e <= len(src) {
+						body = src[b:e]
+					}
+				}
+			}
+		}
+		ret := ""
+		if n.Type != nil {
+			qt := n.Type.QualType
+			if p := strings.Index(qt, "("); p != -1 {
+				ret = qt[:p]
+			}
+			ret = mapType(strings.TrimSpace(ret))
+		}
+		if body != "" {
+			*funcs = append(*funcs, Func{Name: n.Name, Params: params, Ret: ret, Body: body})
+		}
+	case "CXXMethodDecl":
+		if parent == "" || n.Range == nil || n.Range.Begin.Offset < 0 || n.Range.End.Offset > len(src) {
+			break
+		}
+		var params []Param
+		var body string
+		for i := range n.Inner {
+			c := &n.Inner[i]
+			switch c.Kind {
+			case "ParmVarDecl":
+				typ := ""
+				if c.Type != nil {
+					typ = mapType(c.Type.QualType)
+				}
+				params = append(params, Param{Name: c.Name, Typ: typ})
+			case "CompoundStmt":
+				if c.Range != nil {
+					b := c.Range.Begin.Offset
+					e := c.Range.End.Offset
+					if b >= 0 && e >= b && e <= len(src) {
+						body = src[b:e]
+					}
+				}
+			}
+		}
+		ret := ""
+		if n.Type != nil {
+			qt := n.Type.QualType
+			if p := strings.Index(qt, "("); p != -1 {
+				ret = qt[:p]
+			}
+			ret = mapType(strings.TrimSpace(ret))
+		}
+		name := parent + "." + n.Name
+		*funcs = append(*funcs, Func{Name: name, Params: params, Ret: ret, Body: body})
+	case "EnumDecl":
+		if n.Range == nil || n.Range.Begin.Offset < 0 || n.Range.End.Offset > len(src) {
+			break
+		}
+		var vars []string
+		for i := range n.Inner {
+			c := &n.Inner[i]
+			if c.Kind == "EnumConstantDecl" {
+				vars = append(vars, c.Name)
+			}
+		}
+		if len(vars) > 0 && n.Name != "" {
+			*enums = append(*enums, Enum{Name: n.Name, Variants: vars})
+		}
+	case "CXXRecordDecl", "RecordDecl":
+		if n.Name != "" && n.Range != nil && n.Range.Begin.Offset >= 0 && n.Range.End.Offset <= len(src) {
+			snippet := src[n.Range.Begin.Offset:n.Range.End.Offset]
+			if strings.Contains(snippet, "struct "+n.Name) || strings.Contains(snippet, "class "+n.Name) {
+				var fields []Field
+				for i := range n.Inner {
+					c := &n.Inner[i]
+					if c.Kind == "FieldDecl" && c.Type != nil {
+						fields = append(fields, Field{Name: c.Name, Typ: mapType(c.Type.QualType)})
+					}
+				}
+				if len(fields) > 0 {
+					*structs = append(*structs, Struct{Name: n.Name, Fields: fields})
+				}
+			}
+		}
+	}
+	for i := range n.Inner {
+		nextParent := parent
+		if n.Kind == "CXXRecordDecl" || n.Kind == "RecordDecl" {
+			if n.Name != "" {
+				nextParent = n.Name
+			}
+		}
+		if n.Inner[i].Kind == "CXXMethodDecl" {
+			continue
+		}
+		collectAST(&n.Inner[i], src, funcs, enums, structs, nextParent)
+	}
+}
+
+func convertBodyString(body string) []string {
+	lines := strings.Split(body, "\n")
+	if len(lines) > 0 && strings.TrimSpace(lines[0]) == "{" {
+		lines = lines[1:]
+	}
+	if len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "}" {
+		lines = lines[:len(lines)-1]
+	}
+	var out []string
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		l = strings.TrimSuffix(l, ";")
+		if l == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(l, "return"):
+			out = append(out, l)
+		case strings.Contains(l, "std::cout") || strings.HasPrefix(l, "cout <<"):
+			l = strings.TrimPrefix(l, "std::cout <<")
+			l = strings.TrimPrefix(l, "cout <<")
+			l = strings.TrimSuffix(l, "<< std::endl")
+			l = strings.TrimSuffix(l, "<< endl")
+			l = strings.TrimSpace(l)
+			out = append(out, "print("+l+")")
+		case strings.HasPrefix(l, "for (") && strings.Contains(l, ":"):
+			re := regexp.MustCompile(`^for \((?:const\s+)?(?:auto|[\w:<>,]+)[\s*&]*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([^\)]+)\)\s*\{?$`)
+			if m := re.FindStringSubmatch(l); m != nil {
+				name := m[1]
+				src := strings.TrimSpace(m[2])
+				out = append(out, fmt.Sprintf("for %s in %s {", name, src))
+			} else {
+				out = append(out, l)
+			}
+		case strings.HasPrefix(l, "while ("):
+			if m := regexp.MustCompile(`^while \((.*)\)\s*\{?$`).FindStringSubmatch(l); m != nil {
+				cond := strings.TrimSpace(m[1])
+				out = append(out, fmt.Sprintf("while %s {", cond))
+			} else {
+				out = append(out, l)
+			}
+		case strings.HasPrefix(l, "if ("):
+			if m := regexp.MustCompile(`^if \((.*)\)\s*\{?$`).FindStringSubmatch(l); m != nil {
+				cond := strings.TrimSpace(m[1])
+				out = append(out, fmt.Sprintf("if %s {", cond))
+			} else {
+				out = append(out, l)
+			}
+		default:
+			decl := false
+			if strings.HasPrefix(l, "const ") {
+				l = strings.TrimPrefix(l, "const ")
+			}
+			for _, pre := range []string{"int ", "float ", "double ", "long ", "unsigned ", "bool ", "std::string ", "string ", "auto "} {
+				if strings.HasPrefix(l, pre) {
+					l = strings.TrimPrefix(l, pre)
+					decl = true
+					break
+				}
+			}
+			if !decl {
+				for _, pre := range []string{"std::vector<", "vector<", "std::map<", "std::unordered_map<", "map<", "unordered_map<", "std::set<", "set<", "std::array<", "array<"} {
+					if strings.HasPrefix(l, pre) {
+						if idx := strings.Index(l, ">"); idx != -1 {
+							l = strings.TrimSpace(l[idx+1:])
+							decl = true
+						}
+						break
+					}
+				}
+			}
+			if decl {
+				l = "let " + l
+			}
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func mapType(typ string) string {
+	typ = strings.TrimSpace(typ)
+	for strings.HasSuffix(typ, "*") || strings.HasSuffix(typ, "&") {
+		typ = strings.TrimSpace(typ[:len(typ)-1])
+	}
+	typ = strings.TrimPrefix(typ, "const ")
+	typ = strings.TrimPrefix(typ, "unsigned ")
+	switch typ {
+	case "", "void":
+		return ""
+	case "int", "size_t", "long", "short":
+		return "int"
+	case "float", "double":
+		return "float"
+	case "bool":
+		return "bool"
+	case "char", "char16_t", "char32_t", "std::string", "string":
+		return "string"
+	}
+	if strings.HasPrefix(typ, "std::vector<") && strings.HasSuffix(typ, ">") {
+		inner := mapType(typ[len("std::vector<") : len(typ)-1])
+		if inner == "" {
+			inner = "any"
+		}
+		return "list<" + inner + ">"
+	}
+	return typ
+}

--- a/tools/a2mochi/x/cpp/convert_test.go
+++ b/tools/a2mochi/x/cpp/convert_test.go
@@ -1,0 +1,87 @@
+package cpp_test
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"mochi/tools/a2mochi/x/cpp"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestConvert_Golden(t *testing.T) {
+	if _, err := exec.LookPath("clang++"); err != nil {
+		t.Skipf("clang++ not installed: %v", err)
+	}
+
+	root := findRepoRoot(t)
+	pattern := filepath.Join(root, "tests/transpiler/x/cpp", "*.cpp")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+
+	outDir := filepath.Join(root, "tests/a2mochi/x/cpp")
+	os.MkdirAll(outDir, 0o755)
+
+	for _, srcPath := range files {
+		name := strings.TrimSuffix(filepath.Base(srcPath), ".cpp")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			node, err := cpp.Parse(string(data))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			src, err := cpp.ConvertSource(node)
+			if err != nil {
+				t.Fatalf("convert source: %v", err)
+			}
+			astNode, err := cpp.Convert(string(data))
+			if err != nil {
+				t.Fatalf("convert: %v", err)
+			}
+			got := []byte(astNode.String())
+			outPath := filepath.Join(outDir, name+".ast")
+			if *update {
+				os.WriteFile(outPath, got, 0644)
+				os.WriteFile(filepath.Join(outDir, name+".mochi"), []byte(src), 0644)
+			}
+			want, err := os.ReadFile(outPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(got) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add experimental C++ converter in `tools/a2mochi/x/cpp`
- include tests and basic README

## Testing
- `go vet ./...`
- `go test ./tools/a2mochi/x/cpp -c`
- `go test ./tools/a2mochi/x/py -c`
- `go test ./tools/a2mochi/x/ts -c`


------
https://chatgpt.com/codex/tasks/task_e_68871e35bae08320b2143c88c5b1d058