### PR TITLE
Fix ts a2mochi parse helper

### DIFF
--- a/tools/a2mochi/x/ts/README.md
+++ b/tools/a2mochi/x/ts/README.md
@@ -1,7 +1,7 @@
 # a2mochi TypeScript Converter
 
 Completed programs: 105/105
-Date: 2025-07-29 15:07:38 GMT+7
+Date: 2025-07-29 17:58:11 GMT+7
 
 This directory holds golden outputs for the TypeScript to Mochi converter.
 Each `.ts` source in `tests/transpiler/x/ts` has a matching `.mochi` and `.ast`

--- a/tools/a2mochi/x/ts/parse.go
+++ b/tools/a2mochi/x/ts/parse.go
@@ -96,5 +96,23 @@ func Parse(src string) (*Program, error) {
 	if err := json.Unmarshal(out, &nodes); err != nil {
 		return nil, err
 	}
-	return &Program{Nodes: nodes, Source: src}, nil
+        return &Program{Nodes: nodes, Source: src}, nil
+}
+
+func repoRoot() (string, error) {
+       dir, err := os.Getwd()
+       if err != nil {
+               return "", err
+       }
+       for i := 0; i < 10; i++ {
+               if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+                       return dir, nil
+               }
+               parent := filepath.Dir(dir)
+               if parent == dir {
+                       break
+               }
+               dir = parent
+       }
+       return "", os.ErrNotExist
 }


### PR DESCRIPTION
## Summary
- add repoRoot helper for TypeScript converter
- update auto-generated README

## Testing
- `go test ./tools/a2mochi/x/ts -tags slow -run TestTransformGolden -update -count=1`

------
https://chatgpt.com/codex/tasks/task_e_6888a7d202c083209e2ef50ce99ec5c3