### PR TITLE
Update v0.10.48 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Additional program conversions and builtins across many a2mochi converters
 * Embedded Java parser and function type support for Kotlin transformations
+* Go converter handles list for-loops and struct types
+* Dart, Prolog and Lua gain new builtins and loop conversions
+* Racket, Scala and PHP transformers cover more examples and nested conditions
+* Python, Java and Swift golden files refreshed with extra tests
 
 ### Changed
 

--- a/releases/v0.10.48.md
+++ b/releases/v0.10.48.md
@@ -9,8 +9,13 @@ Mochi v0.10.48 refactors the a2mochi converters and expands their coverage acros
 - Converter test suites rewritten with shared helpers and no JSON round-trips
 - Embedded Java parser with improved Kotlin and Swift transformations
 - Additional loop, membership and builtin support for C, C++, Rust, Scheme and others
+- Go converter handles list for-loops and struct types
+- Dart, Prolog and Lua gain new builtins and loop conversions
+- Racket, Scala and PHP transformers cover more examples and nested conditions
+- Python, Java and Swift golden files refreshed with extra tests
 
 ## Documentation
 
 - Converter READMEs updated for Haskell, OCaml and PHP
 - Golden files refreshed with new VM samples
+- Progress tables updated for Java and Ruby converters


### PR DESCRIPTION
## Summary
- expand v0.10.48 release notes with new converter improvements
- update CHANGELOG for v0.10.48

## Testing
- `go test ./parser -run TestParser -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68889e853d648320aa38d5a1ce2ed52a