### PR TITLE
Add stub Pascal converter for a2mochi

### DIFF
--- a/tools/a2mochi/x/pas/README.md
+++ b/tools/a2mochi/x/pas/README.md
@@ -1,0 +1,6 @@
+# a2mochi Pascal Converter
+
+This directory is a placeholder for a future Pascal to Mochi converter.
+No Pascal programs are currently supported.
+
+Completed programs: 0/104

--- a/tools/a2mochi/x/pas/convert.go
+++ b/tools/a2mochi/x/pas/convert.go
@@ -1,0 +1,27 @@
+package pas
+
+import (
+	"fmt"
+
+	"mochi/ast"
+)
+
+// Node is a placeholder type used until the Pascal
+// conversion implementation is written.
+type Node struct{}
+
+// ErrNotImplemented is returned for all functions in this
+// stub implementation.
+var ErrNotImplemented = fmt.Errorf("pascal conversion not implemented")
+
+// Parse returns ErrNotImplemented.
+func Parse(src string) (*Node, error) {
+	_ = src
+	return nil, ErrNotImplemented
+}
+
+// Convert returns ErrNotImplemented.
+func Convert(n *Node) (*ast.Node, error) {
+	_ = n
+	return nil, ErrNotImplemented
+}

--- a/tools/a2mochi/x/pas/convert_test.go
+++ b/tools/a2mochi/x/pas/convert_test.go
@@ -1,0 +1,19 @@
+package pas_test
+
+import (
+	"testing"
+
+	"mochi/tools/a2mochi/x/pas"
+)
+
+func TestParse_NotImplemented(t *testing.T) {
+	if _, err := pas.Parse("{}"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestConvert_NotImplemented(t *testing.T) {
+	if _, err := pas.Convert(&pas.Node{}); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- start pascal support under `tools/a2mochi/x`
- stub `Parse` and `Convert` functions for pascal
- placeholder tests
- add minimal README

## Testing
- `go test ./tools/a2mochi/x/...`

------
https://chatgpt.com/codex/tasks/task_e_68871eb4e0a083209d93da8ba8c0ac3a