### PR TITLE
Fix go build/test for fs updatehelpers

### DIFF
--- a/tools/a2mochi/x/fs/updatehelpers.go
+++ b/tools/a2mochi/x/fs/updatehelpers.go
@@ -42,3 +42,18 @@ func UpdateReadme() {
 	buf.WriteString("\n")
 	_ = os.WriteFile(readme, buf.Bytes(), 0o644)
 }
+
+func repoRoot() string {
+	dir, _ := os.Getwd()
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return dir
+}


### PR DESCRIPTION
## Summary
- fix missing `repoRoot` in `tools/a2mochi/x/fs/updatehelpers.go`
- `go test ./...` and `go build ./...` now succeed

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888ac9c4ff48320a4311b5a0bbb660c