### PR TITLE
Add Prolog converter with meta header

### DIFF
--- a/tests/a2mochi/x/prolog/avg_builtin.ast
+++ b/tests/a2mochi/x/prolog/avg_builtin.ast
@@ -1,0 +1,5 @@
+(program
+  (fun main
+    (call print (int 2))
+  )
+)

--- a/tests/a2mochi/x/prolog/avg_builtin.mochi
+++ b/tests/a2mochi/x/prolog/avg_builtin.mochi
@@ -1,0 +1,11 @@
+// a2mochi 0.10.47 2025-07-28 15:40:37
+/*
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln(2).
+*/
+fun main() {
+  print(2)
+}

--- a/tests/a2mochi/x/prolog/print_hello.ast
+++ b/tests/a2mochi/x/prolog/print_hello.ast
@@ -1,0 +1,5 @@
+(program
+  (fun main
+    (call print (string hello))
+  )
+)

--- a/tests/a2mochi/x/prolog/print_hello.mochi
+++ b/tests/a2mochi/x/prolog/print_hello.mochi
@@ -1,0 +1,11 @@
+// a2mochi 0.10.47 2025-07-28 15:40:37
+/*
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln("hello").
+*/
+fun main() {
+  print("hello")
+}

--- a/tests/a2mochi/x/prolog/unary_neg.ast
+++ b/tests/a2mochi/x/prolog/unary_neg.ast
@@ -1,0 +1,16 @@
+(program
+  (fun main
+    (call print
+      (unary - (int 3))
+    )
+    (let R1
+      (binary +
+        (int 5)
+        (group
+          (unary - (int 2))
+        )
+      )
+    )
+    (call print (selector R1))
+  )
+)

--- a/tests/a2mochi/x/prolog/unary_neg.mochi
+++ b/tests/a2mochi/x/prolog/unary_neg.mochi
@@ -1,0 +1,14 @@
+// a2mochi 0.10.47 2025-07-28 15:40:37
+/*
+:- initialization(main).
+:- style_check(-singleton).
+
+main :-
+    writeln(-3),
+    R1 is 5 + (-2), writeln(R1).
+*/
+fun main() {
+  print(-3)
+  let R1 = 5 + (-2)
+  print(R1)
+}

--- a/tools/a2mochi/x/prolog/README.md
+++ b/tools/a2mochi/x/prolog/README.md
@@ -1,0 +1,9 @@
+# a2mochi Prolog Converter
+
+This directory contains golden outputs for converting Prolog programs under `tests/transpiler/x/pl` into Mochi AST form. Only a tiny subset of programs is currently supported.
+
+Completed programs: 3/104
+
+- [x] avg_builtin
+- [x] print_hello
+- [x] unary_neg

--- a/tools/a2mochi/x/prolog/convert.go
+++ b/tools/a2mochi/x/prolog/convert.go
@@ -1,0 +1,169 @@
+package prolog
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"mochi/ast"
+	"mochi/parser"
+)
+
+const version = "0.10.47"
+
+// ConvertSource converts Prolog source code into Mochi source.
+func ConvertSource(src string) (string, error) {
+	funcs := parseFuncs(src)
+	if len(funcs) == 0 {
+		if strings.Contains(src, "main :-") || strings.Contains(src, "main:-") {
+			funcs = append(funcs, function{name: "main", body: ""})
+		} else {
+			return "", fmt.Errorf("no convertible symbols found")
+		}
+	}
+	var b strings.Builder
+	now := time.Now().In(time.FixedZone("GMT+7", 7*3600))
+	fmt.Fprintf(&b, "// a2mochi %s %s\n", version, now.Format("2006-01-02 15:04:05"))
+	b.WriteString("/*\n")
+	b.WriteString(src)
+	if !strings.HasSuffix(src, "\n") {
+		b.WriteByte('\n')
+	}
+	b.WriteString("*/\n")
+	for _, f := range funcs {
+		b.WriteString("fun ")
+		b.WriteString(f.name)
+		b.WriteByte('(')
+		for i, p := range f.params {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(p)
+		}
+		b.WriteString(") {\n")
+		for _, line := range parseBody(f.body) {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+		b.WriteString("}\n")
+	}
+	return b.String(), nil
+}
+
+// Convert parses Prolog source and returns a Mochi AST node.
+func Convert(src string) (*ast.Node, error) {
+	code, err := ConvertSource(src)
+	if err != nil {
+		return nil, err
+	}
+	prog, err := parser.ParseString(code)
+	if err != nil {
+		return nil, err
+	}
+	return ast.FromProgram(prog), nil
+}
+
+// ConvertFile reads a file and converts it.
+func ConvertFile(path string) (*ast.Node, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return Convert(string(data))
+}
+
+// --- Helpers from archived converter ---
+
+type function struct {
+	name   string
+	params []string
+	body   string
+}
+
+func parseFuncs(src string) []function {
+	var funcs []function
+	re := regexp.MustCompile(`(?ms)^\s*(\w+)(?:\(([^)]*)\))?\s*:-\s*(.*?)\.`)
+	matches := re.FindAllStringSubmatch(src, -1)
+	for _, m := range matches {
+		name := m[1]
+		paramList := strings.TrimSpace(m[2])
+		var params []string
+		if paramList != "" {
+			for _, p := range strings.Split(paramList, ",") {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					params = append(params, p)
+				}
+			}
+		}
+		body := strings.TrimSpace(m[3])
+		if strings.HasSuffix(body, ".") {
+			body = strings.TrimSuffix(body, ".")
+		}
+		funcs = append(funcs, function{name: name, params: params, body: body})
+	}
+	return funcs
+}
+
+func parseBody(body string) []string {
+	clauses := splitClauses(body)
+	var out []string
+	for _, c := range clauses {
+		c = strings.TrimSpace(c)
+		switch {
+		case c == "" || c == "true":
+			continue
+		case strings.HasPrefix(c, "write("):
+			arg := strings.TrimSuffix(strings.TrimPrefix(c, "write("), ")")
+			out = append(out, "  print("+arg+")")
+		case strings.HasPrefix(c, "writeln("):
+			arg := strings.TrimSuffix(strings.TrimPrefix(c, "writeln("), ")")
+			out = append(out, "  print("+arg+")")
+		case c == "nl":
+			continue
+		case strings.Contains(c, " is "):
+			parts := strings.SplitN(c, " is ", 2)
+			name := strings.TrimSpace(parts[0])
+			expr := strings.TrimSpace(parts[1])
+			out = append(out, "  let "+name+" = "+expr)
+		case strings.Contains(c, " = "):
+			parts := strings.SplitN(c, " = ", 2)
+			name := strings.TrimSpace(parts[0])
+			expr := strings.TrimSpace(parts[1])
+			out = append(out, "  let "+name+" = "+expr)
+		default:
+			out = append(out, "  // "+c)
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, "  pass")
+	}
+	return out
+}
+
+func splitClauses(body string) []string {
+	var clauses []string
+	depth := 0
+	start := 0
+	for i, r := range body {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				clauses = append(clauses, strings.TrimSpace(body[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		clauses = append(clauses, strings.TrimSpace(body[start:]))
+	}
+	return clauses
+}

--- a/tools/a2mochi/x/prolog/convert_test.go
+++ b/tools/a2mochi/x/prolog/convert_test.go
@@ -1,0 +1,87 @@
+package prolog_test
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	prolog "mochi/tools/a2mochi/x/prolog"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func findRepoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func TestConvert_Golden(t *testing.T) {
+	root := findRepoRoot(t)
+	pattern := filepath.Join(root, "tests/transpiler/x/pl", "*.pl")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no files: %s", pattern)
+	}
+
+	allowed := map[string]bool{
+		"avg_builtin": true,
+		"print_hello": true,
+		"unary_neg":   true,
+	}
+
+	outDir := filepath.Join(root, "tests/a2mochi/x/prolog")
+	os.MkdirAll(outDir, 0o755)
+
+	for _, srcPath := range files {
+		name := strings.TrimSuffix(filepath.Base(srcPath), ".pl")
+		if !allowed[name] {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			src, err := prolog.ConvertSource(string(data))
+			if err != nil {
+				t.Fatalf("convert source: %v", err)
+			}
+			node, err := prolog.Convert(string(data))
+			if err != nil {
+				t.Fatalf("convert: %v", err)
+			}
+			astPath := filepath.Join(outDir, name+".ast")
+			if *update {
+				os.WriteFile(astPath, []byte(node.String()), 0o644)
+				os.WriteFile(filepath.Join(outDir, name+".mochi"), []byte(src), 0o644)
+			}
+			want, err := os.ReadFile(astPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			got := []byte(node.String())
+			if string(want) != string(got) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add new Prolog converter under `tools/a2mochi/x`
- write README and golden outputs
- include meta header with version and timestamp
- preserve original source as block comment

## Testing
- `go test ./tools/a2mochi/x/prolog`


------
https://chatgpt.com/codex/tasks/task_e_688735be9ffc83208552872fbc7812fa