### PR TITLE
Enable fs converter tests

### DIFF
--- a/tools/a2mochi/x/fs/convert_test.go
+++ b/tools/a2mochi/x/fs/convert_test.go
@@ -59,7 +59,6 @@ func runMochi(src string) ([]byte, error) {
 }
 
 func TestConvert_Golden(t *testing.T) {
-	t.Skip("fs converter not implemented")
 	root := findRepoRoot(t)
 	pattern := filepath.Join(root, "tests", "transpiler", "x", "fs", "*.fs")
 	files, err := filepath.Glob(pattern)


### PR DESCRIPTION
## Summary
- enable the F# converter golden tests

## Testing
- `go test ./tools/a2mochi/x/fs -run TestConvert_Golden -count=1` *(fails: parse errors and missing golden files)*

------
https://chatgpt.com/codex/tasks/task_e_6887254005b48320a4097375950cdb63