### PR TITLE
Mark a2mochi packages as slow

### DIFF
--- a/tools/a2mochi/x/c/parse.go
+++ b/tools/a2mochi/x/c/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/tools/a2mochi/x/c/print.go
+++ b/tools/a2mochi/x/c/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/tools/a2mochi/x/c/transform.go
+++ b/tools/a2mochi/x/c/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package c
 
 import (

--- a/tools/a2mochi/x/cpp/parse.go
+++ b/tools/a2mochi/x/cpp/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/tools/a2mochi/x/cpp/print.go
+++ b/tools/a2mochi/x/cpp/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package cpp
 
 import (

--- a/tools/a2mochi/x/dart/parse.go
+++ b/tools/a2mochi/x/dart/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/tools/a2mochi/x/dart/print.go
+++ b/tools/a2mochi/x/dart/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/tools/a2mochi/x/dart/transform.go
+++ b/tools/a2mochi/x/dart/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package dart
 
 import (

--- a/tools/a2mochi/x/ex/print.go
+++ b/tools/a2mochi/x/ex/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ex
 
 import (

--- a/tools/a2mochi/x/fortran/convert.go
+++ b/tools/a2mochi/x/fortran/convert.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fortran
 
 import (

--- a/tools/a2mochi/x/fortran/convert_test.go
+++ b/tools/a2mochi/x/fortran/convert_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fortran_test
 
 import (

--- a/tools/a2mochi/x/fs/updatehelpers.go
+++ b/tools/a2mochi/x/fs/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package fs
 
 import (

--- a/tools/a2mochi/x/go/parse.go
+++ b/tools/a2mochi/x/go/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gox
 
 import (

--- a/tools/a2mochi/x/go/print.go
+++ b/tools/a2mochi/x/go/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gox
 
 import (

--- a/tools/a2mochi/x/go/transform.go
+++ b/tools/a2mochi/x/go/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package gox
 
 import (

--- a/tools/a2mochi/x/php/updatehelpers.go
+++ b/tools/a2mochi/x/php/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package php
 
 import (

--- a/tools/a2mochi/x/prolog/print.go
+++ b/tools/a2mochi/x/prolog/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package prolog
 
 import (

--- a/tools/a2mochi/x/prolog/updatehelpers.go
+++ b/tools/a2mochi/x/prolog/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package prolog
 
 import (

--- a/tools/a2mochi/x/ruby/updatehelpers.go
+++ b/tools/a2mochi/x/ruby/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package ruby
 
 import (

--- a/tools/a2mochi/x/rust/mochibuilder.go
+++ b/tools/a2mochi/x/rust/mochibuilder.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rust
 
 import (

--- a/tools/a2mochi/x/rust/print.go
+++ b/tools/a2mochi/x/rust/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package rust
 
 import (

--- a/tools/a2mochi/x/scala/parse.go
+++ b/tools/a2mochi/x/scala/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scala
 
 import (

--- a/tools/a2mochi/x/scala/print.go
+++ b/tools/a2mochi/x/scala/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scala
 
 import (

--- a/tools/a2mochi/x/scala/transform.go
+++ b/tools/a2mochi/x/scala/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package scala
 
 import (

--- a/tools/a2mochi/x/swift/parse.go
+++ b/tools/a2mochi/x/swift/parse.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/tools/a2mochi/x/swift/print.go
+++ b/tools/a2mochi/x/swift/print.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/tools/a2mochi/x/swift/transform.go
+++ b/tools/a2mochi/x/swift/transform.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/tools/a2mochi/x/swift/updatehelpers.go
+++ b/tools/a2mochi/x/swift/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package swift
 
 import (

--- a/tools/a2mochi/x/zig/updatehelpers.go
+++ b/tools/a2mochi/x/zig/updatehelpers.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package zig
 
 import (


### PR DESCRIPTION
## Summary
- exclude tools/a2mochi from default builds by adding `//go:build slow` tags

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6888b00f0adc83209cb42d91470da470