### PR TITLE
Add runtime checks for Clojure converter

### DIFF
--- a/tools/a2mochi/x/clj/convert_test.go
+++ b/tools/a2mochi/x/clj/convert_test.go
@@ -1,12 +1,18 @@
 package clj_test
 
 import (
+	"bytes"
 	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"mochi/ast"
+	"mochi/parser"
+	"mochi/runtime/vm"
+	"mochi/types"
 
 	"mochi/tools/a2mochi/x/clj"
 )
@@ -30,6 +36,27 @@ func findRepoRoot(t *testing.T) string {
 	}
 	t.Fatal("go.mod not found")
 	return ""
+}
+
+func runMochi(src string) ([]byte, error) {
+	prog, err := parser.ParseString(src)
+	if err != nil {
+		return nil, err
+	}
+	env := types.NewEnv(nil)
+	if errs := types.Check(prog, env); len(errs) > 0 {
+		return nil, errs[0]
+	}
+	p, err := vm.Compile(prog, env)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	m := vm.New(p, &out)
+	if err := m.Run(); err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(out.Bytes()), nil
 }
 
 func TestConvert_Golden(t *testing.T) {
@@ -60,18 +87,13 @@ func TestConvert_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse: %v", err)
 			}
-			src, err := clj.ConvertSource(prog)
-			if err != nil {
-				t.Fatalf("convert source: %v", err)
-			}
 			node, err := clj.Convert(prog)
 			if err != nil {
 				t.Fatalf("convert: %v", err)
 			}
 			astPath := filepath.Join(outDir, name+".ast")
 			if *update {
-				os.WriteFile(astPath, []byte(node.String()), 0644)
-				os.WriteFile(filepath.Join(outDir, name+".mochi"), []byte(src), 0644)
+				os.WriteFile(astPath, []byte(node.String()), 0o644)
 			}
 			want, err := os.ReadFile(astPath)
 			if err != nil {
@@ -79,6 +101,32 @@ func TestConvert_Golden(t *testing.T) {
 			}
 			if node.String() != string(want) {
 				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", node.String(), want)
+			}
+
+			var buf bytes.Buffer
+			if err := ast.Fprint(&buf, node); err != nil {
+				t.Fatalf("print: %v", err)
+			}
+			code := buf.String()
+			mochiPath := filepath.Join(outDir, name+".mochi")
+			if *update {
+				os.WriteFile(mochiPath, []byte(code), 0o644)
+			}
+
+			gotOut, err := runMochi(code)
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			vmSrc, err := os.ReadFile(filepath.Join(root, "tests", "vm", "valid", name+".mochi"))
+			if err != nil {
+				t.Fatalf("missing vm source: %v", err)
+			}
+			wantOut, err := runMochi(string(vmSrc))
+			if err != nil {
+				t.Fatalf("run vm: %v", err)
+			}
+			if !bytes.Equal(gotOut, wantOut) {
+				t.Fatalf("output mismatch\nGot: %s\nWant: %s", gotOut, wantOut)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- enhance the Clojure a2mochi golden test
- run generated Mochi code and compare output with known VM golden files

## Testing
- `go test ./tools/a2mochi/x/clj -run TestConvert_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_688723f317388320b43ec7ca96588831