### PR TITLE
Add release notes for v0.10.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 📦 CHANGELOG.md
 
+## [0.10.48] – 2025-07-29T09:06:36+07:00
+
+### Added
+
+* Additional program conversions and builtins across many a2mochi converters
+* Embedded Java parser and function type support for Kotlin transformations
+
+### Changed
+
+* Converter test suites rewritten without JSON round-trips and shared helpers
+* More VM samples pass with refreshed golden files across languages
+
+### Fixed
+
+* Zig output regressions corrected with updated tests
+* Various converter bugs uncovered by new coverage
+
 ## [0.10.43] – 2025-07-28T11:11:30+07:00
 
 ### Added

--- a/releases/v0.10.48.md
+++ b/releases/v0.10.48.md
@@ -1,0 +1,16 @@
+# Jul 2025 (v0.10.48)
+
+Released on Tue Jul 29 09:06:36 2025 +0700.
+
+Mochi v0.10.48 refactors the a2mochi converters and expands their coverage across many languages.
+
+## Tooling
+
+- Converter test suites rewritten with shared helpers and no JSON round-trips
+- Embedded Java parser with improved Kotlin and Swift transformations
+- Additional loop, membership and builtin support for C, C++, Rust, Scheme and others
+
+## Documentation
+
+- Converter READMEs updated for Haskell, OCaml and PHP
+- Golden files refreshed with new VM samples


### PR DESCRIPTION
## Summary
- add CHANGELOG entry for v0.10.48
- document release in `releases/v0.10.48.md`

## Testing
- `go test ./... -run TestBasic -count=1` *(fails: build failed in `mochi/tools/a2mochi/x/scheme`)*

------
https://chatgpt.com/codex/tasks/task_e_68882cf5cb0883209f235e802be4c34d