### PR TITLE
Enhance Dart converter output

### DIFF
--- a/tools/a2mochi/x/dart/convert.go
+++ b/tools/a2mochi/x/dart/convert.go
@@ -12,6 +12,7 @@ import (
 
 	"mochi/ast"
 	"mochi/parser"
+	"mochi/transpiler/meta"
 )
 
 // Param represents a Dart function parameter.
@@ -111,6 +112,13 @@ func decode(data []byte) ([]Function, []Class, error) {
 // ConvertSource converts the parsed Dart node into Mochi source code.
 func ConvertSource(n *Node) (string, error) {
 	var b strings.Builder
+	b.Write(meta.Header("// "))
+	b.WriteString("/*\n")
+	b.WriteString(n.Src)
+	if !strings.HasSuffix(n.Src, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("*/\n")
 	for _, v := range parseTopLevelVars(n.Src, n.Functions, n.Classes) {
 		b.WriteString(v)
 		b.WriteByte('\n')


### PR DESCRIPTION
## Summary
- embed a header comment with build version and timestamp
- include the original Dart source as a block comment when generating Mochi code

## Testing
- `go vet ./tools/a2mochi/x/dart`
- `go test ./tools/a2mochi/x/dart` *(fails: missing golden files and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_688734a2e2ec83209e5edfacc01c5a27