### PR TITLE
Add Python AST inspection tool

### DIFF
--- a/tests/json-ast/x/py/append_builtin.py.json
+++ b/tests/json-ast/x/py/append_builtin.py.json
@@ -1,0 +1,121 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "a",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 6
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 10
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "a",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "List",
+                "elts": [
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 11,
+                    "end_col_offset": 12
+                  }
+                ],
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 10,
+                "end_col_offset": 13
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 13
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 14
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 14
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/avg_builtin.py.json
+++ b/tests/json-ast/x/py/avg_builtin.py.json
@@ -1,0 +1,219 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "List",
+                "elts": [
+                  {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 43,
+                    "end_col_offset": 44
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 46,
+                    "end_col_offset": 47
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 49,
+                    "end_col_offset": 50
+                  }
+                ],
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 42,
+                "end_col_offset": 51
+              },
+              "body": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "sum",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 7,
+                    "end_col_offset": 10
+                  },
+                  "args": [
+                    {
+                      "_type": "List",
+                      "elts": [
+                        {
+                          "_type": "Constant",
+                          "value": 1,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 12,
+                          "end_col_offset": 13
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": 2,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 15,
+                          "end_col_offset": 16
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": 3,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 18,
+                          "end_col_offset": 19
+                        }
+                      ],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 20
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 7,
+                  "end_col_offset": 21
+                },
+                "op": {
+                  "_type": "Div"
+                },
+                "right": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "len",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 24,
+                    "end_col_offset": 27
+                  },
+                  "args": [
+                    {
+                      "_type": "List",
+                      "elts": [
+                        {
+                          "_type": "Constant",
+                          "value": 1,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 29,
+                          "end_col_offset": 30
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": 2,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 32,
+                          "end_col_offset": 33
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": 3,
+                          "kind": null,
+                          "lineno": 3,
+                          "end_lineno": 3,
+                          "col_offset": 35,
+                          "end_col_offset": 36
+                        }
+                      ],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 28,
+                      "end_col_offset": 37
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 24,
+                  "end_col_offset": 38
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 7,
+                "end_col_offset": 38
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0.0,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 57,
+                "end_col_offset": 60
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 7,
+              "end_col_offset": 60
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 62
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 62
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/basic_compare.py.json
+++ b/tests/json-ast/x/py/basic_compare.py.json
@@ -1,0 +1,303 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "a",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "Constant",
+            "value": 10,
+            "kind": null,
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 4,
+            "end_col_offset": 6
+          },
+          "op": {
+            "_type": "Sub"
+          },
+          "right": {
+            "_type": "Constant",
+            "value": 3,
+            "kind": null,
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 9,
+            "end_col_offset": 10
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 10
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "b",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "Constant",
+            "value": 2,
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 5
+          },
+          "op": {
+            "_type": "Add"
+          },
+          "right": {
+            "_type": "Constant",
+            "value": 2,
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 8,
+            "end_col_offset": 9
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 9
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "a",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 7
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 8
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 8
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "a",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 7,
+                    "kind": null,
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  }
+                ],
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 18
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 24,
+                "end_col_offset": 25
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 27
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 27
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "b",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "Lt"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 5,
+                    "kind": null,
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 16,
+                    "end_col_offset": 17
+                  }
+                ],
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 12,
+                "end_col_offset": 17
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 23,
+                "end_col_offset": 24
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 24
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 26
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 26
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/bench_block.py.json
+++ b/tests/json-ast/x/py/bench_block.py.json
@@ -1,0 +1,933 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Import",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Import",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 9
+      },
+      {
+        "_type": "Import",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Import",
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "sys",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 0,
+              "end_col_offset": 3
+            },
+            "attr": "set_int_max_str_digits",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 0,
+            "end_col_offset": 26
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 0,
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 27,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_now_seed",
+            "lineno": 11,
+            "end_lineno": 11,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 0,
+          "kind": null,
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 12,
+          "end_col_offset": 13
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_now_seeded",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 11
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": false,
+          "kind": null,
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 14,
+          "end_col_offset": 19
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "os",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "attr": "getenv",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "MOCHI_NOW_SEED",
+              "kind": null,
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 14,
+              "end_col_offset": 30
+            }
+          ],
+          "keywords": [],
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 4,
+          "end_col_offset": 31
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 31
+      },
+      {
+        "_type": "If",
+        "body": [
+          {
+            "_type": "Try",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "_now_seed",
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 8,
+                    "end_col_offset": 17
+                  }
+                ],
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "int",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 20,
+                    "end_col_offset": 23
+                  },
+                  "args": [
+                    {
+                      "_type": "Name",
+                      "id": "s",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 16,
+                      "end_lineno": 16,
+                      "col_offset": 24,
+                      "end_col_offset": 25
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 20,
+                  "end_col_offset": 26
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 8,
+                "end_col_offset": 26
+              },
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "_now_seeded",
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 8,
+                    "end_col_offset": 19
+                  }
+                ],
+                "value": {
+                  "_type": "Constant",
+                  "value": true,
+                  "kind": null,
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 22,
+                  "end_col_offset": 26
+                },
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 8,
+                "end_col_offset": 26
+              }
+            ],
+            "lineno": 15,
+            "end_lineno": 19,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "test": {
+          "_type": "BoolOp",
+          "op": {
+            "_type": "And"
+          },
+          "values": [
+            {
+              "_type": "Name",
+              "id": "s",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 3,
+              "end_col_offset": 4
+            },
+            {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "s",
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 9,
+                "end_col_offset": 10
+              },
+              "ops": [
+                {
+                  "_type": "NotEq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": "",
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 14,
+                  "end_col_offset": 16
+                }
+              ],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 9,
+              "end_col_offset": 16
+            }
+          ],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 3,
+          "end_col_offset": 16
+        },
+        "lineno": 14,
+        "end_lineno": 19,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "FunctionDef",
+        "name": "_now",
+        "body": [
+          {
+            "_type": "Global",
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "_now_seed",
+                    "lineno": 24,
+                    "end_lineno": 24,
+                    "col_offset": 8,
+                    "end_col_offset": 17
+                  }
+                ],
+                "value": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "BinOp",
+                    "left": {
+                      "_type": "BinOp",
+                      "left": {
+                        "_type": "Name",
+                        "id": "_now_seed",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 24,
+                        "end_lineno": 24,
+                        "col_offset": 21,
+                        "end_col_offset": 30
+                      },
+                      "op": {
+                        "_type": "Mult"
+                      },
+                      "right": {
+                        "_type": "Constant",
+                        "value": 1664525,
+                        "kind": null,
+                        "lineno": 24,
+                        "end_lineno": 24,
+                        "col_offset": 33,
+                        "end_col_offset": 40
+                      },
+                      "lineno": 24,
+                      "end_lineno": 24,
+                      "col_offset": 21,
+                      "end_col_offset": 40
+                    },
+                    "op": {
+                      "_type": "Add"
+                    },
+                    "right": {
+                      "_type": "Constant",
+                      "value": 1013904223,
+                      "kind": null,
+                      "lineno": 24,
+                      "end_lineno": 24,
+                      "col_offset": 43,
+                      "end_col_offset": 53
+                    },
+                    "lineno": 24,
+                    "end_lineno": 24,
+                    "col_offset": 21,
+                    "end_col_offset": 53
+                  },
+                  "op": {
+                    "_type": "Mod"
+                  },
+                  "right": {
+                    "_type": "Constant",
+                    "value": 2147483647,
+                    "kind": null,
+                    "lineno": 24,
+                    "end_lineno": 24,
+                    "col_offset": 57,
+                    "end_col_offset": 67
+                  },
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 20,
+                  "end_col_offset": 67
+                },
+                "lineno": 24,
+                "end_lineno": 24,
+                "col_offset": 8,
+                "end_col_offset": 67
+              },
+              {
+                "_type": "Return",
+                "value": {
+                  "_type": "Name",
+                  "id": "_now_seed",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 15,
+                  "end_col_offset": 24
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 8,
+                "end_col_offset": 24
+              }
+            ],
+            "test": {
+              "_type": "Name",
+              "id": "_now_seeded",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 7,
+              "end_col_offset": 18
+            },
+            "lineno": 23,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 24
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "int",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 11,
+                "end_col_offset": 14
+              },
+              "args": [
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "time",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 26,
+                      "end_lineno": 26,
+                      "col_offset": 15,
+                      "end_col_offset": 19
+                    },
+                    "attr": "time_ns",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 26,
+                    "end_lineno": 26,
+                    "col_offset": 15,
+                    "end_col_offset": 27
+                  },
+                  "args": [],
+                  "keywords": [],
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 15,
+                  "end_col_offset": 29
+                }
+              ],
+              "keywords": [],
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 11,
+              "end_col_offset": 30
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 30
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 21,
+        "end_lineno": 26,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_bench_start",
+            "lineno": 28,
+            "end_lineno": 28,
+            "end_col_offset": 12
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "_now",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 15,
+            "end_col_offset": 19
+          },
+          "args": [],
+          "keywords": [],
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 15,
+          "end_col_offset": 21
+        },
+        "lineno": 28,
+        "end_lineno": 28,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "n",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 1000,
+          "kind": null,
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 4,
+          "end_col_offset": 8
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 8
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 30,
+            "end_lineno": 30,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 0,
+          "kind": null,
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "s",
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 4,
+                "end_col_offset": 5
+              }
+            ],
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "s",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 8,
+                "end_col_offset": 9
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 12,
+                "end_col_offset": 13
+              },
+              "lineno": 32,
+              "end_lineno": 32,
+              "col_offset": 8,
+              "end_col_offset": 13
+            },
+            "lineno": 32,
+            "end_lineno": 32,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "i",
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "range",
+            "lineno": 31,
+            "end_lineno": 31,
+            "col_offset": 9,
+            "end_col_offset": 14
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 15,
+              "end_col_offset": 16
+            },
+            {
+              "_type": "Name",
+              "id": "n",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 9,
+          "end_col_offset": 20
+        },
+        "lineno": 31,
+        "end_lineno": 32,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_bench_end",
+            "lineno": 33,
+            "end_lineno": 33,
+            "end_col_offset": 10
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "_now",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 33,
+            "end_lineno": 33,
+            "col_offset": 13,
+            "end_col_offset": 17
+          },
+          "args": [],
+          "keywords": [],
+          "lineno": 33,
+          "end_lineno": 33,
+          "col_offset": 13,
+          "end_col_offset": 19
+        },
+        "lineno": 33,
+        "end_lineno": 33,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "json",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "attr": "dumps",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 34,
+                "end_lineno": 34,
+                "col_offset": 6,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Dict",
+                  "keys": [
+                    {
+                      "_type": "Constant",
+                      "value": "duration_us",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 18,
+                      "end_col_offset": 31
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "memory_bytes",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 68,
+                      "end_col_offset": 82
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "name",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 87,
+                      "end_col_offset": 93
+                    }
+                  ],
+                  "values": [
+                    {
+                      "_type": "BinOp",
+                      "left": {
+                        "_type": "BinOp",
+                        "left": {
+                          "_type": "Name",
+                          "id": "_bench_end",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 34,
+                          "end_lineno": 34,
+                          "col_offset": 34,
+                          "end_col_offset": 44
+                        },
+                        "op": {
+                          "_type": "Sub"
+                        },
+                        "right": {
+                          "_type": "Name",
+                          "id": "_bench_start",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 34,
+                          "end_lineno": 34,
+                          "col_offset": 47,
+                          "end_col_offset": 59
+                        },
+                        "lineno": 34,
+                        "end_lineno": 34,
+                        "col_offset": 34,
+                        "end_col_offset": 59
+                      },
+                      "op": {
+                        "_type": "FloorDiv"
+                      },
+                      "right": {
+                        "_type": "Constant",
+                        "value": 1000,
+                        "kind": null,
+                        "lineno": 34,
+                        "end_lineno": 34,
+                        "col_offset": 62,
+                        "end_col_offset": 66
+                      },
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 33,
+                      "end_col_offset": 66
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 0,
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 84,
+                      "end_col_offset": 85
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "simple",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 95,
+                      "end_col_offset": 103
+                    }
+                  ],
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 17,
+                  "end_col_offset": 104
+                }
+              ],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "indent",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 34,
+                    "end_lineno": 34,
+                    "col_offset": 113,
+                    "end_col_offset": 114
+                  },
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 106,
+                  "end_col_offset": 114
+                }
+              ],
+              "lineno": 34,
+              "end_lineno": 34,
+              "col_offset": 6,
+              "end_col_offset": 115
+            }
+          ],
+          "keywords": [],
+          "lineno": 34,
+          "end_lineno": 34,
+          "col_offset": 0,
+          "end_col_offset": 116
+        },
+        "lineno": 34,
+        "end_lineno": 34,
+        "end_col_offset": 116
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/binary_precedence.py.json
+++ b/tests/json-ast/x/py/binary_precedence.py.json
@@ -1,0 +1,303 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                },
+                "op": {
+                  "_type": "Mult"
+                },
+                "right": {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 7,
+                  "end_col_offset": 8
+                },
+                "op": {
+                  "_type": "Add"
+                },
+                "right": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 12
+              },
+              "op": {
+                "_type": "Mult"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 3,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 6,
+                  "end_col_offset": 7
+                },
+                "op": {
+                  "_type": "Mult"
+                },
+                "right": {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 11
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 2,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Mult"
+              },
+              "right": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "op": {
+                  "_type": "Add"
+                },
+                "right": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 11,
+                "end_col_offset": 16
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/bool_chain.py.json
+++ b/tests/json-ast/x/py/bool_chain.py.json
@@ -1,0 +1,567 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "boom",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "boom",
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 4,
+              "end_col_offset": 17
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 17
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Constant",
+              "value": true,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 5,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "And"
+                },
+                "values": [
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 12,
+                      "end_col_offset": 13
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 16,
+                        "end_col_offset": 17
+                      }
+                    ],
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 12,
+                    "end_col_offset": 17
+                  },
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 22,
+                      "end_col_offset": 23
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 26,
+                        "end_col_offset": 27
+                      }
+                    ],
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 22,
+                    "end_col_offset": 27
+                  },
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 3,
+                      "kind": null,
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 32,
+                      "end_col_offset": 33
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 4,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 36,
+                        "end_col_offset": 37
+                      }
+                    ],
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 32,
+                    "end_col_offset": 37
+                  }
+                ],
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 37
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 43,
+                "end_col_offset": 44
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 44
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 46
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 46
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "And"
+                },
+                "values": [
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 12,
+                      "end_col_offset": 13
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 16,
+                        "end_col_offset": 17
+                      }
+                    ],
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 12,
+                    "end_col_offset": 17
+                  },
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 22,
+                      "end_col_offset": 23
+                    },
+                    "ops": [
+                      {
+                        "_type": "Gt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 26,
+                        "end_col_offset": 27
+                      }
+                    ],
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 22,
+                    "end_col_offset": 27
+                  },
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "boom",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 32,
+                      "end_col_offset": 36
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 32,
+                    "end_col_offset": 38
+                  }
+                ],
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 12,
+                "end_col_offset": 38
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 44,
+                "end_col_offset": 45
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 45
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 47
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 47
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "And"
+                },
+                "values": [
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 8,
+                      "end_lineno": 8,
+                      "col_offset": 12,
+                      "end_col_offset": 13
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 8,
+                        "end_lineno": 8,
+                        "col_offset": 16,
+                        "end_col_offset": 17
+                      }
+                    ],
+                    "lineno": 8,
+                    "end_lineno": 8,
+                    "col_offset": 12,
+                    "end_col_offset": 17
+                  },
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 8,
+                      "end_lineno": 8,
+                      "col_offset": 22,
+                      "end_col_offset": 23
+                    },
+                    "ops": [
+                      {
+                        "_type": "Lt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 8,
+                        "end_lineno": 8,
+                        "col_offset": 26,
+                        "end_col_offset": 27
+                      }
+                    ],
+                    "lineno": 8,
+                    "end_lineno": 8,
+                    "col_offset": 22,
+                    "end_col_offset": 27
+                  },
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Constant",
+                      "value": 3,
+                      "kind": null,
+                      "lineno": 8,
+                      "end_lineno": 8,
+                      "col_offset": 32,
+                      "end_col_offset": 33
+                    },
+                    "ops": [
+                      {
+                        "_type": "Gt"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Constant",
+                        "value": 4,
+                        "kind": null,
+                        "lineno": 8,
+                        "end_lineno": 8,
+                        "col_offset": 36,
+                        "end_col_offset": 37
+                      }
+                    ],
+                    "lineno": 8,
+                    "end_lineno": 8,
+                    "col_offset": 32,
+                    "end_col_offset": 37
+                  },
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "boom",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 8,
+                      "end_lineno": 8,
+                      "col_offset": 42,
+                      "end_col_offset": 46
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 8,
+                    "end_lineno": 8,
+                    "col_offset": 42,
+                    "end_col_offset": 48
+                  }
+                ],
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 12,
+                "end_col_offset": 48
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 54,
+                "end_col_offset": 55
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 7,
+              "end_col_offset": 55
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 0,
+          "end_col_offset": 57
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 57
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/break_continue.py.json
+++ b/tests/json-ast/x/py/break_continue.py.json
@@ -1,0 +1,297 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "numbers",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 15
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 17,
+              "end_col_offset": 18
+            },
+            {
+              "_type": "Constant",
+              "value": 4,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 20,
+              "end_col_offset": 21
+            },
+            {
+              "_type": "Constant",
+              "value": 5,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 23,
+              "end_col_offset": 24
+            },
+            {
+              "_type": "Constant",
+              "value": 6,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 26,
+              "end_col_offset": 27
+            },
+            {
+              "_type": "Constant",
+              "value": 7,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 29,
+              "end_col_offset": 30
+            },
+            {
+              "_type": "Constant",
+              "value": 8,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 32,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Constant",
+              "value": 9,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 35,
+              "end_col_offset": 36
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 10,
+          "end_col_offset": 37
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 37
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Continue",
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 8,
+                "end_col_offset": 16
+              }
+            ],
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "BinOp",
+                "op": {
+                  "_type": "Mod"
+                },
+                "left": {
+                  "_type": "Name",
+                  "id": "n",
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 7,
+                  "end_col_offset": 8
+                },
+                "right": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 12
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                }
+              ],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 17
+            },
+            "lineno": 5,
+            "end_lineno": 6,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Break",
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 8,
+                "end_col_offset": 13
+              }
+            ],
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "n",
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "ops": [
+                {
+                  "_type": "Gt"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 7,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                }
+              ],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 12
+            },
+            "lineno": 7,
+            "end_lineno": 8,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "odd number:",
+                  "kind": null,
+                  "lineno": 9,
+                  "end_lineno": 9,
+                  "col_offset": 10,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Name",
+                  "id": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 9,
+                  "end_lineno": 9,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 27
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 27
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "n",
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "numbers",
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 9,
+          "end_col_offset": 16
+        },
+        "lineno": 4,
+        "end_lineno": 9,
+        "end_col_offset": 27
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/cast_string_to_int.py.json
+++ b/tests/json-ast/x/py/cast_string_to_int.py.json
@@ -1,0 +1,64 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "int",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "1995",
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 18
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/cast_struct.py.json
+++ b/tests/json-ast/x/py/cast_struct.py.json
@@ -1,0 +1,170 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Todo",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "title",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 9,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "todo",
+            "lineno": 11,
+            "end_lineno": 11,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "Todo",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 7,
+            "end_col_offset": 11
+          },
+          "args": [],
+          "keywords": [
+            {
+              "_type": "keyword",
+              "arg": "title",
+              "value": {
+                "_type": "Constant",
+                "value": "hi",
+                "kind": null,
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 18,
+                "end_col_offset": 22
+              },
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 12,
+              "end_col_offset": 22
+            }
+          ],
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 7,
+          "end_col_offset": 23
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 23
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "todo",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "attr": "title",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 6,
+              "end_col_offset": 16
+            }
+          ],
+          "keywords": [],
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 0,
+          "end_col_offset": 17
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 17
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/closure.py.json
+++ b/tests/json-ast/x/py/closure.py.json
@@ -1,0 +1,206 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "makeAdder",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Lambda",
+              "args": {
+                "_type": "arguments",
+                "posonlyargs": [],
+                "args": [
+                  {
+                    "_type": "arg",
+                    "arg": "x",
+                    "annotation": null,
+                    "type_comment": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 18,
+                    "end_col_offset": 19
+                  }
+                ],
+                "vararg": null,
+                "kwonlyargs": [],
+                "kw_defaults": [],
+                "kwarg": null,
+                "defaults": []
+              },
+              "body": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Name",
+                  "id": "x",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                "op": {
+                  "_type": "Add"
+                },
+                "right": {
+                  "_type": "Name",
+                  "id": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 21,
+                "end_col_offset": 26
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 11,
+              "end_col_offset": 26
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 26
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "n",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 15
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "add10",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "makeAdder",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 8,
+            "end_col_offset": 17
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 10,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 18,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 8,
+          "end_col_offset": 21
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "add10",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 11
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 7,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 14
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 15
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 15
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/count_builtin.py.json
+++ b/tests/json-ast/x/py/count_builtin.py.json
@@ -1,0 +1,94 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "List",
+                  "elts": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 12
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 14,
+                      "end_col_offset": 15
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 3,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 17,
+                      "end_col_offset": 18
+                    }
+                  ],
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 19
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 21
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/cross_join.py.json
+++ b/tests/json-ast/x/py/cross_join.py.json
@@ -1,0 +1,1012 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 55,
+                "end_col_offset": 63
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 55,
+              "end_col_offset": 77
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 78
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 78
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": 250,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 24,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 30,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 36,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": 125,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 30,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 50,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 61,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Constant",
+                  "value": 300,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 64,
+                  "end_col_offset": 67
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 50,
+              "end_col_offset": 68
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 69
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 69
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 21,
+              "end_col_offset": 24
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderCustomerId",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 19
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 24
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 24,
+              "end_col_offset": 27
+            },
+            "target": {
+              "_type": "Name",
+              "id": "pairedCustomerName",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 4,
+            "end_col_offset": 27
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderTotal",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 25,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 27,
+            "end_lineno": 27,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "id",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 23,
+                  "end_col_offset": 24
+                },
+                "attr": "customerId",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 23,
+                "end_col_offset": 35
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 37,
+                  "end_col_offset": 38
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 37,
+                "end_col_offset": 43
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 45,
+                  "end_col_offset": 46
+                },
+                "attr": "total",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 45,
+                "end_col_offset": 52
+              }
+            ],
+            "keywords": [],
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 10,
+            "end_col_offset": 53
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "o",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 58,
+                "end_col_offset": 59
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "orders",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 63,
+                "end_col_offset": 69
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 74,
+                "end_col_offset": 75
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "customers",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 79,
+                "end_col_offset": 88
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 9,
+          "end_col_offset": 89
+        },
+        "lineno": 27,
+        "end_lineno": 27,
+        "end_col_offset": 89
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Cross Join: All order-customer pairs ---",
+              "kind": null,
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 6,
+              "end_col_offset": 52
+            }
+          ],
+          "keywords": [],
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 0,
+          "end_col_offset": 53
+        },
+        "lineno": 28,
+        "end_lineno": 28,
+        "end_col_offset": 53
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Order",
+                  "kind": null,
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 10,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 19,
+                    "end_col_offset": 24
+                  },
+                  "attr": "orderId",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 19,
+                  "end_col_offset": 32
+                },
+                {
+                  "_type": "Constant",
+                  "value": "(customerId:",
+                  "kind": null,
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 34,
+                  "end_col_offset": 48
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 50,
+                    "end_col_offset": 55
+                  },
+                  "attr": "orderCustomerId",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 50,
+                  "end_col_offset": 71
+                },
+                {
+                  "_type": "Constant",
+                  "value": ", total: $",
+                  "kind": null,
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 73,
+                  "end_col_offset": 85
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 87,
+                    "end_col_offset": 92
+                  },
+                  "attr": "orderTotal",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 87,
+                  "end_col_offset": 103
+                },
+                {
+                  "_type": "Constant",
+                  "value": ") paired with",
+                  "kind": null,
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 105,
+                  "end_col_offset": 120
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 122,
+                    "end_col_offset": 127
+                  },
+                  "attr": "pairedCustomerName",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 122,
+                  "end_col_offset": 146
+                }
+              ],
+              "keywords": [],
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 4,
+              "end_col_offset": 147
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 4,
+            "end_col_offset": 147
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "entry",
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 13,
+          "end_col_offset": 19
+        },
+        "lineno": 29,
+        "end_lineno": 30,
+        "end_col_offset": 147
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/cross_join_filter.py.json
+++ b/tests/json-ast/x/py/cross_join_filter.py.json
@@ -1,0 +1,498 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 11,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 14,
+              "end_col_offset": 15
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 7,
+          "end_col_offset": 16
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "letters",
+            "lineno": 8,
+            "end_lineno": 8,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": "A",
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            {
+              "_type": "Constant",
+              "value": "B",
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 16,
+              "end_col_offset": 19
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 10,
+          "end_col_offset": 20
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Pair",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 10,
+        "end_lineno": 12,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "pairs",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Pair",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "args": [
+              {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              {
+                "_type": "Name",
+                "id": "l",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 17,
+                "end_col_offset": 18
+              }
+            ],
+            "keywords": [],
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 9,
+            "end_col_offset": 19
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 24,
+                "end_col_offset": 25
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "nums",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 29,
+                "end_col_offset": 33
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "l",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 38,
+                "end_col_offset": 39
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "letters",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 43,
+                "end_col_offset": 50
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "BinOp",
+                    "left": {
+                      "_type": "Name",
+                      "id": "n",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 14,
+                      "end_lineno": 14,
+                      "col_offset": 54,
+                      "end_col_offset": 55
+                    },
+                    "op": {
+                      "_type": "Mod"
+                    },
+                    "right": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 14,
+                      "end_lineno": 14,
+                      "col_offset": 58,
+                      "end_col_offset": 59
+                    },
+                    "lineno": 14,
+                    "end_lineno": 14,
+                    "col_offset": 54,
+                    "end_col_offset": 59
+                  },
+                  "ops": [
+                    {
+                      "_type": "Eq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 0,
+                      "kind": null,
+                      "lineno": 14,
+                      "end_lineno": 14,
+                      "col_offset": 63,
+                      "end_col_offset": 64
+                    }
+                  ],
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 54,
+                  "end_col_offset": 64
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 8,
+          "end_col_offset": 65
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 65
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Even pairs ---",
+              "kind": null,
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 6,
+              "end_col_offset": 26
+            }
+          ],
+          "keywords": [],
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 0,
+          "end_col_offset": 27
+        },
+        "lineno": 15,
+        "end_lineno": 15,
+        "end_col_offset": 27
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "p",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 10,
+                  "end_col_offset": 13
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "p",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 15,
+                    "end_col_offset": 16
+                  },
+                  "attr": "l",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 15,
+                  "end_col_offset": 18
+                }
+              ],
+              "keywords": [],
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 19
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "p",
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "pairs",
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 16,
+        "end_lineno": 17,
+        "end_col_offset": 19
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/cross_join_triple.py.json
+++ b/tests/json-ast/x/py/cross_join_triple.py.json
@@ -1,0 +1,589 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 7,
+          "end_col_offset": 13
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "letters",
+            "lineno": 8,
+            "end_lineno": 8,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": "A",
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            {
+              "_type": "Constant",
+              "value": "B",
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 16,
+              "end_col_offset": 19
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 10,
+          "end_col_offset": 20
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "bools",
+            "lineno": 9,
+            "end_lineno": 9,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": true,
+              "kind": null,
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            {
+              "_type": "Constant",
+              "value": false,
+              "kind": null,
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 15,
+              "end_col_offset": 20
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 9,
+          "end_lineno": 9,
+          "col_offset": 8,
+          "end_col_offset": 21
+        },
+        "lineno": 9,
+        "end_lineno": 9,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Combo",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l",
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "bool",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 7,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "b",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 4,
+            "end_col_offset": 11
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 11,
+        "end_lineno": 14,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "combos",
+            "lineno": 16,
+            "end_lineno": 16,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Combo",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 10,
+              "end_col_offset": 15
+            },
+            "args": [
+              {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              {
+                "_type": "Name",
+                "id": "l",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 19,
+                "end_col_offset": 20
+              },
+              {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 22,
+                "end_col_offset": 23
+              }
+            ],
+            "keywords": [],
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 10,
+            "end_col_offset": 24
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 29,
+                "end_col_offset": 30
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "nums",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 34,
+                "end_col_offset": 38
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "l",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 43,
+                "end_col_offset": 44
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "letters",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 48,
+                "end_col_offset": 55
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 60,
+                "end_col_offset": 61
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "bools",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 65,
+                "end_col_offset": 70
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 9,
+          "end_col_offset": 71
+        },
+        "lineno": 16,
+        "end_lineno": 16,
+        "end_col_offset": 71
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Cross Join of three lists ---",
+              "kind": null,
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 6,
+              "end_col_offset": 41
+            }
+          ],
+          "keywords": [],
+          "lineno": 17,
+          "end_lineno": 17,
+          "col_offset": 0,
+          "end_col_offset": 42
+        },
+        "lineno": 17,
+        "end_lineno": 17,
+        "end_col_offset": 42
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "c",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 10,
+                  "end_col_offset": 13
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "c",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 15,
+                    "end_col_offset": 16
+                  },
+                  "attr": "l",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 15,
+                  "end_col_offset": 18
+                },
+                {
+                  "_type": "IfExp",
+                  "test": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "c",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 19,
+                      "end_lineno": 19,
+                      "col_offset": 31,
+                      "end_col_offset": 32
+                    },
+                    "attr": "b",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 31,
+                    "end_col_offset": 34
+                  },
+                  "body": {
+                    "_type": "Constant",
+                    "value": "true",
+                    "kind": null,
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 21,
+                    "end_col_offset": 27
+                  },
+                  "orelse": {
+                    "_type": "Constant",
+                    "value": "false",
+                    "kind": null,
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 40,
+                    "end_col_offset": 47
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 4,
+              "end_col_offset": 49
+            },
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 4,
+            "end_col_offset": 49
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "c",
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "combos",
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 18,
+        "end_lineno": 19,
+        "end_col_offset": 49
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/dataset_sort_take_limit.py.json
+++ b/tests/json-ast/x/py/dataset_sort_take_limit.py.json
@@ -1,0 +1,783 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Product",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "price",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "products",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 12,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Laptop",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 20,
+                  "end_col_offset": 28
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1500,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 30,
+                  "end_col_offset": 34
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 12,
+              "end_col_offset": 35
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 37,
+                "end_col_offset": 44
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Smartphone",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 45,
+                  "end_col_offset": 57
+                },
+                {
+                  "_type": "Constant",
+                  "value": 900,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 59,
+                  "end_col_offset": 62
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 37,
+              "end_col_offset": 63
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 65,
+                "end_col_offset": 72
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Tablet",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 73,
+                  "end_col_offset": 81
+                },
+                {
+                  "_type": "Constant",
+                  "value": 600,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 83,
+                  "end_col_offset": 86
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 65,
+              "end_col_offset": 87
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 89,
+                "end_col_offset": 96
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Monitor",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 97,
+                  "end_col_offset": 106
+                },
+                {
+                  "_type": "Constant",
+                  "value": 300,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 108,
+                  "end_col_offset": 111
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 89,
+              "end_col_offset": 112
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 114,
+                "end_col_offset": 121
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Keyboard",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 122,
+                  "end_col_offset": 132
+                },
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 134,
+                  "end_col_offset": 137
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 114,
+              "end_col_offset": 138
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 140,
+                "end_col_offset": 147
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Mouse",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 148,
+                  "end_col_offset": 155
+                },
+                {
+                  "_type": "Constant",
+                  "value": 50,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 157,
+                  "end_col_offset": 159
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 140,
+              "end_col_offset": 160
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Product",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 162,
+                "end_col_offset": 169
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Headphones",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 170,
+                  "end_col_offset": 182
+                },
+                {
+                  "_type": "Constant",
+                  "value": 200,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 184,
+                  "end_col_offset": 187
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 162,
+              "end_col_offset": 188
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 11,
+          "end_col_offset": 189
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 189
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "expensive",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "Subscript",
+          "value": {
+            "_type": "ListComp",
+            "elt": {
+              "_type": "Name",
+              "id": "p",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 13,
+              "end_col_offset": 14
+            },
+            "generators": [
+              {
+                "_type": "comprehension",
+                "target": {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Store"
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                "iter": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "sorted",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 24,
+                    "end_col_offset": 30
+                  },
+                  "args": [
+                    {
+                      "_type": "ListComp",
+                      "elt": {
+                        "_type": "Name",
+                        "id": "p",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 13,
+                        "end_lineno": 13,
+                        "col_offset": 32,
+                        "end_col_offset": 33
+                      },
+                      "generators": [
+                        {
+                          "_type": "comprehension",
+                          "target": {
+                            "_type": "Name",
+                            "id": "p",
+                            "ctx": {
+                              "_type": "Store"
+                            },
+                            "lineno": 13,
+                            "end_lineno": 13,
+                            "col_offset": 38,
+                            "end_col_offset": 39
+                          },
+                          "iter": {
+                            "_type": "Name",
+                            "id": "products",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 13,
+                            "end_lineno": 13,
+                            "col_offset": 43,
+                            "end_col_offset": 51
+                          },
+                          "ifs": [],
+                          "is_async": 0
+                        }
+                      ],
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 31,
+                      "end_col_offset": 52
+                    }
+                  ],
+                  "keywords": [
+                    {
+                      "_type": "keyword",
+                      "arg": "key",
+                      "value": {
+                        "_type": "Lambda",
+                        "args": {
+                          "_type": "arguments",
+                          "posonlyargs": [],
+                          "args": [
+                            {
+                              "_type": "arg",
+                              "arg": "p",
+                              "annotation": null,
+                              "type_comment": null,
+                              "lineno": 13,
+                              "end_lineno": 13,
+                              "col_offset": 65,
+                              "end_col_offset": 66
+                            }
+                          ],
+                          "vararg": null,
+                          "kwonlyargs": [],
+                          "kw_defaults": [],
+                          "kwarg": null,
+                          "defaults": []
+                        },
+                        "body": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "p",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 13,
+                            "end_lineno": 13,
+                            "col_offset": 68,
+                            "end_col_offset": 69
+                          },
+                          "attr": "price",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 13,
+                          "end_lineno": 13,
+                          "col_offset": 68,
+                          "end_col_offset": 75
+                        },
+                        "lineno": 13,
+                        "end_lineno": 13,
+                        "col_offset": 58,
+                        "end_col_offset": 75
+                      },
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 54,
+                      "end_col_offset": 75
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "reverse",
+                      "value": {
+                        "_type": "Constant",
+                        "value": true,
+                        "kind": null,
+                        "lineno": 13,
+                        "end_lineno": 13,
+                        "col_offset": 85,
+                        "end_col_offset": 89
+                      },
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 77,
+                      "end_col_offset": 89
+                    }
+                  ],
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 24,
+                  "end_col_offset": 90
+                },
+                "ifs": [],
+                "is_async": 0
+              }
+            ],
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 12,
+            "end_col_offset": 91
+          },
+          "slice": {
+            "_type": "Slice",
+            "lower": {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 92,
+              "end_col_offset": 93
+            },
+            "upper": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 94,
+                "end_col_offset": 95
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 3,
+                "kind": null,
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 98,
+                "end_col_offset": 99
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 94,
+              "end_col_offset": 99
+            },
+            "step": null,
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 92,
+            "end_col_offset": 99
+          },
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 12,
+          "end_col_offset": 100
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 100
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Top products (excluding most expensive) ---",
+              "kind": null,
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 6,
+              "end_col_offset": 55
+            }
+          ],
+          "keywords": [],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 0,
+          "end_col_offset": 56
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 56
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "item",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 10,
+                    "end_col_offset": 14
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 10,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": "costs $",
+                  "kind": null,
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 21,
+                  "end_col_offset": 30
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "item",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 32,
+                    "end_col_offset": 36
+                  },
+                  "attr": "price",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 32,
+                  "end_col_offset": 42
+                }
+              ],
+              "keywords": [],
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 43
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 43
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "item",
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 4,
+          "end_col_offset": 8
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "expensive",
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 12,
+          "end_col_offset": 21
+        },
+        "lineno": 15,
+        "end_lineno": 16,
+        "end_col_offset": 43
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/dataset_where_filter.py.json
+++ b/tests/json-ast/x/py/dataset_where_filter.py.json
@@ -1,0 +1,761 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 17,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "Constant",
+                  "value": 30,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 26,
+                  "end_col_offset": 28
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 10,
+              "end_col_offset": 29
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 31,
+                "end_col_offset": 37
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 38,
+                  "end_col_offset": 43
+                },
+                {
+                  "_type": "Constant",
+                  "value": 15,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 45,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 31,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 50,
+                "end_col_offset": 56
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 57,
+                  "end_col_offset": 66
+                },
+                {
+                  "_type": "Constant",
+                  "value": 65,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 68,
+                  "end_col_offset": 70
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 50,
+              "end_col_offset": 71
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 73,
+                "end_col_offset": 79
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Diana",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 80,
+                  "end_col_offset": 87
+                },
+                {
+                  "_type": "Constant",
+                  "value": 45,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 89,
+                  "end_col_offset": 91
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 73,
+              "end_col_offset": 92
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 9,
+          "end_col_offset": 93
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 93
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Adult",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "bool",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 15,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "is_senior",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "adults",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Adult",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 15
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "person",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 22
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 16,
+                "end_col_offset": 27
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "person",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 29,
+                  "end_col_offset": 35
+                },
+                "attr": "age",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 29,
+                "end_col_offset": 39
+              },
+              {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "person",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 41,
+                    "end_col_offset": 47
+                  },
+                  "attr": "age",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 51
+                },
+                "ops": [
+                  {
+                    "_type": "GtE"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 60,
+                    "kind": null,
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 55,
+                    "end_col_offset": 57
+                  }
+                ],
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 41,
+                "end_col_offset": 57
+              }
+            ],
+            "keywords": [],
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 10,
+            "end_col_offset": 58
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "person",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 63,
+                "end_col_offset": 69
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "people",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 73,
+                "end_col_offset": 79
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "person",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 19,
+                      "end_lineno": 19,
+                      "col_offset": 83,
+                      "end_col_offset": 89
+                    },
+                    "attr": "age",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 83,
+                    "end_col_offset": 93
+                  },
+                  "ops": [
+                    {
+                      "_type": "GtE"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 18,
+                      "kind": null,
+                      "lineno": 19,
+                      "end_lineno": 19,
+                      "col_offset": 97,
+                      "end_col_offset": 99
+                    }
+                  ],
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 83,
+                  "end_col_offset": 99
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 100
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 100
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Adults ---",
+              "kind": null,
+              "lineno": 20,
+              "end_lineno": 20,
+              "col_offset": 6,
+              "end_col_offset": 22
+            }
+          ],
+          "keywords": [],
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 0,
+          "end_col_offset": 23
+        },
+        "lineno": 20,
+        "end_lineno": 20,
+        "end_col_offset": 23
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "person",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 10,
+                    "end_col_offset": 16
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 10,
+                  "end_col_offset": 21
+                },
+                {
+                  "_type": "Constant",
+                  "value": "is",
+                  "kind": null,
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 23,
+                  "end_col_offset": 27
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "person",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 29,
+                    "end_col_offset": 35
+                  },
+                  "attr": "age",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 29,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "IfExp",
+                  "test": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "person",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 22,
+                      "end_lineno": 22,
+                      "col_offset": 57,
+                      "end_col_offset": 63
+                    },
+                    "attr": "is_senior",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 57,
+                    "end_col_offset": 73
+                  },
+                  "body": {
+                    "_type": "Constant",
+                    "value": " (senior)",
+                    "kind": null,
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 42,
+                    "end_col_offset": 53
+                  },
+                  "orelse": {
+                    "_type": "Constant",
+                    "value": "",
+                    "kind": null,
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 79,
+                    "end_col_offset": 81
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 42,
+                  "end_col_offset": 81
+                }
+              ],
+              "keywords": [],
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 83
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 83
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "person",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 4,
+          "end_col_offset": 10
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "adults",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 14,
+          "end_col_offset": 20
+        },
+        "lineno": 21,
+        "end_lineno": 22,
+        "end_col_offset": 83
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/exists_builtin.py.json
+++ b/tests/json-ast/x/py/exists_builtin.py.json
@@ -1,0 +1,256 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "data",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 13
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "flag",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Compare",
+          "left": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "len",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "args": [
+              {
+                "_type": "ListComp",
+                "elt": {
+                  "_type": "Name",
+                  "id": "x",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "generators": [
+                  {
+                    "_type": "comprehension",
+                    "target": {
+                      "_type": "Name",
+                      "id": "x",
+                      "ctx": {
+                        "_type": "Store"
+                      },
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 18,
+                      "end_col_offset": 19
+                    },
+                    "iter": {
+                      "_type": "Name",
+                      "id": "data",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 23,
+                      "end_col_offset": 27
+                    },
+                    "ifs": [
+                      {
+                        "_type": "Compare",
+                        "left": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 4,
+                          "end_lineno": 4,
+                          "col_offset": 31,
+                          "end_col_offset": 32
+                        },
+                        "ops": [
+                          {
+                            "_type": "Eq"
+                          }
+                        ],
+                        "comparators": [
+                          {
+                            "_type": "Constant",
+                            "value": 1,
+                            "kind": null,
+                            "lineno": 4,
+                            "end_lineno": 4,
+                            "col_offset": 36,
+                            "end_col_offset": 37
+                          }
+                        ],
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 31,
+                        "end_col_offset": 37
+                      }
+                    ],
+                    "is_async": 0
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 38
+              }
+            ],
+            "keywords": [],
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 7,
+            "end_col_offset": 39
+          },
+          "ops": [
+            {
+              "_type": "Gt"
+            }
+          ],
+          "comparators": [
+            {
+              "_type": "Constant",
+              "value": 0,
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 42,
+              "end_col_offset": 43
+            }
+          ],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 7,
+          "end_col_offset": 43
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 43
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Name",
+                "id": "flag",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "true",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 13
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": "false",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 27,
+                "end_col_offset": 34
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 34
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 36
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 36
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/for_list_collection.py.json
+++ b/tests/json-ast/x/py/for_list_collection.py.json
@@ -1,0 +1,95 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "n",
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 14
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 16,
+              "end_col_offset": 17
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 18
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/for_loop.py.json
+++ b/tests/json-ast/x/py/for_loop.py.json
@@ -1,0 +1,97 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "i",
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "range",
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 9,
+            "end_col_offset": 14
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 15,
+              "end_col_offset": 16
+            },
+            {
+              "_type": "Constant",
+              "value": 4,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/for_map_collection.py.json
+++ b/tests/json-ast/x/py/for_map_collection.py.json
@@ -1,0 +1,132 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 16
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "k",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "k",
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "m",
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 9,
+          "end_col_offset": 10
+        },
+        "lineno": 4,
+        "end_lineno": 5,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/fun_call.py.json
+++ b/tests/json-ast/x/py/fun_call.py.json
@@ -1,0 +1,152 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "add",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "a",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 15,
+                "end_col_offset": 16
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 11,
+              "end_col_offset": 16
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "a",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "arg",
+              "arg": "b",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "add",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 13,
+                  "end_col_offset": 14
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 16
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/fun_expr_in_let.py.json
+++ b/tests/json-ast/x/py/fun_expr_in_let.py.json
@@ -1,0 +1,139 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "square",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Lambda",
+          "args": {
+            "_type": "arguments",
+            "posonlyargs": [],
+            "args": [
+              {
+                "_type": "arg",
+                "arg": "x",
+                "annotation": null,
+                "type_comment": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 16,
+                "end_col_offset": 17
+              }
+            ],
+            "vararg": null,
+            "kwonlyargs": [],
+            "kw_defaults": [],
+            "kwarg": null,
+            "defaults": []
+          },
+          "body": {
+            "_type": "BinOp",
+            "left": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 19,
+              "end_col_offset": 20
+            },
+            "op": {
+              "_type": "Mult"
+            },
+            "right": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 23,
+              "end_col_offset": 24
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 19,
+            "end_col_offset": 24
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 24
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 24
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "square",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 12
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 6,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 13,
+                  "end_col_offset": 14
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/fun_three_args.py.json
+++ b/tests/json-ast/x/py/fun_three_args.py.json
@@ -1,0 +1,192 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "sum3",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Name",
+                  "id": "a",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "op": {
+                  "_type": "Add"
+                },
+                "right": {
+                  "_type": "Name",
+                  "id": "b",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 16
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 19,
+                "end_col_offset": 20
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 11,
+              "end_col_offset": 20
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 20
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "a",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 9,
+              "end_col_offset": 10
+            },
+            {
+              "_type": "arg",
+              "arg": "b",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 12,
+              "end_col_offset": 13
+            },
+            {
+              "_type": "arg",
+              "arg": "c",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 15,
+              "end_col_offset": 16
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "sum3",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 19
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 20
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 20
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/go_auto.py.json
+++ b/tests/json-ast/x/py/go_auto.py.json
@@ -1,0 +1,134 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 2,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 3,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 10,
+                "end_col_offset": 11
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 3.14,
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 42,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 8
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 9
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 9
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by.py.json
+++ b/tests/json-ast/x/py/group_by.py.json
@@ -1,0 +1,1427 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "city",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 11,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 17,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "Constant",
+                  "value": 30,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 26,
+                  "end_col_offset": 28
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 30,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 10,
+              "end_col_offset": 38
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 40,
+                "end_col_offset": 46
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                },
+                {
+                  "_type": "Constant",
+                  "value": 15,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 54,
+                  "end_col_offset": 56
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 58,
+                  "end_col_offset": 65
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 40,
+              "end_col_offset": 66
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 68,
+                "end_col_offset": 74
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 75,
+                  "end_col_offset": 84
+                },
+                {
+                  "_type": "Constant",
+                  "value": 65,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 86,
+                  "end_col_offset": 88
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 90,
+                  "end_col_offset": 97
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 68,
+              "end_col_offset": 98
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 100,
+                "end_col_offset": 106
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Diana",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 107,
+                  "end_col_offset": 114
+                },
+                {
+                  "_type": "Constant",
+                  "value": 45,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 116,
+                  "end_col_offset": 118
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 120,
+                  "end_col_offset": 127
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 100,
+              "end_col_offset": 128
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 130,
+                "end_col_offset": 136
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Eve",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 137,
+                  "end_col_offset": 142
+                },
+                {
+                  "_type": "Constant",
+                  "value": 70,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 144,
+                  "end_col_offset": 146
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 148,
+                  "end_col_offset": 155
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 130,
+              "end_col_offset": 156
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 158,
+                "end_col_offset": 164
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Frank",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 165,
+                  "end_col_offset": 172
+                },
+                {
+                  "_type": "Constant",
+                  "value": 22,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 174,
+                  "end_col_offset": 176
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 178,
+                  "end_col_offset": 185
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 158,
+              "end_col_offset": 186
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 9,
+          "end_col_offset": 187
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 187
+      },
+      {
+        "_type": "ClassDef",
+        "name": "StatsGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 15,
+        "end_lineno": 17,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_stats_groups",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 13
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 16,
+          "end_col_offset": 18
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_stats_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 9,
+                  "end_col_offset": 22
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 9,
+                "end_col_offset": 33
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "person",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 21,
+                    "end_lineno": 21,
+                    "col_offset": 34,
+                    "end_col_offset": 40
+                  },
+                  "attr": "city",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 34,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "StatsGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 21,
+                    "end_lineno": 21,
+                    "col_offset": 47,
+                    "end_col_offset": 57
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "person",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 21,
+                        "end_lineno": 21,
+                        "col_offset": 58,
+                        "end_col_offset": 64
+                      },
+                      "attr": "city",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 21,
+                      "end_lineno": 21,
+                      "col_offset": 58,
+                      "end_col_offset": 69
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 21,
+                      "end_lineno": 21,
+                      "col_offset": 71,
+                      "end_col_offset": 73
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 47,
+                  "end_col_offset": 74
+                }
+              ],
+              "keywords": [],
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 9,
+              "end_col_offset": 75
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 75
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "person",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 20,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 27
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 27
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "person",
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 4,
+          "end_col_offset": 10
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "people",
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 14,
+          "end_col_offset": 20
+        },
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 27
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Stat",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "city",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "count",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 13,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "avg_age",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 18
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 24,
+        "end_lineno": 27,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "stats",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Stat",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 14,
+                "end_col_offset": 19
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "len",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 21,
+                  "end_col_offset": 24
+                },
+                "args": [
+                  {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "g",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 25,
+                      "end_col_offset": 26
+                    },
+                    "attr": "items",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 25,
+                    "end_col_offset": 32
+                  }
+                ],
+                "keywords": [],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 21,
+                "end_col_offset": 33
+              },
+              {
+                "_type": "IfExp",
+                "test": {
+                  "_type": "ListComp",
+                  "elt": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "p",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 102,
+                      "end_col_offset": 103
+                    },
+                    "attr": "age",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 102,
+                    "end_col_offset": 107
+                  },
+                  "generators": [
+                    {
+                      "_type": "comprehension",
+                      "target": {
+                        "_type": "Name",
+                        "id": "p",
+                        "ctx": {
+                          "_type": "Store"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 112,
+                        "end_col_offset": 113
+                      },
+                      "iter": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "g",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 117,
+                          "end_col_offset": 118
+                        },
+                        "attr": "items",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 117,
+                        "end_col_offset": 124
+                      },
+                      "ifs": [],
+                      "is_async": 0
+                    }
+                  ],
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 101,
+                  "end_col_offset": 125
+                },
+                "body": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "sum",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 36,
+                      "end_col_offset": 39
+                    },
+                    "args": [
+                      {
+                        "_type": "ListComp",
+                        "elt": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "p",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 41,
+                            "end_col_offset": 42
+                          },
+                          "attr": "age",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 41,
+                          "end_col_offset": 46
+                        },
+                        "generators": [
+                          {
+                            "_type": "comprehension",
+                            "target": {
+                              "_type": "Name",
+                              "id": "p",
+                              "ctx": {
+                                "_type": "Store"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 51,
+                              "end_col_offset": 52
+                            },
+                            "iter": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "g",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 29,
+                                "end_lineno": 29,
+                                "col_offset": 56,
+                                "end_col_offset": 57
+                              },
+                              "attr": "items",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 56,
+                              "end_col_offset": 63
+                            },
+                            "ifs": [],
+                            "is_async": 0
+                          }
+                        ],
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 40,
+                        "end_col_offset": 64
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 36,
+                    "end_col_offset": 65
+                  },
+                  "op": {
+                    "_type": "Div"
+                  },
+                  "right": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "len",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 68,
+                      "end_col_offset": 71
+                    },
+                    "args": [
+                      {
+                        "_type": "ListComp",
+                        "elt": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "p",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 73,
+                            "end_col_offset": 74
+                          },
+                          "attr": "age",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 73,
+                          "end_col_offset": 78
+                        },
+                        "generators": [
+                          {
+                            "_type": "comprehension",
+                            "target": {
+                              "_type": "Name",
+                              "id": "p",
+                              "ctx": {
+                                "_type": "Store"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 83,
+                              "end_col_offset": 84
+                            },
+                            "iter": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "g",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 29,
+                                "end_lineno": 29,
+                                "col_offset": 88,
+                                "end_col_offset": 89
+                              },
+                              "attr": "items",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 88,
+                              "end_col_offset": 95
+                            },
+                            "ifs": [],
+                            "is_async": 0
+                          }
+                        ],
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 72,
+                        "end_col_offset": 96
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 68,
+                    "end_col_offset": 97
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 36,
+                  "end_col_offset": 97
+                },
+                "orelse": {
+                  "_type": "Constant",
+                  "value": 0.0,
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 131,
+                  "end_col_offset": 134
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 36,
+                "end_col_offset": 134
+              }
+            ],
+            "keywords": [],
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 9,
+            "end_col_offset": 136
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 141,
+                "end_col_offset": 142
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_stats_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 146,
+                    "end_col_offset": 159
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 146,
+                  "end_col_offset": 166
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 146,
+                "end_col_offset": 168
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 8,
+          "end_col_offset": 169
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 169
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- People grouped by city ---",
+              "kind": null,
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 6,
+              "end_col_offset": 38
+            }
+          ],
+          "keywords": [],
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 0,
+          "end_col_offset": 39
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 39
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "city",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": ": count =",
+                  "kind": null,
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 18,
+                  "end_col_offset": 29
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 31,
+                    "end_col_offset": 32
+                  },
+                  "attr": "count",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 31,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Constant",
+                  "value": ", avg_age =",
+                  "kind": null,
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 40,
+                  "end_col_offset": 53
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 55,
+                    "end_col_offset": 56
+                  },
+                  "attr": "avg_age",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 55,
+                  "end_col_offset": 64
+                }
+              ],
+              "keywords": [],
+              "lineno": 32,
+              "end_lineno": 32,
+              "col_offset": 4,
+              "end_col_offset": 65
+            },
+            "lineno": 32,
+            "end_lineno": 32,
+            "col_offset": 4,
+            "end_col_offset": 65
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "s",
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "stats",
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 31,
+        "end_lineno": 32,
+        "end_col_offset": 65
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_conditional_sum.py.json
+++ b/tests/json-ast/x/py/group_by_conditional_sum.py.json
@@ -1,0 +1,1189 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "cat",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "val",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "bool",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 10,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "flag",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 12,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 14,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Constant",
+                  "value": 10,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 19,
+                  "end_col_offset": 21
+                },
+                {
+                  "_type": "Constant",
+                  "value": true,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 23,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 9,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 30,
+                "end_col_offset": 34
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 35,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 40,
+                  "end_col_offset": 41
+                },
+                {
+                  "_type": "Constant",
+                  "value": false,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 43,
+                  "end_col_offset": 48
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 30,
+              "end_col_offset": 49
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 51,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 20,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 61,
+                  "end_col_offset": 63
+                },
+                {
+                  "_type": "Constant",
+                  "value": true,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 65,
+                  "end_col_offset": 69
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 51,
+              "end_col_offset": 70
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 8,
+          "end_col_offset": 71
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 71
+      },
+      {
+        "_type": "ClassDef",
+        "name": "ResultGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 18,
+            "end_lineno": 18,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 16,
+        "end_lineno": 18,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_result_groups",
+            "lineno": 20,
+            "end_lineno": 20,
+            "end_col_offset": 14
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 17,
+          "end_col_offset": 19
+        },
+        "lineno": 20,
+        "end_lineno": 20,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_result_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 9,
+                  "end_col_offset": 23
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 9,
+                "end_col_offset": 34
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "i",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 35,
+                    "end_col_offset": 36
+                  },
+                  "attr": "cat",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 35,
+                  "end_col_offset": 40
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "ResultGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 42,
+                    "end_col_offset": 53
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "i",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 22,
+                        "end_lineno": 22,
+                        "col_offset": 54,
+                        "end_col_offset": 55
+                      },
+                      "attr": "cat",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 22,
+                      "end_lineno": 22,
+                      "col_offset": 54,
+                      "end_col_offset": 59
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 22,
+                      "end_lineno": 22,
+                      "col_offset": 61,
+                      "end_col_offset": 63
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 42,
+                  "end_col_offset": 64
+                }
+              ],
+              "keywords": [],
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 9,
+              "end_col_offset": 65
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 65
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 23,
+                "end_lineno": 23,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "i",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "items",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "cat",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "share",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 25,
+        "end_lineno": 27,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 17,
+                "end_col_offset": 22
+              },
+              {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "sum",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 24,
+                    "end_col_offset": 27
+                  },
+                  "args": [
+                    {
+                      "_type": "ListComp",
+                      "elt": {
+                        "_type": "IfExp",
+                        "test": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "x",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 39,
+                            "end_col_offset": 40
+                          },
+                          "attr": "flag",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 39,
+                          "end_col_offset": 45
+                        },
+                        "body": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "x",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 30,
+                            "end_col_offset": 31
+                          },
+                          "attr": "val",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 30,
+                          "end_col_offset": 35
+                        },
+                        "orelse": {
+                          "_type": "Constant",
+                          "value": 0,
+                          "kind": null,
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 51,
+                          "end_col_offset": 52
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 30,
+                        "end_col_offset": 52
+                      },
+                      "generators": [
+                        {
+                          "_type": "comprehension",
+                          "target": {
+                            "_type": "Name",
+                            "id": "x",
+                            "ctx": {
+                              "_type": "Store"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 58,
+                            "end_col_offset": 59
+                          },
+                          "iter": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "g",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 63,
+                              "end_col_offset": 64
+                            },
+                            "attr": "items",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 63,
+                            "end_col_offset": 70
+                          },
+                          "ifs": [],
+                          "is_async": 0
+                        }
+                      ],
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 28,
+                      "end_col_offset": 71
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 24,
+                  "end_col_offset": 72
+                },
+                "op": {
+                  "_type": "FloorDiv"
+                },
+                "right": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "sum",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 76,
+                    "end_col_offset": 79
+                  },
+                  "args": [
+                    {
+                      "_type": "ListComp",
+                      "elt": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 81,
+                          "end_col_offset": 82
+                        },
+                        "attr": "val",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 81,
+                        "end_col_offset": 86
+                      },
+                      "generators": [
+                        {
+                          "_type": "comprehension",
+                          "target": {
+                            "_type": "Name",
+                            "id": "x",
+                            "ctx": {
+                              "_type": "Store"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 91,
+                            "end_col_offset": 92
+                          },
+                          "iter": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "g",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 29,
+                              "end_lineno": 29,
+                              "col_offset": 96,
+                              "end_col_offset": 97
+                            },
+                            "attr": "items",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 96,
+                            "end_col_offset": 103
+                          },
+                          "ifs": [],
+                          "is_async": 0
+                        }
+                      ],
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 80,
+                      "end_col_offset": 104
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 76,
+                  "end_col_offset": 105
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 24,
+                "end_col_offset": 105
+              }
+            ],
+            "keywords": [],
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 10,
+            "end_col_offset": 106
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 111,
+                "end_col_offset": 112
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 116,
+                  "end_col_offset": 122
+                },
+                "args": [
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_result_groups",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 123,
+                        "end_col_offset": 137
+                      },
+                      "attr": "values",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 123,
+                      "end_col_offset": 144
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 123,
+                    "end_col_offset": 146
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "g",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 159,
+                            "end_col_offset": 160
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "g",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 162,
+                          "end_col_offset": 163
+                        },
+                        "attr": "key",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 162,
+                        "end_col_offset": 167
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 152,
+                      "end_col_offset": 167
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 148,
+                    "end_col_offset": 167
+                  }
+                ],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 116,
+                "end_col_offset": 168
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 9,
+          "end_col_offset": 169
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 169
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "result",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 40,
+                    "end_col_offset": 46
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 6,
+              "end_col_offset": 47
+            }
+          ],
+          "keywords": [],
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 0,
+          "end_col_offset": 48
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 48
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_having.py.json
+++ b/tests/json-ast/x/py/group_by_having.py.json
@@ -1,0 +1,1152 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Import",
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "city",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 10,
+        "end_lineno": 12,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 17,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 26,
+                  "end_col_offset": 33
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 10,
+              "end_col_offset": 34
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 36,
+                "end_col_offset": 42
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 43,
+                  "end_col_offset": 48
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 50,
+                  "end_col_offset": 57
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 36,
+              "end_col_offset": 58
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 60,
+                "end_col_offset": 66
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 78,
+                  "end_col_offset": 85
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 60,
+              "end_col_offset": 86
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 88,
+                "end_col_offset": 94
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Diana",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 95,
+                  "end_col_offset": 102
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 104,
+                  "end_col_offset": 111
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 88,
+              "end_col_offset": 112
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 114,
+                "end_col_offset": 120
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Eve",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 121,
+                  "end_col_offset": 126
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 128,
+                  "end_col_offset": 135
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 114,
+              "end_col_offset": 136
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 138,
+                "end_col_offset": 144
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Frank",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 145,
+                  "end_col_offset": 152
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Hanoi",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 154,
+                  "end_col_offset": 161
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 138,
+              "end_col_offset": 162
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 164,
+                "end_col_offset": 170
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "George",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 171,
+                  "end_col_offset": 179
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Paris",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 181,
+                  "end_col_offset": 188
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 164,
+              "end_col_offset": 189
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 9,
+          "end_col_offset": 190
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 190
+      },
+      {
+        "_type": "ClassDef",
+        "name": "BigGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 18,
+            "end_lineno": 18,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 16,
+        "end_lineno": 18,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_big_groups",
+            "lineno": 20,
+            "end_lineno": 20,
+            "end_col_offset": 11
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 14,
+          "end_col_offset": 16
+        },
+        "lineno": 20,
+        "end_lineno": 20,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_big_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 9,
+                  "end_col_offset": 20
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 9,
+                "end_col_offset": 31
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "p",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 32,
+                    "end_col_offset": 33
+                  },
+                  "attr": "city",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 32,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "BigGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 40,
+                    "end_col_offset": 48
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "p",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 22,
+                        "end_lineno": 22,
+                        "col_offset": 49,
+                        "end_col_offset": 50
+                      },
+                      "attr": "city",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 22,
+                      "end_lineno": 22,
+                      "col_offset": 49,
+                      "end_col_offset": 55
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 22,
+                      "end_lineno": 22,
+                      "col_offset": 57,
+                      "end_col_offset": 59
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 40,
+                  "end_col_offset": 60
+                }
+              ],
+              "keywords": [],
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 9,
+              "end_col_offset": 61
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 61
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 23,
+                "end_lineno": 23,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "p",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "people",
+          "lineno": 21,
+          "end_lineno": 21,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Big",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "city",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "num",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 25,
+        "end_lineno": 27,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "big",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 3
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Big",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 11,
+                "end_col_offset": 16
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "len",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 18,
+                  "end_col_offset": 21
+                },
+                "args": [
+                  {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "g",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 22,
+                      "end_col_offset": 23
+                    },
+                    "attr": "items",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 22,
+                    "end_col_offset": 29
+                  }
+                ],
+                "keywords": [],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 18,
+                "end_col_offset": 30
+              }
+            ],
+            "keywords": [],
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 7,
+            "end_col_offset": 31
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 36,
+                "end_col_offset": 37
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_big_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 41,
+                    "end_col_offset": 52
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 41,
+                  "end_col_offset": 59
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 41,
+                "end_col_offset": 61
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "len",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 65,
+                      "end_col_offset": 68
+                    },
+                    "args": [
+                      {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "g",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 69,
+                          "end_col_offset": 70
+                        },
+                        "attr": "items",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 69,
+                        "end_col_offset": 76
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 65,
+                    "end_col_offset": 77
+                  },
+                  "ops": [
+                    {
+                      "_type": "GtE"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 4,
+                      "kind": null,
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 81,
+                      "end_col_offset": 82
+                    }
+                  ],
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 65,
+                  "end_col_offset": 82
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 6,
+          "end_col_offset": 83
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 83
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "json",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "attr": "dumps",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 6,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "ListComp",
+                  "elt": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "dataclasses",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 18,
+                        "end_col_offset": 29
+                      },
+                      "attr": "asdict",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 30,
+                      "end_lineno": 30,
+                      "col_offset": 18,
+                      "end_col_offset": 36
+                    },
+                    "args": [
+                      {
+                        "_type": "Name",
+                        "id": "_x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 37,
+                        "end_col_offset": 39
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 18,
+                    "end_col_offset": 40
+                  },
+                  "generators": [
+                    {
+                      "_type": "comprehension",
+                      "target": {
+                        "_type": "Name",
+                        "id": "_x",
+                        "ctx": {
+                          "_type": "Store"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 45,
+                        "end_col_offset": 47
+                      },
+                      "iter": {
+                        "_type": "Name",
+                        "id": "big",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 51,
+                        "end_col_offset": 54
+                      },
+                      "ifs": [],
+                      "is_async": 0
+                    }
+                  ],
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 17,
+                  "end_col_offset": 55
+                }
+              ],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "indent",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 64,
+                    "end_col_offset": 65
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 57,
+                  "end_col_offset": 65
+                }
+              ],
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 6,
+              "end_col_offset": 66
+            }
+          ],
+          "keywords": [],
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 0,
+          "end_col_offset": 67
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 67
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_join.py.json
+++ b/tests/json-ast/x/py/group_by_join.py.json
@@ -1,0 +1,1280 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 54
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 16,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 18,
+            "end_lineno": 18,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 10,
+              "end_col_offset": 23
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 25,
+                "end_col_offset": 30
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 36,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 25,
+              "end_col_offset": 38
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 40,
+                "end_col_offset": 45
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 46,
+                  "end_col_offset": 49
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 51,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 40,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 9,
+          "end_col_offset": 54
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "StatsGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "ClassDef",
+        "name": "StatsRow",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 25,
+        "end_lineno": 27,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_stats_groups",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 13
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 16,
+          "end_col_offset": 18
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "For",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "_g",
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 8,
+                    "end_col_offset": 10
+                  }
+                ],
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "_stats_groups",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 13,
+                      "end_col_offset": 26
+                    },
+                    "attr": "setdefault",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 13,
+                    "end_col_offset": 37
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "c",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 32,
+                        "end_lineno": 32,
+                        "col_offset": 38,
+                        "end_col_offset": 39
+                      },
+                      "attr": "name",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 38,
+                      "end_col_offset": 44
+                    },
+                    {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "StatsGroup",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 32,
+                        "end_lineno": 32,
+                        "col_offset": 46,
+                        "end_col_offset": 56
+                      },
+                      "args": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 32,
+                            "end_lineno": 32,
+                            "col_offset": 57,
+                            "end_col_offset": 58
+                          },
+                          "attr": "name",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 57,
+                          "end_col_offset": 63
+                        },
+                        {
+                          "_type": "List",
+                          "elts": [],
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 65,
+                          "end_col_offset": 67
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 46,
+                      "end_col_offset": 68
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 13,
+                  "end_col_offset": 69
+                },
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 8,
+                "end_col_offset": 69
+              },
+              {
+                "_type": "Expr",
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_g",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 8,
+                        "end_col_offset": 10
+                      },
+                      "attr": "items",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 8,
+                      "end_col_offset": 16
+                    },
+                    "attr": "append",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 8,
+                    "end_col_offset": 23
+                  },
+                  "args": [
+                    {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "StatsRow",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 24,
+                        "end_col_offset": 32
+                      },
+                      "args": [
+                        {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 33,
+                          "end_col_offset": 34
+                        },
+                        {
+                          "_type": "Name",
+                          "id": "c",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 36,
+                          "end_col_offset": 37
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 24,
+                      "end_col_offset": 38
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 8,
+                  "end_col_offset": 39
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 8,
+                "end_col_offset": 39
+              }
+            ],
+            "target": {
+              "_type": "Name",
+              "id": "c",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            "iter": {
+              "_type": "ListComp",
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "c",
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 20,
+                    "end_col_offset": 21
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "customers",
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 25,
+                    "end_col_offset": 34
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 31,
+                          "end_lineno": 31,
+                          "col_offset": 38,
+                          "end_col_offset": 39
+                        },
+                        "attr": "customerId",
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 38,
+                        "end_col_offset": 50
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 31,
+                            "end_lineno": 31,
+                            "col_offset": 54,
+                            "end_col_offset": 55
+                          },
+                          "attr": "id",
+                          "lineno": 31,
+                          "end_lineno": 31,
+                          "col_offset": 54,
+                          "end_col_offset": 58
+                        }
+                      ],
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 38,
+                      "end_col_offset": 58
+                    }
+                  ]
+                }
+              ],
+              "elt": {
+                "_type": "Name",
+                "id": "c",
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 13,
+              "end_col_offset": 59
+            },
+            "lineno": 31,
+            "end_lineno": 33,
+            "col_offset": 4,
+            "end_col_offset": 39
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "o",
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "orders",
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 30,
+        "end_lineno": 33,
+        "end_col_offset": 39
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Stat",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 36,
+            "end_lineno": 36,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "count",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 37,
+            "end_lineno": 37,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 35,
+        "end_lineno": 37,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "stats",
+            "lineno": 39,
+            "end_lineno": 39,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Stat",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 39,
+              "end_lineno": 39,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 14,
+                "end_col_offset": 19
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "len",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 21,
+                  "end_col_offset": 24
+                },
+                "args": [
+                  {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "g",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 39,
+                      "end_lineno": 39,
+                      "col_offset": 25,
+                      "end_col_offset": 26
+                    },
+                    "attr": "items",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 39,
+                    "end_lineno": 39,
+                    "col_offset": 25,
+                    "end_col_offset": 32
+                  }
+                ],
+                "keywords": [],
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 21,
+                "end_col_offset": 33
+              }
+            ],
+            "keywords": [],
+            "lineno": 39,
+            "end_lineno": 39,
+            "col_offset": 9,
+            "end_col_offset": 34
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 39,
+                "end_col_offset": 40
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_stats_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 39,
+                    "end_lineno": 39,
+                    "col_offset": 44,
+                    "end_col_offset": 57
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 44,
+                  "end_col_offset": 64
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 44,
+                "end_col_offset": 66
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 39,
+          "end_lineno": 39,
+          "col_offset": 8,
+          "end_col_offset": 67
+        },
+        "lineno": 39,
+        "end_lineno": 39,
+        "end_col_offset": 67
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 40,
+            "end_lineno": 40,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Orders per customer ---",
+              "kind": null,
+              "lineno": 40,
+              "end_lineno": 40,
+              "col_offset": 6,
+              "end_col_offset": 35
+            }
+          ],
+          "keywords": [],
+          "lineno": 40,
+          "end_lineno": 40,
+          "col_offset": 0,
+          "end_col_offset": 36
+        },
+        "lineno": 40,
+        "end_lineno": 40,
+        "end_col_offset": 36
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 42,
+                "end_lineno": 42,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 42,
+                    "end_lineno": 42,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": "orders:",
+                  "kind": null,
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 18,
+                  "end_col_offset": 27
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 42,
+                    "end_lineno": 42,
+                    "col_offset": 29,
+                    "end_col_offset": 30
+                  },
+                  "attr": "count",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 29,
+                  "end_col_offset": 36
+                }
+              ],
+              "keywords": [],
+              "lineno": 42,
+              "end_lineno": 42,
+              "col_offset": 4,
+              "end_col_offset": 37
+            },
+            "lineno": 42,
+            "end_lineno": 42,
+            "col_offset": 4,
+            "end_col_offset": 37
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "s",
+          "lineno": 41,
+          "end_lineno": 41,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "stats",
+          "lineno": 41,
+          "end_lineno": 41,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 41,
+        "end_lineno": 42,
+        "end_col_offset": 37
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_left_join.py.json
+++ b/tests/json-ast/x/py/group_by_left_join.py.json
@@ -1,0 +1,1407 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 55,
+                "end_col_offset": 63
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 55,
+              "end_col_offset": 77
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 78
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 78
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 16,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 18,
+            "end_lineno": 18,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 10,
+              "end_col_offset": 23
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 25,
+                "end_col_offset": 30
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 36,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 25,
+              "end_col_offset": 38
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 40,
+                "end_col_offset": 45
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 46,
+                  "end_col_offset": 49
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 51,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 40,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 9,
+          "end_col_offset": 54
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "StatsGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "ClassDef",
+        "name": "StatsRow",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 25,
+        "end_lineno": 27,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_stats_groups",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 13
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 16,
+          "end_col_offset": 18
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "For",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "_g",
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 8,
+                    "end_col_offset": 10
+                  }
+                ],
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "_stats_groups",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 13,
+                      "end_col_offset": 26
+                    },
+                    "attr": "setdefault",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 13,
+                    "end_col_offset": 37
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "c",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 32,
+                        "end_lineno": 32,
+                        "col_offset": 38,
+                        "end_col_offset": 39
+                      },
+                      "attr": "name",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 38,
+                      "end_col_offset": 44
+                    },
+                    {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "StatsGroup",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 32,
+                        "end_lineno": 32,
+                        "col_offset": 46,
+                        "end_col_offset": 56
+                      },
+                      "args": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 32,
+                            "end_lineno": 32,
+                            "col_offset": 57,
+                            "end_col_offset": 58
+                          },
+                          "attr": "name",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 57,
+                          "end_col_offset": 63
+                        },
+                        {
+                          "_type": "List",
+                          "elts": [],
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 65,
+                          "end_col_offset": 67
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 46,
+                      "end_col_offset": 68
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 32,
+                  "end_lineno": 32,
+                  "col_offset": 13,
+                  "end_col_offset": 69
+                },
+                "lineno": 32,
+                "end_lineno": 32,
+                "col_offset": 8,
+                "end_col_offset": 69
+              },
+              {
+                "_type": "Expr",
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_g",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 8,
+                        "end_col_offset": 10
+                      },
+                      "attr": "items",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 8,
+                      "end_col_offset": 16
+                    },
+                    "attr": "append",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 8,
+                    "end_col_offset": 23
+                  },
+                  "args": [
+                    {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "StatsRow",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 24,
+                        "end_col_offset": 32
+                      },
+                      "args": [
+                        {
+                          "_type": "Name",
+                          "id": "c",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 33,
+                          "end_col_offset": 34
+                        },
+                        {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 36,
+                          "end_col_offset": 37
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 24,
+                      "end_col_offset": 38
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 8,
+                  "end_col_offset": 39
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 8,
+                "end_col_offset": 39
+              }
+            ],
+            "target": {
+              "_type": "Name",
+              "id": "o",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            "iter": {
+              "_type": "BoolOp",
+              "op": {
+                "_type": "Or"
+              },
+              "values": [
+                {
+                  "_type": "ListComp",
+                  "generators": [
+                    {
+                      "_type": "comprehension",
+                      "target": {
+                        "_type": "Name",
+                        "id": "o",
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 20,
+                        "end_col_offset": 21
+                      },
+                      "iter": {
+                        "_type": "Name",
+                        "id": "orders",
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 25,
+                        "end_col_offset": 31
+                      },
+                      "ifs": [
+                        {
+                          "_type": "Compare",
+                          "left": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "o",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 31,
+                              "end_lineno": 31,
+                              "col_offset": 35,
+                              "end_col_offset": 36
+                            },
+                            "attr": "customerId",
+                            "lineno": 31,
+                            "end_lineno": 31,
+                            "col_offset": 35,
+                            "end_col_offset": 47
+                          },
+                          "ops": [
+                            {
+                              "_type": "Eq"
+                            }
+                          ],
+                          "comparators": [
+                            {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "c",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 31,
+                                "end_lineno": 31,
+                                "col_offset": 51,
+                                "end_col_offset": 52
+                              },
+                              "attr": "id",
+                              "lineno": 31,
+                              "end_lineno": 31,
+                              "col_offset": 51,
+                              "end_col_offset": 55
+                            }
+                          ],
+                          "lineno": 31,
+                          "end_lineno": 31,
+                          "col_offset": 35,
+                          "end_col_offset": 55
+                        }
+                      ]
+                    }
+                  ],
+                  "elt": {
+                    "_type": "Name",
+                    "id": "o",
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 14,
+                    "end_col_offset": 15
+                  },
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 13,
+                  "end_col_offset": 56
+                },
+                {
+                  "_type": "List",
+                  "elts": [
+                    {
+                      "_type": "Constant",
+                      "value": null,
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 61,
+                      "end_col_offset": 65
+                    }
+                  ],
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 60,
+                  "end_col_offset": 66
+                }
+              ],
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 13,
+              "end_col_offset": 66
+            },
+            "lineno": 31,
+            "end_lineno": 33,
+            "col_offset": 4,
+            "end_col_offset": 39
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "c",
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "customers",
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 9,
+          "end_col_offset": 18
+        },
+        "lineno": 30,
+        "end_lineno": 33,
+        "end_col_offset": 39
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Stat",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 36,
+            "end_lineno": 36,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "count",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 37,
+            "end_lineno": 37,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 35,
+        "end_lineno": 37,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "stats",
+            "lineno": 39,
+            "end_lineno": 39,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Stat",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 39,
+              "end_lineno": 39,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 14,
+                "end_col_offset": 19
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "len",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 21,
+                  "end_col_offset": 24
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "r",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 39,
+                      "end_lineno": 39,
+                      "col_offset": 26,
+                      "end_col_offset": 27
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "r",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 39,
+                          "end_lineno": 39,
+                          "col_offset": 32,
+                          "end_col_offset": 33
+                        },
+                        "iter": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "g",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 39,
+                            "end_lineno": 39,
+                            "col_offset": 37,
+                            "end_col_offset": 38
+                          },
+                          "attr": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 39,
+                          "end_lineno": 39,
+                          "col_offset": 37,
+                          "end_col_offset": 44
+                        },
+                        "ifs": [
+                          {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "r",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 39,
+                              "end_lineno": 39,
+                              "col_offset": 48,
+                              "end_col_offset": 49
+                            },
+                            "attr": "o",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 39,
+                            "end_lineno": 39,
+                            "col_offset": 48,
+                            "end_col_offset": 51
+                          }
+                        ],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 39,
+                    "end_lineno": 39,
+                    "col_offset": 25,
+                    "end_col_offset": 52
+                  }
+                ],
+                "keywords": [],
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 21,
+                "end_col_offset": 53
+              }
+            ],
+            "keywords": [],
+            "lineno": 39,
+            "end_lineno": 39,
+            "col_offset": 9,
+            "end_col_offset": 54
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 59,
+                "end_col_offset": 60
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_stats_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 39,
+                    "end_lineno": 39,
+                    "col_offset": 64,
+                    "end_col_offset": 77
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 64,
+                  "end_col_offset": 84
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 64,
+                "end_col_offset": 86
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 39,
+          "end_lineno": 39,
+          "col_offset": 8,
+          "end_col_offset": 87
+        },
+        "lineno": 39,
+        "end_lineno": 39,
+        "end_col_offset": 87
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 40,
+            "end_lineno": 40,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Group Left Join ---",
+              "kind": null,
+              "lineno": 40,
+              "end_lineno": 40,
+              "col_offset": 6,
+              "end_col_offset": 31
+            }
+          ],
+          "keywords": [],
+          "lineno": 40,
+          "end_lineno": 40,
+          "col_offset": 0,
+          "end_col_offset": 32
+        },
+        "lineno": 40,
+        "end_lineno": 40,
+        "end_col_offset": 32
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 42,
+                "end_lineno": 42,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 42,
+                    "end_lineno": 42,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": "orders:",
+                  "kind": null,
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 18,
+                  "end_col_offset": 27
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 42,
+                    "end_lineno": 42,
+                    "col_offset": 29,
+                    "end_col_offset": 30
+                  },
+                  "attr": "count",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 29,
+                  "end_col_offset": 36
+                }
+              ],
+              "keywords": [],
+              "lineno": 42,
+              "end_lineno": 42,
+              "col_offset": 4,
+              "end_col_offset": 37
+            },
+            "lineno": 42,
+            "end_lineno": 42,
+            "col_offset": 4,
+            "end_col_offset": 37
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "s",
+          "lineno": 41,
+          "end_lineno": 41,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "stats",
+          "lineno": 41,
+          "end_lineno": 41,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 41,
+        "end_lineno": 42,
+        "end_col_offset": 37
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_multi_join.py.json
+++ b/tests/json-ast/x/py/group_by_multi_join.py.json
@@ -1,0 +1,1809 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Nation",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 11,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nations",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Nation",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 11,
+                "end_col_offset": 17
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 18,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": "A",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 21,
+                  "end_col_offset": 24
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 11,
+              "end_col_offset": 25
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Nation",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 27,
+                "end_col_offset": 33
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 34,
+                  "end_col_offset": 35
+                },
+                {
+                  "_type": "Constant",
+                  "value": "B",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 37,
+                  "end_col_offset": 40
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 27,
+              "end_col_offset": 41
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 10,
+          "end_col_offset": 42
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 42
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Supplier",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "nation",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 15,
+        "end_lineno": 17,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "suppliers",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Supplier",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 13,
+              "end_col_offset": 27
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Supplier",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 29,
+                "end_col_offset": 37
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 38,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 29,
+              "end_col_offset": 43
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 12,
+          "end_col_offset": 44
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 44
+      },
+      {
+        "_type": "ClassDef",
+        "name": "PartSupp",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "part",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 14,
+              "end_col_offset": 17
+            },
+            "target": {
+              "_type": "Name",
+              "id": "supplier",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 17
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 10,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "cost",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 4,
+            "end_col_offset": 15
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "qty",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 25,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "partsupp",
+            "lineno": 27,
+            "end_lineno": 27,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "PartSupp",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 21,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 26,
+                  "end_col_offset": 27
+                },
+                {
+                  "_type": "Constant",
+                  "value": 10.0,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 29,
+                  "end_col_offset": 33
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 35,
+                  "end_col_offset": 36
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 12,
+              "end_col_offset": 37
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "PartSupp",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 39,
+                "end_col_offset": 47
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 48,
+                  "end_col_offset": 51
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 53,
+                  "end_col_offset": 54
+                },
+                {
+                  "_type": "Constant",
+                  "value": 20.0,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 56,
+                  "end_col_offset": 60
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 62,
+                  "end_col_offset": 63
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 39,
+              "end_col_offset": 64
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "PartSupp",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 66,
+                "end_col_offset": 74
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 200,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 75,
+                  "end_col_offset": 78
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 80,
+                  "end_col_offset": 81
+                },
+                {
+                  "_type": "Constant",
+                  "value": 5.0,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 83,
+                  "end_col_offset": 86
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 88,
+                  "end_col_offset": 89
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 66,
+              "end_col_offset": 90
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 11,
+          "end_col_offset": 91
+        },
+        "lineno": 27,
+        "end_lineno": 27,
+        "end_col_offset": 91
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Filtered",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "part",
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 11,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "value",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 31,
+            "end_lineno": 31,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 29,
+        "end_lineno": 31,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "filtered",
+            "lineno": 33,
+            "end_lineno": 33,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Filtered",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 33,
+              "end_lineno": 33,
+              "col_offset": 12,
+              "end_col_offset": 20
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "ps",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 21,
+                  "end_col_offset": 23
+                },
+                "attr": "part",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 21,
+                "end_col_offset": 28
+              },
+              {
+                "_type": "BinOp",
+                "left": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "ps",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 30,
+                    "end_col_offset": 32
+                  },
+                  "attr": "cost",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 30,
+                  "end_col_offset": 37
+                },
+                "op": {
+                  "_type": "Mult"
+                },
+                "right": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "ps",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 40,
+                    "end_col_offset": 42
+                  },
+                  "attr": "qty",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 40,
+                  "end_col_offset": 46
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 30,
+                "end_col_offset": 46
+              }
+            ],
+            "keywords": [],
+            "lineno": 33,
+            "end_lineno": 33,
+            "col_offset": 12,
+            "end_col_offset": 47
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "ps",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 52,
+                "end_col_offset": 54
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "partsupp",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 58,
+                "end_col_offset": 66
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "s",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 71,
+                "end_col_offset": 72
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "suppliers",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 76,
+                "end_col_offset": 85
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 90,
+                "end_col_offset": 91
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "nations",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 95,
+                "end_col_offset": 102
+              },
+              "ifs": [
+                {
+                  "_type": "BoolOp",
+                  "op": {
+                    "_type": "And"
+                  },
+                  "values": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "s",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 106,
+                          "end_col_offset": 107
+                        },
+                        "attr": "id",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 106,
+                        "end_col_offset": 110
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "ps",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 33,
+                            "end_lineno": 33,
+                            "col_offset": 114,
+                            "end_col_offset": 116
+                          },
+                          "attr": "supplier",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 114,
+                          "end_col_offset": 125
+                        }
+                      ],
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 106,
+                      "end_col_offset": 125
+                    },
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "n",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 130,
+                          "end_col_offset": 131
+                        },
+                        "attr": "id",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 130,
+                        "end_col_offset": 134
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "s",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 33,
+                            "end_lineno": 33,
+                            "col_offset": 138,
+                            "end_col_offset": 139
+                          },
+                          "attr": "nation",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 138,
+                          "end_col_offset": 146
+                        }
+                      ],
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 130,
+                      "end_col_offset": 146
+                    },
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "n",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 151,
+                          "end_col_offset": 152
+                        },
+                        "attr": "name",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 33,
+                        "end_lineno": 33,
+                        "col_offset": 151,
+                        "end_col_offset": 157
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Constant",
+                          "value": "A",
+                          "kind": null,
+                          "lineno": 33,
+                          "end_lineno": 33,
+                          "col_offset": 161,
+                          "end_col_offset": 164
+                        }
+                      ],
+                      "lineno": 33,
+                      "end_lineno": 33,
+                      "col_offset": 151,
+                      "end_col_offset": 164
+                    }
+                  ],
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 106,
+                  "end_col_offset": 164
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 33,
+          "end_lineno": 33,
+          "col_offset": 11,
+          "end_col_offset": 165
+        },
+        "lineno": 33,
+        "end_lineno": 33,
+        "end_col_offset": 165
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GroupedGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 36,
+            "end_lineno": 36,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 37,
+            "end_lineno": 37,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 35,
+        "end_lineno": 37,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_grouped_groups",
+            "lineno": 39,
+            "end_lineno": 39,
+            "end_col_offset": 15
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 39,
+          "end_lineno": 39,
+          "col_offset": 18,
+          "end_col_offset": 20
+        },
+        "lineno": 39,
+        "end_lineno": 39,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 41,
+                "end_lineno": 41,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_grouped_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 41,
+                  "end_lineno": 41,
+                  "col_offset": 9,
+                  "end_col_offset": 24
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 41,
+                "end_lineno": 41,
+                "col_offset": 9,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 41,
+                    "end_lineno": 41,
+                    "col_offset": 36,
+                    "end_col_offset": 37
+                  },
+                  "attr": "part",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 41,
+                  "end_lineno": 41,
+                  "col_offset": 36,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "GroupedGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 41,
+                    "end_lineno": 41,
+                    "col_offset": 44,
+                    "end_col_offset": 56
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 41,
+                        "end_lineno": 41,
+                        "col_offset": 57,
+                        "end_col_offset": 58
+                      },
+                      "attr": "part",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 41,
+                      "end_lineno": 41,
+                      "col_offset": 57,
+                      "end_col_offset": 63
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 41,
+                      "end_lineno": 41,
+                      "col_offset": 65,
+                      "end_col_offset": 67
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 41,
+                  "end_lineno": 41,
+                  "col_offset": 44,
+                  "end_col_offset": 68
+                }
+              ],
+              "keywords": [],
+              "lineno": 41,
+              "end_lineno": 41,
+              "col_offset": 9,
+              "end_col_offset": 69
+            },
+            "lineno": 41,
+            "end_lineno": 41,
+            "col_offset": 4,
+            "end_col_offset": 69
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 42,
+                    "end_lineno": 42,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 42,
+                "end_lineno": 42,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "x",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 42,
+                  "end_lineno": 42,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 42,
+              "end_lineno": 42,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 42,
+            "end_lineno": 42,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "x",
+          "lineno": 40,
+          "end_lineno": 40,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "filtered",
+          "lineno": 40,
+          "end_lineno": 40,
+          "col_offset": 9,
+          "end_col_offset": 17
+        },
+        "lineno": 40,
+        "end_lineno": 42,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Grouped",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 45,
+              "end_lineno": 45,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "part",
+              "lineno": 45,
+              "end_lineno": 45,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 45,
+            "end_lineno": 45,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 46,
+              "end_lineno": 46,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 46,
+              "end_lineno": 46,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 46,
+            "end_lineno": 46,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 43,
+            "end_lineno": 43,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 44,
+        "end_lineno": 46,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "grouped",
+            "lineno": 48,
+            "end_lineno": 48,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Grouped",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 48,
+              "end_lineno": 48,
+              "col_offset": 11,
+              "end_col_offset": 18
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 48,
+                  "end_lineno": 48,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 48,
+                "end_lineno": 48,
+                "col_offset": 19,
+                "end_col_offset": 24
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sum",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 48,
+                  "end_lineno": 48,
+                  "col_offset": 26,
+                  "end_col_offset": 29
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "r",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 48,
+                        "end_lineno": 48,
+                        "col_offset": 31,
+                        "end_col_offset": 32
+                      },
+                      "attr": "value",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 48,
+                      "end_lineno": 48,
+                      "col_offset": 31,
+                      "end_col_offset": 38
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "r",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 48,
+                          "end_lineno": 48,
+                          "col_offset": 43,
+                          "end_col_offset": 44
+                        },
+                        "iter": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "g",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 48,
+                            "end_lineno": 48,
+                            "col_offset": 48,
+                            "end_col_offset": 49
+                          },
+                          "attr": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 48,
+                          "end_lineno": 48,
+                          "col_offset": 48,
+                          "end_col_offset": 55
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 48,
+                    "end_lineno": 48,
+                    "col_offset": 30,
+                    "end_col_offset": 56
+                  }
+                ],
+                "keywords": [],
+                "lineno": 48,
+                "end_lineno": 48,
+                "col_offset": 26,
+                "end_col_offset": 57
+              }
+            ],
+            "keywords": [],
+            "lineno": 48,
+            "end_lineno": 48,
+            "col_offset": 11,
+            "end_col_offset": 58
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 48,
+                "end_lineno": 48,
+                "col_offset": 63,
+                "end_col_offset": 64
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_grouped_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 48,
+                    "end_lineno": 48,
+                    "col_offset": 68,
+                    "end_col_offset": 83
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 48,
+                  "end_lineno": 48,
+                  "col_offset": 68,
+                  "end_col_offset": 90
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 48,
+                "end_lineno": 48,
+                "col_offset": 68,
+                "end_col_offset": 92
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 48,
+          "end_lineno": 48,
+          "col_offset": 10,
+          "end_col_offset": 93
+        },
+        "lineno": 48,
+        "end_lineno": 48,
+        "end_col_offset": 93
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 49,
+            "end_lineno": 49,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 49,
+                    "end_lineno": 49,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 49,
+                  "end_lineno": 49,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 49,
+                    "end_lineno": 49,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 49,
+                "end_lineno": 49,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 49,
+                    "end_lineno": 49,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "grouped",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 49,
+                    "end_lineno": 49,
+                    "col_offset": 40,
+                    "end_col_offset": 47
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 49,
+              "end_lineno": 49,
+              "col_offset": 6,
+              "end_col_offset": 48
+            }
+          ],
+          "keywords": [],
+          "lineno": 49,
+          "end_lineno": 49,
+          "col_offset": 0,
+          "end_col_offset": 49
+        },
+        "lineno": 49,
+        "end_lineno": 49,
+        "end_col_offset": 49
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_multi_join_sort.py.json
+++ b/tests/json-ast/x/py/group_by_multi_join_sort.py.json
@@ -1,0 +1,3461 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Nation",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 17,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n_nationkey",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 15
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n_name",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 11,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nation",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Nation",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                {
+                  "_type": "Constant",
+                  "value": "BRAZIL",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 20,
+                  "end_col_offset": 28
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 10,
+              "end_col_offset": 29
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 9,
+          "end_col_offset": 30
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_custkey",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_name",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 15
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 15,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_acctbal",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 18,
+            "end_lineno": 18,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 17,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_nationkey",
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 4,
+              "end_col_offset": 15
+            },
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 20,
+              "end_lineno": 20,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_address",
+              "lineno": 20,
+              "end_lineno": 20,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_phone",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_comment",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 18
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 15,
+        "end_lineno": 22,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customer",
+            "lineno": 24,
+            "end_lineno": 24,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 24,
+                "end_lineno": 24,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 24,
+                  "end_col_offset": 31
+                },
+                {
+                  "_type": "Constant",
+                  "value": 100.0,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 33,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 40,
+                  "end_col_offset": 41
+                },
+                {
+                  "_type": "Constant",
+                  "value": "123 St",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 43,
+                  "end_col_offset": 51
+                },
+                {
+                  "_type": "Constant",
+                  "value": "123-456",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 53,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Loyal",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 64,
+                  "end_col_offset": 71
+                }
+              ],
+              "keywords": [],
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 12,
+              "end_col_offset": 72
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 11,
+          "end_col_offset": 73
+        },
+        "lineno": 24,
+        "end_lineno": 24,
+        "end_col_offset": 73
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o_orderkey",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o_custkey",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 17,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o_orderdate",
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 4,
+              "end_col_offset": 15
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 4,
+            "end_col_offset": 20
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 26,
+        "end_lineno": 29,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 31,
+            "end_lineno": 31,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1000,
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 16,
+                  "end_col_offset": 20
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "1993-10-15",
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 25,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 10,
+              "end_col_offset": 38
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 40,
+                "end_col_offset": 45
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2000,
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 46,
+                  "end_col_offset": 50
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 52,
+                  "end_col_offset": 53
+                },
+                {
+                  "_type": "Constant",
+                  "value": "1994-01-02",
+                  "kind": null,
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 55,
+                  "end_col_offset": 67
+                }
+              ],
+              "keywords": [],
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 40,
+              "end_col_offset": 68
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 9,
+          "end_col_offset": 69
+        },
+        "lineno": 31,
+        "end_lineno": 31,
+        "end_col_offset": 69
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Lineitem",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 34,
+              "end_lineno": 34,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l_orderkey",
+              "lineno": 34,
+              "end_lineno": 34,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 35,
+              "end_lineno": 35,
+              "col_offset": 18,
+              "end_col_offset": 21
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l_returnflag",
+              "lineno": 35,
+              "end_lineno": 35,
+              "col_offset": 4,
+              "end_col_offset": 16
+            },
+            "lineno": 35,
+            "end_lineno": 35,
+            "col_offset": 4,
+            "end_col_offset": 21
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 21,
+              "end_col_offset": 26
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l_extendedprice",
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 4,
+              "end_col_offset": 19
+            },
+            "lineno": 36,
+            "end_lineno": 36,
+            "col_offset": 4,
+            "end_col_offset": 26
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 16,
+              "end_col_offset": 21
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l_discount",
+              "lineno": 37,
+              "end_lineno": 37,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 37,
+            "end_lineno": 37,
+            "col_offset": 4,
+            "end_col_offset": 21
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 32,
+            "end_lineno": 32,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 33,
+        "end_lineno": 37,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "lineitem",
+            "lineno": 39,
+            "end_lineno": 39,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Lineitem",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1000,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 21,
+                  "end_col_offset": 25
+                },
+                {
+                  "_type": "Constant",
+                  "value": "R",
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 27,
+                  "end_col_offset": 30
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1000.0,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 32,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Constant",
+                  "value": 0.1,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 40,
+                  "end_col_offset": 43
+                }
+              ],
+              "keywords": [],
+              "lineno": 39,
+              "end_lineno": 39,
+              "col_offset": 12,
+              "end_col_offset": 44
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Lineitem",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 39,
+                "end_lineno": 39,
+                "col_offset": 46,
+                "end_col_offset": 54
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2000,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 55,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": "N",
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 61,
+                  "end_col_offset": 64
+                },
+                {
+                  "_type": "Constant",
+                  "value": 500.0,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 66,
+                  "end_col_offset": 71
+                },
+                {
+                  "_type": "Constant",
+                  "value": 0.0,
+                  "kind": null,
+                  "lineno": 39,
+                  "end_lineno": 39,
+                  "col_offset": 73,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 39,
+              "end_lineno": 39,
+              "col_offset": 46,
+              "end_col_offset": 77
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 39,
+          "end_lineno": 39,
+          "col_offset": 11,
+          "end_col_offset": 78
+        },
+        "lineno": 39,
+        "end_lineno": 39,
+        "end_col_offset": 78
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "start_date",
+            "lineno": 40,
+            "end_lineno": 40,
+            "end_col_offset": 10
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "1993-10-01",
+          "kind": null,
+          "lineno": 40,
+          "end_lineno": 40,
+          "col_offset": 13,
+          "end_col_offset": 25
+        },
+        "lineno": 40,
+        "end_lineno": 40,
+        "end_col_offset": 25
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "end_date",
+            "lineno": 41,
+            "end_lineno": 41,
+            "end_col_offset": 8
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "1994-01-01",
+          "kind": null,
+          "lineno": 41,
+          "end_lineno": 41,
+          "col_offset": 11,
+          "end_col_offset": 23
+        },
+        "lineno": 41,
+        "end_lineno": 41,
+        "end_col_offset": 23
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GKey",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 44,
+              "end_lineno": 44,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_custkey",
+              "lineno": 44,
+              "end_lineno": 44,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 44,
+            "end_lineno": 44,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 45,
+              "end_lineno": 45,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_name",
+              "lineno": 45,
+              "end_lineno": 45,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 45,
+            "end_lineno": 45,
+            "col_offset": 4,
+            "end_col_offset": 15
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 46,
+              "end_lineno": 46,
+              "col_offset": 15,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_acctbal",
+              "lineno": 46,
+              "end_lineno": 46,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 46,
+            "end_lineno": 46,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 47,
+              "end_lineno": 47,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_address",
+              "lineno": 47,
+              "end_lineno": 47,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 47,
+            "end_lineno": 47,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 48,
+              "end_lineno": 48,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_phone",
+              "lineno": 48,
+              "end_lineno": 48,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 48,
+            "end_lineno": 48,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 49,
+              "end_lineno": 49,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_comment",
+              "lineno": 49,
+              "end_lineno": 49,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 49,
+            "end_lineno": 49,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 50,
+              "end_lineno": 50,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n_name",
+              "lineno": 50,
+              "end_lineno": 50,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 50,
+            "end_lineno": 50,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 42,
+            "end_lineno": 42,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 43,
+        "end_lineno": 50,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "ClassDef",
+        "name": "ResultGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "GKey",
+              "lineno": 54,
+              "end_lineno": 54,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 54,
+              "end_lineno": 54,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 54,
+            "end_lineno": 54,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 55,
+              "end_lineno": 55,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 55,
+              "end_lineno": 55,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 55,
+            "end_lineno": 55,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 52,
+            "end_lineno": 52,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 53,
+        "end_lineno": 55,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "ClassDef",
+        "name": "ResultRow",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 59,
+              "end_lineno": 59,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c",
+              "lineno": 59,
+              "end_lineno": 59,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 59,
+            "end_lineno": 59,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 60,
+              "end_lineno": 60,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "o",
+              "lineno": 60,
+              "end_lineno": 60,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 60,
+            "end_lineno": 60,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 61,
+              "end_lineno": 61,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "l",
+              "lineno": 61,
+              "end_lineno": 61,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 61,
+            "end_lineno": 61,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 62,
+              "end_lineno": 62,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n",
+              "lineno": 62,
+              "end_lineno": 62,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 62,
+            "end_lineno": 62,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 57,
+            "end_lineno": 57,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 58,
+        "end_lineno": 62,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_result_groups",
+            "lineno": 64,
+            "end_lineno": 64,
+            "end_col_offset": 14
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 64,
+          "end_lineno": 64,
+          "col_offset": 17,
+          "end_col_offset": 19
+        },
+        "lineno": 64,
+        "end_lineno": 64,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "For",
+            "body": [
+              {
+                "_type": "For",
+                "body": [
+                  {
+                    "_type": "For",
+                    "body": [
+                      {
+                        "_type": "If",
+                        "body": [
+                          {
+                            "_type": "Assign",
+                            "targets": [
+                              {
+                                "_type": "Name",
+                                "id": "_g",
+                                "lineno": 70,
+                                "end_lineno": 70,
+                                "col_offset": 20,
+                                "end_col_offset": 22
+                              }
+                            ],
+                            "value": {
+                              "_type": "Call",
+                              "func": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "_result_groups",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 70,
+                                  "end_lineno": 70,
+                                  "col_offset": 25,
+                                  "end_col_offset": 39
+                                },
+                                "attr": "setdefault",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 70,
+                                "end_lineno": 70,
+                                "col_offset": 25,
+                                "end_col_offset": 50
+                              },
+                              "args": [
+                                {
+                                  "_type": "Call",
+                                  "func": {
+                                    "_type": "Name",
+                                    "id": "tuple",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 70,
+                                    "end_lineno": 70,
+                                    "col_offset": 51,
+                                    "end_col_offset": 56
+                                  },
+                                  "args": [
+                                    {
+                                      "_type": "List",
+                                      "elts": [
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 58,
+                                            "end_col_offset": 59
+                                          },
+                                          "attr": "c_custkey",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 58,
+                                          "end_col_offset": 69
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 71,
+                                            "end_col_offset": 72
+                                          },
+                                          "attr": "c_name",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 71,
+                                          "end_col_offset": 79
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 81,
+                                            "end_col_offset": 82
+                                          },
+                                          "attr": "c_acctbal",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 81,
+                                          "end_col_offset": 92
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 94,
+                                            "end_col_offset": 95
+                                          },
+                                          "attr": "c_address",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 94,
+                                          "end_col_offset": 105
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 107,
+                                            "end_col_offset": 108
+                                          },
+                                          "attr": "c_phone",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 107,
+                                          "end_col_offset": 116
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 118,
+                                            "end_col_offset": 119
+                                          },
+                                          "attr": "c_comment",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 118,
+                                          "end_col_offset": 129
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "n",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 131,
+                                            "end_col_offset": 132
+                                          },
+                                          "attr": "n_name",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 131,
+                                          "end_col_offset": 139
+                                        }
+                                      ],
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 70,
+                                      "end_lineno": 70,
+                                      "col_offset": 57,
+                                      "end_col_offset": 140
+                                    }
+                                  ],
+                                  "keywords": [],
+                                  "lineno": 70,
+                                  "end_lineno": 70,
+                                  "col_offset": 51,
+                                  "end_col_offset": 141
+                                },
+                                {
+                                  "_type": "Call",
+                                  "func": {
+                                    "_type": "Name",
+                                    "id": "ResultGroup",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 70,
+                                    "end_lineno": 70,
+                                    "col_offset": 143,
+                                    "end_col_offset": 154
+                                  },
+                                  "args": [
+                                    {
+                                      "_type": "Call",
+                                      "func": {
+                                        "_type": "Name",
+                                        "id": "GKey",
+                                        "ctx": {
+                                          "_type": "Load"
+                                        },
+                                        "lineno": 70,
+                                        "end_lineno": 70,
+                                        "col_offset": 155,
+                                        "end_col_offset": 159
+                                      },
+                                      "args": [
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 160,
+                                            "end_col_offset": 161
+                                          },
+                                          "attr": "c_custkey",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 160,
+                                          "end_col_offset": 171
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 173,
+                                            "end_col_offset": 174
+                                          },
+                                          "attr": "c_name",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 173,
+                                          "end_col_offset": 181
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 183,
+                                            "end_col_offset": 184
+                                          },
+                                          "attr": "c_acctbal",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 183,
+                                          "end_col_offset": 194
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 196,
+                                            "end_col_offset": 197
+                                          },
+                                          "attr": "c_address",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 196,
+                                          "end_col_offset": 207
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 209,
+                                            "end_col_offset": 210
+                                          },
+                                          "attr": "c_phone",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 209,
+                                          "end_col_offset": 218
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "c",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 220,
+                                            "end_col_offset": 221
+                                          },
+                                          "attr": "c_comment",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 220,
+                                          "end_col_offset": 231
+                                        },
+                                        {
+                                          "_type": "Attribute",
+                                          "value": {
+                                            "_type": "Name",
+                                            "id": "n",
+                                            "ctx": {
+                                              "_type": "Load"
+                                            },
+                                            "lineno": 70,
+                                            "end_lineno": 70,
+                                            "col_offset": 233,
+                                            "end_col_offset": 234
+                                          },
+                                          "attr": "n_name",
+                                          "ctx": {
+                                            "_type": "Load"
+                                          },
+                                          "lineno": 70,
+                                          "end_lineno": 70,
+                                          "col_offset": 233,
+                                          "end_col_offset": 241
+                                        }
+                                      ],
+                                      "keywords": [],
+                                      "lineno": 70,
+                                      "end_lineno": 70,
+                                      "col_offset": 155,
+                                      "end_col_offset": 242
+                                    },
+                                    {
+                                      "_type": "List",
+                                      "elts": [],
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 70,
+                                      "end_lineno": 70,
+                                      "col_offset": 244,
+                                      "end_col_offset": 246
+                                    }
+                                  ],
+                                  "keywords": [],
+                                  "lineno": 70,
+                                  "end_lineno": 70,
+                                  "col_offset": 143,
+                                  "end_col_offset": 247
+                                }
+                              ],
+                              "keywords": [],
+                              "lineno": 70,
+                              "end_lineno": 70,
+                              "col_offset": 25,
+                              "end_col_offset": 248
+                            },
+                            "lineno": 70,
+                            "end_lineno": 70,
+                            "col_offset": 20,
+                            "end_col_offset": 248
+                          },
+                          {
+                            "_type": "Expr",
+                            "value": {
+                              "_type": "Call",
+                              "func": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "_g",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 71,
+                                    "end_lineno": 71,
+                                    "col_offset": 20,
+                                    "end_col_offset": 22
+                                  },
+                                  "attr": "items",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 71,
+                                  "end_lineno": 71,
+                                  "col_offset": 20,
+                                  "end_col_offset": 28
+                                },
+                                "attr": "append",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 71,
+                                "end_lineno": 71,
+                                "col_offset": 20,
+                                "end_col_offset": 35
+                              },
+                              "args": [
+                                {
+                                  "_type": "Call",
+                                  "func": {
+                                    "_type": "Name",
+                                    "id": "ResultRow",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 71,
+                                    "end_lineno": 71,
+                                    "col_offset": 36,
+                                    "end_col_offset": 45
+                                  },
+                                  "args": [
+                                    {
+                                      "_type": "Name",
+                                      "id": "c",
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 71,
+                                      "end_lineno": 71,
+                                      "col_offset": 46,
+                                      "end_col_offset": 47
+                                    },
+                                    {
+                                      "_type": "Name",
+                                      "id": "o",
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 71,
+                                      "end_lineno": 71,
+                                      "col_offset": 49,
+                                      "end_col_offset": 50
+                                    },
+                                    {
+                                      "_type": "Name",
+                                      "id": "l",
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 71,
+                                      "end_lineno": 71,
+                                      "col_offset": 52,
+                                      "end_col_offset": 53
+                                    },
+                                    {
+                                      "_type": "Name",
+                                      "id": "n",
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 71,
+                                      "end_lineno": 71,
+                                      "col_offset": 55,
+                                      "end_col_offset": 56
+                                    }
+                                  ],
+                                  "keywords": [],
+                                  "lineno": 71,
+                                  "end_lineno": 71,
+                                  "col_offset": 36,
+                                  "end_col_offset": 57
+                                }
+                              ],
+                              "keywords": [],
+                              "lineno": 71,
+                              "end_lineno": 71,
+                              "col_offset": 20,
+                              "end_col_offset": 58
+                            },
+                            "lineno": 71,
+                            "end_lineno": 71,
+                            "col_offset": 20,
+                            "end_col_offset": 58
+                          }
+                        ],
+                        "test": {
+                          "_type": "BoolOp",
+                          "op": {
+                            "_type": "And"
+                          },
+                          "values": [
+                            {
+                              "_type": "Compare",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "o",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 19,
+                                  "end_col_offset": 20
+                                },
+                                "attr": "o_orderdate",
+                                "lineno": 69,
+                                "end_lineno": 69,
+                                "col_offset": 19,
+                                "end_col_offset": 32
+                              },
+                              "ops": [
+                                {
+                                  "_type": "GtE"
+                                }
+                              ],
+                              "comparators": [
+                                {
+                                  "_type": "Name",
+                                  "id": "start_date",
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 36,
+                                  "end_col_offset": 46
+                                }
+                              ],
+                              "lineno": 69,
+                              "end_lineno": 69,
+                              "col_offset": 19,
+                              "end_col_offset": 46
+                            },
+                            {
+                              "_type": "Compare",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "o",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 51,
+                                  "end_col_offset": 52
+                                },
+                                "attr": "o_orderdate",
+                                "lineno": 69,
+                                "end_lineno": 69,
+                                "col_offset": 51,
+                                "end_col_offset": 64
+                              },
+                              "ops": [
+                                {
+                                  "_type": "Lt"
+                                }
+                              ],
+                              "comparators": [
+                                {
+                                  "_type": "Name",
+                                  "id": "end_date",
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 67,
+                                  "end_col_offset": 75
+                                }
+                              ],
+                              "lineno": 69,
+                              "end_lineno": 69,
+                              "col_offset": 51,
+                              "end_col_offset": 75
+                            },
+                            {
+                              "_type": "Compare",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "l",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 80,
+                                  "end_col_offset": 81
+                                },
+                                "attr": "l_returnflag",
+                                "lineno": 69,
+                                "end_lineno": 69,
+                                "col_offset": 80,
+                                "end_col_offset": 94
+                              },
+                              "ops": [
+                                {
+                                  "_type": "Eq"
+                                }
+                              ],
+                              "comparators": [
+                                {
+                                  "_type": "Constant",
+                                  "value": "R",
+                                  "lineno": 69,
+                                  "end_lineno": 69,
+                                  "col_offset": 98,
+                                  "end_col_offset": 101
+                                }
+                              ],
+                              "lineno": 69,
+                              "end_lineno": 69,
+                              "col_offset": 80,
+                              "end_col_offset": 101
+                            }
+                          ],
+                          "lineno": 69,
+                          "end_lineno": 69,
+                          "col_offset": 19,
+                          "end_col_offset": 101
+                        },
+                        "lineno": 69,
+                        "end_lineno": 71,
+                        "col_offset": 16,
+                        "end_col_offset": 58
+                      }
+                    ],
+                    "target": {
+                      "_type": "Name",
+                      "id": "n",
+                      "lineno": 68,
+                      "end_lineno": 68,
+                      "col_offset": 16,
+                      "end_col_offset": 17
+                    },
+                    "iter": {
+                      "_type": "ListComp",
+                      "generators": [
+                        {
+                          "_type": "comprehension",
+                          "target": {
+                            "_type": "Name",
+                            "id": "n",
+                            "lineno": 68,
+                            "end_lineno": 68,
+                            "col_offset": 28,
+                            "end_col_offset": 29
+                          },
+                          "iter": {
+                            "_type": "Name",
+                            "id": "nation",
+                            "lineno": 68,
+                            "end_lineno": 68,
+                            "col_offset": 33,
+                            "end_col_offset": 39
+                          },
+                          "ifs": [
+                            {
+                              "_type": "Compare",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "n",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 68,
+                                  "end_lineno": 68,
+                                  "col_offset": 43,
+                                  "end_col_offset": 44
+                                },
+                                "attr": "n_nationkey",
+                                "lineno": 68,
+                                "end_lineno": 68,
+                                "col_offset": 43,
+                                "end_col_offset": 56
+                              },
+                              "ops": [
+                                {
+                                  "_type": "Eq"
+                                }
+                              ],
+                              "comparators": [
+                                {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "c",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 68,
+                                    "end_lineno": 68,
+                                    "col_offset": 60,
+                                    "end_col_offset": 61
+                                  },
+                                  "attr": "c_nationkey",
+                                  "lineno": 68,
+                                  "end_lineno": 68,
+                                  "col_offset": 60,
+                                  "end_col_offset": 73
+                                }
+                              ],
+                              "lineno": 68,
+                              "end_lineno": 68,
+                              "col_offset": 43,
+                              "end_col_offset": 73
+                            }
+                          ]
+                        }
+                      ],
+                      "elt": {
+                        "_type": "Name",
+                        "id": "n",
+                        "lineno": 68,
+                        "end_lineno": 68,
+                        "col_offset": 22,
+                        "end_col_offset": 23
+                      },
+                      "lineno": 68,
+                      "end_lineno": 68,
+                      "col_offset": 21,
+                      "end_col_offset": 74
+                    },
+                    "lineno": 68,
+                    "end_lineno": 71,
+                    "col_offset": 12,
+                    "end_col_offset": 58
+                  }
+                ],
+                "target": {
+                  "_type": "Name",
+                  "id": "l",
+                  "lineno": 67,
+                  "end_lineno": 67,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "iter": {
+                  "_type": "ListComp",
+                  "generators": [
+                    {
+                      "_type": "comprehension",
+                      "target": {
+                        "_type": "Name",
+                        "id": "l",
+                        "lineno": 67,
+                        "end_lineno": 67,
+                        "col_offset": 24,
+                        "end_col_offset": 25
+                      },
+                      "iter": {
+                        "_type": "Name",
+                        "id": "lineitem",
+                        "lineno": 67,
+                        "end_lineno": 67,
+                        "col_offset": 29,
+                        "end_col_offset": 37
+                      },
+                      "ifs": [
+                        {
+                          "_type": "Compare",
+                          "left": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "l",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 67,
+                              "end_lineno": 67,
+                              "col_offset": 41,
+                              "end_col_offset": 42
+                            },
+                            "attr": "l_orderkey",
+                            "lineno": 67,
+                            "end_lineno": 67,
+                            "col_offset": 41,
+                            "end_col_offset": 53
+                          },
+                          "ops": [
+                            {
+                              "_type": "Eq"
+                            }
+                          ],
+                          "comparators": [
+                            {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 67,
+                                "end_lineno": 67,
+                                "col_offset": 57,
+                                "end_col_offset": 58
+                              },
+                              "attr": "o_orderkey",
+                              "lineno": 67,
+                              "end_lineno": 67,
+                              "col_offset": 57,
+                              "end_col_offset": 69
+                            }
+                          ],
+                          "lineno": 67,
+                          "end_lineno": 67,
+                          "col_offset": 41,
+                          "end_col_offset": 69
+                        }
+                      ]
+                    }
+                  ],
+                  "elt": {
+                    "_type": "Name",
+                    "id": "l",
+                    "lineno": 67,
+                    "end_lineno": 67,
+                    "col_offset": 18,
+                    "end_col_offset": 19
+                  },
+                  "lineno": 67,
+                  "end_lineno": 67,
+                  "col_offset": 17,
+                  "end_col_offset": 70
+                },
+                "lineno": 67,
+                "end_lineno": 71,
+                "col_offset": 8,
+                "end_col_offset": 58
+              }
+            ],
+            "target": {
+              "_type": "Name",
+              "id": "o",
+              "lineno": 66,
+              "end_lineno": 66,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            "iter": {
+              "_type": "ListComp",
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "o",
+                    "lineno": 66,
+                    "end_lineno": 66,
+                    "col_offset": 20,
+                    "end_col_offset": 21
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "orders",
+                    "lineno": 66,
+                    "end_lineno": 66,
+                    "col_offset": 25,
+                    "end_col_offset": 31
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 66,
+                          "end_lineno": 66,
+                          "col_offset": 35,
+                          "end_col_offset": 36
+                        },
+                        "attr": "o_custkey",
+                        "lineno": 66,
+                        "end_lineno": 66,
+                        "col_offset": 35,
+                        "end_col_offset": 46
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 66,
+                            "end_lineno": 66,
+                            "col_offset": 50,
+                            "end_col_offset": 51
+                          },
+                          "attr": "c_custkey",
+                          "lineno": 66,
+                          "end_lineno": 66,
+                          "col_offset": 50,
+                          "end_col_offset": 61
+                        }
+                      ],
+                      "lineno": 66,
+                      "end_lineno": 66,
+                      "col_offset": 35,
+                      "end_col_offset": 61
+                    }
+                  ]
+                }
+              ],
+              "elt": {
+                "_type": "Name",
+                "id": "o",
+                "lineno": 66,
+                "end_lineno": 66,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "lineno": 66,
+              "end_lineno": 66,
+              "col_offset": 13,
+              "end_col_offset": 62
+            },
+            "lineno": 66,
+            "end_lineno": 71,
+            "col_offset": 4,
+            "end_col_offset": 58
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "c",
+          "lineno": 65,
+          "end_lineno": 65,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "customer",
+          "lineno": 65,
+          "end_lineno": 65,
+          "col_offset": 9,
+          "end_col_offset": 17
+        },
+        "lineno": 65,
+        "end_lineno": 71,
+        "end_col_offset": 58
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 74,
+              "end_lineno": 74,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_custkey",
+              "lineno": 74,
+              "end_lineno": 74,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 74,
+            "end_lineno": 74,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 75,
+              "end_lineno": 75,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_name",
+              "lineno": 75,
+              "end_lineno": 75,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 75,
+            "end_lineno": 75,
+            "col_offset": 4,
+            "end_col_offset": 15
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 76,
+              "end_lineno": 76,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "revenue",
+              "lineno": 76,
+              "end_lineno": 76,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 76,
+            "end_lineno": 76,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 77,
+              "end_lineno": 77,
+              "col_offset": 15,
+              "end_col_offset": 20
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_acctbal",
+              "lineno": 77,
+              "end_lineno": 77,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 77,
+            "end_lineno": 77,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 78,
+              "end_lineno": 78,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n_name",
+              "lineno": 78,
+              "end_lineno": 78,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 78,
+            "end_lineno": 78,
+            "col_offset": 4,
+            "end_col_offset": 15
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 79,
+              "end_lineno": 79,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_address",
+              "lineno": 79,
+              "end_lineno": 79,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 79,
+            "end_lineno": 79,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 80,
+              "end_lineno": 80,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_phone",
+              "lineno": 80,
+              "end_lineno": 80,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 80,
+            "end_lineno": 80,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 81,
+              "end_lineno": 81,
+              "col_offset": 15,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "c_comment",
+              "lineno": 81,
+              "end_lineno": 81,
+              "col_offset": 4,
+              "end_col_offset": 13
+            },
+            "lineno": 81,
+            "end_lineno": 81,
+            "col_offset": 4,
+            "end_col_offset": 18
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 72,
+            "end_lineno": 72,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 73,
+        "end_lineno": 81,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 83,
+            "end_lineno": 83,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 83,
+              "end_lineno": 83,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 17,
+                  "end_col_offset": 22
+                },
+                "attr": "c_custkey",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 17,
+                "end_col_offset": 32
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 34,
+                    "end_col_offset": 35
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 34,
+                  "end_col_offset": 39
+                },
+                "attr": "c_name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 34,
+                "end_col_offset": 46
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sum",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 48,
+                  "end_col_offset": 51
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "BinOp",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "x",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 83,
+                            "end_lineno": 83,
+                            "col_offset": 53,
+                            "end_col_offset": 54
+                          },
+                          "attr": "l",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 53,
+                          "end_col_offset": 56
+                        },
+                        "attr": "l_extendedprice",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 83,
+                        "end_lineno": 83,
+                        "col_offset": 53,
+                        "end_col_offset": 72
+                      },
+                      "op": {
+                        "_type": "Mult"
+                      },
+                      "right": {
+                        "_type": "BinOp",
+                        "left": {
+                          "_type": "Constant",
+                          "value": 1,
+                          "kind": null,
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 76,
+                          "end_col_offset": 77
+                        },
+                        "op": {
+                          "_type": "Sub"
+                        },
+                        "right": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "x",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 83,
+                              "end_lineno": 83,
+                              "col_offset": 80,
+                              "end_col_offset": 81
+                            },
+                            "attr": "l",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 83,
+                            "end_lineno": 83,
+                            "col_offset": 80,
+                            "end_col_offset": 83
+                          },
+                          "attr": "l_discount",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 80,
+                          "end_col_offset": 94
+                        },
+                        "lineno": 83,
+                        "end_lineno": 83,
+                        "col_offset": 76,
+                        "end_col_offset": 94
+                      },
+                      "lineno": 83,
+                      "end_lineno": 83,
+                      "col_offset": 53,
+                      "end_col_offset": 95
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 100,
+                          "end_col_offset": 101
+                        },
+                        "iter": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "g",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 83,
+                            "end_lineno": 83,
+                            "col_offset": 105,
+                            "end_col_offset": 106
+                          },
+                          "attr": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 105,
+                          "end_col_offset": 112
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 52,
+                    "end_col_offset": 113
+                  }
+                ],
+                "keywords": [],
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 48,
+                "end_col_offset": 114
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 116,
+                    "end_col_offset": 117
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 116,
+                  "end_col_offset": 121
+                },
+                "attr": "c_acctbal",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 116,
+                "end_col_offset": 131
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 133,
+                    "end_col_offset": 134
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 133,
+                  "end_col_offset": 138
+                },
+                "attr": "n_name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 133,
+                "end_col_offset": 145
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 147,
+                    "end_col_offset": 148
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 147,
+                  "end_col_offset": 152
+                },
+                "attr": "c_address",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 147,
+                "end_col_offset": 162
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 164,
+                    "end_col_offset": 165
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 164,
+                  "end_col_offset": 169
+                },
+                "attr": "c_phone",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 164,
+                "end_col_offset": 177
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 179,
+                    "end_col_offset": 180
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 179,
+                  "end_col_offset": 184
+                },
+                "attr": "c_comment",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 179,
+                "end_col_offset": 194
+              }
+            ],
+            "keywords": [],
+            "lineno": 83,
+            "end_lineno": 83,
+            "col_offset": 10,
+            "end_col_offset": 195
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 200,
+                "end_col_offset": 201
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 83,
+                  "end_lineno": 83,
+                  "col_offset": 205,
+                  "end_col_offset": 211
+                },
+                "args": [
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_result_groups",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 83,
+                        "end_lineno": 83,
+                        "col_offset": 212,
+                        "end_col_offset": 226
+                      },
+                      "attr": "values",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 83,
+                      "end_lineno": 83,
+                      "col_offset": 212,
+                      "end_col_offset": 233
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 212,
+                    "end_col_offset": 235
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "g",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 83,
+                            "end_lineno": 83,
+                            "col_offset": 248,
+                            "end_col_offset": 249
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Call",
+                        "func": {
+                          "_type": "Name",
+                          "id": "sum",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 83,
+                          "end_lineno": 83,
+                          "col_offset": 251,
+                          "end_col_offset": 254
+                        },
+                        "args": [
+                          {
+                            "_type": "ListComp",
+                            "elt": {
+                              "_type": "BinOp",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "x",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 83,
+                                    "end_lineno": 83,
+                                    "col_offset": 256,
+                                    "end_col_offset": 257
+                                  },
+                                  "attr": "l",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 83,
+                                  "end_lineno": 83,
+                                  "col_offset": 256,
+                                  "end_col_offset": 259
+                                },
+                                "attr": "l_extendedprice",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 83,
+                                "end_lineno": 83,
+                                "col_offset": 256,
+                                "end_col_offset": 275
+                              },
+                              "op": {
+                                "_type": "Mult"
+                              },
+                              "right": {
+                                "_type": "BinOp",
+                                "left": {
+                                  "_type": "Constant",
+                                  "value": 1,
+                                  "kind": null,
+                                  "lineno": 83,
+                                  "end_lineno": 83,
+                                  "col_offset": 279,
+                                  "end_col_offset": 280
+                                },
+                                "op": {
+                                  "_type": "Sub"
+                                },
+                                "right": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Attribute",
+                                    "value": {
+                                      "_type": "Name",
+                                      "id": "x",
+                                      "ctx": {
+                                        "_type": "Load"
+                                      },
+                                      "lineno": 83,
+                                      "end_lineno": 83,
+                                      "col_offset": 283,
+                                      "end_col_offset": 284
+                                    },
+                                    "attr": "l",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 83,
+                                    "end_lineno": 83,
+                                    "col_offset": 283,
+                                    "end_col_offset": 286
+                                  },
+                                  "attr": "l_discount",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 83,
+                                  "end_lineno": 83,
+                                  "col_offset": 283,
+                                  "end_col_offset": 297
+                                },
+                                "lineno": 83,
+                                "end_lineno": 83,
+                                "col_offset": 279,
+                                "end_col_offset": 297
+                              },
+                              "lineno": 83,
+                              "end_lineno": 83,
+                              "col_offset": 256,
+                              "end_col_offset": 298
+                            },
+                            "generators": [
+                              {
+                                "_type": "comprehension",
+                                "target": {
+                                  "_type": "Name",
+                                  "id": "x",
+                                  "ctx": {
+                                    "_type": "Store"
+                                  },
+                                  "lineno": 83,
+                                  "end_lineno": 83,
+                                  "col_offset": 303,
+                                  "end_col_offset": 304
+                                },
+                                "iter": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "g",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 83,
+                                    "end_lineno": 83,
+                                    "col_offset": 308,
+                                    "end_col_offset": 309
+                                  },
+                                  "attr": "items",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 83,
+                                  "end_lineno": 83,
+                                  "col_offset": 308,
+                                  "end_col_offset": 315
+                                },
+                                "ifs": [],
+                                "is_async": 0
+                              }
+                            ],
+                            "lineno": 83,
+                            "end_lineno": 83,
+                            "col_offset": 255,
+                            "end_col_offset": 316
+                          }
+                        ],
+                        "keywords": [],
+                        "lineno": 83,
+                        "end_lineno": 83,
+                        "col_offset": 251,
+                        "end_col_offset": 317
+                      },
+                      "lineno": 83,
+                      "end_lineno": 83,
+                      "col_offset": 241,
+                      "end_col_offset": 317
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 237,
+                    "end_col_offset": 317
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "reverse",
+                    "value": {
+                      "_type": "Constant",
+                      "value": true,
+                      "kind": null,
+                      "lineno": 83,
+                      "end_lineno": 83,
+                      "col_offset": 327,
+                      "end_col_offset": 331
+                    },
+                    "lineno": 83,
+                    "end_lineno": 83,
+                    "col_offset": 319,
+                    "end_col_offset": 331
+                  }
+                ],
+                "lineno": 83,
+                "end_lineno": 83,
+                "col_offset": 205,
+                "end_col_offset": 332
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 83,
+          "end_lineno": 83,
+          "col_offset": 9,
+          "end_col_offset": 333
+        },
+        "lineno": 83,
+        "end_lineno": 83,
+        "end_col_offset": 333
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 84,
+            "end_lineno": 84,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 84,
+                    "end_lineno": 84,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 84,
+                  "end_lineno": 84,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 84,
+                    "end_lineno": 84,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 84,
+                "end_lineno": 84,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 84,
+                    "end_lineno": 84,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "result",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 84,
+                    "end_lineno": 84,
+                    "col_offset": 40,
+                    "end_col_offset": 46
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 84,
+              "end_lineno": 84,
+              "col_offset": 6,
+              "end_col_offset": 47
+            }
+          ],
+          "keywords": [],
+          "lineno": 84,
+          "end_lineno": 84,
+          "col_offset": 0,
+          "end_col_offset": 48
+        },
+        "lineno": 84,
+        "end_lineno": 84,
+        "end_col_offset": 48
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_multi_sort.py.json
+++ b/tests/json-ast/x/py/group_by_multi_sort.py.json
@@ -1,0 +1,1417 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "a",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "b",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "val",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 12,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "x",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 14,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 9,
+              "end_col_offset": 24
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 26,
+                "end_col_offset": 30
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "x",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 36,
+                  "end_col_offset": 37
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 39,
+                  "end_col_offset": 40
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 26,
+              "end_col_offset": 41
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 43,
+                "end_col_offset": 47
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "y",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 48,
+                  "end_col_offset": 51
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 53,
+                  "end_col_offset": 54
+                },
+                {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 56,
+                  "end_col_offset": 57
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 43,
+              "end_col_offset": 58
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 60,
+                "end_col_offset": 64
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "y",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 65,
+                  "end_col_offset": 68
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 70,
+                  "end_col_offset": 71
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 73,
+                  "end_col_offset": 74
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 60,
+              "end_col_offset": 75
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 8,
+          "end_col_offset": 76
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 76
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GKey",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "a",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "b",
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 18,
+            "end_lineno": 18,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 16,
+        "end_lineno": 18,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GroupedGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "GKey",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 9,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_grouped_groups",
+            "lineno": 25,
+            "end_lineno": 25,
+            "end_col_offset": 15
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 25,
+          "end_lineno": 25,
+          "col_offset": 18,
+          "end_col_offset": 20
+        },
+        "lineno": 25,
+        "end_lineno": 25,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_grouped_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 9,
+                  "end_col_offset": 24
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 9,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "tuple",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 36,
+                    "end_col_offset": 41
+                  },
+                  "args": [
+                    {
+                      "_type": "List",
+                      "elts": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "i",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 27,
+                            "end_lineno": 27,
+                            "col_offset": 43,
+                            "end_col_offset": 44
+                          },
+                          "attr": "a",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 27,
+                          "end_lineno": 27,
+                          "col_offset": 43,
+                          "end_col_offset": 46
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "i",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 27,
+                            "end_lineno": 27,
+                            "col_offset": 48,
+                            "end_col_offset": 49
+                          },
+                          "attr": "b",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 27,
+                          "end_lineno": 27,
+                          "col_offset": 48,
+                          "end_col_offset": 51
+                        }
+                      ],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 27,
+                      "end_lineno": 27,
+                      "col_offset": 42,
+                      "end_col_offset": 52
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 36,
+                  "end_col_offset": 53
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "GroupedGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 55,
+                    "end_col_offset": 67
+                  },
+                  "args": [
+                    {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "GKey",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 27,
+                        "end_lineno": 27,
+                        "col_offset": 68,
+                        "end_col_offset": 72
+                      },
+                      "args": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "i",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 27,
+                            "end_lineno": 27,
+                            "col_offset": 73,
+                            "end_col_offset": 74
+                          },
+                          "attr": "a",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 27,
+                          "end_lineno": 27,
+                          "col_offset": 73,
+                          "end_col_offset": 76
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "i",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 27,
+                            "end_lineno": 27,
+                            "col_offset": 78,
+                            "end_col_offset": 79
+                          },
+                          "attr": "b",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 27,
+                          "end_lineno": 27,
+                          "col_offset": 78,
+                          "end_col_offset": 81
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 27,
+                      "end_lineno": 27,
+                      "col_offset": 68,
+                      "end_col_offset": 82
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 27,
+                      "end_lineno": 27,
+                      "col_offset": 84,
+                      "end_col_offset": 86
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 55,
+                  "end_col_offset": 87
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 9,
+              "end_col_offset": 88
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 88
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 28,
+                  "end_lineno": 28,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 28,
+                  "end_lineno": 28,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "i",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "items",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 26,
+        "end_lineno": 28,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Grouped",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "a",
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 31,
+            "end_lineno": 31,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 32,
+              "end_lineno": 32,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "b",
+              "lineno": 32,
+              "end_lineno": 32,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 32,
+            "end_lineno": 32,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 33,
+              "end_lineno": 33,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 33,
+              "end_lineno": 33,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 33,
+            "end_lineno": 33,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 30,
+        "end_lineno": 33,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "grouped",
+            "lineno": 35,
+            "end_lineno": 35,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Grouped",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 35,
+              "end_lineno": 35,
+              "col_offset": 11,
+              "end_col_offset": 18
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 35,
+                  "end_lineno": 35,
+                  "col_offset": 19,
+                  "end_col_offset": 24
+                },
+                "attr": "a",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 35,
+                "end_lineno": 35,
+                "col_offset": 19,
+                "end_col_offset": 26
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 28,
+                    "end_col_offset": 29
+                  },
+                  "attr": "key",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 35,
+                  "end_lineno": 35,
+                  "col_offset": 28,
+                  "end_col_offset": 33
+                },
+                "attr": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 35,
+                "end_lineno": 35,
+                "col_offset": 28,
+                "end_col_offset": 35
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sum",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 35,
+                  "end_lineno": 35,
+                  "col_offset": 37,
+                  "end_col_offset": 40
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 35,
+                        "end_lineno": 35,
+                        "col_offset": 42,
+                        "end_col_offset": 43
+                      },
+                      "attr": "val",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 35,
+                      "end_lineno": 35,
+                      "col_offset": 42,
+                      "end_col_offset": 47
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 35,
+                          "end_lineno": 35,
+                          "col_offset": 52,
+                          "end_col_offset": 53
+                        },
+                        "iter": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "g",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 35,
+                            "end_lineno": 35,
+                            "col_offset": 57,
+                            "end_col_offset": 58
+                          },
+                          "attr": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 35,
+                          "end_lineno": 35,
+                          "col_offset": 57,
+                          "end_col_offset": 64
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 41,
+                    "end_col_offset": 65
+                  }
+                ],
+                "keywords": [],
+                "lineno": 35,
+                "end_lineno": 35,
+                "col_offset": 37,
+                "end_col_offset": 66
+              }
+            ],
+            "keywords": [],
+            "lineno": 35,
+            "end_lineno": 35,
+            "col_offset": 11,
+            "end_col_offset": 67
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 35,
+                "end_lineno": 35,
+                "col_offset": 72,
+                "end_col_offset": 73
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 35,
+                  "end_lineno": 35,
+                  "col_offset": 77,
+                  "end_col_offset": 83
+                },
+                "args": [
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_grouped_groups",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 35,
+                        "end_lineno": 35,
+                        "col_offset": 84,
+                        "end_col_offset": 99
+                      },
+                      "attr": "values",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 35,
+                      "end_lineno": 35,
+                      "col_offset": 84,
+                      "end_col_offset": 106
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 84,
+                    "end_col_offset": 108
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "g",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 35,
+                            "end_lineno": 35,
+                            "col_offset": 121,
+                            "end_col_offset": 122
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Call",
+                        "func": {
+                          "_type": "Name",
+                          "id": "sum",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 35,
+                          "end_lineno": 35,
+                          "col_offset": 124,
+                          "end_col_offset": 127
+                        },
+                        "args": [
+                          {
+                            "_type": "ListComp",
+                            "elt": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "x",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 35,
+                                "end_lineno": 35,
+                                "col_offset": 129,
+                                "end_col_offset": 130
+                              },
+                              "attr": "val",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 35,
+                              "end_lineno": 35,
+                              "col_offset": 129,
+                              "end_col_offset": 134
+                            },
+                            "generators": [
+                              {
+                                "_type": "comprehension",
+                                "target": {
+                                  "_type": "Name",
+                                  "id": "x",
+                                  "ctx": {
+                                    "_type": "Store"
+                                  },
+                                  "lineno": 35,
+                                  "end_lineno": 35,
+                                  "col_offset": 139,
+                                  "end_col_offset": 140
+                                },
+                                "iter": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "g",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 35,
+                                    "end_lineno": 35,
+                                    "col_offset": 144,
+                                    "end_col_offset": 145
+                                  },
+                                  "attr": "items",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 35,
+                                  "end_lineno": 35,
+                                  "col_offset": 144,
+                                  "end_col_offset": 151
+                                },
+                                "ifs": [],
+                                "is_async": 0
+                              }
+                            ],
+                            "lineno": 35,
+                            "end_lineno": 35,
+                            "col_offset": 128,
+                            "end_col_offset": 152
+                          }
+                        ],
+                        "keywords": [],
+                        "lineno": 35,
+                        "end_lineno": 35,
+                        "col_offset": 124,
+                        "end_col_offset": 153
+                      },
+                      "lineno": 35,
+                      "end_lineno": 35,
+                      "col_offset": 114,
+                      "end_col_offset": 153
+                    },
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 110,
+                    "end_col_offset": 153
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "reverse",
+                    "value": {
+                      "_type": "Constant",
+                      "value": true,
+                      "kind": null,
+                      "lineno": 35,
+                      "end_lineno": 35,
+                      "col_offset": 163,
+                      "end_col_offset": 167
+                    },
+                    "lineno": 35,
+                    "end_lineno": 35,
+                    "col_offset": 155,
+                    "end_col_offset": 167
+                  }
+                ],
+                "lineno": 35,
+                "end_lineno": 35,
+                "col_offset": 77,
+                "end_col_offset": 168
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 35,
+          "end_lineno": 35,
+          "col_offset": 10,
+          "end_col_offset": 169
+        },
+        "lineno": 35,
+        "end_lineno": 35,
+        "end_col_offset": 169
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 36,
+            "end_lineno": 36,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 36,
+                    "end_lineno": 36,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 36,
+                  "end_lineno": 36,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 36,
+                    "end_lineno": 36,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 36,
+                "end_lineno": 36,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 36,
+                    "end_lineno": 36,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "grouped",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 36,
+                    "end_lineno": 36,
+                    "col_offset": 40,
+                    "end_col_offset": 47
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 36,
+              "end_lineno": 36,
+              "col_offset": 6,
+              "end_col_offset": 48
+            }
+          ],
+          "keywords": [],
+          "lineno": 36,
+          "end_lineno": 36,
+          "col_offset": 0,
+          "end_col_offset": 49
+        },
+        "lineno": 36,
+        "end_lineno": 36,
+        "end_col_offset": 49
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_by_sort.py.json
+++ b/tests/json-ast/x/py/group_by_sort.py.json
@@ -1,0 +1,1124 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "cat",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "val",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 11,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 14,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 9,
+              "end_col_offset": 21
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 23,
+                "end_col_offset": 27
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 28,
+                  "end_col_offset": 31
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 33,
+                  "end_col_offset": 34
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 23,
+              "end_col_offset": 35
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 37,
+                "end_col_offset": 41
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 42,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 47,
+                  "end_col_offset": 48
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 37,
+              "end_col_offset": 49
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 51,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 61,
+                  "end_col_offset": 62
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 51,
+              "end_col_offset": 63
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 8,
+          "end_col_offset": 64
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 64
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GroupedGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 15,
+        "end_lineno": 17,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_grouped_groups",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 15
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 18,
+          "end_col_offset": 20
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_grouped_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 9,
+                  "end_col_offset": 24
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 9,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "i",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 21,
+                    "end_lineno": 21,
+                    "col_offset": 36,
+                    "end_col_offset": 37
+                  },
+                  "attr": "cat",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 36,
+                  "end_col_offset": 41
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "GroupedGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 21,
+                    "end_lineno": 21,
+                    "col_offset": 43,
+                    "end_col_offset": 55
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "i",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 21,
+                        "end_lineno": 21,
+                        "col_offset": 56,
+                        "end_col_offset": 57
+                      },
+                      "attr": "cat",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 21,
+                      "end_lineno": 21,
+                      "col_offset": 56,
+                      "end_col_offset": 61
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 21,
+                      "end_lineno": 21,
+                      "col_offset": 63,
+                      "end_col_offset": 65
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 43,
+                  "end_col_offset": 66
+                }
+              ],
+              "keywords": [],
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 9,
+              "end_col_offset": 67
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 67
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "i",
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "items",
+          "lineno": 20,
+          "end_lineno": 20,
+          "col_offset": 9,
+          "end_col_offset": 14
+        },
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Grouped",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "cat",
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 24,
+        "end_lineno": 26,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "grouped",
+            "lineno": 28,
+            "end_lineno": 28,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Grouped",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 11,
+              "end_col_offset": 18
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "g",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 28,
+                  "end_lineno": 28,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                "attr": "key",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 19,
+                "end_col_offset": 24
+              },
+              {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sum",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 28,
+                  "end_lineno": 28,
+                  "col_offset": 26,
+                  "end_col_offset": 29
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 31,
+                        "end_col_offset": 32
+                      },
+                      "attr": "val",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 28,
+                      "end_lineno": 28,
+                      "col_offset": 31,
+                      "end_col_offset": 36
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 28,
+                          "end_lineno": 28,
+                          "col_offset": 41,
+                          "end_col_offset": 42
+                        },
+                        "iter": {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "g",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 28,
+                            "end_lineno": 28,
+                            "col_offset": 46,
+                            "end_col_offset": 47
+                          },
+                          "attr": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 28,
+                          "end_lineno": 28,
+                          "col_offset": 46,
+                          "end_col_offset": 53
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 30,
+                    "end_col_offset": 54
+                  }
+                ],
+                "keywords": [],
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 26,
+                "end_col_offset": 55
+              }
+            ],
+            "keywords": [],
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 11,
+            "end_col_offset": 56
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 61,
+                "end_col_offset": 62
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 28,
+                  "end_lineno": 28,
+                  "col_offset": 66,
+                  "end_col_offset": 72
+                },
+                "args": [
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "_grouped_groups",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 73,
+                        "end_col_offset": 88
+                      },
+                      "attr": "values",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 28,
+                      "end_lineno": 28,
+                      "col_offset": 73,
+                      "end_col_offset": 95
+                    },
+                    "args": [],
+                    "keywords": [],
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 73,
+                    "end_col_offset": 97
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "g",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 28,
+                            "end_lineno": 28,
+                            "col_offset": 110,
+                            "end_col_offset": 111
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Call",
+                        "func": {
+                          "_type": "Name",
+                          "id": "sum",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 28,
+                          "end_lineno": 28,
+                          "col_offset": 113,
+                          "end_col_offset": 116
+                        },
+                        "args": [
+                          {
+                            "_type": "ListComp",
+                            "elt": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "x",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 28,
+                                "end_lineno": 28,
+                                "col_offset": 118,
+                                "end_col_offset": 119
+                              },
+                              "attr": "val",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 28,
+                              "end_lineno": 28,
+                              "col_offset": 118,
+                              "end_col_offset": 123
+                            },
+                            "generators": [
+                              {
+                                "_type": "comprehension",
+                                "target": {
+                                  "_type": "Name",
+                                  "id": "x",
+                                  "ctx": {
+                                    "_type": "Store"
+                                  },
+                                  "lineno": 28,
+                                  "end_lineno": 28,
+                                  "col_offset": 128,
+                                  "end_col_offset": 129
+                                },
+                                "iter": {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "g",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 28,
+                                    "end_lineno": 28,
+                                    "col_offset": 133,
+                                    "end_col_offset": 134
+                                  },
+                                  "attr": "items",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 28,
+                                  "end_lineno": 28,
+                                  "col_offset": 133,
+                                  "end_col_offset": 140
+                                },
+                                "ifs": [],
+                                "is_async": 0
+                              }
+                            ],
+                            "lineno": 28,
+                            "end_lineno": 28,
+                            "col_offset": 117,
+                            "end_col_offset": 141
+                          }
+                        ],
+                        "keywords": [],
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 113,
+                        "end_col_offset": 142
+                      },
+                      "lineno": 28,
+                      "end_lineno": 28,
+                      "col_offset": 103,
+                      "end_col_offset": 142
+                    },
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 99,
+                    "end_col_offset": 142
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "reverse",
+                    "value": {
+                      "_type": "Constant",
+                      "value": true,
+                      "kind": null,
+                      "lineno": 28,
+                      "end_lineno": 28,
+                      "col_offset": 152,
+                      "end_col_offset": 156
+                    },
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 144,
+                    "end_col_offset": 156
+                  }
+                ],
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 66,
+                "end_col_offset": 157
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 10,
+          "end_col_offset": 158
+        },
+        "lineno": 28,
+        "end_lineno": 28,
+        "end_col_offset": 158
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "grouped",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 40,
+                    "end_col_offset": 47
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 6,
+              "end_col_offset": 48
+            }
+          ],
+          "keywords": [],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 0,
+          "end_col_offset": 49
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 49
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/group_items_iteration.py.json
+++ b/tests/json-ast/x/py/group_items_iteration.py.json
@@ -1,0 +1,1127 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Data",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "tag",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "val",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "data",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 8,
+                "end_col_offset": 12
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 13,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 18,
+                  "end_col_offset": 19
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 8,
+              "end_col_offset": 20
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 22,
+                "end_col_offset": 26
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 27,
+                  "end_col_offset": 30
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 32,
+                  "end_col_offset": 33
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 22,
+              "end_col_offset": 34
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 36,
+                "end_col_offset": 40
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 41,
+                  "end_col_offset": 44
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 46,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 36,
+              "end_col_offset": 48
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 7,
+          "end_col_offset": 49
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 49
+      },
+      {
+        "_type": "ClassDef",
+        "name": "GroupsGroup",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "key",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "list",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "items",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 16,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "_groups_groups",
+            "lineno": 18,
+            "end_lineno": 18,
+            "end_col_offset": 14
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [],
+          "values": [],
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 17,
+          "end_col_offset": 19
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_g",
+                "lineno": 20,
+                "end_lineno": 20,
+                "col_offset": 4,
+                "end_col_offset": 6
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "_groups_groups",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 20,
+                  "end_lineno": 20,
+                  "col_offset": 9,
+                  "end_col_offset": 23
+                },
+                "attr": "setdefault",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 20,
+                "end_lineno": 20,
+                "col_offset": 9,
+                "end_col_offset": 34
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "d",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 20,
+                    "end_lineno": 20,
+                    "col_offset": 35,
+                    "end_col_offset": 36
+                  },
+                  "attr": "tag",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 20,
+                  "end_lineno": 20,
+                  "col_offset": 35,
+                  "end_col_offset": 40
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "GroupsGroup",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 20,
+                    "end_lineno": 20,
+                    "col_offset": 42,
+                    "end_col_offset": 53
+                  },
+                  "args": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "d",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 20,
+                        "end_lineno": 20,
+                        "col_offset": 54,
+                        "end_col_offset": 55
+                      },
+                      "attr": "tag",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 20,
+                      "end_lineno": 20,
+                      "col_offset": 54,
+                      "end_col_offset": 59
+                    },
+                    {
+                      "_type": "List",
+                      "elts": [],
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 20,
+                      "end_lineno": 20,
+                      "col_offset": 61,
+                      "end_col_offset": 63
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 20,
+                  "end_lineno": 20,
+                  "col_offset": 42,
+                  "end_col_offset": 64
+                }
+              ],
+              "keywords": [],
+              "lineno": 20,
+              "end_lineno": 20,
+              "col_offset": 9,
+              "end_col_offset": 65
+            },
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 4,
+            "end_col_offset": 65
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_g",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 21,
+                    "end_lineno": 21,
+                    "col_offset": 4,
+                    "end_col_offset": 6
+                  },
+                  "attr": "items",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 4,
+                  "end_col_offset": 12
+                },
+                "attr": "append",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 4,
+                "end_col_offset": 19
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "d",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 22
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "d",
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "data",
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 13
+        },
+        "lineno": 19,
+        "end_lineno": 21,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "groups",
+            "lineno": 22,
+            "end_lineno": 22,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Name",
+            "id": "g",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 10,
+            "end_col_offset": 11
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "_groups_groups",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 22,
+                    "end_lineno": 22,
+                    "col_offset": 21,
+                    "end_col_offset": 35
+                  },
+                  "attr": "values",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 22,
+                  "end_lineno": 22,
+                  "col_offset": 21,
+                  "end_col_offset": 42
+                },
+                "args": [],
+                "keywords": [],
+                "lineno": 22,
+                "end_lineno": 22,
+                "col_offset": 21,
+                "end_col_offset": 44
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 22,
+          "end_lineno": 22,
+          "col_offset": 9,
+          "end_col_offset": 45
+        },
+        "lineno": 22,
+        "end_lineno": 22,
+        "end_col_offset": 45
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "tmp",
+            "lineno": 23,
+            "end_lineno": 23,
+            "end_col_offset": 3
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 23,
+          "end_lineno": 23,
+          "col_offset": 6,
+          "end_col_offset": 8
+        },
+        "lineno": 23,
+        "end_lineno": 23,
+        "end_col_offset": 8
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "total",
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 4,
+                "end_col_offset": 9
+              }
+            ],
+            "value": {
+              "_type": "Constant",
+              "value": 0,
+              "kind": null,
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 12,
+              "end_col_offset": 13
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "For",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Name",
+                    "id": "total",
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 8,
+                    "end_col_offset": 13
+                  }
+                ],
+                "value": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Name",
+                    "id": "total",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 16,
+                    "end_col_offset": 21
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "x",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 27,
+                      "end_lineno": 27,
+                      "col_offset": 24,
+                      "end_col_offset": 25
+                    },
+                    "attr": "val",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 24,
+                    "end_col_offset": 29
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 16,
+                  "end_col_offset": 29
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 8,
+                "end_col_offset": 29
+              }
+            ],
+            "target": {
+              "_type": "Name",
+              "id": "x",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            "iter": {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "g",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 13,
+                "end_col_offset": 14
+              },
+              "attr": "items",
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 13,
+              "end_col_offset": 20
+            },
+            "lineno": 26,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 29
+          },
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "tmp",
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 4,
+                "end_col_offset": 7
+              }
+            ],
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "tmp",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 10,
+                "end_col_offset": 13
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "List",
+                "elts": [
+                  {
+                    "_type": "Dict",
+                    "keys": [
+                      {
+                        "_type": "Constant",
+                        "value": "tag",
+                        "kind": null,
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 18,
+                        "end_col_offset": 23
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": "total",
+                        "kind": null,
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 32,
+                        "end_col_offset": 39
+                      }
+                    ],
+                    "values": [
+                      {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "g",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 28,
+                          "end_lineno": 28,
+                          "col_offset": 25,
+                          "end_col_offset": 26
+                        },
+                        "attr": "key",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 25,
+                        "end_col_offset": 30
+                      },
+                      {
+                        "_type": "Name",
+                        "id": "total",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 28,
+                        "end_lineno": 28,
+                        "col_offset": 41,
+                        "end_col_offset": 46
+                      }
+                    ],
+                    "lineno": 28,
+                    "end_lineno": 28,
+                    "col_offset": 17,
+                    "end_col_offset": 47
+                  }
+                ],
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 16,
+                "end_col_offset": 48
+              },
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 10,
+              "end_col_offset": 48
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 4,
+            "end_col_offset": 48
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "g",
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "groups",
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 24,
+        "end_lineno": 28,
+        "end_col_offset": 48
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 29,
+            "end_lineno": 29,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Name",
+            "id": "r",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 10,
+            "end_col_offset": 11
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "r",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 21,
+                  "end_col_offset": 27
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "r",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 29,
+                      "end_col_offset": 30
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "r",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 35,
+                          "end_col_offset": 36
+                        },
+                        "iter": {
+                          "_type": "Name",
+                          "id": "tmp",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 40,
+                          "end_col_offset": 43
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 28,
+                    "end_col_offset": 44
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "r",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 29,
+                            "end_lineno": 29,
+                            "col_offset": 57,
+                            "end_col_offset": 58
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Subscript",
+                        "value": {
+                          "_type": "Name",
+                          "id": "r",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 60,
+                          "end_col_offset": 61
+                        },
+                        "slice": {
+                          "_type": "Constant",
+                          "value": "tag",
+                          "kind": null,
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 62,
+                          "end_col_offset": 67
+                        },
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 60,
+                        "end_col_offset": 68
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 50,
+                      "end_col_offset": 68
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 46,
+                    "end_col_offset": 68
+                  }
+                ],
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 21,
+                "end_col_offset": 69
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 29,
+          "end_lineno": 29,
+          "col_offset": 9,
+          "end_col_offset": 70
+        },
+        "lineno": 29,
+        "end_lineno": 29,
+        "end_col_offset": 70
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/if_else.py.json
+++ b/tests/json-ast/x/py/if_else.py.json
@@ -1,0 +1,145 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 5,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "If",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "big",
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 15
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 4,
+              "end_col_offset": 16
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "test": {
+          "_type": "Compare",
+          "left": {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 3,
+            "end_col_offset": 4
+          },
+          "ops": [
+            {
+              "_type": "Gt"
+            }
+          ],
+          "comparators": [
+            {
+              "_type": "Constant",
+              "value": 3,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 8
+            }
+          ],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 3,
+          "end_col_offset": 8
+        },
+        "orelse": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "small",
+                  "kind": null,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 10,
+                  "end_col_offset": 17
+                }
+              ],
+              "keywords": [],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 4,
+              "end_col_offset": 18
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 4,
+            "end_col_offset": 18
+          }
+        ],
+        "lineno": 4,
+        "end_lineno": 7,
+        "end_col_offset": 18
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/if_then_else.py.json
+++ b/tests/json-ast/x/py/if_then_else.py.json
@@ -1,0 +1,143 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 12,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 6
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 6
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "msg",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 3
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 16,
+              "end_col_offset": 17
+            },
+            "ops": [
+              {
+                "_type": "Gt"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": 10,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 20,
+                "end_col_offset": 22
+              }
+            ],
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 16,
+            "end_col_offset": 22
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "yes",
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 7,
+            "end_col_offset": 12
+          },
+          "orelse": {
+            "_type": "Constant",
+            "value": "no",
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 28,
+            "end_col_offset": 32
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 7,
+          "end_col_offset": 32
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "msg",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 9
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 10
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 10
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/if_then_else_nested.py.json
+++ b/tests/json-ast/x/py/if_then_else_nested.py.json
@@ -1,0 +1,193 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 8,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "msg",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 3
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 16,
+              "end_col_offset": 17
+            },
+            "ops": [
+              {
+                "_type": "Gt"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": 10,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 20,
+                "end_col_offset": 22
+              }
+            ],
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 16,
+            "end_col_offset": 22
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "big",
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 7,
+            "end_col_offset": 12
+          },
+          "orelse": {
+            "_type": "IfExp",
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 41,
+                "end_col_offset": 42
+              },
+              "ops": [
+                {
+                  "_type": "Gt"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 45,
+                  "end_col_offset": 46
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 41,
+              "end_col_offset": 46
+            },
+            "body": {
+              "_type": "Constant",
+              "value": "medium",
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 29,
+              "end_col_offset": 37
+            },
+            "orelse": {
+              "_type": "Constant",
+              "value": "small",
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 52,
+              "end_col_offset": 59
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 29,
+            "end_col_offset": 59
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 7,
+          "end_col_offset": 60
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 61
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "msg",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 9
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 10
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 10
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/in_operator.py.json
+++ b/tests/json-ast/x/py/in_operator.py.json
@@ -1,0 +1,243 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "xs",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 7
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 9,
+              "end_col_offset": 10
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 12,
+              "end_col_offset": 13
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 5,
+          "end_col_offset": 14
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "xs",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 17,
+                    "end_col_offset": 19
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 19
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 25,
+                "end_col_offset": 26
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 26
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 28
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 28
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "UnaryOp",
+                "op": {
+                  "_type": "Not"
+                },
+                "operand": {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Constant",
+                    "value": 5,
+                    "kind": null,
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  },
+                  "ops": [
+                    {
+                      "_type": "In"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Name",
+                      "id": "xs",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 5,
+                      "end_lineno": 5,
+                      "col_offset": 26,
+                      "end_col_offset": 28
+                    }
+                  ],
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 21,
+                  "end_col_offset": 28
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 17,
+                "end_col_offset": 28
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "true",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 13
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": "false",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 34,
+                "end_col_offset": 41
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 41
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 43
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 43
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/in_operator_extended.py.json
+++ b/tests/json-ast/x/py/in_operator_extended.py.json
@@ -1,0 +1,761 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "xs",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 7
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 9,
+              "end_col_offset": 10
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 12,
+              "end_col_offset": 13
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 5,
+          "end_col_offset": 14
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "ys",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Name",
+            "id": "x",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 6,
+            "end_col_offset": 7
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 13
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "xs",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 17,
+                "end_col_offset": 19
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "BinOp",
+                    "left": {
+                      "_type": "Name",
+                      "id": "x",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 23,
+                      "end_col_offset": 24
+                    },
+                    "op": {
+                      "_type": "Mod"
+                    },
+                    "right": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 27,
+                      "end_col_offset": 28
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 23,
+                    "end_col_offset": 28
+                  },
+                  "ops": [
+                    {
+                      "_type": "Eq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 32,
+                      "end_col_offset": 33
+                    }
+                  ],
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 23,
+                  "end_col_offset": 33
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 5,
+          "end_col_offset": 34
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "ys",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 17,
+                    "end_col_offset": 19
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 19
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 25,
+                "end_col_offset": 26
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 26
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 28
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 28
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "ys",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 17,
+                    "end_col_offset": 19
+                  }
+                ],
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 19
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 25,
+                "end_col_offset": 26
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 26
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 28
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 28
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 5,
+              "end_col_offset": 8
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 10,
+              "end_col_offset": 11
+            }
+          ],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 4,
+          "end_col_offset": 12
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 8,
+                  "end_lineno": 8,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 8,
+                    "end_lineno": 8,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  }
+                ],
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 7,
+              "end_col_offset": 27
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 9,
+                  "end_lineno": 9,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 9,
+                    "end_lineno": 9,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  }
+                ],
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 7,
+              "end_col_offset": 27
+            }
+          ],
+          "keywords": [],
+          "lineno": 9,
+          "end_lineno": 9,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 9,
+        "end_lineno": 9,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 10,
+            "end_lineno": 10,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "hello",
+          "kind": null,
+          "lineno": 10,
+          "end_lineno": 10,
+          "col_offset": 4,
+          "end_col_offset": 11
+        },
+        "lineno": 10,
+        "end_lineno": 10,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "ell",
+                  "kind": null,
+                  "lineno": 11,
+                  "end_lineno": 11,
+                  "col_offset": 12,
+                  "end_col_offset": 17
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 11,
+                    "end_lineno": 11,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 31
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "foo",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 12,
+                  "end_col_offset": 17
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 12,
+                    "end_lineno": 12,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 31
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/inner_join.py.json
+++ b/tests/json-ast/x/py/inner_join.py.json
@@ -1,0 +1,1042 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 55,
+                "end_col_offset": 63
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 55,
+              "end_col_offset": 77
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 78
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 78
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": 250,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 24,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 30,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 36,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": 125,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 30,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 50,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 61,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Constant",
+                  "value": 300,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 64,
+                  "end_col_offset": 67
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 50,
+              "end_col_offset": 68
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 70,
+                "end_col_offset": 75
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 103,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 76,
+                  "end_col_offset": 79
+                },
+                {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 81,
+                  "end_col_offset": 82
+                },
+                {
+                  "_type": "Constant",
+                  "value": 80,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 84,
+                  "end_col_offset": 86
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 70,
+              "end_col_offset": 87
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 88
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 88
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 18,
+              "end_col_offset": 21
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerName",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 16
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 21
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 24,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 26,
+            "end_lineno": 26,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "id",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 23,
+                  "end_col_offset": 24
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 23,
+                "end_col_offset": 29
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 31,
+                  "end_col_offset": 32
+                },
+                "attr": "total",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 31,
+                "end_col_offset": 38
+              }
+            ],
+            "keywords": [],
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 10,
+            "end_col_offset": 39
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "o",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 44,
+                "end_col_offset": 45
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "orders",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 49,
+                "end_col_offset": 55
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 60,
+                "end_col_offset": 61
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "customers",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 65,
+                "end_col_offset": 74
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "o",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 26,
+                      "end_lineno": 26,
+                      "col_offset": 78,
+                      "end_col_offset": 79
+                    },
+                    "attr": "customerId",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 26,
+                    "end_lineno": 26,
+                    "col_offset": 78,
+                    "end_col_offset": 90
+                  },
+                  "ops": [
+                    {
+                      "_type": "Eq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "c",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 26,
+                        "end_lineno": 26,
+                        "col_offset": 94,
+                        "end_col_offset": 95
+                      },
+                      "attr": "id",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 26,
+                      "end_lineno": 26,
+                      "col_offset": 94,
+                      "end_col_offset": 98
+                    }
+                  ],
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 78,
+                  "end_col_offset": 98
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 9,
+          "end_col_offset": 99
+        },
+        "lineno": 26,
+        "end_lineno": 26,
+        "end_col_offset": 99
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Orders with customer info ---",
+              "kind": null,
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 6,
+              "end_col_offset": 41
+            }
+          ],
+          "keywords": [],
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 0,
+          "end_col_offset": 42
+        },
+        "lineno": 27,
+        "end_lineno": 27,
+        "end_col_offset": 42
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Order",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 10,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 19,
+                    "end_col_offset": 24
+                  },
+                  "attr": "orderId",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 19,
+                  "end_col_offset": 32
+                },
+                {
+                  "_type": "Constant",
+                  "value": "by",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 34,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 40,
+                    "end_col_offset": 45
+                  },
+                  "attr": "customerName",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 40,
+                  "end_col_offset": 58
+                },
+                {
+                  "_type": "Constant",
+                  "value": "- $",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 60,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 67,
+                    "end_col_offset": 72
+                  },
+                  "attr": "total",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 67,
+                  "end_col_offset": 78
+                }
+              ],
+              "keywords": [],
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 4,
+              "end_col_offset": 79
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 4,
+            "end_col_offset": 79
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "entry",
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 13,
+          "end_col_offset": 19
+        },
+        "lineno": 28,
+        "end_lineno": 29,
+        "end_col_offset": 79
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/join_multi.py.json
+++ b/tests/json-ast/x/py/join_multi.py.json
@@ -1,0 +1,1048 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 54
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 16,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 18,
+            "end_lineno": 18,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 10,
+              "end_col_offset": 23
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 25,
+                "end_col_offset": 30
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 36,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 25,
+              "end_col_offset": 38
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 9,
+          "end_col_offset": 39
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 39
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "sku",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 24,
+            "end_lineno": 24,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 24,
+                "end_lineno": 24,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 14,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 19,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 9,
+              "end_col_offset": 23
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 24,
+                "end_lineno": 24,
+                "col_offset": 25,
+                "end_col_offset": 29
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 30,
+                  "end_col_offset": 33
+                },
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 35,
+                  "end_col_offset": 38
+                }
+              ],
+              "keywords": [],
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 25,
+              "end_col_offset": 39
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 8,
+          "end_col_offset": 40
+        },
+        "lineno": 24,
+        "end_lineno": 24,
+        "end_col_offset": 40
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "sku",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 26,
+        "end_lineno": 28,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 30,
+            "end_lineno": 30,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 30,
+              "end_lineno": 30,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 17,
+                "end_col_offset": 23
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                },
+                "attr": "sku",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 25,
+                "end_col_offset": 30
+              }
+            ],
+            "keywords": [],
+            "lineno": 30,
+            "end_lineno": 30,
+            "col_offset": 10,
+            "end_col_offset": 31
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "o",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 36,
+                "end_col_offset": 37
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "orders",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 41,
+                "end_col_offset": 47
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 52,
+                "end_col_offset": 53
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "customers",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 57,
+                "end_col_offset": 66
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 71,
+                "end_col_offset": 72
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "items",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 30,
+                "end_lineno": 30,
+                "col_offset": 76,
+                "end_col_offset": 81
+              },
+              "ifs": [
+                {
+                  "_type": "BoolOp",
+                  "op": {
+                    "_type": "And"
+                  },
+                  "values": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 85,
+                          "end_col_offset": 86
+                        },
+                        "attr": "customerId",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 85,
+                        "end_col_offset": 97
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 30,
+                            "end_lineno": 30,
+                            "col_offset": 101,
+                            "end_col_offset": 102
+                          },
+                          "attr": "id",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 101,
+                          "end_col_offset": 105
+                        }
+                      ],
+                      "lineno": 30,
+                      "end_lineno": 30,
+                      "col_offset": 85,
+                      "end_col_offset": 105
+                    },
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 110,
+                          "end_col_offset": 111
+                        },
+                        "attr": "id",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 110,
+                        "end_col_offset": 114
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "i",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 30,
+                            "end_lineno": 30,
+                            "col_offset": 118,
+                            "end_col_offset": 119
+                          },
+                          "attr": "orderId",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 118,
+                          "end_col_offset": 127
+                        }
+                      ],
+                      "lineno": 30,
+                      "end_lineno": 30,
+                      "col_offset": 110,
+                      "end_col_offset": 127
+                    }
+                  ],
+                  "lineno": 30,
+                  "end_lineno": 30,
+                  "col_offset": 85,
+                  "end_col_offset": 127
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 30,
+          "end_lineno": 30,
+          "col_offset": 9,
+          "end_col_offset": 128
+        },
+        "lineno": 30,
+        "end_lineno": 30,
+        "end_col_offset": 128
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 31,
+            "end_lineno": 31,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Multi Join ---",
+              "kind": null,
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 6,
+              "end_col_offset": 26
+            }
+          ],
+          "keywords": [],
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 0,
+          "end_col_offset": 27
+        },
+        "lineno": 31,
+        "end_lineno": 31,
+        "end_col_offset": 27
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 33,
+                "end_lineno": 33,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "r",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": "bought item",
+                  "kind": null,
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 18,
+                  "end_col_offset": 31
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "r",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 33,
+                    "end_lineno": 33,
+                    "col_offset": 33,
+                    "end_col_offset": 34
+                  },
+                  "attr": "sku",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 33,
+                  "end_lineno": 33,
+                  "col_offset": 33,
+                  "end_col_offset": 38
+                }
+              ],
+              "keywords": [],
+              "lineno": 33,
+              "end_lineno": 33,
+              "col_offset": 4,
+              "end_col_offset": 39
+            },
+            "lineno": 33,
+            "end_lineno": 33,
+            "col_offset": 4,
+            "end_col_offset": 39
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "r",
+          "lineno": 32,
+          "end_lineno": 32,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 32,
+          "end_lineno": 32,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 32,
+        "end_lineno": 33,
+        "end_col_offset": 39
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/json_builtin.py.json
+++ b/tests/json-ast/x/py/json_builtin.py.json
@@ -1,0 +1,163 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Import",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 13,
+              "end_col_offset": 16
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "json",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "attr": "dumps",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "m",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                }
+              ],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "indent",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 27,
+                    "end_col_offset": 28
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 20,
+                  "end_col_offset": 28
+                }
+              ],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 30
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 30
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/left_join.py.json
+++ b/tests/json-ast/x/py/left_join.py.json
@@ -1,0 +1,965 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 54
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": 250,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 24,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 30,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 36,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": 80,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 46
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 30,
+              "end_col_offset": 47
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 48
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 48
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 14,
+              "end_col_offset": 17
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customer",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 17
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 24,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 26,
+            "end_lineno": 26,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "id",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 23,
+                "end_col_offset": 24
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 26,
+                  "end_lineno": 26,
+                  "col_offset": 26,
+                  "end_col_offset": 27
+                },
+                "attr": "total",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 26,
+                "end_col_offset": 33
+              }
+            ],
+            "keywords": [],
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 10,
+            "end_col_offset": 34
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "o",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 39,
+                "end_col_offset": 40
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "orders",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 44,
+                "end_col_offset": 50
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 55,
+                "end_col_offset": 56
+              },
+              "iter": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "Or"
+                },
+                "values": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "c",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 26,
+                      "end_lineno": 26,
+                      "col_offset": 61,
+                      "end_col_offset": 62
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "c",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 26,
+                          "end_lineno": 26,
+                          "col_offset": 67,
+                          "end_col_offset": 68
+                        },
+                        "iter": {
+                          "_type": "Name",
+                          "id": "customers",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 26,
+                          "end_lineno": 26,
+                          "col_offset": 72,
+                          "end_col_offset": 81
+                        },
+                        "ifs": [
+                          {
+                            "_type": "Compare",
+                            "left": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 26,
+                                "end_lineno": 26,
+                                "col_offset": 85,
+                                "end_col_offset": 86
+                              },
+                              "attr": "customerId",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 26,
+                              "end_lineno": 26,
+                              "col_offset": 85,
+                              "end_col_offset": 97
+                            },
+                            "ops": [
+                              {
+                                "_type": "Eq"
+                              }
+                            ],
+                            "comparators": [
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "c",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 26,
+                                  "end_lineno": 26,
+                                  "col_offset": 101,
+                                  "end_col_offset": 102
+                                },
+                                "attr": "id",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 26,
+                                "end_lineno": 26,
+                                "col_offset": 101,
+                                "end_col_offset": 105
+                              }
+                            ],
+                            "lineno": 26,
+                            "end_lineno": 26,
+                            "col_offset": 85,
+                            "end_col_offset": 105
+                          }
+                        ],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 26,
+                    "end_lineno": 26,
+                    "col_offset": 60,
+                    "end_col_offset": 106
+                  },
+                  {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": null,
+                        "kind": null,
+                        "lineno": 26,
+                        "end_lineno": 26,
+                        "col_offset": 111,
+                        "end_col_offset": 115
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 26,
+                    "end_lineno": 26,
+                    "col_offset": 110,
+                    "end_col_offset": 116
+                  }
+                ],
+                "lineno": 26,
+                "end_lineno": 26,
+                "col_offset": 60,
+                "end_col_offset": 116
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 9,
+          "end_col_offset": 117
+        },
+        "lineno": 26,
+        "end_lineno": 26,
+        "end_col_offset": 117
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Left Join ---",
+              "kind": null,
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 6,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 0,
+          "end_col_offset": 26
+        },
+        "lineno": 27,
+        "end_lineno": 27,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Order",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 10,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 19,
+                    "end_col_offset": 24
+                  },
+                  "attr": "orderId",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 19,
+                  "end_col_offset": 32
+                },
+                {
+                  "_type": "Constant",
+                  "value": "customer",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 34,
+                  "end_col_offset": 44
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 46,
+                    "end_col_offset": 51
+                  },
+                  "attr": "customer",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 46,
+                  "end_col_offset": 60
+                },
+                {
+                  "_type": "Constant",
+                  "value": "total",
+                  "kind": null,
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 62,
+                  "end_col_offset": 69
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "entry",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 71,
+                    "end_col_offset": 76
+                  },
+                  "attr": "total",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 71,
+                  "end_col_offset": 82
+                }
+              ],
+              "keywords": [],
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 4,
+              "end_col_offset": 83
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 4,
+            "end_col_offset": 83
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "entry",
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 28,
+          "end_lineno": 28,
+          "col_offset": 13,
+          "end_col_offset": 19
+        },
+        "lineno": 28,
+        "end_lineno": 29,
+        "end_col_offset": 83
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/left_join_multi.py.json
+++ b/tests/json-ast/x/py/left_join_multi.py.json
@@ -1,0 +1,1115 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 54
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 54
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 16,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 18,
+            "end_lineno": 18,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 10,
+              "end_col_offset": 23
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 25,
+                "end_col_offset": 30
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 36,
+                  "end_col_offset": 37
+                }
+              ],
+              "keywords": [],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 25,
+              "end_col_offset": 38
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 9,
+          "end_col_offset": 39
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 39
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "sku",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 19,
+            "end_lineno": 19,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 20,
+        "end_lineno": 22,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 24,
+            "end_lineno": 24,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 24,
+                "end_lineno": 24,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 14,
+                  "end_col_offset": 17
+                },
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 24,
+                  "end_lineno": 24,
+                  "col_offset": 19,
+                  "end_col_offset": 22
+                }
+              ],
+              "keywords": [],
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 9,
+              "end_col_offset": 23
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 8,
+          "end_col_offset": 24
+        },
+        "lineno": 24,
+        "end_lineno": 24,
+        "end_col_offset": 24
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            "target": {
+              "_type": "Name",
+              "id": "orderId",
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 11
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 16
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 28,
+            "end_lineno": 28,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "item",
+              "lineno": 29,
+              "end_lineno": 29,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 29,
+            "end_lineno": 29,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 26,
+        "end_lineno": 29,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 31,
+            "end_lineno": 31,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 31,
+              "end_lineno": 31,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "attr": "id",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 23,
+                  "end_col_offset": 24
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 23,
+                "end_col_offset": 29
+              },
+              {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 31,
+                "end_col_offset": 32
+              }
+            ],
+            "keywords": [],
+            "lineno": 31,
+            "end_lineno": 31,
+            "col_offset": 10,
+            "end_col_offset": 33
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "o",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 38,
+                "end_col_offset": 39
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "orders",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 43,
+                "end_col_offset": 49
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 54,
+                "end_col_offset": 55
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "customers",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 59,
+                "end_col_offset": 68
+              },
+              "ifs": [],
+              "is_async": 0
+            },
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 73,
+                "end_col_offset": 74
+              },
+              "iter": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "Or"
+                },
+                "values": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "i",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 79,
+                      "end_col_offset": 80
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "i",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 31,
+                          "end_lineno": 31,
+                          "col_offset": 85,
+                          "end_col_offset": 86
+                        },
+                        "iter": {
+                          "_type": "Name",
+                          "id": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 31,
+                          "end_lineno": 31,
+                          "col_offset": 90,
+                          "end_col_offset": 95
+                        },
+                        "ifs": [
+                          {
+                            "_type": "Compare",
+                            "left": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 31,
+                                "end_lineno": 31,
+                                "col_offset": 99,
+                                "end_col_offset": 100
+                              },
+                              "attr": "id",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 31,
+                              "end_lineno": 31,
+                              "col_offset": 99,
+                              "end_col_offset": 103
+                            },
+                            "ops": [
+                              {
+                                "_type": "Eq"
+                              }
+                            ],
+                            "comparators": [
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "i",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 31,
+                                  "end_lineno": 31,
+                                  "col_offset": 107,
+                                  "end_col_offset": 108
+                                },
+                                "attr": "orderId",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 31,
+                                "end_lineno": 31,
+                                "col_offset": 107,
+                                "end_col_offset": 116
+                              }
+                            ],
+                            "lineno": 31,
+                            "end_lineno": 31,
+                            "col_offset": 99,
+                            "end_col_offset": 116
+                          }
+                        ],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 78,
+                    "end_col_offset": 117
+                  },
+                  {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": null,
+                        "kind": null,
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 122,
+                        "end_col_offset": 126
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 121,
+                    "end_col_offset": 127
+                  }
+                ],
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 78,
+                "end_col_offset": 127
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "o",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 131,
+                      "end_col_offset": 132
+                    },
+                    "attr": "customerId",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 131,
+                    "end_col_offset": 143
+                  },
+                  "ops": [
+                    {
+                      "_type": "Eq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "c",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 147,
+                        "end_col_offset": 148
+                      },
+                      "attr": "id",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 147,
+                      "end_col_offset": 151
+                    }
+                  ],
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 131,
+                  "end_col_offset": 151
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 31,
+          "end_lineno": 31,
+          "col_offset": 9,
+          "end_col_offset": 152
+        },
+        "lineno": 31,
+        "end_lineno": 31,
+        "end_col_offset": 152
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 32,
+            "end_lineno": 32,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Left Join Multi ---",
+              "kind": null,
+              "lineno": 32,
+              "end_lineno": 32,
+              "col_offset": 6,
+              "end_col_offset": 31
+            }
+          ],
+          "keywords": [],
+          "lineno": 32,
+          "end_lineno": 32,
+          "col_offset": 0,
+          "end_col_offset": 32
+        },
+        "lineno": 32,
+        "end_lineno": 32,
+        "end_col_offset": 32
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 34,
+                "end_lineno": 34,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "r",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 34,
+                    "end_lineno": 34,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "orderId",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 10,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "r",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 34,
+                    "end_lineno": 34,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 21,
+                  "end_col_offset": 27
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "r",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 34,
+                    "end_lineno": 34,
+                    "col_offset": 29,
+                    "end_col_offset": 30
+                  },
+                  "attr": "item",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 29,
+                  "end_col_offset": 35
+                }
+              ],
+              "keywords": [],
+              "lineno": 34,
+              "end_lineno": 34,
+              "col_offset": 4,
+              "end_col_offset": 36
+            },
+            "lineno": 34,
+            "end_lineno": 34,
+            "col_offset": 4,
+            "end_col_offset": 36
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "r",
+          "lineno": 33,
+          "end_lineno": 33,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 33,
+          "end_lineno": 33,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 33,
+        "end_lineno": 34,
+        "end_col_offset": 36
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/len_builtin.py.json
+++ b/tests/json-ast/x/py/len_builtin.py.json
@@ -1,0 +1,94 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "List",
+                  "elts": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 12
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 14,
+                      "end_col_offset": 15
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 3,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 17,
+                      "end_col_offset": 18
+                    }
+                  ],
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 19
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 21
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/len_map.py.json
+++ b/tests/json-ast/x/py/len_map.py.json
@@ -1,0 +1,102 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Dict",
+                  "keys": [
+                    {
+                      "_type": "Constant",
+                      "value": "a",
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 14
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "b",
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 19,
+                      "end_col_offset": 22
+                    }
+                  ],
+                  "values": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 16,
+                      "end_col_offset": 17
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 24,
+                      "end_col_offset": 25
+                    }
+                  ],
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 27
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 28
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 28
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/len_string.py.json
+++ b/tests/json-ast/x/py/len_string.py.json
@@ -1,0 +1,64 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "mochi",
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 17
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 18
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 19
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 19
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/let_and_print.py.json
+++ b/tests/json-ast/x/py/let_and_print.py.json
@@ -1,0 +1,114 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "a",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 10,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 6
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 6
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "b",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 20,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 6
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 6
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "a",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 10,
+                "end_col_offset": 11
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/list_assign.py.json
+++ b/tests/json-ast/x/py/list_assign.py.json
@@ -1,0 +1,151 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 13
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Subscript",
+            "value": {
+              "_type": "Name",
+              "id": "nums",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 0,
+              "end_col_offset": 4
+            },
+            "slice": {
+              "_type": "Constant",
+              "value": 1,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 5,
+              "end_col_offset": 6
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 3,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 10,
+          "end_col_offset": 11
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "nums",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 13
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 14
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 14
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/list_index.py.json
+++ b/tests/json-ast/x/py/list_index.py.json
@@ -1,0 +1,118 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "xs",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 10,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": 20,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 30,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 16
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 5,
+          "end_col_offset": 17
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 17
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "xs",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 8
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 9,
+                "end_col_offset": 10
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/list_nested_assign.py.json
+++ b/tests/json-ast/x/py/list_nested_assign.py.json
@@ -1,0 +1,231 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "matrix",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "List",
+              "elts": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                }
+              ],
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 16
+            },
+            {
+              "_type": "List",
+              "elts": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                }
+              ],
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 24
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 25
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 25
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Subscript",
+            "value": {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "matrix",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 0,
+                "end_col_offset": 6
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 0,
+              "end_col_offset": 9
+            },
+            "slice": {
+              "_type": "Constant",
+              "value": 0,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 5,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 15,
+          "end_col_offset": 16
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Subscript",
+                "value": {
+                  "_type": "Name",
+                  "id": "matrix",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 6,
+                  "end_col_offset": 12
+                },
+                "slice": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 13,
+                  "end_col_offset": 14
+                },
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 15
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 18
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 19
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 19
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/list_set_ops.py.json
+++ b/tests/json-ast/x/py/list_set_ops.py.json
@@ -1,0 +1,592 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "list",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "args": [
+                {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "set",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 14
+                    },
+                    "args": [
+                      {
+                        "_type": "List",
+                        "elts": [
+                          {
+                            "_type": "Constant",
+                            "value": 1,
+                            "kind": null,
+                            "lineno": 3,
+                            "end_lineno": 3,
+                            "col_offset": 16,
+                            "end_col_offset": 17
+                          },
+                          {
+                            "_type": "Constant",
+                            "value": 2,
+                            "kind": null,
+                            "lineno": 3,
+                            "end_lineno": 3,
+                            "col_offset": 19,
+                            "end_col_offset": 20
+                          }
+                        ],
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 3,
+                        "end_lineno": 3,
+                        "col_offset": 15,
+                        "end_col_offset": 21
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 11,
+                    "end_col_offset": 22
+                  },
+                  "op": {
+                    "_type": "BitOr"
+                  },
+                  "right": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "set",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 25,
+                      "end_col_offset": 28
+                    },
+                    "args": [
+                      {
+                        "_type": "List",
+                        "elts": [
+                          {
+                            "_type": "Constant",
+                            "value": 2,
+                            "kind": null,
+                            "lineno": 3,
+                            "end_lineno": 3,
+                            "col_offset": 30,
+                            "end_col_offset": 31
+                          },
+                          {
+                            "_type": "Constant",
+                            "value": 3,
+                            "kind": null,
+                            "lineno": 3,
+                            "end_lineno": 3,
+                            "col_offset": 33,
+                            "end_col_offset": 34
+                          }
+                        ],
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 3,
+                        "end_lineno": 3,
+                        "col_offset": 29,
+                        "end_col_offset": 35
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 25,
+                    "end_col_offset": 36
+                  },
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 11,
+                  "end_col_offset": 36
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 37
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 38
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 38
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  },
+                  "iter": {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 19,
+                        "end_col_offset": 20
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 22,
+                        "end_col_offset": 23
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 25,
+                        "end_col_offset": 26
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 18,
+                    "end_col_offset": 27
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Name",
+                        "id": "x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 31,
+                        "end_col_offset": 32
+                      },
+                      "ops": [
+                        {
+                          "_type": "NotIn"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "List",
+                          "elts": [
+                            {
+                              "_type": "Constant",
+                              "value": 2,
+                              "kind": null,
+                              "lineno": 4,
+                              "end_lineno": 4,
+                              "col_offset": 41,
+                              "end_col_offset": 42
+                            }
+                          ],
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 4,
+                          "end_lineno": 4,
+                          "col_offset": 40,
+                          "end_col_offset": 43
+                        }
+                      ],
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 31,
+                      "end_col_offset": 43
+                    }
+                  ],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 44
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 45
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 45
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  },
+                  "iter": {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 5,
+                        "end_lineno": 5,
+                        "col_offset": 19,
+                        "end_col_offset": 20
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 5,
+                        "end_lineno": 5,
+                        "col_offset": 22,
+                        "end_col_offset": 23
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 5,
+                        "end_lineno": 5,
+                        "col_offset": 25,
+                        "end_col_offset": 26
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 18,
+                    "end_col_offset": 27
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Name",
+                        "id": "x",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 5,
+                        "end_lineno": 5,
+                        "col_offset": 31,
+                        "end_col_offset": 32
+                      },
+                      "ops": [
+                        {
+                          "_type": "In"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "List",
+                          "elts": [
+                            {
+                              "_type": "Constant",
+                              "value": 2,
+                              "kind": null,
+                              "lineno": 5,
+                              "end_lineno": 5,
+                              "col_offset": 37,
+                              "end_col_offset": 38
+                            },
+                            {
+                              "_type": "Constant",
+                              "value": 4,
+                              "kind": null,
+                              "lineno": 5,
+                              "end_lineno": 5,
+                              "col_offset": 40,
+                              "end_col_offset": 41
+                            }
+                          ],
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 5,
+                          "end_lineno": 5,
+                          "col_offset": 36,
+                          "end_col_offset": 42
+                        }
+                      ],
+                      "lineno": 5,
+                      "end_lineno": 5,
+                      "col_offset": 31,
+                      "end_col_offset": 42
+                    }
+                  ],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 43
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 44
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 44
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 12,
+                        "end_col_offset": 13
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 15,
+                        "end_col_offset": 16
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 11,
+                    "end_col_offset": 17
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "List",
+                    "elts": [
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 21,
+                        "end_col_offset": 22
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 3,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 24,
+                        "end_col_offset": 25
+                      }
+                    ],
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 20,
+                    "end_col_offset": 26
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 11,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 29
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/load_jsonl.py.json
+++ b/tests/json-ast/x/py/load_jsonl.py.json
@@ -1,0 +1,703 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Person",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 11,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "float",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 9,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 30.0,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 17,
+                  "end_col_offset": 21
+                },
+                {
+                  "_type": "Constant",
+                  "value": "alice@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 23,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 51
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 52
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 54,
+                "end_col_offset": 60
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 15.0,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 61,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "bob@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 67,
+                  "end_col_offset": 84
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 86,
+                  "end_col_offset": 91
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 54,
+              "end_col_offset": 92
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 94,
+                "end_col_offset": 100
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 20.0,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 101,
+                  "end_col_offset": 105
+                },
+                {
+                  "_type": "Constant",
+                  "value": "charlie@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 107,
+                  "end_col_offset": 128
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 130,
+                  "end_col_offset": 139
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 94,
+              "end_col_offset": 140
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 141
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 141
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Adult",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "adults",
+            "lineno": 25,
+            "end_lineno": 25,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Adult",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 10,
+              "end_col_offset": 15
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 16,
+                "end_col_offset": 22
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 24,
+                  "end_col_offset": 25
+                },
+                "attr": "email",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 24,
+                "end_col_offset": 31
+              }
+            ],
+            "keywords": [],
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 10,
+            "end_col_offset": 32
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "p",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 37,
+                "end_col_offset": 38
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "people",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 42,
+                "end_col_offset": 48
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "p",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 52,
+                      "end_col_offset": 53
+                    },
+                    "attr": "age",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 52,
+                    "end_col_offset": 57
+                  },
+                  "ops": [
+                    {
+                      "_type": "GtE"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 18,
+                      "kind": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 61,
+                      "end_col_offset": 63
+                    }
+                  ],
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 52,
+                  "end_col_offset": 63
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 25,
+          "end_lineno": 25,
+          "col_offset": 9,
+          "end_col_offset": 64
+        },
+        "lineno": 25,
+        "end_lineno": 25,
+        "end_col_offset": 64
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "a",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "a",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 18,
+                    "end_col_offset": 19
+                  },
+                  "attr": "email",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 18,
+                  "end_col_offset": 25
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 26
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 26
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "a",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "adults",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 26,
+        "end_lineno": 27,
+        "end_col_offset": 26
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/load_yaml.py.json
+++ b/tests/json-ast/x/py/load_yaml.py.json
@@ -1,0 +1,703 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Person",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 11,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 30,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 17,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": "alice@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 40
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 42,
+                  "end_col_offset": 49
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 50
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 52,
+                "end_col_offset": 58
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 15,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 59,
+                  "end_col_offset": 61
+                },
+                {
+                  "_type": "Constant",
+                  "value": "bob@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 63,
+                  "end_col_offset": 80
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 82,
+                  "end_col_offset": 87
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 52,
+              "end_col_offset": 88
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 90,
+                "end_col_offset": 96
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 20,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 97,
+                  "end_col_offset": 99
+                },
+                {
+                  "_type": "Constant",
+                  "value": "charlie@example.com",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 101,
+                  "end_col_offset": 122
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 124,
+                  "end_col_offset": 133
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 90,
+              "end_col_offset": 134
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 135
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 135
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Adult",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "email",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "adults",
+            "lineno": 25,
+            "end_lineno": 25,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "Adult",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 10,
+              "end_col_offset": 15
+            },
+            "args": [
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "attr": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 16,
+                "end_col_offset": 22
+              },
+              {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "p",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 24,
+                  "end_col_offset": 25
+                },
+                "attr": "email",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 24,
+                "end_col_offset": 31
+              }
+            ],
+            "keywords": [],
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 10,
+            "end_col_offset": 32
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "p",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 37,
+                "end_col_offset": 38
+              },
+              "iter": {
+                "_type": "Name",
+                "id": "people",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 42,
+                "end_col_offset": 48
+              },
+              "ifs": [
+                {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "p",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 52,
+                      "end_col_offset": 53
+                    },
+                    "attr": "age",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 52,
+                    "end_col_offset": 57
+                  },
+                  "ops": [
+                    {
+                      "_type": "GtE"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 18,
+                      "kind": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 61,
+                      "end_col_offset": 63
+                    }
+                  ],
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 52,
+                  "end_col_offset": 63
+                }
+              ],
+              "is_async": 0
+            }
+          ],
+          "lineno": 25,
+          "end_lineno": 25,
+          "col_offset": 9,
+          "end_col_offset": 64
+        },
+        "lineno": 25,
+        "end_lineno": 25,
+        "end_col_offset": 64
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 27,
+                "end_lineno": 27,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "a",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "a",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 27,
+                    "end_lineno": 27,
+                    "col_offset": 18,
+                    "end_col_offset": 19
+                  },
+                  "attr": "email",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 27,
+                  "end_lineno": 27,
+                  "col_offset": 18,
+                  "end_col_offset": 25
+                }
+              ],
+              "keywords": [],
+              "lineno": 27,
+              "end_lineno": 27,
+              "col_offset": 4,
+              "end_col_offset": 26
+            },
+            "lineno": 27,
+            "end_lineno": 27,
+            "col_offset": 4,
+            "end_col_offset": 26
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "a",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "adults",
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 26,
+        "end_lineno": 27,
+        "end_col_offset": 26
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_assign.py.json
+++ b/tests/json-ast/x/py/map_assign.py.json
@@ -1,0 +1,150 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "scores",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "alice",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 17
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 19,
+              "end_col_offset": 20
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 21
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Subscript",
+            "value": {
+              "_type": "Name",
+              "id": "scores",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 0,
+              "end_col_offset": 6
+            },
+            "slice": {
+              "_type": "Constant",
+              "value": "bob",
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 12
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 16,
+          "end_col_offset": 17
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 17
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "scores",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 12
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "bob",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 13,
+                "end_col_offset": 18
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 19
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 20
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 20
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_in_operator.py.json
+++ b/tests/json-ast/x/py/map_in_operator.py.json
@@ -1,0 +1,241 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 6
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 14
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 16,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 18
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 24,
+                "end_col_offset": 25
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 27
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 27
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 18
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 24,
+                "end_col_offset": 25
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 27
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 27
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_index.py.json
+++ b/tests/json-ast/x/py/map_index.py.json
@@ -1,0 +1,126 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 16
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "m",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "b",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 8,
+                "end_col_offset": 11
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_int_key.py.json
+++ b/tests/json-ast/x/py/map_int_key.py.json
@@ -1,0 +1,126 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 6
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 14
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 16,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "m",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 8,
+                "end_col_offset": 9
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 11
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_literal_dynamic.py.json
+++ b/tests/json-ast/x/py/map_literal_dynamic.py.json
@@ -1,0 +1,208 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 3,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "y",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 4,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 13,
+              "end_col_offset": 16
+            }
+          ],
+          "values": [
+            {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Name",
+              "id": "y",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "m",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "a",
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 8,
+                "end_col_offset": 11
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "m",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "b",
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 16,
+                "end_col_offset": 19
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 14,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 21
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_membership.py.json
+++ b/tests/json-ast/x/py/map_membership.py.json
@@ -1,0 +1,241 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 16
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 19
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 20
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 20
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 27
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "c",
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "m",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 20
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 27
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/map_nested_assign.py.json
+++ b/tests/json-ast/x/py/map_nested_assign.py.json
@@ -1,0 +1,208 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "data",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "outer",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 15
+            }
+          ],
+          "values": [
+            {
+              "_type": "Dict",
+              "keys": [
+                {
+                  "_type": "Constant",
+                  "value": "inner",
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 18,
+                  "end_col_offset": 25
+                }
+              ],
+              "values": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 27,
+                  "end_col_offset": 28
+                }
+              ],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 17,
+              "end_col_offset": 29
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 30
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Subscript",
+            "value": {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 0,
+                "end_col_offset": 4
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "outer",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 5,
+                "end_col_offset": 12
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 0,
+              "end_col_offset": 13
+            },
+            "slice": {
+              "_type": "Constant",
+              "value": "inner",
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 14,
+              "end_col_offset": 21
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 25,
+          "end_col_offset": 26
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Subscript",
+                "value": {
+                  "_type": "Name",
+                  "id": "data",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "slice": {
+                  "_type": "Constant",
+                  "value": "outer",
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 11,
+                  "end_col_offset": 18
+                },
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 19
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": "inner",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 20,
+                "end_col_offset": 27
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/match_expr.py.json
+++ b/tests/json-ast/x/py/match_expr.py.json
@@ -1,0 +1,243 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "label",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 18,
+              "end_col_offset": 19
+            },
+            "ops": [
+              {
+                "_type": "Eq"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 23,
+                "end_col_offset": 24
+              }
+            ],
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 18,
+            "end_col_offset": 24
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "one",
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 9,
+            "end_col_offset": 14
+          },
+          "orelse": {
+            "_type": "IfExp",
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 40,
+                "end_col_offset": 41
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 45,
+                  "end_col_offset": 46
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 40,
+              "end_col_offset": 46
+            },
+            "body": {
+              "_type": "Constant",
+              "value": "two",
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 31,
+              "end_col_offset": 36
+            },
+            "orelse": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "x",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 69,
+                    "end_col_offset": 70
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 64,
+                "end_col_offset": 70
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "three",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 53,
+                "end_col_offset": 60
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": "unknown",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 76,
+                "end_col_offset": 85
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 53,
+              "end_col_offset": 85
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 31,
+            "end_col_offset": 86
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 9,
+          "end_col_offset": 87
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 88
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "label",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/match_full.py.json
+++ b/tests/json-ast/x/py/match_full.py.json
@@ -1,0 +1,925 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "label",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 18,
+              "end_col_offset": 19
+            },
+            "ops": [
+              {
+                "_type": "Eq"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 23,
+                "end_col_offset": 24
+              }
+            ],
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 18,
+            "end_col_offset": 24
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "one",
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 9,
+            "end_col_offset": 14
+          },
+          "orelse": {
+            "_type": "IfExp",
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 40,
+                "end_col_offset": 41
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 45,
+                  "end_col_offset": 46
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 40,
+              "end_col_offset": 46
+            },
+            "body": {
+              "_type": "Constant",
+              "value": "two",
+              "kind": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 31,
+              "end_col_offset": 36
+            },
+            "orelse": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "x",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 69,
+                    "end_col_offset": 70
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 64,
+                "end_col_offset": 70
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "three",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 53,
+                "end_col_offset": 60
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": "unknown",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 76,
+                "end_col_offset": 85
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 53,
+              "end_col_offset": 85
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 31,
+            "end_col_offset": 86
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 9,
+          "end_col_offset": 87
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 88
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "label",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "day",
+            "lineno": 6,
+            "end_lineno": 6,
+            "end_col_offset": 3
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "sun",
+          "kind": null,
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 6,
+          "end_col_offset": 11
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "mood",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "day",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 19,
+              "end_col_offset": 22
+            },
+            "ops": [
+              {
+                "_type": "Eq"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": "mon",
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 26,
+                "end_col_offset": 31
+              }
+            ],
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 19,
+            "end_col_offset": 31
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "tired",
+            "kind": null,
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 8,
+            "end_col_offset": 15
+          },
+          "orelse": {
+            "_type": "IfExp",
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "day",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 51,
+                "end_col_offset": 54
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": "fri",
+                  "kind": null,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 58,
+                  "end_col_offset": 63
+                }
+              ],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 51,
+              "end_col_offset": 63
+            },
+            "body": {
+              "_type": "Constant",
+              "value": "excited",
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 38,
+              "end_col_offset": 47
+            },
+            "orelse": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "day",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 83,
+                  "end_col_offset": 86
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": "sun",
+                    "kind": null,
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 90,
+                    "end_col_offset": 95
+                  }
+                ],
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 83,
+                "end_col_offset": 95
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "relaxed",
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 70,
+                "end_col_offset": 79
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": "normal",
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 101,
+                "end_col_offset": 109
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 70,
+              "end_col_offset": 109
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 38,
+            "end_col_offset": 110
+          },
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 8,
+          "end_col_offset": 111
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 112
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "mood",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "ok",
+            "lineno": 9,
+            "end_lineno": 9,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": true,
+          "kind": null,
+          "lineno": 9,
+          "end_lineno": 9,
+          "col_offset": 5,
+          "end_col_offset": 9
+        },
+        "lineno": 9,
+        "end_lineno": 9,
+        "end_col_offset": 9
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "status",
+            "lineno": 10,
+            "end_lineno": 10,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "IfExp",
+          "test": {
+            "_type": "Compare",
+            "left": {
+              "_type": "Name",
+              "id": "ok",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 25,
+              "end_col_offset": 27
+            },
+            "ops": [
+              {
+                "_type": "Eq"
+              }
+            ],
+            "comparators": [
+              {
+                "_type": "Constant",
+                "value": true,
+                "kind": null,
+                "lineno": 10,
+                "end_lineno": 10,
+                "col_offset": 31,
+                "end_col_offset": 35
+              }
+            ],
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 25,
+            "end_col_offset": 35
+          },
+          "body": {
+            "_type": "Constant",
+            "value": "confirmed",
+            "kind": null,
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 10,
+            "end_col_offset": 21
+          },
+          "orelse": {
+            "_type": "IfExp",
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "ok",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 10,
+                "end_lineno": 10,
+                "col_offset": 54,
+                "end_col_offset": 56
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": false,
+                  "kind": null,
+                  "lineno": 10,
+                  "end_lineno": 10,
+                  "col_offset": 60,
+                  "end_col_offset": 65
+                }
+              ],
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 54,
+              "end_col_offset": 65
+            },
+            "body": {
+              "_type": "Constant",
+              "value": "denied",
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 42,
+              "end_col_offset": 50
+            },
+            "orelse": {
+              "_type": "Constant",
+              "value": null,
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 71,
+              "end_col_offset": 75
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 42,
+            "end_col_offset": 75
+          },
+          "lineno": 10,
+          "end_lineno": 10,
+          "col_offset": 10,
+          "end_col_offset": 76
+        },
+        "lineno": 10,
+        "end_lineno": 10,
+        "end_col_offset": 77
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "status",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "FunctionDef",
+        "name": "classify",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": 0,
+                    "kind": null,
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 27,
+                    "end_col_offset": 28
+                  }
+                ],
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 22,
+                "end_col_offset": 28
+              },
+              "body": {
+                "_type": "Constant",
+                "value": "zero",
+                "kind": null,
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 12,
+                "end_col_offset": 18
+              },
+              "orelse": {
+                "_type": "IfExp",
+                "test": {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Name",
+                    "id": "n",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 44,
+                    "end_col_offset": 45
+                  },
+                  "ops": [
+                    {
+                      "_type": "Eq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 49,
+                      "end_col_offset": 50
+                    }
+                  ],
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 44,
+                  "end_col_offset": 50
+                },
+                "body": {
+                  "_type": "Constant",
+                  "value": "one",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 35,
+                  "end_col_offset": 40
+                },
+                "orelse": {
+                  "_type": "Constant",
+                  "value": "many",
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 56,
+                  "end_col_offset": 62
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 35,
+                "end_col_offset": 62
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 12,
+              "end_col_offset": 63
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 4,
+            "end_col_offset": 64
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "n",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 14
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 12,
+        "end_lineno": 13,
+        "end_col_offset": 64
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "classify",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 6,
+                "end_col_offset": 14
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "classify",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 15,
+                "end_lineno": 15,
+                "col_offset": 6,
+                "end_col_offset": 14
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 15,
+        "end_lineno": 15,
+        "end_col_offset": 18
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/math_ops.py.json
+++ b/tests/json-ast/x/py/math_ops.py.json
@@ -1,0 +1,172 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 6,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Mult"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 7,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 10,
+                "end_col_offset": 11
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 7,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "FloorDiv"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 2,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 7,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Mod"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 2,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 10,
+                "end_col_offset": 11
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 11
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 12
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 12
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/membership.py.json
+++ b/tests/json-ast/x/py/membership.py.json
@@ -1,0 +1,233 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 15
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 16
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "nums",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 17,
+                    "end_col_offset": 21
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 21
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 27,
+                "end_col_offset": 28
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 30
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "nums",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 17,
+                    "end_col_offset": 21
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 21
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 27,
+                "end_col_offset": 28
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 30
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 30
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/min_max_builtin.py.json
+++ b/tests/json-ast/x/py/min_max_builtin.py.json
@@ -1,0 +1,179 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 4,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 15
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 16
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "min",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "nums",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 10,
+                  "end_col_offset": 14
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "max",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "nums",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 14
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 16
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/mix_go_python.py.json
+++ b/tests/json-ast/x/py/mix_go_python.py.json
@@ -1,0 +1,359 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Import",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "rawName",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 7
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "   alice  ",
+          "kind": null,
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 10,
+          "end_col_offset": 22
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "radius",
+            "lineno": 6,
+            "end_lineno": 6,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 3.0,
+          "kind": null,
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 9,
+          "end_col_offset": 12
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "name",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "rawName",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 7,
+                  "end_col_offset": 14
+                },
+                "attr": "strip",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 20
+              },
+              "args": [],
+              "keywords": [],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 22
+            },
+            "attr": "upper",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 7,
+            "end_col_offset": 28
+          },
+          "args": [],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 7,
+          "end_col_offset": 30
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "area",
+            "lineno": 8,
+            "end_lineno": 8,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "math",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 7,
+              "end_col_offset": 11
+            },
+            "attr": "pi",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 7,
+            "end_col_offset": 14
+          },
+          "op": {
+            "_type": "Mult"
+          },
+          "right": {
+            "_type": "Call",
+            "func": {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "math",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              "attr": "pow",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 17,
+              "end_col_offset": 25
+            },
+            "args": [
+              {
+                "_type": "Name",
+                "id": "radius",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 26,
+                "end_col_offset": 32
+              },
+              {
+                "_type": "Constant",
+                "value": 2.0,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 34,
+                "end_col_offset": 37
+              }
+            ],
+            "keywords": [],
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 17,
+            "end_col_offset": 38
+          },
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 7,
+          "end_col_offset": 38
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 38
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "Hello",
+              "kind": null,
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 6,
+              "end_col_offset": 13
+            },
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "name",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 15,
+                "end_col_offset": 19
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": "!",
+                "kind": null,
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 22,
+                "end_col_offset": 25
+              },
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 15,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 9,
+          "end_lineno": 9,
+          "col_offset": 0,
+          "end_col_offset": 26
+        },
+        "lineno": 9,
+        "end_lineno": 9,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "The area of a circle with radius",
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 6,
+              "end_col_offset": 40
+            },
+            {
+              "_type": "Name",
+              "id": "radius",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 42,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Constant",
+              "value": "is",
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 50,
+              "end_col_offset": 54
+            },
+            {
+              "_type": "Name",
+              "id": "area",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 56,
+              "end_col_offset": 60
+            }
+          ],
+          "keywords": [],
+          "lineno": 10,
+          "end_lineno": 10,
+          "col_offset": 0,
+          "end_col_offset": 61
+        },
+        "lineno": 10,
+        "end_lineno": 10,
+        "end_col_offset": 61
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/nested_function.py.json
+++ b/tests/json-ast/x/py/nested_function.py.json
@@ -1,0 +1,201 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "outer",
+        "body": [
+          {
+            "_type": "FunctionDef",
+            "name": "inner",
+            "body": [
+              {
+                "_type": "Return",
+                "value": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Name",
+                    "id": "x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 15,
+                    "end_col_offset": 16
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Name",
+                    "id": "y",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 15,
+                  "end_col_offset": 20
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 8,
+                "end_col_offset": 20
+              }
+            ],
+            "args": {
+              "_type": "arguments",
+              "posonlyargs": [],
+              "args": [
+                {
+                  "_type": "arg",
+                  "arg": "y",
+                  "annotation": null,
+                  "type_comment": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                }
+              ],
+              "vararg": null,
+              "kwonlyargs": [],
+              "kw_defaults": [],
+              "kwarg": null,
+              "defaults": []
+            },
+            "lineno": 4,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 20
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "inner",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 11,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 11,
+              "end_col_offset": 19
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "x",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 6,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "outer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 6,
+                "end_col_offset": 11
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                }
+              ],
+              "keywords": [],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 6,
+              "end_col_offset": 14
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 15
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 15
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/order_by_map.py.json
+++ b/tests/json-ast/x/py/order_by_map.py.json
@@ -1,0 +1,581 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Data",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "a",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "b",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 11,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "data",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 8,
+                "end_col_offset": 12
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 13,
+                  "end_col_offset": 14
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 8,
+              "end_col_offset": 18
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 20,
+                "end_col_offset": 24
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 28,
+                  "end_col_offset": 29
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 20,
+              "end_col_offset": 30
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Data",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 32,
+                "end_col_offset": 36
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 37,
+                  "end_col_offset": 38
+                },
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 40,
+                  "end_col_offset": 41
+                }
+              ],
+              "keywords": [],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 32,
+              "end_col_offset": 42
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 7,
+          "end_col_offset": 43
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 43
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "sorted",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Name",
+            "id": "x",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 10,
+            "end_col_offset": 11
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 16,
+                "end_col_offset": 17
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 21,
+                  "end_col_offset": 27
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "x",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 14,
+                      "end_lineno": 14,
+                      "col_offset": 29,
+                      "end_col_offset": 30
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "x",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 14,
+                          "end_lineno": 14,
+                          "col_offset": 35,
+                          "end_col_offset": 36
+                        },
+                        "iter": {
+                          "_type": "Name",
+                          "id": "data",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 14,
+                          "end_lineno": 14,
+                          "col_offset": 40,
+                          "end_col_offset": 44
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 14,
+                    "end_lineno": 14,
+                    "col_offset": 28,
+                    "end_col_offset": 45
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "x",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 14,
+                            "end_lineno": 14,
+                            "col_offset": 58,
+                            "end_col_offset": 59
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Call",
+                        "func": {
+                          "_type": "Name",
+                          "id": "tuple",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 14,
+                          "end_lineno": 14,
+                          "col_offset": 61,
+                          "end_col_offset": 66
+                        },
+                        "args": [
+                          {
+                            "_type": "List",
+                            "elts": [
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "x",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 14,
+                                  "end_lineno": 14,
+                                  "col_offset": 68,
+                                  "end_col_offset": 69
+                                },
+                                "attr": "a",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 14,
+                                "end_lineno": 14,
+                                "col_offset": 68,
+                                "end_col_offset": 71
+                              },
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "x",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 14,
+                                  "end_lineno": 14,
+                                  "col_offset": 73,
+                                  "end_col_offset": 74
+                                },
+                                "attr": "b",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 14,
+                                "end_lineno": 14,
+                                "col_offset": 73,
+                                "end_col_offset": 76
+                              }
+                            ],
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 14,
+                            "end_lineno": 14,
+                            "col_offset": 67,
+                            "end_col_offset": 77
+                          }
+                        ],
+                        "keywords": [],
+                        "lineno": 14,
+                        "end_lineno": 14,
+                        "col_offset": 61,
+                        "end_col_offset": 78
+                      },
+                      "lineno": 14,
+                      "end_lineno": 14,
+                      "col_offset": 51,
+                      "end_col_offset": 78
+                    },
+                    "lineno": 14,
+                    "end_lineno": 14,
+                    "col_offset": 47,
+                    "end_col_offset": 78
+                  }
+                ],
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 21,
+                "end_col_offset": 79
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 9,
+          "end_col_offset": 80
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 80
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 7,
+                    "end_col_offset": 18
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 7,
+                  "end_col_offset": 25
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 26,
+                    "end_col_offset": 28
+                  }
+                ],
+                "keywords": [],
+                "lineno": 15,
+                "end_lineno": 15,
+                "col_offset": 7,
+                "end_col_offset": 29
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "_x",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 34,
+                    "end_col_offset": 36
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "sorted",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 40,
+                    "end_col_offset": 46
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 6,
+              "end_col_offset": 47
+            }
+          ],
+          "keywords": [],
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 0,
+          "end_col_offset": 48
+        },
+        "lineno": 15,
+        "end_lineno": 15,
+        "end_col_offset": 48
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/outer_join.py.json
+++ b/tests/json-ast/x/py/outer_join.py.json
@@ -1,0 +1,1835 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 55,
+                "end_col_offset": 63
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 55,
+              "end_col_offset": 77
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 79,
+                "end_col_offset": 87
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 88,
+                  "end_col_offset": 89
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Diana",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 91,
+                  "end_col_offset": 98
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 79,
+              "end_col_offset": 99
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 100
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 100
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": 250,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 24,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 30,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 36,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": 125,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 30,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 50,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 61,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Constant",
+                  "value": 300,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 64,
+                  "end_col_offset": 67
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 50,
+              "end_col_offset": 68
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 70,
+                "end_col_offset": 75
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 103,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 76,
+                  "end_col_offset": 79
+                },
+                {
+                  "_type": "Constant",
+                  "value": 5,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 81,
+                  "end_col_offset": 82
+                },
+                {
+                  "_type": "Constant",
+                  "value": 80,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 84,
+                  "end_col_offset": 86
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 70,
+              "end_col_offset": 87
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 88
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 88
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "order",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 14,
+              "end_col_offset": 17
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customer",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 17
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 17
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 25,
+            "end_lineno": 25,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "BinOp",
+            "left": {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "Result",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "o",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  },
+                  {
+                    "_type": "Name",
+                    "id": "c",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 20,
+                    "end_col_offset": 21
+                  }
+                ],
+                "keywords": [],
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 10,
+                "end_col_offset": 22
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "o",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 27,
+                    "end_col_offset": 28
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "orders",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 32,
+                    "end_col_offset": 38
+                  },
+                  "ifs": [],
+                  "is_async": 0
+                },
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "c",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 43,
+                    "end_col_offset": 44
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "customers",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 48,
+                    "end_col_offset": 57
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "o",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 61,
+                          "end_col_offset": 62
+                        },
+                        "attr": "customerId",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 61,
+                        "end_col_offset": 73
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "c",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 25,
+                            "end_lineno": 25,
+                            "col_offset": 77,
+                            "end_col_offset": 78
+                          },
+                          "attr": "id",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 77,
+                          "end_col_offset": 81
+                        }
+                      ],
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 61,
+                      "end_col_offset": 81
+                    }
+                  ],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 9,
+              "end_col_offset": 82
+            },
+            "op": {
+              "_type": "Add"
+            },
+            "right": {
+              "_type": "ListComp",
+              "elt": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Lambda",
+                  "args": {
+                    "_type": "arguments",
+                    "posonlyargs": [],
+                    "args": [
+                      {
+                        "_type": "arg",
+                        "arg": "c",
+                        "annotation": null,
+                        "type_comment": null,
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 94,
+                        "end_col_offset": 95
+                      }
+                    ],
+                    "vararg": null,
+                    "kwonlyargs": [],
+                    "kw_defaults": [],
+                    "kwarg": null,
+                    "defaults": []
+                  },
+                  "body": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "Result",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 97,
+                      "end_col_offset": 103
+                    },
+                    "args": [
+                      {
+                        "_type": "Name",
+                        "id": "o",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 104,
+                        "end_col_offset": 105
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": null,
+                        "kind": null,
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 107,
+                        "end_col_offset": 111
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 97,
+                    "end_col_offset": 112
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 87,
+                  "end_col_offset": 112
+                },
+                "args": [
+                  {
+                    "_type": "Constant",
+                    "value": null,
+                    "kind": null,
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 114,
+                    "end_col_offset": 118
+                  }
+                ],
+                "keywords": [],
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 86,
+                "end_col_offset": 119
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "o",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 124,
+                    "end_col_offset": 125
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "orders",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 129,
+                    "end_col_offset": 135
+                  },
+                  "ifs": [
+                    {
+                      "_type": "UnaryOp",
+                      "op": {
+                        "_type": "Not"
+                      },
+                      "operand": {
+                        "_type": "Call",
+                        "func": {
+                          "_type": "Name",
+                          "id": "any",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 143,
+                          "end_col_offset": 146
+                        },
+                        "args": [
+                          {
+                            "_type": "ListComp",
+                            "elt": {
+                              "_type": "Compare",
+                              "left": {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "o",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 148,
+                                  "end_col_offset": 149
+                                },
+                                "attr": "customerId",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 148,
+                                "end_col_offset": 160
+                              },
+                              "ops": [
+                                {
+                                  "_type": "Eq"
+                                }
+                              ],
+                              "comparators": [
+                                {
+                                  "_type": "Attribute",
+                                  "value": {
+                                    "_type": "Name",
+                                    "id": "c",
+                                    "ctx": {
+                                      "_type": "Load"
+                                    },
+                                    "lineno": 25,
+                                    "end_lineno": 25,
+                                    "col_offset": 164,
+                                    "end_col_offset": 165
+                                  },
+                                  "attr": "id",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 164,
+                                  "end_col_offset": 168
+                                }
+                              ],
+                              "lineno": 25,
+                              "end_lineno": 25,
+                              "col_offset": 148,
+                              "end_col_offset": 168
+                            },
+                            "generators": [
+                              {
+                                "_type": "comprehension",
+                                "target": {
+                                  "_type": "Name",
+                                  "id": "c",
+                                  "ctx": {
+                                    "_type": "Store"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 173,
+                                  "end_col_offset": 174
+                                },
+                                "iter": {
+                                  "_type": "Name",
+                                  "id": "customers",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 178,
+                                  "end_col_offset": 187
+                                },
+                                "ifs": [],
+                                "is_async": 0
+                              }
+                            ],
+                            "lineno": 25,
+                            "end_lineno": 25,
+                            "col_offset": 147,
+                            "end_col_offset": 188
+                          }
+                        ],
+                        "keywords": [],
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 143,
+                        "end_col_offset": 189
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 139,
+                      "end_col_offset": 189
+                    }
+                  ],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 85,
+              "end_col_offset": 190
+            },
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 9,
+            "end_col_offset": 190
+          },
+          "op": {
+            "_type": "Add"
+          },
+          "right": {
+            "_type": "ListComp",
+            "elt": {
+              "_type": "Call",
+              "func": {
+                "_type": "Lambda",
+                "args": {
+                  "_type": "arguments",
+                  "posonlyargs": [],
+                  "args": [
+                    {
+                      "_type": "arg",
+                      "arg": "o",
+                      "annotation": null,
+                      "type_comment": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 202,
+                      "end_col_offset": 203
+                    }
+                  ],
+                  "vararg": null,
+                  "kwonlyargs": [],
+                  "kw_defaults": [],
+                  "kwarg": null,
+                  "defaults": []
+                },
+                "body": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Result",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 205,
+                    "end_col_offset": 211
+                  },
+                  "args": [
+                    {
+                      "_type": "Constant",
+                      "value": null,
+                      "kind": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 212,
+                      "end_col_offset": 216
+                    },
+                    {
+                      "_type": "Name",
+                      "id": "c",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 218,
+                      "end_col_offset": 219
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 205,
+                  "end_col_offset": 220
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 195,
+                "end_col_offset": 220
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": null,
+                  "kind": null,
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 222,
+                  "end_col_offset": 226
+                }
+              ],
+              "keywords": [],
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 194,
+              "end_col_offset": 227
+            },
+            "generators": [
+              {
+                "_type": "comprehension",
+                "target": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Store"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 232,
+                  "end_col_offset": 233
+                },
+                "iter": {
+                  "_type": "Name",
+                  "id": "customers",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 237,
+                  "end_col_offset": 246
+                },
+                "ifs": [
+                  {
+                    "_type": "UnaryOp",
+                    "op": {
+                      "_type": "Not"
+                    },
+                    "operand": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "any",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 254,
+                        "end_col_offset": 257
+                      },
+                      "args": [
+                        {
+                          "_type": "ListComp",
+                          "elt": {
+                            "_type": "Compare",
+                            "left": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 259,
+                                "end_col_offset": 260
+                              },
+                              "attr": "customerId",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 25,
+                              "end_lineno": 25,
+                              "col_offset": 259,
+                              "end_col_offset": 271
+                            },
+                            "ops": [
+                              {
+                                "_type": "Eq"
+                              }
+                            ],
+                            "comparators": [
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "c",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 275,
+                                  "end_col_offset": 276
+                                },
+                                "attr": "id",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 275,
+                                "end_col_offset": 279
+                              }
+                            ],
+                            "lineno": 25,
+                            "end_lineno": 25,
+                            "col_offset": 259,
+                            "end_col_offset": 279
+                          },
+                          "generators": [
+                            {
+                              "_type": "comprehension",
+                              "target": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Store"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 284,
+                                "end_col_offset": 285
+                              },
+                              "iter": {
+                                "_type": "Name",
+                                "id": "orders",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 289,
+                                "end_col_offset": 295
+                              },
+                              "ifs": [],
+                              "is_async": 0
+                            }
+                          ],
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 258,
+                          "end_col_offset": 296
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 254,
+                      "end_col_offset": 297
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 250,
+                    "end_col_offset": 297
+                  }
+                ],
+                "is_async": 0
+              }
+            ],
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 193,
+            "end_col_offset": 298
+          },
+          "lineno": 25,
+          "end_lineno": 25,
+          "col_offset": 9,
+          "end_col_offset": 298
+        },
+        "lineno": 25,
+        "end_lineno": 25,
+        "end_col_offset": 298
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Outer Join using syntax ---",
+              "kind": null,
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 6,
+              "end_col_offset": 39
+            }
+          ],
+          "keywords": [],
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 0,
+          "end_col_offset": 40
+        },
+        "lineno": 26,
+        "end_lineno": 26,
+        "end_col_offset": 40
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "If",
+                "body": [
+                  {
+                    "_type": "Expr",
+                    "value": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "print",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 30,
+                        "end_lineno": 30,
+                        "col_offset": 12,
+                        "end_col_offset": 17
+                      },
+                      "args": [
+                        {
+                          "_type": "Constant",
+                          "value": "Order",
+                          "kind": null,
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 18,
+                          "end_col_offset": 25
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "row",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 30,
+                              "end_lineno": 30,
+                              "col_offset": 27,
+                              "end_col_offset": 30
+                            },
+                            "attr": "order",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 30,
+                            "end_lineno": 30,
+                            "col_offset": 27,
+                            "end_col_offset": 36
+                          },
+                          "attr": "id",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 27,
+                          "end_col_offset": 39
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": "by",
+                          "kind": null,
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 41,
+                          "end_col_offset": 45
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "row",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 30,
+                              "end_lineno": 30,
+                              "col_offset": 47,
+                              "end_col_offset": 50
+                            },
+                            "attr": "customer",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 30,
+                            "end_lineno": 30,
+                            "col_offset": 47,
+                            "end_col_offset": 59
+                          },
+                          "attr": "name",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 47,
+                          "end_col_offset": 64
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": "- $",
+                          "kind": null,
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 66,
+                          "end_col_offset": 71
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "row",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 30,
+                              "end_lineno": 30,
+                              "col_offset": 73,
+                              "end_col_offset": 76
+                            },
+                            "attr": "order",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 30,
+                            "end_lineno": 30,
+                            "col_offset": 73,
+                            "end_col_offset": 82
+                          },
+                          "attr": "total",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 30,
+                          "end_lineno": 30,
+                          "col_offset": 73,
+                          "end_col_offset": 88
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 30,
+                      "end_lineno": 30,
+                      "col_offset": 12,
+                      "end_col_offset": 89
+                    },
+                    "lineno": 30,
+                    "end_lineno": 30,
+                    "col_offset": 12,
+                    "end_col_offset": 89
+                  }
+                ],
+                "test": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "row",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 11,
+                    "end_col_offset": 14
+                  },
+                  "attr": "customer",
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 11,
+                  "end_col_offset": 23
+                },
+                "orelse": [
+                  {
+                    "_type": "Expr",
+                    "value": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "print",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 32,
+                        "end_lineno": 32,
+                        "col_offset": 12,
+                        "end_col_offset": 17
+                      },
+                      "args": [
+                        {
+                          "_type": "Constant",
+                          "value": "Order",
+                          "kind": null,
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 18,
+                          "end_col_offset": 25
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "row",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 32,
+                              "end_lineno": 32,
+                              "col_offset": 27,
+                              "end_col_offset": 30
+                            },
+                            "attr": "order",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 32,
+                            "end_lineno": 32,
+                            "col_offset": 27,
+                            "end_col_offset": 36
+                          },
+                          "attr": "id",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 27,
+                          "end_col_offset": 39
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": "by",
+                          "kind": null,
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 41,
+                          "end_col_offset": 45
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": "Unknown",
+                          "kind": null,
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 47,
+                          "end_col_offset": 56
+                        },
+                        {
+                          "_type": "Constant",
+                          "value": "- $",
+                          "kind": null,
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 58,
+                          "end_col_offset": 63
+                        },
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Attribute",
+                            "value": {
+                              "_type": "Name",
+                              "id": "row",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 32,
+                              "end_lineno": 32,
+                              "col_offset": 65,
+                              "end_col_offset": 68
+                            },
+                            "attr": "order",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 32,
+                            "end_lineno": 32,
+                            "col_offset": 65,
+                            "end_col_offset": 74
+                          },
+                          "attr": "total",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 32,
+                          "end_lineno": 32,
+                          "col_offset": 65,
+                          "end_col_offset": 80
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 32,
+                      "end_lineno": 32,
+                      "col_offset": 12,
+                      "end_col_offset": 81
+                    },
+                    "lineno": 32,
+                    "end_lineno": 32,
+                    "col_offset": 12,
+                    "end_col_offset": 81
+                  }
+                ],
+                "lineno": 29,
+                "end_lineno": 32,
+                "col_offset": 8,
+                "end_col_offset": 81
+              }
+            ],
+            "test": {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "row",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 7,
+                "end_col_offset": 10
+              },
+              "attr": "order",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 7,
+              "end_col_offset": 16
+            },
+            "orelse": [
+              {
+                "_type": "Expr",
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "print",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 34,
+                    "end_lineno": 34,
+                    "col_offset": 8,
+                    "end_col_offset": 13
+                  },
+                  "args": [
+                    {
+                      "_type": "Constant",
+                      "value": "Customer",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 14,
+                      "end_col_offset": 24
+                    },
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "row",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 34,
+                          "end_lineno": 34,
+                          "col_offset": 26,
+                          "end_col_offset": 29
+                        },
+                        "attr": "customer",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 34,
+                        "end_lineno": 34,
+                        "col_offset": 26,
+                        "end_col_offset": 38
+                      },
+                      "attr": "name",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 26,
+                      "end_col_offset": 43
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "has no orders",
+                      "kind": null,
+                      "lineno": 34,
+                      "end_lineno": 34,
+                      "col_offset": 45,
+                      "end_col_offset": 60
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 34,
+                  "end_lineno": 34,
+                  "col_offset": 8,
+                  "end_col_offset": 61
+                },
+                "lineno": 34,
+                "end_lineno": 34,
+                "col_offset": 8,
+                "end_col_offset": 61
+              }
+            ],
+            "lineno": 28,
+            "end_lineno": 34,
+            "col_offset": 4,
+            "end_col_offset": 61
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "row",
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 4,
+          "end_col_offset": 7
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 11,
+          "end_col_offset": 17
+        },
+        "lineno": 27,
+        "end_lineno": 34,
+        "end_col_offset": 61
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/partial_application.py.json
+++ b/tests/json-ast/x/py/partial_application.py.json
@@ -1,0 +1,227 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "add",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "a",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 15,
+                "end_col_offset": 16
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 11,
+              "end_col_offset": 16
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "a",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "arg",
+              "arg": "b",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "add5",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Lambda",
+          "args": {
+            "_type": "arguments",
+            "posonlyargs": [],
+            "args": [
+              {
+                "_type": "arg",
+                "arg": "b",
+                "annotation": null,
+                "type_comment": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 14,
+                "end_col_offset": 15
+              }
+            ],
+            "vararg": null,
+            "kwonlyargs": [],
+            "kw_defaults": [],
+            "kwarg": null,
+            "defaults": []
+          },
+          "body": {
+            "_type": "Call",
+            "func": {
+              "_type": "Name",
+              "id": "add",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 17,
+              "end_col_offset": 20
+            },
+            "args": [
+              {
+                "_type": "Constant",
+                "value": 5,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 21,
+                "end_col_offset": 22
+              },
+              {
+                "_type": "Name",
+                "id": "b",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 24,
+                "end_col_offset": 25
+              }
+            ],
+            "keywords": [],
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 17,
+            "end_col_offset": 26
+          },
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 7,
+          "end_col_offset": 26
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "add5",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 13
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 14
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 14
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/print_hello.py.json
+++ b/tests/json-ast/x/py/print_hello.py.json
@@ -1,0 +1,43 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "hello",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 13
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 14
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 14
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/pure_fold.py.json
+++ b/tests/json-ast/x/py/pure_fold.py.json
@@ -1,0 +1,150 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "triple",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "op": {
+                "_type": "Mult"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 3,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 15,
+                "end_col_offset": 16
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 11,
+              "end_col_offset": 16
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "x",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 4,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "triple",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 12
+              },
+              "args": [
+                {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 13,
+                  "end_col_offset": 18
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 19
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 20
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 20
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/pure_global_fold.py.json
+++ b/tests/json-ast/x/py/pure_global_fold.py.json
@@ -1,0 +1,157 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "k",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "FunctionDef",
+        "name": "inc",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "x",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 11,
+                "end_col_offset": 12
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Name",
+                "id": "k",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 15,
+                "end_col_offset": 16
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 11,
+              "end_col_offset": 16
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 16
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "x",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 8,
+              "end_col_offset": 9
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 4,
+        "end_lineno": 5,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "inc",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/python_auto.py.json
+++ b/tests/json-ast/x/py/python_auto.py.json
@@ -1,0 +1,130 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Import",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "math",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "attr": "sqrt",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 16.0,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 16,
+                  "end_col_offset": 20
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 21
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 22
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "math",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "attr": "pi",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 13
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 14
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 14
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/python_math.py.json
+++ b/tests/json-ast/x/py/python_math.py.json
@@ -1,0 +1,557 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Import",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "r",
+            "lineno": 5,
+            "end_lineno": 5,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 3.0,
+          "kind": null,
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 4,
+          "end_col_offset": 7
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 7
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "area",
+            "lineno": 6,
+            "end_lineno": 6,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "math",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 11
+            },
+            "attr": "pi",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 7,
+            "end_col_offset": 14
+          },
+          "op": {
+            "_type": "Mult"
+          },
+          "right": {
+            "_type": "Call",
+            "func": {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "math",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              "attr": "pow",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 17,
+              "end_col_offset": 25
+            },
+            "args": [
+              {
+                "_type": "Name",
+                "id": "r",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              {
+                "_type": "Constant",
+                "value": 2.0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 29,
+                "end_col_offset": 32
+              }
+            ],
+            "keywords": [],
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 17,
+            "end_col_offset": 33
+          },
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 7,
+          "end_col_offset": 33
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "root",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "math",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 11
+            },
+            "attr": "sqrt",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 7,
+            "end_col_offset": 16
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 49.0,
+              "kind": null,
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 17,
+              "end_col_offset": 21
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 7,
+          "end_col_offset": 22
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "sin45",
+            "lineno": 8,
+            "end_lineno": 8,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "math",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 8,
+              "end_col_offset": 12
+            },
+            "attr": "sin",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 8,
+            "end_col_offset": 16
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "math",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 8,
+                  "end_lineno": 8,
+                  "col_offset": 17,
+                  "end_col_offset": 21
+                },
+                "attr": "pi",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 17,
+                "end_col_offset": 24
+              },
+              "op": {
+                "_type": "Div"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 4.0,
+                "kind": null,
+                "lineno": 8,
+                "end_lineno": 8,
+                "col_offset": 27,
+                "end_col_offset": 30
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 17,
+              "end_col_offset": 30
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 8,
+          "end_col_offset": 31
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 31
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "log_e",
+            "lineno": 9,
+            "end_lineno": 9,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "math",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 12
+            },
+            "attr": "log",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 8,
+            "end_col_offset": 16
+          },
+          "args": [
+            {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "math",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 9,
+                "end_lineno": 9,
+                "col_offset": 17,
+                "end_col_offset": 21
+              },
+              "attr": "e",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 17,
+              "end_col_offset": 23
+            }
+          ],
+          "keywords": [],
+          "lineno": 9,
+          "end_lineno": 9,
+          "col_offset": 8,
+          "end_col_offset": 24
+        },
+        "lineno": 9,
+        "end_lineno": 9,
+        "end_col_offset": 24
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "Circle area with r =",
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 6,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Name",
+              "id": "r",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 30,
+              "end_col_offset": 31
+            },
+            {
+              "_type": "Constant",
+              "value": "=\u003e",
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 33,
+              "end_col_offset": 37
+            },
+            {
+              "_type": "Name",
+              "id": "area",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 39,
+              "end_col_offset": 43
+            }
+          ],
+          "keywords": [],
+          "lineno": 10,
+          "end_lineno": 10,
+          "col_offset": 0,
+          "end_col_offset": 44
+        },
+        "lineno": 10,
+        "end_lineno": 10,
+        "end_col_offset": 44
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "Square root of 49:",
+              "kind": null,
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 6,
+              "end_col_offset": 26
+            },
+            {
+              "_type": "Name",
+              "id": "root",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 28,
+              "end_col_offset": 32
+            }
+          ],
+          "keywords": [],
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 0,
+          "end_col_offset": 33
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "sin(\u03c0/4):",
+              "kind": null,
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 6,
+              "end_col_offset": 18
+            },
+            {
+              "_type": "Name",
+              "id": "sin45",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 20,
+              "end_col_offset": 25
+            }
+          ],
+          "keywords": [],
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 0,
+          "end_col_offset": 26
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 26
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "log(e):",
+              "kind": null,
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 6,
+              "end_col_offset": 15
+            },
+            {
+              "_type": "Name",
+              "id": "log_e",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 17,
+              "end_col_offset": 22
+            }
+          ],
+          "keywords": [],
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 0,
+          "end_col_offset": 23
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 23
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/query_sum_select.py.json
+++ b/tests/json-ast/x/py/query_sum_select.py.json
@@ -1,0 +1,217 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "nums",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 12
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 14,
+              "end_col_offset": 15
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 7,
+          "end_col_offset": 16
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "sum",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 9,
+            "end_col_offset": 12
+          },
+          "args": [
+            {
+              "_type": "GeneratorExp",
+              "elt": {
+                "_type": "Name",
+                "id": "n",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "generators": [
+                {
+                  "_type": "comprehension",
+                  "target": {
+                    "_type": "Name",
+                    "id": "n",
+                    "ctx": {
+                      "_type": "Store"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 20,
+                    "end_col_offset": 21
+                  },
+                  "iter": {
+                    "_type": "Name",
+                    "id": "nums",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 25,
+                    "end_col_offset": 29
+                  },
+                  "ifs": [
+                    {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "Name",
+                        "id": "n",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 4,
+                        "end_lineno": 4,
+                        "col_offset": 33,
+                        "end_col_offset": 34
+                      },
+                      "ops": [
+                        {
+                          "_type": "Gt"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Constant",
+                          "value": 1,
+                          "kind": null,
+                          "lineno": 4,
+                          "end_lineno": 4,
+                          "col_offset": 37,
+                          "end_col_offset": 38
+                        }
+                      ],
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 33,
+                      "end_col_offset": 38
+                    }
+                  ],
+                  "is_async": 0
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 13,
+              "end_col_offset": 39
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 9,
+          "end_col_offset": 40
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 40
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/record_assign.py.json
+++ b/tests/json-ast/x/py/record_assign.py.json
@@ -1,0 +1,354 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Counter",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 10,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "FunctionDef",
+        "name": "inc",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "c",
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 4,
+                "end_col_offset": 5
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "dataclasses",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 8,
+                  "end_col_offset": 19
+                },
+                "attr": "replace",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 8,
+                "end_col_offset": 27
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 28,
+                  "end_col_offset": 29
+                }
+              ],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "n",
+                  "value": {
+                    "_type": "BinOp",
+                    "left": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "c",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 13,
+                        "end_lineno": 13,
+                        "col_offset": 33,
+                        "end_col_offset": 34
+                      },
+                      "attr": "n",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 33,
+                      "end_col_offset": 36
+                    },
+                    "op": {
+                      "_type": "Add"
+                    },
+                    "right": {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 39,
+                      "end_col_offset": 40
+                    },
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 33,
+                    "end_col_offset": 40
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 31,
+                  "end_col_offset": 40
+                }
+              ],
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 8,
+              "end_col_offset": 41
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 4,
+            "end_col_offset": 41
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "c",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 8,
+              "end_col_offset": 9
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 12,
+        "end_lineno": 13,
+        "end_col_offset": 41
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "c",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "Counter",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          "args": [],
+          "keywords": [
+            {
+              "_type": "keyword",
+              "arg": "n",
+              "value": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 14,
+                "end_col_offset": 15
+              },
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 12,
+              "end_col_offset": 15
+            }
+          ],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 4,
+          "end_col_offset": 16
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "inc",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 0,
+            "end_col_offset": 3
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "c",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 5
+            }
+          ],
+          "keywords": [],
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 0,
+          "end_col_offset": 6
+        },
+        "lineno": 15,
+        "end_lineno": 15,
+        "end_col_offset": 6
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "c",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "attr": "n",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 6,
+              "end_col_offset": 9
+            }
+          ],
+          "keywords": [],
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 0,
+          "end_col_offset": 10
+        },
+        "lineno": 16,
+        "end_lineno": 16,
+        "end_col_offset": 10
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/right_join.py.json
+++ b/tests/json-ast/x/py/right_join.py.json
@@ -1,0 +1,1356 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Customer",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "customers",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 9
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 21
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 25,
+                  "end_col_offset": 32
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 13,
+              "end_col_offset": 33
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 35,
+                "end_col_offset": 43
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 44,
+                  "end_col_offset": 45
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 47,
+                  "end_col_offset": 52
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 35,
+              "end_col_offset": 53
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 55,
+                "end_col_offset": 63
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 64,
+                  "end_col_offset": 65
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Charlie",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 67,
+                  "end_col_offset": 76
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 55,
+              "end_col_offset": 77
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Customer",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 79,
+                "end_col_offset": 87
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 88,
+                  "end_col_offset": 89
+                },
+                {
+                  "_type": "Constant",
+                  "value": "Diana",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 91,
+                  "end_col_offset": 98
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 79,
+              "end_col_offset": 99
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 12,
+          "end_col_offset": 100
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 100
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Order",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 8,
+              "end_col_offset": 11
+            },
+            "target": {
+              "_type": "Name",
+              "id": "id",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 6
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 11
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 16,
+              "end_col_offset": 19
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerId",
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 4,
+              "end_col_offset": 14
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 19
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "total",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 14,
+        "end_lineno": 17,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "orders",
+            "lineno": 19,
+            "end_lineno": 19,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 10,
+                "end_col_offset": 15
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 100,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 16,
+                  "end_col_offset": 19
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 21,
+                  "end_col_offset": 22
+                },
+                {
+                  "_type": "Constant",
+                  "value": 250,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 24,
+                  "end_col_offset": 27
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 10,
+              "end_col_offset": 28
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 30,
+                "end_col_offset": 35
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 101,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 36,
+                  "end_col_offset": 39
+                },
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 41,
+                  "end_col_offset": 42
+                },
+                {
+                  "_type": "Constant",
+                  "value": 125,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 44,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 30,
+              "end_col_offset": 48
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Order",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 50,
+                "end_col_offset": 55
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 102,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 56,
+                  "end_col_offset": 59
+                },
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 61,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Constant",
+                  "value": 300,
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 64,
+                  "end_col_offset": 67
+                }
+              ],
+              "keywords": [],
+              "lineno": 19,
+              "end_lineno": 19,
+              "col_offset": 50,
+              "end_col_offset": 68
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 19,
+          "end_lineno": 19,
+          "col_offset": 9,
+          "end_col_offset": 69
+        },
+        "lineno": 19,
+        "end_lineno": 19,
+        "end_col_offset": 69
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Result",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 18,
+              "end_col_offset": 21
+            },
+            "target": {
+              "_type": "Name",
+              "id": "customerName",
+              "lineno": 22,
+              "end_lineno": 22,
+              "col_offset": 4,
+              "end_col_offset": 16
+            },
+            "lineno": 22,
+            "end_lineno": 22,
+            "col_offset": 4,
+            "end_col_offset": 21
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "any",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "order",
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 4,
+            "end_col_offset": 14
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 20,
+            "end_lineno": 20,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 21,
+        "end_lineno": 23,
+        "end_col_offset": 14
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 25,
+            "end_lineno": 25,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "ListComp",
+            "elt": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Result",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "c",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  },
+                  "attr": "name",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 17,
+                  "end_col_offset": 23
+                },
+                {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 25,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 10,
+              "end_col_offset": 27
+            },
+            "generators": [
+              {
+                "_type": "comprehension",
+                "target": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Store"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 32,
+                  "end_col_offset": 33
+                },
+                "iter": {
+                  "_type": "Name",
+                  "id": "orders",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 37,
+                  "end_col_offset": 43
+                },
+                "ifs": [],
+                "is_async": 0
+              },
+              {
+                "_type": "comprehension",
+                "target": {
+                  "_type": "Name",
+                  "id": "c",
+                  "ctx": {
+                    "_type": "Store"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 48,
+                  "end_col_offset": 49
+                },
+                "iter": {
+                  "_type": "Name",
+                  "id": "customers",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 53,
+                  "end_col_offset": 62
+                },
+                "ifs": [
+                  {
+                    "_type": "Compare",
+                    "left": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "o",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 66,
+                        "end_col_offset": 67
+                      },
+                      "attr": "customerId",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 66,
+                      "end_col_offset": 78
+                    },
+                    "ops": [
+                      {
+                        "_type": "Eq"
+                      }
+                    ],
+                    "comparators": [
+                      {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "c",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 82,
+                          "end_col_offset": 83
+                        },
+                        "attr": "id",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 82,
+                        "end_col_offset": 86
+                      }
+                    ],
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 66,
+                    "end_col_offset": 86
+                  }
+                ],
+                "is_async": 0
+              }
+            ],
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 9,
+            "end_col_offset": 87
+          },
+          "op": {
+            "_type": "Add"
+          },
+          "right": {
+            "_type": "ListComp",
+            "elt": {
+              "_type": "Call",
+              "func": {
+                "_type": "Lambda",
+                "args": {
+                  "_type": "arguments",
+                  "posonlyargs": [],
+                  "args": [
+                    {
+                      "_type": "arg",
+                      "arg": "c",
+                      "annotation": null,
+                      "type_comment": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 99,
+                      "end_col_offset": 100
+                    }
+                  ],
+                  "vararg": null,
+                  "kwonlyargs": [],
+                  "kw_defaults": [],
+                  "kwarg": null,
+                  "defaults": []
+                },
+                "body": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Result",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 102,
+                    "end_col_offset": 108
+                  },
+                  "args": [
+                    {
+                      "_type": "Constant",
+                      "value": null,
+                      "kind": null,
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 109,
+                      "end_col_offset": 113
+                    },
+                    {
+                      "_type": "Name",
+                      "id": "o",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 115,
+                      "end_col_offset": 116
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 102,
+                  "end_col_offset": 117
+                },
+                "lineno": 25,
+                "end_lineno": 25,
+                "col_offset": 92,
+                "end_col_offset": 117
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": null,
+                  "kind": null,
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 119,
+                  "end_col_offset": 123
+                }
+              ],
+              "keywords": [],
+              "lineno": 25,
+              "end_lineno": 25,
+              "col_offset": 91,
+              "end_col_offset": 124
+            },
+            "generators": [
+              {
+                "_type": "comprehension",
+                "target": {
+                  "_type": "Name",
+                  "id": "o",
+                  "ctx": {
+                    "_type": "Store"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 129,
+                  "end_col_offset": 130
+                },
+                "iter": {
+                  "_type": "Name",
+                  "id": "orders",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 25,
+                  "end_lineno": 25,
+                  "col_offset": 134,
+                  "end_col_offset": 140
+                },
+                "ifs": [
+                  {
+                    "_type": "UnaryOp",
+                    "op": {
+                      "_type": "Not"
+                    },
+                    "operand": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "any",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 25,
+                        "end_lineno": 25,
+                        "col_offset": 148,
+                        "end_col_offset": 151
+                      },
+                      "args": [
+                        {
+                          "_type": "ListComp",
+                          "elt": {
+                            "_type": "Compare",
+                            "left": {
+                              "_type": "Attribute",
+                              "value": {
+                                "_type": "Name",
+                                "id": "o",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 153,
+                                "end_col_offset": 154
+                              },
+                              "attr": "customerId",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 25,
+                              "end_lineno": 25,
+                              "col_offset": 153,
+                              "end_col_offset": 165
+                            },
+                            "ops": [
+                              {
+                                "_type": "Eq"
+                              }
+                            ],
+                            "comparators": [
+                              {
+                                "_type": "Attribute",
+                                "value": {
+                                  "_type": "Name",
+                                  "id": "c",
+                                  "ctx": {
+                                    "_type": "Load"
+                                  },
+                                  "lineno": 25,
+                                  "end_lineno": 25,
+                                  "col_offset": 169,
+                                  "end_col_offset": 170
+                                },
+                                "attr": "id",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 169,
+                                "end_col_offset": 173
+                              }
+                            ],
+                            "lineno": 25,
+                            "end_lineno": 25,
+                            "col_offset": 153,
+                            "end_col_offset": 173
+                          },
+                          "generators": [
+                            {
+                              "_type": "comprehension",
+                              "target": {
+                                "_type": "Name",
+                                "id": "c",
+                                "ctx": {
+                                  "_type": "Store"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 178,
+                                "end_col_offset": 179
+                              },
+                              "iter": {
+                                "_type": "Name",
+                                "id": "customers",
+                                "ctx": {
+                                  "_type": "Load"
+                                },
+                                "lineno": 25,
+                                "end_lineno": 25,
+                                "col_offset": 183,
+                                "end_col_offset": 192
+                              },
+                              "ifs": [],
+                              "is_async": 0
+                            }
+                          ],
+                          "lineno": 25,
+                          "end_lineno": 25,
+                          "col_offset": 152,
+                          "end_col_offset": 193
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 25,
+                      "end_lineno": 25,
+                      "col_offset": 148,
+                      "end_col_offset": 194
+                    },
+                    "lineno": 25,
+                    "end_lineno": 25,
+                    "col_offset": 144,
+                    "end_col_offset": 194
+                  }
+                ],
+                "is_async": 0
+              }
+            ],
+            "lineno": 25,
+            "end_lineno": 25,
+            "col_offset": 90,
+            "end_col_offset": 195
+          },
+          "lineno": 25,
+          "end_lineno": 25,
+          "col_offset": 9,
+          "end_col_offset": 195
+        },
+        "lineno": 25,
+        "end_lineno": 25,
+        "end_col_offset": 195
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 26,
+            "end_lineno": 26,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "--- Right Join using syntax ---",
+              "kind": null,
+              "lineno": 26,
+              "end_lineno": 26,
+              "col_offset": 6,
+              "end_col_offset": 39
+            }
+          ],
+          "keywords": [],
+          "lineno": 26,
+          "end_lineno": 26,
+          "col_offset": 0,
+          "end_col_offset": 40
+        },
+        "lineno": 26,
+        "end_lineno": 26,
+        "end_col_offset": 40
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Expr",
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "print",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 29,
+                    "end_lineno": 29,
+                    "col_offset": 8,
+                    "end_col_offset": 13
+                  },
+                  "args": [
+                    {
+                      "_type": "Constant",
+                      "value": "Customer",
+                      "kind": null,
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 14,
+                      "end_col_offset": 24
+                    },
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "entry",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 26,
+                        "end_col_offset": 31
+                      },
+                      "attr": "customerName",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 26,
+                      "end_col_offset": 44
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "has order",
+                      "kind": null,
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 46,
+                      "end_col_offset": 57
+                    },
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "entry",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 59,
+                          "end_col_offset": 64
+                        },
+                        "attr": "order",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 59,
+                        "end_col_offset": 70
+                      },
+                      "attr": "id",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 59,
+                      "end_col_offset": 73
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "- $",
+                      "kind": null,
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 75,
+                      "end_col_offset": 80
+                    },
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "entry",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 29,
+                          "end_lineno": 29,
+                          "col_offset": 82,
+                          "end_col_offset": 87
+                        },
+                        "attr": "order",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 29,
+                        "end_lineno": 29,
+                        "col_offset": 82,
+                        "end_col_offset": 93
+                      },
+                      "attr": "total",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 29,
+                      "end_lineno": 29,
+                      "col_offset": 82,
+                      "end_col_offset": 99
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 29,
+                  "end_lineno": 29,
+                  "col_offset": 8,
+                  "end_col_offset": 100
+                },
+                "lineno": 29,
+                "end_lineno": 29,
+                "col_offset": 8,
+                "end_col_offset": 100
+              }
+            ],
+            "test": {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Name",
+                "id": "entry",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 28,
+                "end_lineno": 28,
+                "col_offset": 7,
+                "end_col_offset": 12
+              },
+              "attr": "order",
+              "lineno": 28,
+              "end_lineno": 28,
+              "col_offset": 7,
+              "end_col_offset": 18
+            },
+            "orelse": [
+              {
+                "_type": "Expr",
+                "value": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "print",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 31,
+                    "end_lineno": 31,
+                    "col_offset": 8,
+                    "end_col_offset": 13
+                  },
+                  "args": [
+                    {
+                      "_type": "Constant",
+                      "value": "Customer",
+                      "kind": null,
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 14,
+                      "end_col_offset": 24
+                    },
+                    {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "entry",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 31,
+                        "end_lineno": 31,
+                        "col_offset": 26,
+                        "end_col_offset": 31
+                      },
+                      "attr": "customerName",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 26,
+                      "end_col_offset": 44
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": "has no orders",
+                      "kind": null,
+                      "lineno": 31,
+                      "end_lineno": 31,
+                      "col_offset": 46,
+                      "end_col_offset": 61
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 31,
+                  "end_lineno": 31,
+                  "col_offset": 8,
+                  "end_col_offset": 62
+                },
+                "lineno": 31,
+                "end_lineno": 31,
+                "col_offset": 8,
+                "end_col_offset": 62
+              }
+            ],
+            "lineno": 28,
+            "end_lineno": 31,
+            "col_offset": 4,
+            "end_col_offset": 62
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "entry",
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "result",
+          "lineno": 27,
+          "end_lineno": 27,
+          "col_offset": 13,
+          "end_col_offset": 19
+        },
+        "lineno": 27,
+        "end_lineno": 31,
+        "end_col_offset": 62
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/save_jsonl_stdout.py.json
+++ b/tests/json-ast/x/py/save_jsonl_stdout.py.json
@@ -1,0 +1,423 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Import",
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "ClassDef",
+        "name": "People",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 10,
+        "end_lineno": 12,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 14,
+            "end_lineno": 14,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Alice",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 17,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "Constant",
+                  "value": 30,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 26,
+                  "end_col_offset": 28
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 10,
+              "end_col_offset": 29
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "People",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 14,
+                "end_lineno": 14,
+                "col_offset": 31,
+                "end_col_offset": 37
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "Bob",
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 38,
+                  "end_col_offset": 43
+                },
+                {
+                  "_type": "Constant",
+                  "value": 25,
+                  "kind": null,
+                  "lineno": 14,
+                  "end_lineno": 14,
+                  "col_offset": 45,
+                  "end_col_offset": 47
+                }
+              ],
+              "keywords": [],
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 31,
+              "end_col_offset": 48
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 9,
+          "end_col_offset": 49
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 49
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "_tmp",
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 4,
+                "end_col_offset": 8
+              }
+            ],
+            "value": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "hasattr",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 39,
+                  "end_col_offset": 46
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_row",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 47,
+                    "end_col_offset": 51
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": "__dataclass_fields__",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 53,
+                    "end_col_offset": 75
+                  }
+                ],
+                "keywords": [],
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 39,
+                "end_col_offset": 76
+              },
+              "body": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Attribute",
+                  "value": {
+                    "_type": "Name",
+                    "id": "dataclasses",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 11,
+                    "end_col_offset": 22
+                  },
+                  "attr": "asdict",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 11,
+                  "end_col_offset": 29
+                },
+                "args": [
+                  {
+                    "_type": "Name",
+                    "id": "_row",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 30,
+                    "end_col_offset": 34
+                  }
+                ],
+                "keywords": [],
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 11,
+                "end_col_offset": 35
+              },
+              "orelse": {
+                "_type": "Name",
+                "id": "_row",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 82,
+                "end_col_offset": 86
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 11,
+              "end_col_offset": 86
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 86
+          },
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "json",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 17,
+                      "end_lineno": 17,
+                      "col_offset": 10,
+                      "end_col_offset": 14
+                    },
+                    "attr": "dumps",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 10,
+                    "end_col_offset": 20
+                  },
+                  "args": [
+                    {
+                      "_type": "Name",
+                      "id": "_tmp",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 17,
+                      "end_lineno": 17,
+                      "col_offset": 21,
+                      "end_col_offset": 25
+                    }
+                  ],
+                  "keywords": [],
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 10,
+                  "end_col_offset": 26
+                }
+              ],
+              "keywords": [],
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 27
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 4,
+            "end_col_offset": 27
+          }
+        ],
+        "target": {
+          "_type": "Name",
+          "id": "_row",
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 4,
+          "end_col_offset": 8
+        },
+        "iter": {
+          "_type": "Name",
+          "id": "people",
+          "lineno": 15,
+          "end_lineno": 15,
+          "col_offset": 12,
+          "end_col_offset": 18
+        },
+        "lineno": 15,
+        "end_lineno": 17,
+        "end_col_offset": 27
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/short_circuit.py.json
+++ b/tests/json-ast/x/py/short_circuit.py.json
@@ -1,0 +1,324 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "boom",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": "boom",
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 10,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 4,
+              "end_col_offset": 17
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 17
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Constant",
+              "value": true,
+              "kind": null,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "a",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 9,
+              "end_col_offset": 10
+            },
+            {
+              "_type": "arg",
+              "arg": "b",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 12,
+              "end_col_offset": 13
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 5,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "And"
+                },
+                "values": [
+                  {
+                    "_type": "Constant",
+                    "value": false,
+                    "kind": null,
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 12,
+                    "end_col_offset": 17
+                  },
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "boom",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 22,
+                      "end_col_offset": 26
+                    },
+                    "args": [
+                      {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 27,
+                        "end_col_offset": 28
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 30,
+                        "end_col_offset": 31
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 22,
+                    "end_col_offset": 32
+                  }
+                ],
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 32
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 38,
+                "end_col_offset": 39
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 39
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 41
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 41
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "BoolOp",
+                "op": {
+                  "_type": "Or"
+                },
+                "values": [
+                  {
+                    "_type": "Constant",
+                    "value": true,
+                    "kind": null,
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 12,
+                    "end_col_offset": 16
+                  },
+                  {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "boom",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 20,
+                      "end_col_offset": 24
+                    },
+                    "args": [
+                      {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 25,
+                        "end_col_offset": 26
+                      },
+                      {
+                        "_type": "Constant",
+                        "value": 2,
+                        "kind": null,
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 28,
+                        "end_col_offset": 29
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 20,
+                    "end_col_offset": 30
+                  }
+                ],
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 12,
+                "end_col_offset": 30
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 36,
+                "end_col_offset": 37
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 37
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 39
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 39
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/slice.py.json
+++ b/tests/json-ast/x/py/slice.py.json
@@ -1,0 +1,283 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "List",
+                "elts": [
+                  {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 7,
+                    "end_col_offset": 8
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  }
+                ],
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 15
+              },
+              "slice": {
+                "_type": "Slice",
+                "lower": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "upper": {
+                  "_type": "Constant",
+                  "value": 3,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 18,
+                  "end_col_offset": 19
+                },
+                "step": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 16,
+                "end_col_offset": 19
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "List",
+                "elts": [
+                  {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 7,
+                    "end_col_offset": 8
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 2,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 10,
+                    "end_col_offset": 11
+                  },
+                  {
+                    "_type": "Constant",
+                    "value": 3,
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  }
+                ],
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 15
+              },
+              "slice": {
+                "_type": "Slice",
+                "lower": {
+                  "_type": "Constant",
+                  "value": 0,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "upper": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 18,
+                  "end_col_offset": 19
+                },
+                "step": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 16,
+                "end_col_offset": 19
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 21
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Constant",
+                "value": "hello",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 13
+              },
+              "slice": {
+                "_type": "Slice",
+                "lower": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "upper": {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "step": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 14,
+                "end_col_offset": 17
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 18
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 19
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 19
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/sort_stable.py.json
+++ b/tests/json-ast/x/py/sort_stable.py.json
@@ -1,0 +1,463 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Item",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "n",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 10
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 7,
+              "end_col_offset": 10
+            },
+            "target": {
+              "_type": "Name",
+              "id": "v",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 5
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 10
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "items",
+            "lineno": 12,
+            "end_lineno": 12,
+            "end_col_offset": 5
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 9,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 17,
+                  "end_col_offset": 20
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 9,
+              "end_col_offset": 21
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 23,
+                "end_col_offset": 27
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 28,
+                  "end_col_offset": 29
+                },
+                {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 31,
+                  "end_col_offset": 34
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 23,
+              "end_col_offset": 35
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Item",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 37,
+                "end_col_offset": 41
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 42,
+                  "end_col_offset": 43
+                },
+                {
+                  "_type": "Constant",
+                  "value": "c",
+                  "kind": null,
+                  "lineno": 12,
+                  "end_lineno": 12,
+                  "col_offset": 45,
+                  "end_col_offset": 48
+                }
+              ],
+              "keywords": [],
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 37,
+              "end_col_offset": 49
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 8,
+          "end_col_offset": 50
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 50
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 13,
+            "end_lineno": 13,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "ListComp",
+          "elt": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "i",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            "attr": "v",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 10,
+            "end_col_offset": 13
+          },
+          "generators": [
+            {
+              "_type": "comprehension",
+              "target": {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Store"
+                },
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 18,
+                "end_col_offset": 19
+              },
+              "iter": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "sorted",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 13,
+                  "end_lineno": 13,
+                  "col_offset": 23,
+                  "end_col_offset": 29
+                },
+                "args": [
+                  {
+                    "_type": "ListComp",
+                    "elt": {
+                      "_type": "Name",
+                      "id": "i",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 31,
+                      "end_col_offset": 32
+                    },
+                    "generators": [
+                      {
+                        "_type": "comprehension",
+                        "target": {
+                          "_type": "Name",
+                          "id": "i",
+                          "ctx": {
+                            "_type": "Store"
+                          },
+                          "lineno": 13,
+                          "end_lineno": 13,
+                          "col_offset": 37,
+                          "end_col_offset": 38
+                        },
+                        "iter": {
+                          "_type": "Name",
+                          "id": "items",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 13,
+                          "end_lineno": 13,
+                          "col_offset": 42,
+                          "end_col_offset": 47
+                        },
+                        "ifs": [],
+                        "is_async": 0
+                      }
+                    ],
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 30,
+                    "end_col_offset": 48
+                  }
+                ],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "key",
+                    "value": {
+                      "_type": "Lambda",
+                      "args": {
+                        "_type": "arguments",
+                        "posonlyargs": [],
+                        "args": [
+                          {
+                            "_type": "arg",
+                            "arg": "i",
+                            "annotation": null,
+                            "type_comment": null,
+                            "lineno": 13,
+                            "end_lineno": 13,
+                            "col_offset": 61,
+                            "end_col_offset": 62
+                          }
+                        ],
+                        "vararg": null,
+                        "kwonlyargs": [],
+                        "kw_defaults": [],
+                        "kwarg": null,
+                        "defaults": []
+                      },
+                      "body": {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "i",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 13,
+                          "end_lineno": 13,
+                          "col_offset": 64,
+                          "end_col_offset": 65
+                        },
+                        "attr": "n",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 13,
+                        "end_lineno": 13,
+                        "col_offset": 64,
+                        "end_col_offset": 67
+                      },
+                      "lineno": 13,
+                      "end_lineno": 13,
+                      "col_offset": 54,
+                      "end_col_offset": 67
+                    },
+                    "lineno": 13,
+                    "end_lineno": 13,
+                    "col_offset": 50,
+                    "end_col_offset": 67
+                  }
+                ],
+                "lineno": 13,
+                "end_lineno": 13,
+                "col_offset": 23,
+                "end_col_offset": 68
+              },
+              "ifs": [],
+              "is_async": 0
+            }
+          ],
+          "lineno": 13,
+          "end_lineno": 13,
+          "col_offset": 9,
+          "end_col_offset": 69
+        },
+        "lineno": 13,
+        "end_lineno": 13,
+        "end_col_offset": 69
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "result",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 14,
+          "end_lineno": 14,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 14,
+        "end_lineno": 14,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/str_builtin.py.json
+++ b/tests/json-ast/x/py/str_builtin.py.json
@@ -1,0 +1,64 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "str",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 123,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 13
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 14
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 15
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 15
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_compare.py.json
+++ b/tests/json-ast/x/py/string_compare.py.json
@@ -1,0 +1,343 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "Lt"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": "b",
+                    "kind": null,
+                    "lineno": 3,
+                    "end_lineno": 3,
+                    "col_offset": 18,
+                    "end_col_offset": 21
+                  }
+                ],
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 12,
+                "end_col_offset": 21
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 27,
+                "end_col_offset": 28
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 7,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 30
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "a",
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "LtE"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": "a",
+                    "kind": null,
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 19,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 31
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "Gt"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": "a",
+                    "kind": null,
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 18,
+                    "end_col_offset": 21
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 21
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 27,
+                "end_col_offset": 28
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 30
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 30
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "b",
+                  "kind": null,
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 12,
+                  "end_col_offset": 15
+                },
+                "ops": [
+                  {
+                    "_type": "GtE"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Constant",
+                    "value": "b",
+                    "kind": null,
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 19,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 31
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_concat.py.json
+++ b/tests/json-ast/x/py/string_concat.py.json
@@ -1,0 +1,62 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": "hello ",
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 14
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": "world",
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 17,
+                "end_col_offset": 24
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 24
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 25
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 25
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_contains.py.json
+++ b/tests/json-ast/x/py/string_contains.py.json
@@ -1,0 +1,153 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "catch",
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 11
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Compare",
+              "left": {
+                "_type": "Constant",
+                "value": "cat",
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 11
+              },
+              "ops": [
+                {
+                  "_type": "In"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Name",
+                  "id": "s",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 16
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 17
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 17
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Compare",
+              "left": {
+                "_type": "Constant",
+                "value": "dog",
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 6,
+                "end_col_offset": 11
+              },
+              "ops": [
+                {
+                  "_type": "In"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Name",
+                  "id": "s",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                }
+              ],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 16
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 17
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 17
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_in_operator.py.json
+++ b/tests/json-ast/x/py/string_in_operator.py.json
@@ -1,0 +1,203 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "catch",
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 11
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "cat",
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 17
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 31
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Constant",
+                  "value": "dog",
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 17
+                },
+                "ops": [
+                  {
+                    "_type": "In"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "s",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 21,
+                    "end_col_offset": 22
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 22
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 28,
+                "end_col_offset": 29
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 29
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 31
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 31
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_index.py.json
+++ b/tests/json-ast/x/py/string_index.py.json
@@ -1,0 +1,88 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "mochi",
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 11
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "s",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 8,
+                "end_col_offset": 9
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 11
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/string_prefix_slice.py.json
+++ b/tests/json-ast/x/py/string_prefix_slice.py.json
@@ -1,0 +1,373 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "prefix",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "fore",
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 9,
+          "end_col_offset": 15
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s1",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "forest",
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 5,
+          "end_col_offset": 13
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Subscript",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s1",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 12,
+                    "end_col_offset": 14
+                  },
+                  "slice": {
+                    "_type": "Slice",
+                    "lower": {
+                      "_type": "Constant",
+                      "value": 0,
+                      "kind": null,
+                      "lineno": 5,
+                      "end_lineno": 5,
+                      "col_offset": 15,
+                      "end_col_offset": 16
+                    },
+                    "upper": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "len",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 5,
+                        "end_lineno": 5,
+                        "col_offset": 17,
+                        "end_col_offset": 20
+                      },
+                      "args": [
+                        {
+                          "_type": "Name",
+                          "id": "prefix",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 5,
+                          "end_lineno": 5,
+                          "col_offset": 21,
+                          "end_col_offset": 27
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 5,
+                      "end_lineno": 5,
+                      "col_offset": 17,
+                      "end_col_offset": 28
+                    },
+                    "step": null,
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 15,
+                    "end_col_offset": 28
+                  },
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 12,
+                  "end_col_offset": 29
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "prefix",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 5,
+                    "end_lineno": 5,
+                    "col_offset": 33,
+                    "end_col_offset": 39
+                  }
+                ],
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 12,
+                "end_col_offset": 39
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 45,
+                "end_col_offset": 46
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 7,
+              "end_col_offset": 46
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 48
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 48
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "s2",
+            "lineno": 6,
+            "end_lineno": 6,
+            "end_col_offset": 2
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": "desert",
+          "kind": null,
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 5,
+          "end_col_offset": 13
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Subscript",
+                  "value": {
+                    "_type": "Name",
+                    "id": "s2",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 12,
+                    "end_col_offset": 14
+                  },
+                  "slice": {
+                    "_type": "Slice",
+                    "lower": {
+                      "_type": "Constant",
+                      "value": 0,
+                      "kind": null,
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 15,
+                      "end_col_offset": 16
+                    },
+                    "upper": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "len",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 17,
+                        "end_col_offset": 20
+                      },
+                      "args": [
+                        {
+                          "_type": "Name",
+                          "id": "prefix",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 7,
+                          "end_lineno": 7,
+                          "col_offset": 21,
+                          "end_col_offset": 27
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 17,
+                      "end_col_offset": 28
+                    },
+                    "step": null,
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 15,
+                    "end_col_offset": 28
+                  },
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 12,
+                  "end_col_offset": 29
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "prefix",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 7,
+                    "end_lineno": 7,
+                    "col_offset": 33,
+                    "end_col_offset": 39
+                  }
+                ],
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 12,
+                "end_col_offset": 39
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "orelse": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 45,
+                "end_col_offset": 46
+              },
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 7,
+              "end_col_offset": 46
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 48
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 48
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/substring_builtin.py.json
+++ b/tests/json-ast/x/py/substring_builtin.py.json
@@ -1,0 +1,79 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Constant",
+                "value": "mochi",
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 13
+              },
+              "slice": {
+                "_type": "Slice",
+                "lower": {
+                  "_type": "Constant",
+                  "value": 1,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 14,
+                  "end_col_offset": 15
+                },
+                "upper": {
+                  "_type": "Constant",
+                  "value": 4,
+                  "kind": null,
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 16,
+                  "end_col_offset": 17
+                },
+                "step": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 14,
+                "end_col_offset": 17
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 18
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 19
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 19
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/sum_builtin.py.json
+++ b/tests/json-ast/x/py/sum_builtin.py.json
@@ -1,0 +1,94 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "sum",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 6,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "List",
+                  "elts": [
+                    {
+                      "_type": "Constant",
+                      "value": 1,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 11,
+                      "end_col_offset": 12
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 14,
+                      "end_col_offset": 15
+                    },
+                    {
+                      "_type": "Constant",
+                      "value": 3,
+                      "kind": null,
+                      "lineno": 3,
+                      "end_lineno": 3,
+                      "col_offset": 17,
+                      "end_col_offset": 18
+                    }
+                  ],
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 3,
+                  "end_lineno": 3,
+                  "col_offset": 10,
+                  "end_col_offset": 19
+                }
+              ],
+              "keywords": [],
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 21
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/tail_recursion.py.json
+++ b/tests/json-ast/x/py/tail_recursion.py.json
@@ -1,0 +1,260 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "sum_rec",
+        "body": [
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Return",
+                "value": {
+                  "_type": "Name",
+                  "id": "acc",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 15,
+                  "end_col_offset": 18
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 8,
+                "end_col_offset": 18
+              }
+            ],
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Name",
+                "id": "n",
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "ops": [
+                {
+                  "_type": "Eq"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                }
+              ],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 7,
+              "end_col_offset": 13
+            },
+            "lineno": 4,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 18
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "sum_rec",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 11,
+                "end_col_offset": 18
+              },
+              "args": [
+                {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Name",
+                    "id": "n",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 19,
+                    "end_col_offset": 20
+                  },
+                  "op": {
+                    "_type": "Sub"
+                  },
+                  "right": {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 23,
+                    "end_col_offset": 24
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 19,
+                  "end_col_offset": 24
+                },
+                {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Name",
+                    "id": "acc",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 26,
+                    "end_col_offset": 29
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Name",
+                    "id": "n",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 32,
+                    "end_col_offset": 33
+                  },
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 26,
+                  "end_col_offset": 33
+                }
+              ],
+              "keywords": [],
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 11,
+              "end_col_offset": 34
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 4,
+            "end_col_offset": 34
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "n",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 12,
+              "end_col_offset": 13
+            },
+            {
+              "_type": "arg",
+              "arg": "acc",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 15,
+              "end_col_offset": 18
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 6,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "sum_rec",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 7,
+                "end_lineno": 7,
+                "col_offset": 6,
+                "end_col_offset": 13
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 10,
+                  "kind": null,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 14,
+                  "end_col_offset": 16
+                },
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "kind": null,
+                  "lineno": 7,
+                  "end_lineno": 7,
+                  "col_offset": 18,
+                  "end_col_offset": 19
+                }
+              ],
+              "keywords": [],
+              "lineno": 7,
+              "end_lineno": 7,
+              "col_offset": 6,
+              "end_col_offset": 20
+            }
+          ],
+          "keywords": [],
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 0,
+          "end_col_offset": 21
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 21
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/test_block.py.json
+++ b/tests/json-ast/x/py/test_block.py.json
@@ -1,0 +1,122 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "BinOp",
+          "left": {
+            "_type": "Constant",
+            "value": 1,
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 5
+          },
+          "op": {
+            "_type": "Add"
+          },
+          "right": {
+            "_type": "Constant",
+            "value": 2,
+            "kind": null,
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 8,
+            "end_col_offset": 9
+          },
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 9
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 9
+      },
+      {
+        "_type": "Assert",
+        "test": {
+          "_type": "Compare",
+          "left": {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 7,
+            "end_col_offset": 8
+          },
+          "ops": [
+            {
+              "_type": "Eq"
+            }
+          ],
+          "comparators": [
+            {
+              "_type": "Constant",
+              "value": 3,
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 12,
+              "end_col_offset": 13
+            }
+          ],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 7,
+          "end_col_offset": 13
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 13
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "ok",
+              "kind": null,
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 6,
+          "end_lineno": 6,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 6,
+        "end_lineno": 6,
+        "end_col_offset": 11
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/tree_sum.py.json
+++ b/tests/json-ast/x/py/tree_sum.py.json
@@ -1,0 +1,622 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "Leaf",
+            "lineno": 7,
+            "end_lineno": 7,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": null,
+          "kind": null,
+          "lineno": 7,
+          "end_lineno": 7,
+          "col_offset": 7,
+          "end_col_offset": 11
+        },
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 11
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Node",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "Tree",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 10,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "left",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "value",
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "Tree",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "right",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 9,
+        "end_lineno": 12,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "FunctionDef",
+        "name": "sum_tree",
+        "body": [
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "IfExp",
+              "test": {
+                "_type": "Compare",
+                "left": {
+                  "_type": "Name",
+                  "id": "t",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                "ops": [
+                  {
+                    "_type": "Eq"
+                  }
+                ],
+                "comparators": [
+                  {
+                    "_type": "Name",
+                    "id": "Leaf",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 22,
+                    "end_col_offset": 26
+                  }
+                ],
+                "lineno": 15,
+                "end_lineno": 15,
+                "col_offset": 17,
+                "end_col_offset": 26
+              },
+              "body": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 15,
+                "end_lineno": 15,
+                "col_offset": 12,
+                "end_col_offset": 13
+              },
+              "orelse": {
+                "_type": "IfExp",
+                "test": {
+                  "_type": "Compare",
+                  "left": {
+                    "_type": "Name",
+                    "id": "t",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 83,
+                    "end_col_offset": 84
+                  },
+                  "ops": [
+                    {
+                      "_type": "NotEq"
+                    }
+                  ],
+                  "comparators": [
+                    {
+                      "_type": "Constant",
+                      "value": null,
+                      "kind": null,
+                      "lineno": 15,
+                      "end_lineno": 15,
+                      "col_offset": 88,
+                      "end_col_offset": 92
+                    }
+                  ],
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 83,
+                  "end_col_offset": 92
+                },
+                "body": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "BinOp",
+                    "left": {
+                      "_type": "Call",
+                      "func": {
+                        "_type": "Name",
+                        "id": "sum_tree",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 15,
+                        "end_lineno": 15,
+                        "col_offset": 33,
+                        "end_col_offset": 41
+                      },
+                      "args": [
+                        {
+                          "_type": "Attribute",
+                          "value": {
+                            "_type": "Name",
+                            "id": "t",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 15,
+                            "end_lineno": 15,
+                            "col_offset": 42,
+                            "end_col_offset": 43
+                          },
+                          "attr": "left",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 15,
+                          "end_lineno": 15,
+                          "col_offset": 42,
+                          "end_col_offset": 48
+                        }
+                      ],
+                      "keywords": [],
+                      "lineno": 15,
+                      "end_lineno": 15,
+                      "col_offset": 33,
+                      "end_col_offset": 49
+                    },
+                    "op": {
+                      "_type": "Add"
+                    },
+                    "right": {
+                      "_type": "Attribute",
+                      "value": {
+                        "_type": "Name",
+                        "id": "t",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 15,
+                        "end_lineno": 15,
+                        "col_offset": 52,
+                        "end_col_offset": 53
+                      },
+                      "attr": "value",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 15,
+                      "end_lineno": 15,
+                      "col_offset": 52,
+                      "end_col_offset": 59
+                    },
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 33,
+                    "end_col_offset": 59
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Call",
+                    "func": {
+                      "_type": "Name",
+                      "id": "sum_tree",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 15,
+                      "end_lineno": 15,
+                      "col_offset": 62,
+                      "end_col_offset": 70
+                    },
+                    "args": [
+                      {
+                        "_type": "Attribute",
+                        "value": {
+                          "_type": "Name",
+                          "id": "t",
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 15,
+                          "end_lineno": 15,
+                          "col_offset": 71,
+                          "end_col_offset": 72
+                        },
+                        "attr": "right",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 15,
+                        "end_lineno": 15,
+                        "col_offset": 71,
+                        "end_col_offset": 78
+                      }
+                    ],
+                    "keywords": [],
+                    "lineno": 15,
+                    "end_lineno": 15,
+                    "col_offset": 62,
+                    "end_col_offset": 79
+                  },
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 33,
+                  "end_col_offset": 79
+                },
+                "orelse": {
+                  "_type": "Constant",
+                  "value": null,
+                  "kind": null,
+                  "lineno": 15,
+                  "end_lineno": 15,
+                  "col_offset": 98,
+                  "end_col_offset": 102
+                },
+                "lineno": 15,
+                "end_lineno": 15,
+                "col_offset": 33,
+                "end_col_offset": 102
+              },
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 12,
+              "end_col_offset": 103
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 104
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "t",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 13,
+              "end_col_offset": 14
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 14,
+        "end_lineno": 15,
+        "end_col_offset": 104
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "t",
+            "lineno": 16,
+            "end_lineno": 16,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "Node",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 16,
+            "end_lineno": 16,
+            "col_offset": 4,
+            "end_col_offset": 8
+          },
+          "args": [],
+          "keywords": [
+            {
+              "_type": "keyword",
+              "arg": "left",
+              "value": {
+                "_type": "Name",
+                "id": "Leaf",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 14,
+                "end_col_offset": 18
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 9,
+              "end_col_offset": 18
+            },
+            {
+              "_type": "keyword",
+              "arg": "value",
+              "value": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 26,
+                "end_col_offset": 27
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 20,
+              "end_col_offset": 27
+            },
+            {
+              "_type": "keyword",
+              "arg": "right",
+              "value": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "Node",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 35,
+                  "end_col_offset": 39
+                },
+                "args": [],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "left",
+                    "value": {
+                      "_type": "Name",
+                      "id": "Leaf",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 16,
+                      "end_lineno": 16,
+                      "col_offset": 45,
+                      "end_col_offset": 49
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 40,
+                    "end_col_offset": 49
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "value",
+                    "value": {
+                      "_type": "Constant",
+                      "value": 2,
+                      "kind": null,
+                      "lineno": 16,
+                      "end_lineno": 16,
+                      "col_offset": 57,
+                      "end_col_offset": 58
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 51,
+                    "end_col_offset": 58
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "right",
+                    "value": {
+                      "_type": "Name",
+                      "id": "Leaf",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 16,
+                      "end_lineno": 16,
+                      "col_offset": 66,
+                      "end_col_offset": 70
+                    },
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 60,
+                    "end_col_offset": 70
+                  }
+                ],
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 35,
+                "end_col_offset": 71
+              },
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 29,
+              "end_col_offset": 71
+            }
+          ],
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 4,
+          "end_col_offset": 72
+        },
+        "lineno": 16,
+        "end_lineno": 16,
+        "end_col_offset": 72
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "sum_tree",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 6,
+                "end_col_offset": 14
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "t",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 15,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 6,
+              "end_col_offset": 17
+            }
+          ],
+          "keywords": [],
+          "lineno": 17,
+          "end_lineno": 17,
+          "col_offset": 0,
+          "end_col_offset": 18
+        },
+        "lineno": 17,
+        "end_lineno": 17,
+        "end_col_offset": 18
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/two-sum.py.json
+++ b/tests/json-ast/x/py/two-sum.py.json
@@ -1,0 +1,623 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "FunctionDef",
+        "name": "twoSum",
+        "body": [
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "n",
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 4,
+                "end_col_offset": 5
+              }
+            ],
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "len",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 8,
+                "end_col_offset": 11
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "nums",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 12,
+                  "end_col_offset": 16
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 8,
+              "end_col_offset": 17
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 4,
+            "end_col_offset": 17
+          },
+          {
+            "_type": "For",
+            "body": [
+              {
+                "_type": "For",
+                "body": [
+                  {
+                    "_type": "If",
+                    "body": [
+                      {
+                        "_type": "Return",
+                        "value": {
+                          "_type": "List",
+                          "elts": [
+                            {
+                              "_type": "Name",
+                              "id": "i",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 8,
+                              "end_lineno": 8,
+                              "col_offset": 24,
+                              "end_col_offset": 25
+                            },
+                            {
+                              "_type": "Name",
+                              "id": "j",
+                              "ctx": {
+                                "_type": "Load"
+                              },
+                              "lineno": 8,
+                              "end_lineno": 8,
+                              "col_offset": 27,
+                              "end_col_offset": 28
+                            }
+                          ],
+                          "ctx": {
+                            "_type": "Load"
+                          },
+                          "lineno": 8,
+                          "end_lineno": 8,
+                          "col_offset": 23,
+                          "end_col_offset": 29
+                        },
+                        "lineno": 8,
+                        "end_lineno": 8,
+                        "col_offset": 16,
+                        "end_col_offset": 29
+                      }
+                    ],
+                    "test": {
+                      "_type": "Compare",
+                      "left": {
+                        "_type": "BinOp",
+                        "op": {
+                          "_type": "Add"
+                        },
+                        "left": {
+                          "_type": "Subscript",
+                          "value": {
+                            "_type": "Name",
+                            "id": "nums",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 7,
+                            "end_lineno": 7,
+                            "col_offset": 15,
+                            "end_col_offset": 19
+                          },
+                          "slice": {
+                            "_type": "Name",
+                            "id": "i",
+                            "lineno": 7,
+                            "end_lineno": 7,
+                            "col_offset": 20,
+                            "end_col_offset": 21
+                          },
+                          "lineno": 7,
+                          "end_lineno": 7,
+                          "col_offset": 15,
+                          "end_col_offset": 22
+                        },
+                        "right": {
+                          "_type": "Subscript",
+                          "value": {
+                            "_type": "Name",
+                            "id": "nums",
+                            "ctx": {
+                              "_type": "Load"
+                            },
+                            "lineno": 7,
+                            "end_lineno": 7,
+                            "col_offset": 25,
+                            "end_col_offset": 29
+                          },
+                          "slice": {
+                            "_type": "Name",
+                            "id": "j",
+                            "lineno": 7,
+                            "end_lineno": 7,
+                            "col_offset": 30,
+                            "end_col_offset": 31
+                          },
+                          "lineno": 7,
+                          "end_lineno": 7,
+                          "col_offset": 25,
+                          "end_col_offset": 32
+                        },
+                        "lineno": 7,
+                        "end_lineno": 7,
+                        "col_offset": 15,
+                        "end_col_offset": 32
+                      },
+                      "ops": [
+                        {
+                          "_type": "Eq"
+                        }
+                      ],
+                      "comparators": [
+                        {
+                          "_type": "Name",
+                          "id": "target",
+                          "lineno": 7,
+                          "end_lineno": 7,
+                          "col_offset": 36,
+                          "end_col_offset": 42
+                        }
+                      ],
+                      "lineno": 7,
+                      "end_lineno": 7,
+                      "col_offset": 15,
+                      "end_col_offset": 42
+                    },
+                    "lineno": 7,
+                    "end_lineno": 8,
+                    "col_offset": 12,
+                    "end_col_offset": 29
+                  }
+                ],
+                "target": {
+                  "_type": "Name",
+                  "id": "j",
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 12,
+                  "end_col_offset": 13
+                },
+                "iter": {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "range",
+                    "lineno": 6,
+                    "end_lineno": 6,
+                    "col_offset": 17,
+                    "end_col_offset": 22
+                  },
+                  "args": [
+                    {
+                      "_type": "BinOp",
+                      "left": {
+                        "_type": "Name",
+                        "id": "i",
+                        "ctx": {
+                          "_type": "Load"
+                        },
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 23,
+                        "end_col_offset": 24
+                      },
+                      "op": {
+                        "_type": "Add"
+                      },
+                      "right": {
+                        "_type": "Constant",
+                        "value": 1,
+                        "kind": null,
+                        "lineno": 6,
+                        "end_lineno": 6,
+                        "col_offset": 27,
+                        "end_col_offset": 28
+                      },
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 23,
+                      "end_col_offset": 28
+                    },
+                    {
+                      "_type": "Name",
+                      "id": "n",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 6,
+                      "end_lineno": 6,
+                      "col_offset": 30,
+                      "end_col_offset": 31
+                    }
+                  ],
+                  "lineno": 6,
+                  "end_lineno": 6,
+                  "col_offset": 17,
+                  "end_col_offset": 32
+                },
+                "lineno": 6,
+                "end_lineno": 8,
+                "col_offset": 8,
+                "end_col_offset": 29
+              }
+            ],
+            "target": {
+              "_type": "Name",
+              "id": "i",
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 8,
+              "end_col_offset": 9
+            },
+            "iter": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "range",
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 13,
+                "end_col_offset": 18
+              },
+              "args": [
+                {
+                  "_type": "Constant",
+                  "value": 0,
+                  "kind": null,
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 19,
+                  "end_col_offset": 20
+                },
+                {
+                  "_type": "Name",
+                  "id": "n",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 22,
+                  "end_col_offset": 23
+                }
+              ],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 13,
+              "end_col_offset": 24
+            },
+            "lineno": 5,
+            "end_lineno": 8,
+            "col_offset": 4,
+            "end_col_offset": 29
+          },
+          {
+            "_type": "Return",
+            "value": {
+              "_type": "List",
+              "elts": [
+                {
+                  "_type": "UnaryOp",
+                  "op": {
+                    "_type": "USub"
+                  },
+                  "operand": {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 9,
+                    "end_lineno": 9,
+                    "col_offset": 13,
+                    "end_col_offset": 14
+                  },
+                  "lineno": 9,
+                  "end_lineno": 9,
+                  "col_offset": 12,
+                  "end_col_offset": 14
+                },
+                {
+                  "_type": "UnaryOp",
+                  "op": {
+                    "_type": "USub"
+                  },
+                  "operand": {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 9,
+                    "end_lineno": 9,
+                    "col_offset": 17,
+                    "end_col_offset": 18
+                  },
+                  "lineno": 9,
+                  "end_lineno": 9,
+                  "col_offset": 16,
+                  "end_col_offset": 18
+                }
+              ],
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 11,
+              "end_col_offset": 19
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 19
+          }
+        ],
+        "args": {
+          "_type": "arguments",
+          "posonlyargs": [],
+          "args": [
+            {
+              "_type": "arg",
+              "arg": "nums",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 11,
+              "end_col_offset": 15
+            },
+            {
+              "_type": "arg",
+              "arg": "target",
+              "annotation": null,
+              "type_comment": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 17,
+              "end_col_offset": 23
+            }
+          ],
+          "vararg": null,
+          "kwonlyargs": [],
+          "kw_defaults": [],
+          "kwarg": null,
+          "defaults": []
+        },
+        "lineno": 3,
+        "end_lineno": 9,
+        "end_col_offset": 19
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "result",
+            "lineno": 10,
+            "end_lineno": 10,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "twoSum",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 9,
+            "end_col_offset": 15
+          },
+          "args": [
+            {
+              "_type": "List",
+              "elts": [
+                {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 10,
+                  "end_lineno": 10,
+                  "col_offset": 17,
+                  "end_col_offset": 18
+                },
+                {
+                  "_type": "Constant",
+                  "value": 7,
+                  "kind": null,
+                  "lineno": 10,
+                  "end_lineno": 10,
+                  "col_offset": 20,
+                  "end_col_offset": 21
+                },
+                {
+                  "_type": "Constant",
+                  "value": 11,
+                  "kind": null,
+                  "lineno": 10,
+                  "end_lineno": 10,
+                  "col_offset": 23,
+                  "end_col_offset": 25
+                },
+                {
+                  "_type": "Constant",
+                  "value": 15,
+                  "kind": null,
+                  "lineno": 10,
+                  "end_lineno": 10,
+                  "col_offset": 27,
+                  "end_col_offset": 29
+                }
+              ],
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 16,
+              "end_col_offset": 30
+            },
+            {
+              "_type": "Constant",
+              "value": 9,
+              "kind": null,
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 32,
+              "end_col_offset": 33
+            }
+          ],
+          "keywords": [],
+          "lineno": 10,
+          "end_lineno": 10,
+          "col_offset": 9,
+          "end_col_offset": 34
+        },
+        "lineno": 10,
+        "end_lineno": 10,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 11,
+            "end_lineno": 11,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "result",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 6,
+                "end_col_offset": 12
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 0,
+                "kind": null,
+                "lineno": 11,
+                "end_lineno": 11,
+                "col_offset": 13,
+                "end_col_offset": 14
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 11,
+              "end_lineno": 11,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 11,
+          "end_lineno": 11,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 11,
+        "end_lineno": 11,
+        "end_col_offset": 16
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Subscript",
+              "value": {
+                "_type": "Name",
+                "id": "result",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 6,
+                "end_col_offset": 12
+              },
+              "slice": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 12,
+                "end_lineno": 12,
+                "col_offset": 13,
+                "end_col_offset": 14
+              },
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 6,
+              "end_col_offset": 15
+            }
+          ],
+          "keywords": [],
+          "lineno": 12,
+          "end_lineno": 12,
+          "col_offset": 0,
+          "end_col_offset": 16
+        },
+        "lineno": 12,
+        "end_lineno": 12,
+        "end_col_offset": 16
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/typed_let.py.json
+++ b/tests/json-ast/x/py/typed_let.py.json
@@ -1,0 +1,69 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "y",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 0,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "y",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 7
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 8
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 8
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/typed_var.py.json
+++ b/tests/json-ast/x/py/typed_var.py.json
@@ -1,0 +1,69 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 0,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 7
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 8
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 8
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/unary_neg.py.json
+++ b/tests/json-ast/x/py/unary_neg.py.json
@@ -1,0 +1,118 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 3,
+            "end_lineno": 3,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "UnaryOp",
+              "op": {
+                "_type": "USub"
+              },
+              "operand": {
+                "_type": "Constant",
+                "value": 3,
+                "kind": null,
+                "lineno": 3,
+                "end_lineno": 3,
+                "col_offset": 7,
+                "end_col_offset": 8
+              },
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 6,
+              "end_col_offset": 8
+            }
+          ],
+          "keywords": [],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 0,
+          "end_col_offset": 9
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 9
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Constant",
+                "value": 5,
+                "kind": null,
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 7
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "UnaryOp",
+                "op": {
+                  "_type": "USub"
+                },
+                "operand": {
+                  "_type": "Constant",
+                  "value": 2,
+                  "kind": null,
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 11,
+                  "end_col_offset": 12
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 10,
+                "end_col_offset": 12
+              },
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 12
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 13
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/update_stmt.py.json
+++ b/tests/json-ast/x/py/update_stmt.py.json
@@ -1,0 +1,1096 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "Import",
+        "lineno": 7,
+        "end_lineno": 7,
+        "end_col_offset": 10
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Attribute",
+            "value": {
+              "_type": "Name",
+              "id": "sys",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 0,
+              "end_col_offset": 3
+            },
+            "attr": "set_int_max_str_digits",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 8,
+            "end_lineno": 8,
+            "col_offset": 0,
+            "end_col_offset": 26
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": 0,
+              "kind": null,
+              "lineno": 8,
+              "end_lineno": 8,
+              "col_offset": 27,
+              "end_col_offset": 28
+            }
+          ],
+          "keywords": [],
+          "lineno": 8,
+          "end_lineno": 8,
+          "col_offset": 0,
+          "end_col_offset": 29
+        },
+        "lineno": 8,
+        "end_lineno": 8,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Person",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 12,
+              "end_lineno": 12,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 13,
+              "end_lineno": 13,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 13,
+            "end_lineno": 13,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 12,
+              "end_col_offset": 15
+            },
+            "target": {
+              "_type": "Name",
+              "id": "status",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 4,
+            "end_col_offset": 15
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 11,
+        "end_lineno": 14,
+        "end_col_offset": 15
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 16,
+            "end_lineno": 16,
+            "end_col_offset": 6
+          }
+        ],
+        "value": {
+          "_type": "List",
+          "elts": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Person",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 10,
+                "end_col_offset": 16
+              },
+              "args": [],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "name",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "Alice",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 22,
+                    "end_col_offset": 29
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 17,
+                  "end_col_offset": 29
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "age",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 17,
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 35,
+                    "end_col_offset": 37
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 31,
+                  "end_col_offset": 37
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "status",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "minor",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 46,
+                    "end_col_offset": 53
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 39,
+                  "end_col_offset": 53
+                }
+              ],
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 10,
+              "end_col_offset": 54
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Person",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 56,
+                "end_col_offset": 62
+              },
+              "args": [],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "name",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "Bob",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 68,
+                    "end_col_offset": 73
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 63,
+                  "end_col_offset": 73
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "age",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 25,
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 79,
+                    "end_col_offset": 81
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 75,
+                  "end_col_offset": 81
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "status",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "unknown",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 90,
+                    "end_col_offset": 99
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 83,
+                  "end_col_offset": 99
+                }
+              ],
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 56,
+              "end_col_offset": 100
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Person",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 102,
+                "end_col_offset": 108
+              },
+              "args": [],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "name",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "Charlie",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 114,
+                    "end_col_offset": 123
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 109,
+                  "end_col_offset": 123
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "age",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 18,
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 129,
+                    "end_col_offset": 131
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 125,
+                  "end_col_offset": 131
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "status",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "unknown",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 140,
+                    "end_col_offset": 149
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 133,
+                  "end_col_offset": 149
+                }
+              ],
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 102,
+              "end_col_offset": 150
+            },
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "Person",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 16,
+                "end_lineno": 16,
+                "col_offset": 152,
+                "end_col_offset": 158
+              },
+              "args": [],
+              "keywords": [
+                {
+                  "_type": "keyword",
+                  "arg": "name",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "Diana",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 164,
+                    "end_col_offset": 171
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 159,
+                  "end_col_offset": 171
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "age",
+                  "value": {
+                    "_type": "Constant",
+                    "value": 16,
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 177,
+                    "end_col_offset": 179
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 173,
+                  "end_col_offset": 179
+                },
+                {
+                  "_type": "keyword",
+                  "arg": "status",
+                  "value": {
+                    "_type": "Constant",
+                    "value": "minor",
+                    "kind": null,
+                    "lineno": 16,
+                    "end_lineno": 16,
+                    "col_offset": 188,
+                    "end_col_offset": 195
+                  },
+                  "lineno": 16,
+                  "end_lineno": 16,
+                  "col_offset": 181,
+                  "end_col_offset": 195
+                }
+              ],
+              "lineno": 16,
+              "end_lineno": 16,
+              "col_offset": 152,
+              "end_col_offset": 196
+            }
+          ],
+          "ctx": {
+            "_type": "Load"
+          },
+          "lineno": 16,
+          "end_lineno": 16,
+          "col_offset": 9,
+          "end_col_offset": 197
+        },
+        "lineno": 16,
+        "end_lineno": 16,
+        "end_col_offset": 197
+      },
+      {
+        "_type": "For",
+        "body": [
+          {
+            "_type": "If",
+            "body": [
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "item",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 19,
+                      "end_lineno": 19,
+                      "col_offset": 8,
+                      "end_col_offset": 12
+                    },
+                    "attr": "status",
+                    "lineno": 19,
+                    "end_lineno": 19,
+                    "col_offset": 8,
+                    "end_col_offset": 19
+                  }
+                ],
+                "value": {
+                  "_type": "Constant",
+                  "value": "adult",
+                  "kind": null,
+                  "lineno": 19,
+                  "end_lineno": 19,
+                  "col_offset": 22,
+                  "end_col_offset": 29
+                },
+                "lineno": 19,
+                "end_lineno": 19,
+                "col_offset": 8,
+                "end_col_offset": 29
+              },
+              {
+                "_type": "Assign",
+                "targets": [
+                  {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "item",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 20,
+                      "end_lineno": 20,
+                      "col_offset": 8,
+                      "end_col_offset": 12
+                    },
+                    "attr": "age",
+                    "lineno": 20,
+                    "end_lineno": 20,
+                    "col_offset": 8,
+                    "end_col_offset": 16
+                  }
+                ],
+                "value": {
+                  "_type": "BinOp",
+                  "left": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "item",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 20,
+                      "end_lineno": 20,
+                      "col_offset": 19,
+                      "end_col_offset": 23
+                    },
+                    "attr": "age",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 20,
+                    "end_lineno": 20,
+                    "col_offset": 19,
+                    "end_col_offset": 27
+                  },
+                  "op": {
+                    "_type": "Add"
+                  },
+                  "right": {
+                    "_type": "Constant",
+                    "value": 1,
+                    "kind": null,
+                    "lineno": 20,
+                    "end_lineno": 20,
+                    "col_offset": 30,
+                    "end_col_offset": 31
+                  },
+                  "lineno": 20,
+                  "end_lineno": 20,
+                  "col_offset": 19,
+                  "end_col_offset": 31
+                },
+                "lineno": 20,
+                "end_lineno": 20,
+                "col_offset": 8,
+                "end_col_offset": 31
+              }
+            ],
+            "test": {
+              "_type": "Compare",
+              "left": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "item",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 7,
+                  "end_col_offset": 11
+                },
+                "attr": "age",
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 7,
+                "end_col_offset": 15
+              },
+              "ops": [
+                {
+                  "_type": "GtE"
+                }
+              ],
+              "comparators": [
+                {
+                  "_type": "Constant",
+                  "value": 18,
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 19,
+                  "end_col_offset": 21
+                }
+              ],
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 7,
+              "end_col_offset": 21
+            },
+            "lineno": 18,
+            "end_lineno": 20,
+            "col_offset": 4,
+            "end_col_offset": 31
+          },
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Subscript",
+                "value": {
+                  "_type": "Name",
+                  "id": "people",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 4,
+                  "end_col_offset": 10
+                },
+                "slice": {
+                  "_type": "Name",
+                  "id": "idx",
+                  "lineno": 21,
+                  "end_lineno": 21,
+                  "col_offset": 11,
+                  "end_col_offset": 14
+                },
+                "lineno": 21,
+                "end_lineno": 21,
+                "col_offset": 4,
+                "end_col_offset": 15
+              }
+            ],
+            "value": {
+              "_type": "Name",
+              "id": "item",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 21,
+              "end_lineno": 21,
+              "col_offset": 18,
+              "end_col_offset": 22
+            },
+            "lineno": 21,
+            "end_lineno": 21,
+            "col_offset": 4,
+            "end_col_offset": 22
+          }
+        ],
+        "target": {
+          "_type": "Tuple",
+          "elts": [
+            {
+              "_type": "Name",
+              "id": "idx",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            {
+              "_type": "Name",
+              "id": "item",
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 9,
+              "end_col_offset": 13
+            }
+          ],
+          "lineno": 17,
+          "end_lineno": 17,
+          "col_offset": 4,
+          "end_col_offset": 13
+        },
+        "iter": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "enumerate",
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 17,
+            "end_col_offset": 26
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "people",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 27,
+              "end_col_offset": 33
+            }
+          ],
+          "lineno": 17,
+          "end_lineno": 17,
+          "col_offset": 17,
+          "end_col_offset": 34
+        },
+        "lineno": 17,
+        "end_lineno": 21,
+        "end_col_offset": 22
+      },
+      {
+        "_type": "Assert",
+        "test": {
+          "_type": "Compare",
+          "left": {
+            "_type": "Name",
+            "id": "people",
+            "lineno": 23,
+            "end_lineno": 23,
+            "col_offset": 7,
+            "end_col_offset": 13
+          },
+          "ops": [
+            {
+              "_type": "Eq"
+            }
+          ],
+          "comparators": [
+            {
+              "_type": "List",
+              "elts": [
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Person",
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 18,
+                    "end_col_offset": 24
+                  },
+                  "args": [],
+                  "keywords": [
+                    {
+                      "_type": "keyword",
+                      "arg": "name",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "Alice",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 30,
+                        "end_col_offset": 37
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 25,
+                      "end_col_offset": 37
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "age",
+                      "value": {
+                        "_type": "Constant",
+                        "value": 17,
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 43,
+                        "end_col_offset": 45
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 39,
+                      "end_col_offset": 45
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "status",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "minor",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 54,
+                        "end_col_offset": 61
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 47,
+                      "end_col_offset": 61
+                    }
+                  ],
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 18,
+                  "end_col_offset": 62
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Person",
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 64,
+                    "end_col_offset": 70
+                  },
+                  "args": [],
+                  "keywords": [
+                    {
+                      "_type": "keyword",
+                      "arg": "name",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "Bob",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 76,
+                        "end_col_offset": 81
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 71,
+                      "end_col_offset": 81
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "age",
+                      "value": {
+                        "_type": "Constant",
+                        "value": 26,
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 87,
+                        "end_col_offset": 89
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 83,
+                      "end_col_offset": 89
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "status",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "adult",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 98,
+                        "end_col_offset": 105
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 91,
+                      "end_col_offset": 105
+                    }
+                  ],
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 64,
+                  "end_col_offset": 106
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Person",
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 108,
+                    "end_col_offset": 114
+                  },
+                  "args": [],
+                  "keywords": [
+                    {
+                      "_type": "keyword",
+                      "arg": "name",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "Charlie",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 120,
+                        "end_col_offset": 129
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 115,
+                      "end_col_offset": 129
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "age",
+                      "value": {
+                        "_type": "Constant",
+                        "value": 19,
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 135,
+                        "end_col_offset": 137
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 131,
+                      "end_col_offset": 137
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "status",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "adult",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 146,
+                        "end_col_offset": 153
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 139,
+                      "end_col_offset": 153
+                    }
+                  ],
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 108,
+                  "end_col_offset": 154
+                },
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Name",
+                    "id": "Person",
+                    "lineno": 23,
+                    "end_lineno": 23,
+                    "col_offset": 156,
+                    "end_col_offset": 162
+                  },
+                  "args": [],
+                  "keywords": [
+                    {
+                      "_type": "keyword",
+                      "arg": "name",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "Diana",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 168,
+                        "end_col_offset": 175
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 163,
+                      "end_col_offset": 175
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "age",
+                      "value": {
+                        "_type": "Constant",
+                        "value": 16,
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 181,
+                        "end_col_offset": 183
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 177,
+                      "end_col_offset": 183
+                    },
+                    {
+                      "_type": "keyword",
+                      "arg": "status",
+                      "value": {
+                        "_type": "Constant",
+                        "value": "minor",
+                        "kind": null,
+                        "lineno": 23,
+                        "end_lineno": 23,
+                        "col_offset": 192,
+                        "end_col_offset": 199
+                      },
+                      "lineno": 23,
+                      "end_lineno": 23,
+                      "col_offset": 185,
+                      "end_col_offset": 199
+                    }
+                  ],
+                  "lineno": 23,
+                  "end_lineno": 23,
+                  "col_offset": 156,
+                  "end_col_offset": 200
+                }
+              ],
+              "lineno": 23,
+              "end_lineno": 23,
+              "col_offset": 17,
+              "end_col_offset": 201
+            }
+          ],
+          "lineno": 23,
+          "end_lineno": 23,
+          "col_offset": 7,
+          "end_col_offset": 201
+        },
+        "lineno": 23,
+        "end_lineno": 23,
+        "end_col_offset": 201
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 24,
+            "end_lineno": 24,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Constant",
+              "value": "ok",
+              "kind": null,
+              "lineno": 24,
+              "end_lineno": 24,
+              "col_offset": 6,
+              "end_col_offset": 10
+            }
+          ],
+          "keywords": [],
+          "lineno": 24,
+          "end_lineno": 24,
+          "col_offset": 0,
+          "end_col_offset": 11
+        },
+        "lineno": 24,
+        "end_lineno": 24,
+        "end_col_offset": 11
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/user_type_literal.py.json
+++ b/tests/json-ast/x/py/user_type_literal.py.json
@@ -1,0 +1,335 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "ImportFrom",
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 34
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 33
+      },
+      {
+        "_type": "ImportFrom",
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 29
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Person",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 10,
+              "end_col_offset": 13
+            },
+            "target": {
+              "_type": "Name",
+              "id": "name",
+              "lineno": 9,
+              "end_lineno": 9,
+              "col_offset": 4,
+              "end_col_offset": 8
+            },
+            "lineno": 9,
+            "end_lineno": 9,
+            "col_offset": 4,
+            "end_col_offset": 13
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "int",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 9,
+              "end_col_offset": 12
+            },
+            "target": {
+              "_type": "Name",
+              "id": "age",
+              "lineno": 10,
+              "end_lineno": 10,
+              "col_offset": 4,
+              "end_col_offset": 7
+            },
+            "lineno": 10,
+            "end_lineno": 10,
+            "col_offset": 4,
+            "end_col_offset": 12
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 7,
+            "end_lineno": 7,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 8,
+        "end_lineno": 10,
+        "end_col_offset": 12
+      },
+      {
+        "_type": "ClassDef",
+        "name": "Book",
+        "body": [
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "str",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 11,
+              "end_col_offset": 14
+            },
+            "target": {
+              "_type": "Name",
+              "id": "title",
+              "lineno": 14,
+              "end_lineno": 14,
+              "col_offset": 4,
+              "end_col_offset": 9
+            },
+            "lineno": 14,
+            "end_lineno": 14,
+            "col_offset": 4,
+            "end_col_offset": 14
+          },
+          {
+            "_type": "AnnAssign",
+            "value": null,
+            "annotation": {
+              "_type": "Name",
+              "id": "Person",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 12,
+              "end_col_offset": 18
+            },
+            "target": {
+              "_type": "Name",
+              "id": "author",
+              "lineno": 15,
+              "end_lineno": 15,
+              "col_offset": 4,
+              "end_col_offset": 10
+            },
+            "lineno": 15,
+            "end_lineno": 15,
+            "col_offset": 4,
+            "end_col_offset": 18
+          }
+        ],
+        "decorator_list": [
+          {
+            "_type": "Name",
+            "id": "dataclass",
+            "lineno": 12,
+            "end_lineno": 12,
+            "col_offset": 1,
+            "end_col_offset": 10
+          }
+        ],
+        "lineno": 13,
+        "end_lineno": 15,
+        "end_col_offset": 18
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "book",
+            "lineno": 17,
+            "end_lineno": 17,
+            "end_col_offset": 4
+          }
+        ],
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "Book",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 17,
+            "end_lineno": 17,
+            "col_offset": 7,
+            "end_col_offset": 11
+          },
+          "args": [],
+          "keywords": [
+            {
+              "_type": "keyword",
+              "arg": "title",
+              "value": {
+                "_type": "Constant",
+                "value": "Go",
+                "kind": null,
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 18,
+                "end_col_offset": 22
+              },
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 12,
+              "end_col_offset": 22
+            },
+            {
+              "_type": "keyword",
+              "arg": "author",
+              "value": {
+                "_type": "Call",
+                "func": {
+                  "_type": "Name",
+                  "id": "Person",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 17,
+                  "end_lineno": 17,
+                  "col_offset": 31,
+                  "end_col_offset": 37
+                },
+                "args": [],
+                "keywords": [
+                  {
+                    "_type": "keyword",
+                    "arg": "name",
+                    "value": {
+                      "_type": "Constant",
+                      "value": "Bob",
+                      "kind": null,
+                      "lineno": 17,
+                      "end_lineno": 17,
+                      "col_offset": 43,
+                      "end_col_offset": 48
+                    },
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 38,
+                    "end_col_offset": 48
+                  },
+                  {
+                    "_type": "keyword",
+                    "arg": "age",
+                    "value": {
+                      "_type": "Constant",
+                      "value": 42,
+                      "kind": null,
+                      "lineno": 17,
+                      "end_lineno": 17,
+                      "col_offset": 54,
+                      "end_col_offset": 56
+                    },
+                    "lineno": 17,
+                    "end_lineno": 17,
+                    "col_offset": 50,
+                    "end_col_offset": 56
+                  }
+                ],
+                "lineno": 17,
+                "end_lineno": 17,
+                "col_offset": 31,
+                "end_col_offset": 57
+              },
+              "lineno": 17,
+              "end_lineno": 17,
+              "col_offset": 24,
+              "end_col_offset": 57
+            }
+          ],
+          "lineno": 17,
+          "end_lineno": 17,
+          "col_offset": 7,
+          "end_col_offset": 58
+        },
+        "lineno": 17,
+        "end_lineno": 17,
+        "end_col_offset": 58
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 18,
+            "end_lineno": 18,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Attribute",
+              "value": {
+                "_type": "Attribute",
+                "value": {
+                  "_type": "Name",
+                  "id": "book",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 18,
+                  "end_lineno": 18,
+                  "col_offset": 6,
+                  "end_col_offset": 10
+                },
+                "attr": "author",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 18,
+                "end_lineno": 18,
+                "col_offset": 6,
+                "end_col_offset": 17
+              },
+              "attr": "name",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 18,
+              "end_lineno": 18,
+              "col_offset": 6,
+              "end_col_offset": 22
+            }
+          ],
+          "keywords": [],
+          "lineno": 18,
+          "end_lineno": 18,
+          "col_offset": 0,
+          "end_col_offset": 23
+        },
+        "lineno": 18,
+        "end_lineno": 18,
+        "end_col_offset": 23
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/values_builtin.py.json
+++ b/tests/json-ast/x/py/values_builtin.py.json
@@ -1,0 +1,166 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "m",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Dict",
+          "keys": [
+            {
+              "_type": "Constant",
+              "value": "a",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 5,
+              "end_col_offset": 8
+            },
+            {
+              "_type": "Constant",
+              "value": "b",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 13,
+              "end_col_offset": 16
+            },
+            {
+              "_type": "Constant",
+              "value": "c",
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 21,
+              "end_col_offset": 24
+            }
+          ],
+          "values": [
+            {
+              "_type": "Constant",
+              "value": 1,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 10,
+              "end_col_offset": 11
+            },
+            {
+              "_type": "Constant",
+              "value": 2,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 18,
+              "end_col_offset": 19
+            },
+            {
+              "_type": "Constant",
+              "value": 3,
+              "kind": null,
+              "lineno": 3,
+              "end_lineno": 3,
+              "col_offset": 26,
+              "end_col_offset": 27
+            }
+          ],
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 28
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 28
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "list",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 4,
+                "end_lineno": 4,
+                "col_offset": 6,
+                "end_col_offset": 10
+              },
+              "args": [
+                {
+                  "_type": "Call",
+                  "func": {
+                    "_type": "Attribute",
+                    "value": {
+                      "_type": "Name",
+                      "id": "m",
+                      "ctx": {
+                        "_type": "Load"
+                      },
+                      "lineno": 4,
+                      "end_lineno": 4,
+                      "col_offset": 11,
+                      "end_col_offset": 12
+                    },
+                    "attr": "values",
+                    "ctx": {
+                      "_type": "Load"
+                    },
+                    "lineno": 4,
+                    "end_lineno": 4,
+                    "col_offset": 11,
+                    "end_col_offset": 19
+                  },
+                  "args": [],
+                  "keywords": [],
+                  "lineno": 4,
+                  "end_lineno": 4,
+                  "col_offset": 11,
+                  "end_col_offset": 21
+                }
+              ],
+              "keywords": [],
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 6,
+              "end_col_offset": 22
+            }
+          ],
+          "keywords": [],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 0,
+          "end_col_offset": 23
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 23
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/var_assignment.py.json
+++ b/tests/json-ast/x/py/var_assignment.py.json
@@ -1,0 +1,93 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 1,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "x",
+            "lineno": 4,
+            "end_lineno": 4,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 2,
+          "kind": null,
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 4,
+        "end_lineno": 4,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "Expr",
+        "value": {
+          "_type": "Call",
+          "func": {
+            "_type": "Name",
+            "id": "print",
+            "ctx": {
+              "_type": "Load"
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 0,
+            "end_col_offset": 5
+          },
+          "args": [
+            {
+              "_type": "Name",
+              "id": "x",
+              "ctx": {
+                "_type": "Load"
+              },
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 6,
+              "end_col_offset": 7
+            }
+          ],
+          "keywords": [],
+          "lineno": 5,
+          "end_lineno": 5,
+          "col_offset": 0,
+          "end_col_offset": 8
+        },
+        "lineno": 5,
+        "end_lineno": 5,
+        "end_col_offset": 8
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/py/while_loop.py.json
+++ b/tests/json-ast/x/py/while_loop.py.json
@@ -1,0 +1,155 @@
+{
+  "module": {
+    "_type": "Module",
+    "body": [
+      {
+        "_type": "Assign",
+        "targets": [
+          {
+            "_type": "Name",
+            "id": "i",
+            "lineno": 3,
+            "end_lineno": 3,
+            "end_col_offset": 1
+          }
+        ],
+        "value": {
+          "_type": "Constant",
+          "value": 0,
+          "kind": null,
+          "lineno": 3,
+          "end_lineno": 3,
+          "col_offset": 4,
+          "end_col_offset": 5
+        },
+        "lineno": 3,
+        "end_lineno": 3,
+        "end_col_offset": 5
+      },
+      {
+        "_type": "While",
+        "body": [
+          {
+            "_type": "Expr",
+            "value": {
+              "_type": "Call",
+              "func": {
+                "_type": "Name",
+                "id": "print",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 5,
+                "end_lineno": 5,
+                "col_offset": 4,
+                "end_col_offset": 9
+              },
+              "args": [
+                {
+                  "_type": "Name",
+                  "id": "i",
+                  "ctx": {
+                    "_type": "Load"
+                  },
+                  "lineno": 5,
+                  "end_lineno": 5,
+                  "col_offset": 10,
+                  "end_col_offset": 11
+                }
+              ],
+              "keywords": [],
+              "lineno": 5,
+              "end_lineno": 5,
+              "col_offset": 4,
+              "end_col_offset": 12
+            },
+            "lineno": 5,
+            "end_lineno": 5,
+            "col_offset": 4,
+            "end_col_offset": 12
+          },
+          {
+            "_type": "Assign",
+            "targets": [
+              {
+                "_type": "Name",
+                "id": "i",
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 4,
+                "end_col_offset": 5
+              }
+            ],
+            "value": {
+              "_type": "BinOp",
+              "left": {
+                "_type": "Name",
+                "id": "i",
+                "ctx": {
+                  "_type": "Load"
+                },
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 8,
+                "end_col_offset": 9
+              },
+              "op": {
+                "_type": "Add"
+              },
+              "right": {
+                "_type": "Constant",
+                "value": 1,
+                "kind": null,
+                "lineno": 6,
+                "end_lineno": 6,
+                "col_offset": 12,
+                "end_col_offset": 13
+              },
+              "lineno": 6,
+              "end_lineno": 6,
+              "col_offset": 8,
+              "end_col_offset": 13
+            },
+            "lineno": 6,
+            "end_lineno": 6,
+            "col_offset": 4,
+            "end_col_offset": 13
+          }
+        ],
+        "test": {
+          "_type": "Compare",
+          "left": {
+            "_type": "Name",
+            "id": "i",
+            "lineno": 4,
+            "end_lineno": 4,
+            "col_offset": 6,
+            "end_col_offset": 7
+          },
+          "ops": [
+            {
+              "_type": "Lt"
+            }
+          ],
+          "comparators": [
+            {
+              "_type": "Constant",
+              "value": 3,
+              "lineno": 4,
+              "end_lineno": 4,
+              "col_offset": 10,
+              "end_col_offset": 11
+            }
+          ],
+          "lineno": 4,
+          "end_lineno": 4,
+          "col_offset": 6,
+          "end_col_offset": 11
+        },
+        "lineno": 4,
+        "end_lineno": 6,
+        "end_col_offset": 13
+      }
+    ]
+  }
+}

--- a/tools/json-ast/x/py/inspect.go
+++ b/tools/json-ast/x/py/inspect.go
@@ -1,0 +1,105 @@
+package py
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// ASTNode mirrors Python's ast.AST structure as produced by the helper script.
+type ASTNode struct {
+	Type          string          `json:"_type"`
+	Name          string          `json:"name,omitempty"`
+	ID            string          `json:"id,omitempty"`
+	Arg           string          `json:"arg,omitempty"`
+	Body          []*ASTNode      `json:"body,omitempty"`
+	Targets       []*ASTNode      `json:"targets,omitempty"`
+	Value         json.RawMessage `json:"value,omitempty"`
+	Func          *ASTNode        `json:"func,omitempty"`
+	Args          json.RawMessage `json:"args,omitempty"`
+	Keywords      []*ASTNode      `json:"keywords,omitempty"`
+	Annotation    *ASTNode        `json:"annotation,omitempty"`
+	Returns       *ASTNode        `json:"returns,omitempty"`
+	Test          *ASTNode        `json:"test,omitempty"`
+	Target        *ASTNode        `json:"target,omitempty"`
+	Iter          *ASTNode        `json:"iter,omitempty"`
+	Operand       *ASTNode        `json:"operand,omitempty"`
+	Orelse        []*ASTNode      `json:"orelse,omitempty"`
+	Op            *ASTNode        `json:"op,omitempty"`
+	Left          *ASTNode        `json:"left,omitempty"`
+	Right         *ASTNode        `json:"right,omitempty"`
+	Attr          string          `json:"attr,omitempty"`
+	Elts          []*ASTNode      `json:"elts,omitempty"`
+	Keys          []*ASTNode      `json:"keys,omitempty"`
+	Values        []*ASTNode      `json:"values,omitempty"`
+	Slice         *ASTNode        `json:"slice,omitempty"`
+	Lower         *ASTNode        `json:"lower,omitempty"`
+	Upper         *ASTNode        `json:"upper,omitempty"`
+	Step          *ASTNode        `json:"step,omitempty"`
+	Ops           []*ASTNode      `json:"ops,omitempty"`
+	Comparators   []*ASTNode      `json:"comparators,omitempty"`
+	DecoratorList []*ASTNode      `json:"decorator_list,omitempty"`
+	Bases         []*ASTNode      `json:"bases,omitempty"`
+	Generators    []*ASTNode      `json:"generators,omitempty"`
+	Ifs           []*ASTNode      `json:"ifs,omitempty"`
+	Elt           *ASTNode        `json:"elt,omitempty"`
+	Line          int             `json:"lineno,omitempty"`
+	EndLine       int             `json:"end_lineno,omitempty"`
+	Col           int             `json:"col_offset,omitempty"`
+	EndCol        int             `json:"end_col_offset,omitempty"`
+}
+
+// Program represents a parsed Python source file.
+type Program struct {
+	Module *ASTNode `json:"module"`
+}
+
+const astScript = `import ast, json, sys
+
+def node_to_dict(node):
+    if isinstance(node, ast.AST):
+        fields = {}
+        for k, v in ast.iter_fields(node):
+            fields[k] = node_to_dict(v)
+        for attr in ("lineno", "end_lineno", "col_offset", "end_col_offset"):
+            if hasattr(node, attr):
+                fields[attr] = getattr(node, attr)
+        return {'_type': node.__class__.__name__, **fields}
+    elif isinstance(node, list):
+        return [node_to_dict(x) for x in node]
+    else:
+        return node
+
+tree = ast.parse(sys.stdin.read())
+json.dump(node_to_dict(tree), sys.stdout)
+`
+
+var pythonCmd = "python3"
+
+// Inspect parses the given Python source code and returns a Program describing
+// its AST.
+func Inspect(src string) (*Program, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, pythonCmd, "-c", astScript)
+	cmd.Stdin = strings.NewReader(src)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errBuf.String())
+		if msg != "" {
+			return nil, fmt.Errorf("%v: %s", err, msg)
+		}
+		return nil, err
+	}
+	var root ASTNode
+	if err := json.Unmarshal(out.Bytes(), &root); err != nil {
+		return nil, err
+	}
+	return &Program{Module: &root}, nil
+}

--- a/tools/json-ast/x/py/inspect_test.go
+++ b/tools/json-ast/x/py/inspect_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+package py_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	py "mochi/tools/json-ast/x/py"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensurePython(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensurePython(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "py")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "py")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".py")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := py.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".py.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement `Inspect` for Python to parse code via Python's `ast` module
- add golden test for generating JSON ASTs of example Python sources
- store JSON outputs under `tests/json-ast/x/py`

## Testing
- `go test ./tools/json-ast/x/py -tags slow -run TestInspect_Golden -update`


------
https://chatgpt.com/codex/tasks/task_e_68891351873883208e7108985f0d1fbe