### PR TITLE
Improve TypeScript console log conversion

### DIFF
--- a/tools/a2mochi/x/ts/README.md
+++ b/tools/a2mochi/x/ts/README.md
@@ -1,7 +1,7 @@
 # a2mochi TypeScript Converter
 
 Completed programs: 26/105
-Date: 2025-07-29 21:28:23 GMT+7
+Date: 2025-07-29 23:36:30 GMT+7
 
 This directory holds golden outputs for the TypeScript to Mochi converter.
 Each `.ts` source in `tests/transpiler/x/ts` has a matching `.mochi` and `.ast`


### PR DESCRIPTION
## Summary
- tweak README timestamp via golden test
- improve `convertConsole` to handle concatenation
- add helper `splitByPlus`

## Testing
- `go test -tags slow ./tools/a2mochi/x/ts -update` *(fails: parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6888f46c536883209468ed76302432c8