### PR TITLE
Fix go build/test with slow tag packages

### DIFF
--- a/tools/a2mochi/x/scheme/print.go
+++ b/tools/a2mochi/x/scheme/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (

--- a/tools/a2mochi/x/scheme/transform.go
+++ b/tools/a2mochi/x/scheme/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scheme
 
 import (


### PR DESCRIPTION
## Summary
- add `//go:build slow` tags to a2mochi scheme converter files

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68882f3b77bc832081b2aece3a245a05