### PR TITLE
Improve Kotlin a2mochi parser

### DIFF
--- a/tools/a2mochi/x/kt/README.md
+++ b/tools/a2mochi/x/kt/README.md
@@ -1,7 +1,7 @@
 # a2mochi Kotlin Converter
 
 Completed programs: 102/102
-Date: 2025-07-30
+Date: 2025-07-31
 
 This directory holds golden outputs for the Kotlin to Mochi converter.
 

--- a/tools/a2mochi/x/kt/parse.go
+++ b/tools/a2mochi/x/kt/parse.go
@@ -149,6 +149,9 @@ func toNodes(a *astJSON) []Node {
 
 func mapType(t string) string {
 	t = strings.TrimSpace(t)
+	if t == "*" {
+		return "any"
+	}
 	if strings.HasSuffix(t, "?") {
 		t = strings.TrimSuffix(t, "?")
 	}
@@ -219,6 +222,20 @@ func mapType(t string) string {
 		}
 		return "list<" + inner + ">"
 	}
+	if strings.HasPrefix(t, "Iterable<") && strings.HasSuffix(t, ">") {
+		inner := mapType(t[9 : len(t)-1])
+		if inner == "" {
+			inner = "any"
+		}
+		return "list<" + inner + ">"
+	}
+	if strings.HasPrefix(t, "Sequence<") && strings.HasSuffix(t, ">") {
+		inner := mapType(t[9 : len(t)-1])
+		if inner == "" {
+			inner = "any"
+		}
+		return "list<" + inner + ">"
+	}
 	if strings.HasPrefix(t, "Set<") && strings.HasSuffix(t, ">") {
 		inner := mapType(t[4 : len(t)-1])
 		if inner == "" {
@@ -279,6 +296,21 @@ func mapType(t string) string {
 	}
 	if strings.HasPrefix(t, "Pair<") && strings.HasSuffix(t, ">") {
 		inner := t[5 : len(t)-1]
+		parts := splitGeneric(inner)
+		first := "any"
+		second := "any"
+		if len(parts) == 2 {
+			if f := mapType(parts[0]); f != "" {
+				first = f
+			}
+			if s := mapType(parts[1]); s != "" {
+				second = s
+			}
+		}
+		return "tuple<" + first + ", " + second + ">"
+	}
+	if strings.HasPrefix(t, "Map.Entry<") && strings.HasSuffix(t, ">") {
+		inner := t[10 : len(t)-1]
 		parts := splitGeneric(inner)
 		first := "any"
 		second := "any"


### PR DESCRIPTION
## Summary
- support Kotlin Iterable, Sequence and Map.Entry types in a2mochi
- allow star-projection mapping in parser
- regenerate Kotlin README with new date

## Testing
- `go test ./tools/a2mochi/x/kt -tags=slow -run TestTransform_Golden`
- `go test ./tools/a2mochi/x/kt -tags=slow -run TestTransform_Golden -update`

------
https://chatgpt.com/codex/tasks/task_e_68886792edc48320a21a8820677e58b4