### PR TITLE
Refactor transform tests

### DIFF
--- a/tools/a2mochi/x/dart/parse.go
+++ b/tools/a2mochi/x/dart/parse.go
@@ -1,0 +1,105 @@
+package dart
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+//go:embed parser.dart
+var parserDart string
+
+// Param represents a Dart function parameter.
+type Param struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Function represents a parsed Dart function.
+type Function struct {
+	Name   string   `json:"name"`
+	Params []Param  `json:"params"`
+	Ret    string   `json:"ret"`
+	Body   []string `json:"body"`
+	Start  int      `json:"start"`
+	End    int      `json:"end"`
+	Doc    string   `json:"doc,omitempty"`
+}
+
+// Field represents a Dart class field.
+type Field struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Class represents a Dart class definition.
+type Class struct {
+	Name   string  `json:"name"`
+	Fields []Field `json:"fields"`
+	Start  int     `json:"start"`
+	End    int     `json:"end"`
+	Doc    string  `json:"doc,omitempty"`
+}
+
+// Program represents a parsed Dart file.
+type Program struct {
+	Functions []Function `json:"functions"`
+	Classes   []Class    `json:"classes"`
+	Src       string     `json:"-"`
+}
+
+// Parse parses Dart source into a Program using the official Dart parser.
+func Parse(src string) (*Program, error) {
+	funcs, classes, err := runParser(src)
+	if err != nil {
+		return nil, err
+	}
+	return &Program{Functions: funcs, Classes: classes, Src: src}, nil
+}
+
+func runParser(src string) ([]Function, []Class, error) {
+	dartPath, err := exec.LookPath("dart")
+	if err != nil {
+		return nil, nil, fmt.Errorf("dart not found: %w", err)
+	}
+	f, err := os.CreateTemp("", "parser-*.dart")
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := f.WriteString(parserDart); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return nil, nil, err
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	cmd := exec.Command(dartPath, f.Name())
+	cmd.Stdin = strings.NewReader(src)
+	var out bytes.Buffer
+	var errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		if errBuf.Len() > 0 {
+			return nil, nil, fmt.Errorf("%v: %s", err, errBuf.String())
+		}
+		return nil, nil, err
+	}
+	return decode(out.Bytes())
+}
+
+func decode(data []byte) ([]Function, []Class, error) {
+	var a struct {
+		Functions []Function `json:"functions"`
+		Classes   []Class    `json:"classes"`
+	}
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, nil, err
+	}
+	return a.Functions, a.Classes, nil
+}

--- a/tools/a2mochi/x/dart/parser.dart
+++ b/tools/a2mochi/x/dart/parser.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:analyzer/dart/analysis/utilities.dart';
+
+void main() async {
+  final src = await stdin.transform(utf8.decoder).join();
+  final unit = parseString(content: src).unit;
+  final funcs = <Map<String, dynamic>>[];
+  final classes = <Map<String, dynamic>>[];
+  for (var d in unit.declarations) {
+    if (d is ClassDeclaration) {
+      final fields = <Map<String, String>>[];
+      for (var m in d.members) {
+        if (m is FieldDeclaration) {
+          final type = m.fields.type?.toSource() ?? 'dynamic';
+          for (var v in m.fields.variables) {
+            fields.add({'name': v.name.lexeme, 'type': type});
+          }
+        }
+      }
+      final start = unit.lineInfo.getLocation(d.offset).lineNumber;
+      final end = unit.lineInfo.getLocation(d.end).lineNumber;
+      final doc = d.documentationComment?.tokens
+              .map((t) => t.toString().replaceFirst('///', '').trim())
+              .join('\n') ?? '';
+      classes.add({
+        'name': d.name.lexeme,
+        'fields': fields,
+        'start': start,
+        'end': end,
+        'doc': doc,
+      });
+    } else if (d is FunctionDeclaration) {
+      final params = <Map<String, String>>[];
+      final pList = d.functionExpression.parameters;
+      if (pList != null) {
+        for (var p in pList.parameters) {
+          params.add({
+            'name': p.identifier?.name ?? '',
+            'type': p is SimpleFormalParameter && p.type != null ? p.type.toSource() : '',
+          });
+        }
+      }
+      final body = d.functionExpression.body.toSource();
+      final start = unit.lineInfo.getLocation(d.offset).lineNumber;
+      final end = unit.lineInfo.getLocation(d.end).lineNumber;
+      final ret = d.returnType?.toSource() ?? '';
+      final doc = d.documentationComment?.tokens
+              .map((t) => t.toString().replaceFirst('///', '').trim())
+              .join('\n') ?? '';
+      funcs.add({
+        'name': d.name.lexeme,
+        'params': params,
+        'ret': ret,
+        'body': body.split('\n'),
+        'start': start,
+        'end': end,
+        'doc': doc,
+      });
+    }
+  }
+  stdout.write(JsonEncoder.withIndent('', '  ').convert({
+    'functions': funcs,
+    'classes': classes,
+  }));
+}

--- a/tools/a2mochi/x/dart/print.go
+++ b/tools/a2mochi/x/dart/print.go
@@ -1,0 +1,23 @@
+package dart
+
+import (
+	"fmt"
+	"strings"
+
+	"mochi/ast"
+)
+
+// Print returns Mochi source code for the given AST node.
+func Print(node *ast.Node) (string, error) {
+	if node == nil {
+		return "", fmt.Errorf("nil node")
+	}
+	var b strings.Builder
+	if err := ast.Fprint(&b, node); err != nil {
+		return "", err
+	}
+	if b.Len() > 0 && b.String()[b.Len()-1] != '\n' {
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
+}


### PR DESCRIPTION
## Summary
- rename `convert_test.go` to `transform_test.go`
- rename helper `findRepoRoot` to `repoRoot`
- add `runTransformFile` to reduce duplication
- update the golden test to use `runTransformFile`

## Testing
- `go vet ./...`
- `go test ./tools/a2mochi/x/dart -run TestTransform_Golden -count=1 -tags slow` *(fails: `dart` executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_688785a0922883209eec5be0ff582248