### PR TITLE
Fix rust push handling

### DIFF
--- a/tools/a2mochi/x/rust/transform.go
+++ b/tools/a2mochi/x/rust/transform.go
@@ -594,15 +594,15 @@ func sanitizeExpr(code string) string {
 				depth++
 			case ')':
 				depth--
-				if depth == 0 {
-					break
-				}
 			}
 			end++
+			if depth == 0 {
+				break
+			}
 		}
-		arg := strings.TrimSpace(code[idx+len(".push(") : end])
+		arg := strings.TrimSpace(code[idx+len(".push(") : end-1])
 		repl := fmt.Sprintf("%s = append(%s, %s)", name, name, arg)
-		code = code[:start] + repl + code[end+1:]
+		code = code[:start] + repl + code[end:]
 	}
 	if strings.HasPrefix(code, "{") && strings.HasSuffix(code, "}") {
 		inner := strings.TrimSpace(code[1 : len(code)-1])


### PR DESCRIPTION
## Summary
- fix push() conversion in rust a2mochi transform so block expressions sanitize correctly

## Testing
- `go test -tags slow ./tools/a2mochi/x/rust -run TestTransformGolden/append_builtin -v` *(fails: output mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_688865c884c48320ab0d81cef0b339c2