### PR TITLE
Update Python AST tests

### DIFF
--- a/tests/a2mochi/x/py/values_builtin.ast
+++ b/tests/a2mochi/x/py/values_builtin.ast
@@ -1,0 +1,12 @@
+(program
+  (var m
+    (map
+      (entry (string a) (int 1))
+      (entry (string b) (int 2))
+      (entry (string c) (int 3))
+    )
+  )
+  (call print
+    (call values (selector m))
+  )
+)

--- a/tests/a2mochi/x/py/values_builtin.mochi
+++ b/tests/a2mochi/x/py/values_builtin.mochi
@@ -1,0 +1,2 @@
+var m = {"a": 1, "b": 2, "c": 3}
+print(values(m))

--- a/tests/a2mochi/x/py/var_assignment.ast
+++ b/tests/a2mochi/x/py/var_assignment.ast
@@ -1,0 +1,5 @@
+(program
+  (var x (int 1))
+  (assign x (int 2))
+  (call print (selector x))
+)

--- a/tests/a2mochi/x/py/var_assignment.mochi
+++ b/tests/a2mochi/x/py/var_assignment.mochi
@@ -1,0 +1,3 @@
+var x = 1
+x = 2
+print(x)

--- a/tools/a2mochi/x/py/README.md
+++ b/tools/a2mochi/x/py/README.md
@@ -5,7 +5,7 @@ Created: 2025-07-28
 This directory contains the test helpers and golden files for converting Python
 programs under `tests/transpiler/x/py` into Mochi AST form.
 
-Completed programs: 27/104
+Completed programs: 29/104
 
 ## Checklist
 - [x] append_builtin
@@ -34,3 +34,5 @@ Completed programs: 27/104
 - [x] string_compare
 - [x] string_index
 - [x] string_prefix_slice
+- [x] values_builtin
+- [x] var_assignment

--- a/tools/a2mochi/x/py/convert.go
+++ b/tools/a2mochi/x/py/convert.go
@@ -613,6 +613,20 @@ func emitExpr(b *strings.Builder, n *Node, lines []string) error {
 			b.WriteString(")")
 			return nil
 		}
+		if fn != nil && fn.Type == "Name" && fn.ID == "list" {
+			args := n.callArgs()
+			if len(args) == 1 && args[0].Type == "Call" {
+				inner := args[0]
+				if inner.Func != nil && inner.Func.Type == "Attribute" && inner.Func.Attr == "values" {
+					b.WriteString("values(")
+					if err := emitExpr(b, inner.Func.valueNode(), lines); err != nil {
+						return err
+					}
+					b.WriteString(")")
+					return nil
+				}
+			}
+		}
 		if fn != nil && fn.Type == "Name" {
 			if len(n.Keywords) > 0 && len(n.callArgs()) == 0 && strings.Title(fn.ID) == fn.ID {
 				b.WriteString(fn.ID)
@@ -631,6 +645,10 @@ func emitExpr(b *strings.Builder, n *Node, lines []string) error {
 				return nil
 			}
 			b.WriteString(fn.ID)
+		} else if fn != nil {
+			if err := emitExpr(b, fn, lines); err != nil {
+				return err
+			}
 		}
 		b.WriteString("(")
 		args := n.callArgs()

--- a/tools/a2mochi/x/py/convert_test.go
+++ b/tools/a2mochi/x/py/convert_test.go
@@ -59,6 +59,14 @@ func runMochi(src string) ([]byte, error) {
 	return bytes.TrimSpace(out.Bytes()), nil
 }
 
+func runMochiFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return runMochi(string(data))
+}
+
 func TestConvert_Golden(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not installed")
@@ -95,6 +103,8 @@ func TestConvert_Golden(t *testing.T) {
 		"string_compare":      true,
 		"string_index":        true,
 		"string_prefix_slice": true,
+		"values_builtin":      true,
+		"var_assignment":      true,
 	}
 	outDir := filepath.Join(root, "tests", "a2mochi", "x", "py")
 	os.MkdirAll(outDir, 0o755)
@@ -138,7 +148,7 @@ func TestConvert_Golden(t *testing.T) {
 			if *update {
 				os.WriteFile(mochiPath, []byte(code), 0o644)
 			}
-			gotOut, err := runMochi(code)
+			gotOut, err := runMochiFile(mochiPath)
 			if err != nil {
 				t.Fatalf("run: %v", err)
 			}


### PR DESCRIPTION
## Summary
- extend Python conversion tests to run printed Mochi files
- support calling methods and list(values())
- add `values_builtin` and `var_assignment` samples
- update Python conversion progress checklist

## Testing
- `go test ./tools/a2mochi/x/py -run TestConvert_Golden -update`
- `go test ./tools/a2mochi/x/py -run TestConvert_Golden`

------
https://chatgpt.com/codex/tasks/task_e_6887232d3d40832081926cc1ea034dc0