### PR TITLE
Enhance ts converter

### DIFF
--- a/tests/a2mochi/x/ts/break_continue.mochi
+++ b/tests/a2mochi/x/ts/break_continue.mochi
@@ -1,1 +1,10 @@
 let numbers: list<int>
+for n in numbers {
+  if ((n % 2) == 0) {
+    continue
+  }
+  if (n > 7) {
+    break
+  }
+  print(("odd number:" + " " + String(n)).trim())
+}

--- a/tests/a2mochi/x/ts/break_continue.out
+++ b/tests/a2mochi/x/ts/break_continue.out
@@ -1,0 +1,4 @@
+odd number: 1
+odd number: 3
+odd number: 5
+odd number: 7


### PR DESCRIPTION
## Summary
- support console.log expressions that include `.trim()` in the TS converter
- update generated Mochi for the break_continue example

## Testing
- `go test ./...`
- `go test -tags slow ./tools/a2mochi/x/ts`

------
https://chatgpt.com/codex/tasks/task_e_68883120a6f88320afd86c6ec81b5e93