### PR TITLE
Improve Racket converter

### DIFF
--- a/tools/a2mochi/x/rkt/README.md
+++ b/tools/a2mochi/x/rkt/README.md
@@ -5,7 +5,7 @@ This directory contains a very small converter that translates simple Racket pro
 The converter does not rely on a language server. It tokenises the input and recognises basic forms such as `define`, `struct` and `for`. Only a subset of expressions and statements are supported.
 
 Completed programs: 45/103
-Date: 2025-07-29 21:41 GMT+7
+Date: 2025-07-30 00:26 GMT+7
 
 ## Checklist
 - [x] append_builtin

--- a/tools/a2mochi/x/rkt/transform.go
+++ b/tools/a2mochi/x/rkt/transform.go
@@ -530,6 +530,10 @@ func exprNode(d any) *ast.Node {
 			if len(v) == 2 {
 				return &ast.Node{Kind: "call", Value: "float", Children: []*ast.Node{exprNode(v[1])}}
 			}
+		case "length":
+			if len(v) == 2 {
+				return &ast.Node{Kind: "call", Value: "len", Children: []*ast.Node{exprNode(v[1])}}
+			}
 		case "+", "-", "*", "/", "<", ">", "<=", ">=", "=", "and", "or":
 			op := head
 			switch head {


### PR DESCRIPTION
## Summary
- support `length` builtin in Racket converter
- auto-generated README timestamp updated

## Testing
- `go test ./tools/a2mochi/x/rkt -tags slow -run ^$`

------
https://chatgpt.com/codex/tasks/task_e_6888fec0c6f08320a2ca2fc2d091f7f7