### PR TITLE
Use real bench timings in VM

### DIFF
--- a/tests/vm/valid/bench_block.ir.out
+++ b/tests/vm/valid/bench_block.ir.out
@@ -1,22 +1,21 @@
-func main (regs=28)
+func __main (regs=28)
   // bench "simple" {
   Mem          0,0,0,0
-  Now          r1
+  RealNow      1,0,0,0
   // let n = 1000
   Const        r2, 1000
   Move         r3, r2
-  // var s = 0
-  Const        r4, 0
+  // var data = []
+  Const        r4, []
   Move         r5, r4
   // for i in 1..n {
   Const        r6, 1
-  Const        r2, 1000
   Move         r7, r6
 L1:
-  LessInt      r8, r7, r2
+  LessInt      r8, r7, r3
   JumpIfFalse  r8, L0
-  // s = s + i
-  AddInt       r9, r5, r7
+  // data = append(data, i)
+  Append       r9, r5, r7
   Move         r5, r9
   // for i in 1..n {
   Const        r10, 1
@@ -25,7 +24,7 @@ L1:
   Jump         L1
 L0:
   // bench "simple" {
-  Now          r12
+  RealNow      12,0,0,0
   Mem          13,0,0,0
   SubInt       r14, r12, r1
   Const        r2, 1000
@@ -44,4 +43,3 @@ L0:
   MakeMap      r27, 3, r21
   JSON         r27
   Return       r0
-

--- a/tests/vm/valid/bench_block.mochi
+++ b/tests/vm/valid/bench_block.mochi
@@ -1,7 +1,7 @@
 bench "simple" {
   let n = 1000
-  var s = 0
+  var data = []
   for i in 1..n {
-    s = s + i
+    data = append(data, i)
   }
 }

--- a/tests/vm/valid/bench_block.out
+++ b/tests/vm/valid/bench_block.out
@@ -1,5 +1,5 @@
 {
-  "duration_us": 571223,
-  "memory_bytes": 0,
+  "duration_us": 81556,
+  "memory_bytes": 1816144,
   "name": "simple"
 }


### PR DESCRIPTION
## Summary
- add `OpRealNow` that ignores the seeded clock
- use new opcode when compiling `bench` blocks
- adjust bench example to allocate some memory

## Testing
- `go fmt` on modified Go code


------
https://chatgpt.com/codex/tasks/task_e_688744a5e96883209ef80af17f39e0e5