### PR TITLE
Improve AST printer

### DIFF
--- a/ast/README.md
+++ b/ast/README.md
@@ -1,4 +1,4 @@
-# AST Printer Support 7/12 (2025-07-28 06:44 GMT+0)
+# AST Printer Support 7/12 (2025-07-28 09:09 GMT+0)
 
 The following programs from `tests/vm/valid` are currently covered by
 `printer_test.go`. Checked items successfully round-trip from source to
@@ -7,7 +7,7 @@ AST and back with matching output.
 - [ ] append_builtin
 - [ ] avg_builtin
 - [ ] basic_compare
-- [ ] binary_precedence
+- [x] binary_precedence
 - [ ] bool_chain
 - [x] break_continue
 - [x] cast_string_to_int


### PR DESCRIPTION
## Summary
- fix operator precedence when converting parser expressions to AST
- keep one decimal when printing integral floats
- indent multi-line query expressions
- update support list in ast README

## Testing
- `go test ./tests/vm/ast -tags slow -run TestASTPrinterGolden -count=1 | tail -n 20` *(fails: append_builtin output mismatch, avg_builtin output mismatch, basic_compare output mismatch, bool_chain output mismatch, cross_join_filter type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68873a9c431c8320ba2b59fef6c43b46