### PR TITLE
Add Java converter skeleton

### DIFF
--- a/tools/a2mochi/x/java/README.md
+++ b/tools/a2mochi/x/java/README.md
@@ -1,0 +1,7 @@
+# a2mochi Java Converter
+
+This directory contains helpers and golden files for converting Java programs under `tests/transpiler/x/java` back into Mochi AST form.
+
+Completed programs: 0/103
+
+The converter is experimental and currently unimplemented.

--- a/tools/a2mochi/x/java/convert.go
+++ b/tools/a2mochi/x/java/convert.go
@@ -1,0 +1,27 @@
+package java
+
+import (
+	mochias "mochi/ast"
+	mochiparser "mochi/parser"
+	"strings"
+)
+
+// Node holds parsed Java source. Parsing is not implemented yet.
+type Node struct {
+	Lines []string
+}
+
+// Parse parses Java source code into a Node. Only splitting lines is done for now.
+func Parse(src string) (*Node, error) {
+	return &Node{Lines: strings.Split(src, "\n")}, nil
+}
+
+// Convert converts a parsed Java Node into a Mochi AST node.
+// The converter is currently unimplemented and returns an empty program.
+func Convert(n *Node) (*mochias.Node, error) {
+	prog, err := mochiparser.ParseString("")
+	if err != nil {
+		return nil, err
+	}
+	return mochias.FromProgram(prog), nil
+}

--- a/tools/a2mochi/x/java/convert_test.go
+++ b/tools/a2mochi/x/java/convert_test.go
@@ -1,0 +1,9 @@
+package java_test
+
+import (
+	"testing"
+)
+
+func TestConvert_Golden(t *testing.T) {
+	t.Skip("java converter not implemented")
+}


### PR DESCRIPTION
## Summary
- set up scaffolding for a Java a2mochi converter
- add placeholder tests and README

## Testing
- `go test ./...` *(fails: TestConvert_Golden in tools/a2mochi/x/dart)*

------
https://chatgpt.com/codex/tasks/task_e_688725ea0f2083208a8d46121514af66