### PR TITLE
Improve TypeScript parser for nested bodies

### DIFF
--- a/tools/a2mochi/x/go/transform.go
+++ b/tools/a2mochi/x/go/transform.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"strconv"
-	"strings"
 
 	mast "mochi/ast"
 )

--- a/tools/a2mochi/x/ts/README.md
+++ b/tools/a2mochi/x/ts/README.md
@@ -1,7 +1,7 @@
 # a2mochi TypeScript Converter
 
 Completed programs: 111/111
-Date: 2025-07-29 03:09:12 UTC
+Date: 2025-07-29 05:26:17 UTC
 
 This directory holds golden outputs for the TypeScript to Mochi converter.
 Each `.ts` source in `tests/transpiler/x/ts` has a matching `.mochi` and `.ast`

--- a/tools/a2mochi/x/ts/parse.ts
+++ b/tools/a2mochi/x/ts/parse.ts
@@ -73,10 +73,12 @@ function parse(src: string): TSDecl[] {
             typ: p.type ? p.type.getText(source) : "",
           }));
           const rt = init.type ? init.type.getText(source) : "";
-          let body = "";
+          let body = init.body.getText(source);
           let bodyNodes: TSDecl[] | undefined = undefined;
           if (ts.isBlock(init.body)) {
-            body = init.body.getText(source).slice(1, -1);
+            body = body.slice(1, -1);
+            bodyNodes = parse(body);
+          } else {
             bodyNodes = parse(body);
           }
           decls.push({
@@ -241,6 +243,8 @@ function parse(src: string): TSDecl[] {
       if (ts.isBlock(stmt.statement)) {
         body = body.slice(1, -1);
         bodyNodes = parse(body);
+      } else {
+        bodyNodes = parse(body);
       }
       decls.push({
         kind: "forof",
@@ -269,6 +273,8 @@ function parse(src: string): TSDecl[] {
       let bodyNodes: TSDecl[] | undefined = undefined;
       if (ts.isBlock(stmt.statement)) {
         body = body.slice(1, -1);
+        bodyNodes = parse(body);
+      } else {
         bodyNodes = parse(body);
       }
       decls.push({
@@ -309,6 +315,8 @@ function parse(src: string): TSDecl[] {
       if (ts.isBlock(stmt.statement)) {
         body = body.slice(1, -1);
         bodyNodes = parse(body);
+      } else {
+        bodyNodes = parse(body);
       }
       decls.push({
         kind: "for",
@@ -334,6 +342,8 @@ function parse(src: string): TSDecl[] {
       if (ts.isBlock(stmt.statement)) {
         body = body.slice(1, -1);
         bodyNodes = parse(body);
+      } else {
+        bodyNodes = parse(body);
       }
       decls.push({
         kind: "while",
@@ -357,6 +367,8 @@ function parse(src: string): TSDecl[] {
       if (ts.isBlock(stmt.thenStatement)) {
         body = body.slice(1, -1);
         bodyNodes = parse(body);
+      } else {
+        bodyNodes = parse(body);
       }
       let elsePart = "";
       let elseNodes: TSDecl[] | undefined = undefined;
@@ -364,6 +376,8 @@ function parse(src: string): TSDecl[] {
         elsePart = stmt.elseStatement.getText(source);
         if (ts.isBlock(stmt.elseStatement)) {
           elsePart = elsePart.slice(1, -1);
+          elseNodes = parse(elsePart);
+        } else {
           elseNodes = parse(elsePart);
         }
       }


### PR DESCRIPTION
## Summary
- parse body of arrow functions and single-line loops/conditionals
- update TypeScript converter docs timestamp

## Testing
- `go test -tags slow ./tools/a2mochi/x/ts`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688848bcd17c832099bbb8071d7f977d