### PR TITLE
Update scheme a2mochi readme generation

### DIFF
--- a/tools/a2mochi/x/scheme/README.md
+++ b/tools/a2mochi/x/scheme/README.md
@@ -1,7 +1,7 @@
 # a2mochi Scheme Converter
 
 Completed programs: 87/87
-Date: 2025-07-29 08:12:06 GMT
+Date: 2025-07-29 15:25:42 GMT+7
 
 This directory holds golden outputs for converting Scheme source files under `tests/transpiler/x/scheme` back into Mochi form.
 

--- a/tools/a2mochi/x/scheme/parse.go
+++ b/tools/a2mochi/x/scheme/parse.go
@@ -77,8 +77,10 @@ func Parse(src string) (*Program, error) {
     [(and (pair? e) (eq? (car e) 'list))
      (hash 'list (map expr->json (cdr e)))]
     [(pair? e)
-     (hash 'call (symbol->string (car e))
-           'args (map expr->json (cdr e)))]
+     (if (symbol? (car e))
+         (hash 'call (symbol->string (car e))
+               'args (map expr->json (cdr e)))
+         null)]
     [else #f]))
 
 (define (item f)

--- a/tools/a2mochi/x/scheme/readme_gen_test.go
+++ b/tools/a2mochi/x/scheme/readme_gen_test.go
@@ -1,0 +1,7 @@
+package scheme_test
+
+import "testing"
+
+func TestGenerateReadme(t *testing.T) {
+	updateReadme()
+}


### PR DESCRIPTION
## Summary
- avoid crashes parsing nested Scheme pairs
- generate README from golden test results
- add README generator test

## Testing
- `go test -tags=slow ./tools/a2mochi/x/scheme -run TestGenerateReadme`
- `go test -tags=slow ./tools/a2mochi/x/scheme -run TestTransform_Golden` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_688883be89348320bb4b3da4306bc295