### PR TITLE
Improve Pascal converter

### DIFF
--- a/tools/a2mochi/x/pas/transform.go
+++ b/tools/a2mochi/x/pas/transform.go
@@ -106,7 +106,7 @@ var (
 	posRe        = regexp.MustCompile(`Pos\(([^,]+),\s*([^\)]+)\)`)
 	posCmpRe     = regexp.MustCompile(`Pos\(([^,]+),\s*([^\)]+)\)\s*(<>|=)\s*0`)
 	strToIntRe   = regexp.MustCompile(`StrToInt\(([^\)]+)\)`)
-	recordLitRe  = regexp.MustCompile(`([=,\[]\s*)\(([^()]*:[^()]*?)\)`)
+	recordLitRe  = regexp.MustCompile(`(^|[=,\[]\s*)\(([^()]*:[^()]*?)\)`)
 	concatRe     = regexp.MustCompile(`(?i)concat\(([^,]+),\s*([^\)]+)\)`)
 	formatSpecRe = regexp.MustCompile(`:[0-9]+(?::[0-9]+)?`)
 )
@@ -325,9 +325,6 @@ func zeroValue(t string) string {
 	if strings.HasPrefix(t, "map") || strings.HasPrefix(t, "{") {
 		return "{}"
 	}
-	if t != "" {
-		return "nil"
-	}
 	return ""
 }
 
@@ -519,8 +516,10 @@ func convertFallback(src string) ([]byte, error) {
 								if typ == "string" {
 									stringVars[name] = true
 								}
+								if v := zeroValue(typ); v != "" {
+									line += " = " + v
+								}
 							}
-							// leave uninitialised to match VM behaviour
 							appendLine(line)
 						}
 					}
@@ -544,8 +543,10 @@ func convertFallback(src string) ([]byte, error) {
 							if typ == "string" {
 								stringVars[nm] = true
 							}
+							if v := zeroValue(typ); v != "" {
+								line += " = " + v
+							}
 						}
-						// leave uninitialised to match VM behaviour
 						appendLine(line)
 					}
 				}

--- a/tools/a2mochi/x/pas/transform_test.go
+++ b/tools/a2mochi/x/pas/transform_test.go
@@ -25,6 +25,12 @@ func updateReadme() {
 	pas.UpdateReadmeForTests()
 }
 
+func TestMain(m *testing.M) {
+	code := m.Run()
+	updateReadme()
+	os.Exit(code)
+}
+
 func findRepoRoot(t *testing.T) string {
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Summary
- extend Pascal record literal regex
- add zeroValue init logic
- update test helper to refresh README after tests

## Testing
- `go test ./tools/a2mochi/x/pas -tags slow -run ^$`

------
https://chatgpt.com/codex/tasks/task_e_68890581e5b883209e28e2633e7f9356