### PR TITLE
Fix repoRoot helper for fs updatehelpers

### DIFF
--- a/tools/a2mochi/x/fs/updatehelpers.go
+++ b/tools/a2mochi/x/fs/updatehelpers.go
@@ -42,3 +42,18 @@ func UpdateReadme() {
 	buf.WriteString("\n")
 	_ = os.WriteFile(readme, buf.Bytes(), 0o644)
 }
+
+func repoRoot() string {
+	dir, _ := os.Getwd()
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return dir
+}


### PR DESCRIPTION
## Summary
- add repoRoot helper function to tools/a2mochi/x/fs/updatehelpers.go
- ensure go test ./... and go build ./... succeed

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888ae95bfac8320b4a2f6ced47e71f4