### PR TITLE
Update ts converter

### DIFF
--- a/tests/a2mochi/x/ts/typed_var.mochi
+++ b/tests/a2mochi/x/ts/typed_var.mochi
@@ -1,1 +1,2 @@
-let x: int
+let x: int = 0
+print(String(x))

--- a/tests/a2mochi/x/ts/var_assignment.mochi
+++ b/tests/a2mochi/x/ts/var_assignment.mochi
@@ -1,1 +1,3 @@
-let x: int
+let x: int = 1
+x = 2
+print(String(x))

--- a/tools/a2mochi/x/ts/README.md
+++ b/tools/a2mochi/x/ts/README.md
@@ -1,7 +1,7 @@
 # a2mochi TypeScript Converter
 
-Completed programs: 109/109
-Date: 2025-07-28 09:06:51 UTC
+Completed programs: 110/110
+Date: 2025-07-28 10:04:20 UTC
 
 This directory holds golden outputs for the TypeScript to Mochi converter.
 Each `.ts` source in `tests/transpiler/x/ts` has a matching `.mochi` and `.ast`
@@ -107,6 +107,7 @@ programs.
 - [x] two-sum
 - [x] typed_let
 - [x] typed_var
+- [x] var_init
 - [x] unary_neg
 - [x] update_stmt
 - [x] user_type_literal

--- a/tools/a2mochi/x/ts/convert.go
+++ b/tools/a2mochi/x/ts/convert.go
@@ -27,6 +27,7 @@ type Node struct {
 	Params   []Param  `json:"params,omitempty"`
 	Ret      string   `json:"ret,omitempty"`
 	Body     string   `json:"body,omitempty"`
+	Value    string   `json:"value,omitempty"`
 	Fields   []Field  `json:"fields,omitempty"`
 	Alias    string   `json:"alias,omitempty"`
 	Variants []string `json:"variants,omitempty"`
@@ -139,6 +140,10 @@ func writeVar(b *strings.Builder, d Node) {
 	if d.Ret != "" {
 		b.WriteString(": ")
 		b.WriteString(d.Ret)
+	}
+	if d.Value != "" {
+		b.WriteString(" = ")
+		b.WriteString(d.Value)
 	}
 	b.WriteByte('\n')
 }

--- a/tools/a2mochi/x/ts/parse.ts
+++ b/tools/a2mochi/x/ts/parse.ts
@@ -17,6 +17,8 @@ interface TSDecl {
   params?: TSParam[];
   ret?: string;
   body?: string;
+  /** initializer expression for variables */
+  value?: string;
   fields?: TSField[];
   alias?: string;
   variants?: string[];
@@ -134,6 +136,7 @@ function parse(src: string): TSDecl[] {
           });
         } else {
           const typ = tsToMochiType(d.type ? d.type.getText(source) : "");
+          const value = init ? init.getText(source) : "";
           decls.push({
             kind: "var",
             name,
@@ -144,6 +147,7 @@ function parse(src: string): TSDecl[] {
             endCol: end.col,
             snippet,
             ret: typ,
+            value,
             startOff: stmt.getStart(source),
             endOff: stmt.end,
             doc,


### PR DESCRIPTION
## Summary
- improve TypeScript converter to capture variable initializers
- update golden `typed_var` and `var_assignment` Mochi files
- refresh checklist timestamp in the converter README

## Testing
- `go test -tags slow ./tools/a2mochi/x/ts -run TestConvert_Golden`

------
https://chatgpt.com/codex/tasks/task_e_68874917186c8320833b3bdad252c021