### PR TITLE
Improve Erlang a2mochi handling

### DIFF
--- a/tools/a2mochi/x/erl/transform.go
+++ b/tools/a2mochi/x/erl/transform.go
@@ -122,11 +122,9 @@ func formatProgram(p *Program) (string, error) {
 		} else {
 			parts = append(parts, funLine+" {")
 			for _, line := range f.Body {
-				plines := strings.Split(line, "\n")
-				for _, ln := range plines {
-					ln = rewriteLine(ln, p.Records)
-					parts = append(parts, "  "+strings.TrimSpace(ln))
-				}
+				ln := strings.ReplaceAll(line, "\n", " ")
+				ln = rewriteLine(ln, p.Records)
+				parts = append(parts, "  "+strings.TrimSpace(ln))
 			}
 			parts = append(parts, "}")
 		}
@@ -202,11 +200,11 @@ func rewriteLine(ln string, recs []Record) string {
 			return "substring(" + target + ", " + start + ", " + start + " + " + length + ")"
 		})
 	}
-	if strings.Contains(ln, " andalso ") {
-		ln = strings.ReplaceAll(ln, " andalso ", " && ")
+	if strings.Contains(ln, "andalso") {
+		ln = strings.ReplaceAll(ln, "andalso", "&&")
 	}
-	if strings.Contains(ln, " orelse ") {
-		ln = strings.ReplaceAll(ln, " orelse ", " || ")
+	if strings.Contains(ln, "orelse") {
+		ln = strings.ReplaceAll(ln, "orelse", "||")
 	}
 	if strings.Contains(ln, "#{") {
 		ln = strings.ReplaceAll(ln, "#{", "{")
@@ -239,12 +237,12 @@ func rewriteLine(ln string, recs []Record) string {
 	return ln
 }
 
+var printfRe = regexp.MustCompile(`^"~[sp]~n",\s*\[(.+)\]\)$`)
+
 func rewritePrint(args string) string {
-	if strings.HasPrefix(args, "\"~s~n\", [") && strings.HasSuffix(args, "])") {
-		return "print(" + strings.TrimSuffix(strings.TrimPrefix(args, "\"~s~n\", ["), "])") + ")"
+	trimmed := strings.TrimSpace(args)
+	if m := printfRe.FindStringSubmatch(trimmed); m != nil {
+		return "print(" + m[1] + ")"
 	}
-	if strings.HasPrefix(args, "\"~p~n\", [") && strings.HasSuffix(args, "])") {
-		return "print(" + strings.TrimSuffix(strings.TrimPrefix(args, "\"~p~n\", ["), "])") + ")"
-	}
-	return "print(" + args
+	return "print(" + trimmed
 }

--- a/tools/a2mochi/x/erl/transform_test.go
+++ b/tools/a2mochi/x/erl/transform_test.go
@@ -141,11 +141,11 @@ func TestTransform_Golden(t *testing.T) {
 		"string_concat":       true,
 		"string_contains":     true,
 		"string_index":        true,
-		"string_prefix_slice": false,
+		"string_prefix_slice": true,
 		"substring_builtin":   true,
 		"sum_builtin":         true,
-		"bool_chain":          false,
-		"short_circuit":       false,
+		"bool_chain":          true,
+		"short_circuit":       true,
 		"unary_neg":           true,
 	}
 	outDir := filepath.Join(root, "tests", "a2mochi", "x", "erl")


### PR DESCRIPTION
## Summary
- handle multi-line Erlang statements when formatting to Mochi
- fix boolean operator rewriting
- parse `io:format` calls with flexible whitespace
- enable more Erlang samples in tests

## Testing
- `go test -tags slow ./tools/a2mochi/x/erl -run TestTransform_Golden -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68882e55bd748320a7118d96cf188d8d