### PR TITLE
Update clj golden tests

### DIFF
--- a/tools/a2mochi/x/clj/transform_test.go
+++ b/tools/a2mochi/x/clj/transform_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"flag"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,9 +71,6 @@ func run(src string) ([]byte, error) {
 }
 
 func TestTransformGolden(t *testing.T) {
-	if _, err := exec.LookPath("clojure"); err != nil {
-		t.Skipf("clojure not installed: %v", err)
-	}
 	root := repoRoot(t)
 	pattern := filepath.Join(root, "tests", "transpiler", "x", "clj", "*.clj")
 	files, err := filepath.Glob(pattern)


### PR DESCRIPTION
## Summary
- remove clojure binary check in clj tests

## Testing
- `go test ./tools/a2mochi/x/clj -tags slow -run TestTransformGolden -update -v` *(fails: `parse: clojure: Execution error (FileNotFoundException) ... Could not locate clojure/data/json__init.class`)*

------
https://chatgpt.com/codex/tasks/task_e_6888d82edb6083209751a39a419b5172