### PR TITLE
Run Mochi code in C++ converter test

### DIFF
--- a/tools/a2mochi/x/cpp/convert_test.go
+++ b/tools/a2mochi/x/cpp/convert_test.go
@@ -1,12 +1,18 @@
 package cpp_test
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"mochi/ast"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
 
 	"mochi/tools/a2mochi/x/cpp"
 )
@@ -30,6 +36,27 @@ func findRepoRoot(t *testing.T) string {
 	}
 	t.Fatal("go.mod not found")
 	return ""
+}
+
+func runMochi(src string) ([]byte, error) {
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return nil, err
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, errs[0]
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	m := vm.New(p, &out)
+	if err := m.Run(); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(out.Bytes()), nil
 }
 
 func TestConvert_Golden(t *testing.T) {
@@ -61,7 +88,7 @@ func TestConvert_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse: %v", err)
 			}
-			src, err := cpp.ConvertSource(node)
+			_, err = cpp.ConvertSource(node)
 			if err != nil {
 				t.Fatalf("convert source: %v", err)
 			}
@@ -73,7 +100,6 @@ func TestConvert_Golden(t *testing.T) {
 			outPath := filepath.Join(outDir, name+".ast")
 			if *update {
 				os.WriteFile(outPath, got, 0644)
-				os.WriteFile(filepath.Join(outDir, name+".mochi"), []byte(src), 0644)
 			}
 			want, err := os.ReadFile(outPath)
 			if err != nil {
@@ -81,6 +107,32 @@ func TestConvert_Golden(t *testing.T) {
 			}
 			if string(got) != string(want) {
 				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", got, want)
+			}
+
+			var buf bytes.Buffer
+			if err := ast.Fprint(&buf, astNode); err != nil {
+				t.Fatalf("print: %v", err)
+			}
+			code := buf.String()
+			mochiPath := filepath.Join(outDir, name+".mochi")
+			if *update {
+				os.WriteFile(mochiPath, []byte(code), 0644)
+			}
+
+			gotOut, err := runMochi(code)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			vmSrc, err := os.ReadFile(filepath.Join(root, "tests", "vm", "valid", name+".mochi"))
+			if err != nil {
+				t.Fatalf("missing vm source: %v", err)
+			}
+			wantOut, err := runMochi(string(vmSrc))
+			if err != nil {
+				t.Fatalf("run vm: %v", err)
+			}
+			if !bytes.Equal(gotOut, wantOut) {
+				t.Fatalf("output mismatch\nGot: %s\nWant: %s", gotOut, wantOut)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- enhance C++ converter golden tests
- run the converted Mochi code and compare its output with vm examples

## Testing
- `go test ./tools/a2mochi/x/cpp -run TestConvert_Golden -count=1`


------
https://chatgpt.com/codex/tasks/task_e_688723adefa88320a44632e3aa625b2c