### PR TITLE
Add Racket AST inspector

### DIFF
--- a/tests/json-ast/x/rkt/append_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/append_builtin.rkt.json
@@ -1,0 +1,61 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "a"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "append"
+          },
+          {
+            "sym": "a"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/avg_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/avg_builtin.rkt.json
@@ -1,0 +1,86 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "null?"
+            },
+            [
+              {
+                "sym": "list"
+              },
+              1,
+              2,
+              3
+            ]
+          ],
+          0,
+          [
+            {
+              "sym": "exact-\u003einexact"
+            },
+            [
+              {
+                "sym": "/"
+              },
+              [
+                {
+                  "sym": "apply"
+                },
+                {
+                  "sym": "+"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2,
+                  3
+                ]
+              ],
+              [
+                {
+                  "sym": "length"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2,
+                  3
+                ]
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/basic_compare.rkt.json
+++ b/tests/json-ast/x/rkt/basic_compare.rkt.json
@@ -1,0 +1,105 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "a"
+        },
+        [
+          {
+            "sym": "-"
+          },
+          10,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "b"
+        },
+        [
+          {
+            "sym": "+"
+          },
+          2,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "a"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "="
+          },
+          {
+            "sym": "a"
+          },
+          7
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "\u003c"
+          },
+          {
+            "sym": "b"
+          },
+          5
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/binary_precedence.rkt.json
+++ b/tests/json-ast/x/rkt/binary_precedence.rkt.json
@@ -1,0 +1,107 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "+"
+          },
+          1,
+          [
+            {
+              "sym": "*"
+            },
+            2,
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "*"
+          },
+          [
+            {
+              "sym": "+"
+            },
+            1,
+            2
+          ],
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "+"
+          },
+          [
+            {
+              "sym": "*"
+            },
+            2,
+            3
+          ],
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "*"
+          },
+          2,
+          [
+            {
+              "sym": "+"
+            },
+            3,
+            1
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/bool_chain.rkt.json
+++ b/tests/json-ast/x/rkt/bool_chain.rkt.json
@@ -1,0 +1,168 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "boom"
+          }
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          "boom"
+        ],
+        true
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "and"
+          },
+          [
+            {
+              "sym": "and"
+            },
+            [
+              {
+                "sym": "\u003c"
+              },
+              1,
+              2
+            ],
+            [
+              {
+                "sym": "\u003c"
+              },
+              2,
+              3
+            ]
+          ],
+          [
+            {
+              "sym": "\u003c"
+            },
+            3,
+            4
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "and"
+          },
+          [
+            {
+              "sym": "and"
+            },
+            [
+              {
+                "sym": "\u003c"
+              },
+              1,
+              2
+            ],
+            [
+              {
+                "sym": "\u003e"
+              },
+              2,
+              3
+            ]
+          ],
+          [
+            {
+              "sym": "boom"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "and"
+          },
+          [
+            {
+              "sym": "and"
+            },
+            [
+              {
+                "sym": "and"
+              },
+              [
+                {
+                  "sym": "\u003c"
+                },
+                1,
+                2
+              ],
+              [
+                {
+                  "sym": "\u003c"
+                },
+                2,
+                3
+              ]
+            ],
+            [
+              {
+                "sym": "\u003e"
+              },
+              3,
+              4
+            ]
+          ],
+          [
+            {
+              "sym": "boom"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/break_continue.rkt.json
+++ b/tests/json-ast/x/rkt/break_continue.rkt.json
@@ -1,0 +1,155 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "numbers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "n"
+            },
+            {
+              "sym": "numbers"
+            }
+          ],
+          {
+            "sym": "break"
+          },
+          [
+            {
+              "sym": "\u003e"
+            },
+            {
+              "sym": "n"
+            },
+            7
+          ],
+          {
+            "sym": "unless"
+          },
+          [
+            {
+              "sym": "="
+            },
+            [
+              {
+                "sym": "modulo"
+              },
+              {
+                "sym": "n"
+              },
+              2
+            ],
+            0
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "odd number:"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  {
+                    "sym": "n"
+                  }
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/cast_string_to_int.rkt.json
+++ b/tests/json-ast/x/rkt/cast_string_to_int.rkt.json
@@ -1,0 +1,63 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "n"
+              },
+              [
+                {
+                  "sym": "string-\u003enumber"
+                },
+                "1995"
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "if"
+            },
+            {
+              "sym": "n"
+            },
+            [
+              {
+                "sym": "inexact-\u003eexact"
+              },
+              {
+                "sym": "n"
+              }
+            ],
+            0
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/cast_struct.rkt.json
+++ b/tests/json-ast/x/rkt/cast_struct.rkt.json
@@ -1,0 +1,56 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "todo"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "title",
+          "hi"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          {
+            "sym": "todo"
+          },
+          "title"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/closure.rkt.json
+++ b/tests/json-ast/x/rkt/closure.rkt.json
@@ -1,0 +1,93 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "makeAdder"
+          },
+          {
+            "sym": "n"
+          }
+        ],
+        [
+          {
+            "sym": "lambda"
+          },
+          [
+            {
+              "sym": "x"
+            }
+          ],
+          [
+            {
+              "sym": "+"
+            },
+            {
+              "sym": "x"
+            },
+            {
+              "sym": "n"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "add10"
+        },
+        [
+          {
+            "sym": "makeAdder"
+          },
+          10
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "add10"
+          },
+          7
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/count_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/count_builtin.rkt.json
@@ -1,0 +1,107 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "string?"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ],
+            [
+              {
+                "sym": "string-length"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ],
+            [
+              {
+                "sym": "hash-count"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            [
+              {
+                "sym": "length"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/cross_join.rkt.json
+++ b/tests/json-ast/x/rkt/cross_join.rkt.json
@@ -1,0 +1,404 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            3,
+            "name",
+            "Charlie"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1,
+            "total",
+            250
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2,
+            "total",
+            125
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            1,
+            "total",
+            300
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "for"
+              },
+              [
+                [
+                  {
+                    "sym": "c"
+                  },
+                  {
+                    "sym": "customers"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "hash"
+                      },
+                      "orderId",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "o"
+                        },
+                        "id"
+                      ],
+                      "orderCustomerId",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "o"
+                        },
+                        "customerId"
+                      ],
+                      "pairedCustomerName",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "c"
+                        },
+                        "name"
+                      ],
+                      "orderTotal",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "o"
+                        },
+                        "total"
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Cross Join: All order-customer pairs ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "entry"
+            },
+            {
+              "sym": "result"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "Order"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "orderId"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "(customerId:"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "orderCustomerId"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  ", total: $"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "orderTotal"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  ") paired with"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "pairedCustomerName"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/cross_join_filter.rkt.json
+++ b/tests/json-ast/x/rkt/cross_join_filter.rkt.json
@@ -1,0 +1,279 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "letters"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          "A",
+          "B"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "pairs"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "n"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "for"
+              },
+              [
+                [
+                  {
+                    "sym": "l"
+                  },
+                  {
+                    "sym": "letters"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "when"
+                },
+                [
+                  {
+                    "sym": "="
+                  },
+                  [
+                    {
+                      "sym": "modulo"
+                    },
+                    {
+                      "sym": "n"
+                    },
+                    2
+                  ],
+                  0
+                ],
+                [
+                  {
+                    "sym": "set!"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "append"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "list"
+                      },
+                      [
+                        {
+                          "sym": "hash"
+                        },
+                        "n",
+                        {
+                          "sym": "n"
+                        },
+                        "l",
+                        {
+                          "sym": "l"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Even pairs ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "p"
+            },
+            {
+              "sym": "pairs"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "p"
+                    },
+                    "n"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "p"
+                    },
+                    "l"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/cross_join_triple.rkt.json
+++ b/tests/json-ast/x/rkt/cross_join_triple.rkt.json
@@ -1,0 +1,311 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "letters"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          "A",
+          "B"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "bools"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          true,
+          false
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "combos"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "n"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "for"
+              },
+              [
+                [
+                  {
+                    "sym": "l"
+                  },
+                  {
+                    "sym": "letters"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "b"
+                    },
+                    {
+                      "sym": "bools"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "set!"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "append"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "list"
+                      },
+                      [
+                        {
+                          "sym": "hash"
+                        },
+                        "n",
+                        {
+                          "sym": "n"
+                        },
+                        "l",
+                        {
+                          "sym": "l"
+                        },
+                        "b",
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Cross Join of three lists ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "c"
+            },
+            {
+              "sym": "combos"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "c"
+                    },
+                    "n"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "c"
+                    },
+                    "l"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "c"
+                    },
+                    "b"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/dataset_sort_take_limit.rkt.json
+++ b/tests/json-ast/x/rkt/dataset_sort_take_limit.rkt.json
@@ -1,0 +1,374 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "products"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Laptop",
+            "price",
+            1500
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Smartphone",
+            "price",
+            900
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Tablet",
+            "price",
+            600
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Monitor",
+            "price",
+            300
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Keyboard",
+            "price",
+            100
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Mouse",
+            "price",
+            50
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Headphones",
+            "price",
+            200
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "expensive"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "p"
+                },
+                {
+                  "sym": "products"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "cons"
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "p"
+                      },
+                      "price"
+                    ],
+                    {
+                      "sym": "p"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              {
+                "sym": "\u003e"
+              },
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "drop"
+              },
+              {
+                "sym": "_res"
+              },
+              1
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "take"
+              },
+              {
+                "sym": "_res"
+              },
+              3
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Top products (excluding most expensive) ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "item"
+            },
+            {
+              "sym": "expensive"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "item"
+                    },
+                    "name"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "costs $"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "item"
+                    },
+                    "price"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/dataset_where_filter.rkt.json
+++ b/tests/json-ast/x/rkt/dataset_where_filter.rkt.json
@@ -1,0 +1,335 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            30
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            15
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "age",
+            65
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Diana",
+            "age",
+            45
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "adults"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "person"
+                },
+                {
+                  "sym": "people"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "when"
+              },
+              [
+                {
+                  "sym": "\u003e="
+                },
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "person"
+                  },
+                  "age"
+                ],
+                18
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "hash"
+                      },
+                      "name",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "person"
+                        },
+                        "name"
+                      ],
+                      "age",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "person"
+                        },
+                        "age"
+                      ],
+                      "is_senior",
+                      [
+                        {
+                          "sym": "\u003e="
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "person"
+                          },
+                          "age"
+                        ],
+                        60
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Adults ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "person"
+            },
+            {
+              "sym": "adults"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "person"
+                    },
+                    "name"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "is"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "person"
+                    },
+                    "age"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "if"
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "person"
+                      },
+                      "is_senior"
+                    ],
+                    " (senior)",
+                    ""
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/exists_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/exists_builtin.rkt.json
@@ -1,0 +1,146 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "data"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "flag"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "null?"
+            },
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "quote"
+                    },
+                    []
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "x"
+                    },
+                    {
+                      "sym": "data"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "="
+                    },
+                    {
+                      "sym": "x"
+                    },
+                    1
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "append"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "list"
+                        },
+                        {
+                          "sym": "x"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              {
+                "sym": "_res"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "flag"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/for_list_collection.rkt.json
+++ b/tests/json-ast/x/rkt/for_list_collection.rkt.json
@@ -1,0 +1,51 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "n"
+            },
+            [
+              {
+                "sym": "list"
+              },
+              1,
+              2,
+              3
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          {
+            "sym": "n"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/for_loop.rkt.json
+++ b/tests/json-ast/x/rkt/for_loop.rkt.json
@@ -1,0 +1,50 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "i"
+            },
+            [
+              {
+                "sym": "in-range"
+              },
+              1,
+              4
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          {
+            "sym": "i"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/for_map_collection.rkt.json
+++ b/tests/json-ast/x/rkt/for_map_collection.rkt.json
@@ -1,0 +1,72 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1,
+          "b",
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "k"
+            },
+            [
+              {
+                "sym": "in-hash-keys"
+              },
+              {
+                "sym": "m"
+              }
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          {
+            "sym": "k"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/fun_call.rkt.json
+++ b/tests/json-ast/x/rkt/fun_call.rkt.json
@@ -1,0 +1,66 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "add"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ],
+        [
+          {
+            "sym": "+"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "add"
+          },
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/fun_expr_in_let.rkt.json
+++ b/tests/json-ast/x/rkt/fun_expr_in_let.rkt.json
@@ -1,0 +1,70 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "square"
+        },
+        [
+          {
+            "sym": "lambda"
+          },
+          [
+            {
+              "sym": "x"
+            }
+          ],
+          [
+            {
+              "sym": "*"
+            },
+            {
+              "sym": "x"
+            },
+            {
+              "sym": "x"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "square"
+          },
+          6
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/fun_three_args.rkt.json
+++ b/tests/json-ast/x/rkt/fun_three_args.rkt.json
@@ -1,0 +1,78 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "sum3"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          },
+          {
+            "sym": "c"
+          }
+        ],
+        [
+          {
+            "sym": "+"
+          },
+          [
+            {
+              "sym": "+"
+            },
+            {
+              "sym": "a"
+            },
+            {
+              "sym": "b"
+            }
+          ],
+          {
+            "sym": "c"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "sum3"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/go_auto.rkt.json
+++ b/tests/json-ast/x/rkt/go_auto.rkt.json
@@ -1,0 +1,116 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "testpkg_Add"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ],
+        [
+          {
+            "sym": "+"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "testpkg_Pi"
+        },
+        3.14
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "testpkg_Answer"
+        },
+        42
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "testpkg_Add"
+          },
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "testpkg_Pi"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "testpkg_Answer"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by.rkt.json
+++ b/tests/json-ast/x/rkt/group_by.rkt.json
@@ -1,0 +1,840 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            30,
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            15,
+            "city",
+            "Hanoi"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "age",
+            65,
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Diana",
+            "age",
+            45,
+            "city",
+            "Hanoi"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Eve",
+            "age",
+            70,
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Frank",
+            "age",
+            22,
+            "city",
+            "Hanoi"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "stats"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "person"
+                },
+                {
+                  "sym": "people"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "person"
+                    },
+                    "city"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "person"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "city",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "g"
+                      },
+                      "key"
+                    ],
+                    "count",
+                    [
+                      {
+                        "sym": "cond"
+                      },
+                      [
+                        [
+                          {
+                            "sym": "string?"
+                          },
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "g"
+                            },
+                            "items"
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "string-length"
+                          },
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "g"
+                            },
+                            "items"
+                          ]
+                        ]
+                      ],
+                      [
+                        [
+                          {
+                            "sym": "hash?"
+                          },
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "g"
+                            },
+                            "items"
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-count"
+                          },
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "g"
+                            },
+                            "items"
+                          ]
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "else"
+                        },
+                        [
+                          {
+                            "sym": "length"
+                          },
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "g"
+                            },
+                            "items"
+                          ]
+                        ]
+                      ]
+                    ],
+                    "avg_age",
+                    [
+                      {
+                        "sym": "if"
+                      },
+                      [
+                        {
+                          "sym": "null?"
+                        },
+                        [
+                          {
+                            "sym": "let"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "quote"
+                                },
+                                []
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "for"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "p"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "g"
+                                  },
+                                  "items"
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "set!"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "append"
+                                },
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "list"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "p"
+                                    },
+                                    "age"
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ],
+                          {
+                            "sym": "_res"
+                          }
+                        ]
+                      ],
+                      0,
+                      [
+                        {
+                          "sym": "exact-\u003einexact"
+                        },
+                        [
+                          {
+                            "sym": "/"
+                          },
+                          [
+                            {
+                              "sym": "apply"
+                            },
+                            {
+                              "sym": "+"
+                            },
+                            [
+                              {
+                                "sym": "let"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "quote"
+                                    },
+                                    []
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "for"
+                                },
+                                [
+                                  [
+                                    {
+                                      "sym": "p"
+                                    },
+                                    [
+                                      {
+                                        "sym": "hash-ref"
+                                      },
+                                      {
+                                        "sym": "g"
+                                      },
+                                      "items"
+                                    ]
+                                  ]
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      [
+                                        {
+                                          "sym": "hash-ref"
+                                        },
+                                        {
+                                          "sym": "p"
+                                        },
+                                        "age"
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ],
+                              {
+                                "sym": "_res"
+                              }
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "length"
+                            },
+                            [
+                              {
+                                "sym": "let"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "quote"
+                                    },
+                                    []
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "for"
+                                },
+                                [
+                                  [
+                                    {
+                                      "sym": "p"
+                                    },
+                                    [
+                                      {
+                                        "sym": "hash-ref"
+                                      },
+                                      {
+                                        "sym": "g"
+                                      },
+                                      "items"
+                                    ]
+                                  ]
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      [
+                                        {
+                                          "sym": "hash-ref"
+                                        },
+                                        {
+                                          "sym": "p"
+                                        },
+                                        "age"
+                                      ]
+                                    ]
+                                  ]
+                                ]
+                              ],
+                              {
+                                "sym": "_res"
+                              }
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- People grouped by city ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "s"
+            },
+            {
+              "sym": "stats"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    "city"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  ": count ="
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    "count"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  ", avg_age ="
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    "avg_age"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_conditional_sum.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_conditional_sum.rkt.json
@@ -1,0 +1,595 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "a",
+            "val",
+            10,
+            "flag",
+            true
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "a",
+            "val",
+            5,
+            "flag",
+            false
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "b",
+            "val",
+            20,
+            "flag",
+            true
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "i"
+                },
+                {
+                  "sym": "items"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "i"
+                    },
+                    "cat"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "i"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "val"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "cat",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "g"
+                      },
+                      "key"
+                    ],
+                    "share",
+                    [
+                      {
+                        "sym": "/"
+                      },
+                      [
+                        {
+                          "sym": "apply"
+                        },
+                        {
+                          "sym": "+"
+                        },
+                        [
+                          {
+                            "sym": "let"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "quote"
+                                },
+                                []
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "for"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "x"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "g"
+                                  },
+                                  "items"
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "set!"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "append"
+                                },
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "list"
+                                  },
+                                  [
+                                    {
+                                      "sym": "if"
+                                    },
+                                    [
+                                      {
+                                        "sym": "hash-ref"
+                                      },
+                                      {
+                                        "sym": "x"
+                                      },
+                                      "flag"
+                                    ],
+                                    [
+                                      {
+                                        "sym": "hash-ref"
+                                      },
+                                      {
+                                        "sym": "x"
+                                      },
+                                      "val"
+                                    ],
+                                    0
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ],
+                          {
+                            "sym": "_res"
+                          }
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "apply"
+                        },
+                        {
+                          "sym": "+"
+                        },
+                        [
+                          {
+                            "sym": "let"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "quote"
+                                },
+                                []
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "for"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "x"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "g"
+                                  },
+                                  "items"
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "set!"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "append"
+                                },
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "list"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "x"
+                                    },
+                                    "val"
+                                  ]
+                                ]
+                              ]
+                            ]
+                          ],
+                          {
+                            "sym": "_res"
+                          }
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "g"
+                    },
+                    "key"
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "cons"
+                      },
+                      {
+                        "sym": "key"
+                      },
+                      {
+                        "sym": "val"
+                      }
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              {
+                "sym": "\u003c"
+              },
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "result"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_having.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_having.rkt.json
@@ -1,0 +1,546 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "city",
+            "Hanoi"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Diana",
+            "city",
+            "Hanoi"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Eve",
+            "city",
+            "Paris"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Frank",
+            "city",
+            "Hanoi"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "George",
+            "city",
+            "Paris"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "big"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "p"
+                },
+                {
+                  "sym": "people"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "p"
+                    },
+                    "city"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "p"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "when"
+              },
+              [
+                {
+                  "sym": "\u003e="
+                },
+                [
+                  {
+                    "sym": "cond"
+                  },
+                  [
+                    [
+                      {
+                        "sym": "string?"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "items"
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "string-length"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "items"
+                      ]
+                    ]
+                  ],
+                  [
+                    [
+                      {
+                        "sym": "hash?"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "items"
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "hash-count"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "items"
+                      ]
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "else"
+                    },
+                    [
+                      {
+                        "sym": "length"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "items"
+                      ]
+                    ]
+                  ]
+                ],
+                4
+              ],
+              [
+                {
+                  "sym": "let"
+                },
+                [
+                  [
+                    {
+                      "sym": "val"
+                    },
+                    [
+                      {
+                        "sym": "hash"
+                      },
+                      "city",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "key"
+                      ],
+                      "num",
+                      [
+                        {
+                          "sym": "cond"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "string?"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "string-length"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ]
+                        ],
+                        [
+                          [
+                            {
+                              "sym": "hash?"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "hash-count"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "else"
+                          },
+                          [
+                            {
+                              "sym": "length"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "val"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ],
+        {
+          "sym": "_res"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_join.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_join.rkt.json
@@ -1,0 +1,118 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_left_join.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_left_join.rkt.json
@@ -1,0 +1,1164 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            3,
+            "name",
+            "Charlie"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "stats"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "c"
+                },
+                {
+                  "sym": "customers"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "matched"
+                  },
+                  false
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "o"
+                    },
+                    {
+                      "sym": "orders"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "="
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "o"
+                      },
+                      "customerId"
+                    ],
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "c"
+                      },
+                      "id"
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "matched"
+                    },
+                    true
+                  ],
+                  [
+                    {
+                      "sym": "let*"
+                    },
+                    [
+                      [
+                        {
+                          "sym": "_key"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "c"
+                          },
+                          "name"
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "_g"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          [
+                            {
+                              "sym": "lambda"
+                            },
+                            [],
+                            [
+                              {
+                                "sym": "let"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "h"
+                                  },
+                                  [
+                                    {
+                                      "sym": "make-hash"
+                                    }
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "h"
+                                },
+                                "key",
+                                {
+                                  "sym": "_key"
+                                }
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "h"
+                                },
+                                "items",
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "_groups"
+                                },
+                                {
+                                  "sym": "_key"
+                                },
+                                {
+                                  "sym": "h"
+                                }
+                              ],
+                              {
+                                "sym": "h"
+                              }
+                            ]
+                          ]
+                        ]
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "hash-set!"
+                      },
+                      {
+                        "sym": "_g"
+                      },
+                      "items",
+                      [
+                        {
+                          "sym": "append"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "_g"
+                          },
+                          "items"
+                        ],
+                        [
+                          {
+                            "sym": "list"
+                          },
+                          [
+                            {
+                              "sym": "hash"
+                            },
+                            "c",
+                            {
+                              "sym": "c"
+                            },
+                            "o",
+                            {
+                              "sym": "o"
+                            }
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "not"
+                    },
+                    {
+                      "sym": "matched"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "let*"
+                    },
+                    [
+                      [
+                        {
+                          "sym": "o"
+                        },
+                        false
+                      ],
+                      [
+                        {
+                          "sym": "_key"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "c"
+                          },
+                          "name"
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "_g"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          [
+                            {
+                              "sym": "lambda"
+                            },
+                            [],
+                            [
+                              {
+                                "sym": "let"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "h"
+                                  },
+                                  [
+                                    {
+                                      "sym": "make-hash"
+                                    }
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "h"
+                                },
+                                "key",
+                                {
+                                  "sym": "_key"
+                                }
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "h"
+                                },
+                                "items",
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "hash-set!"
+                                },
+                                {
+                                  "sym": "_groups"
+                                },
+                                {
+                                  "sym": "_key"
+                                },
+                                {
+                                  "sym": "h"
+                                }
+                              ],
+                              {
+                                "sym": "h"
+                              }
+                            ]
+                          ]
+                        ]
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "hash-set!"
+                      },
+                      {
+                        "sym": "_g"
+                      },
+                      "items",
+                      [
+                        {
+                          "sym": "append"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "_g"
+                          },
+                          "items"
+                        ],
+                        [
+                          {
+                            "sym": "list"
+                          },
+                          [
+                            {
+                              "sym": "hash"
+                            },
+                            "c",
+                            {
+                              "sym": "c"
+                            },
+                            "o",
+                            {
+                              "sym": "o"
+                            }
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "val"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "name",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "g"
+                      },
+                      "key"
+                    ],
+                    "count",
+                    [
+                      {
+                        "sym": "cond"
+                      },
+                      [
+                        [
+                          {
+                            "sym": "string?"
+                          },
+                          [
+                            {
+                              "sym": "let"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "for"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "r"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "g"
+                                    },
+                                    "items"
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "when"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "o"
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      {
+                                        "sym": "r"
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            {
+                              "sym": "_res"
+                            }
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "string-length"
+                          },
+                          [
+                            {
+                              "sym": "let"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "for"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "r"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "g"
+                                    },
+                                    "items"
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "when"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "o"
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      {
+                                        "sym": "r"
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            {
+                              "sym": "_res"
+                            }
+                          ]
+                        ]
+                      ],
+                      [
+                        [
+                          {
+                            "sym": "hash?"
+                          },
+                          [
+                            {
+                              "sym": "let"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "for"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "r"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "g"
+                                    },
+                                    "items"
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "when"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "o"
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      {
+                                        "sym": "r"
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            {
+                              "sym": "_res"
+                            }
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-count"
+                          },
+                          [
+                            {
+                              "sym": "let"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "for"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "r"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "g"
+                                    },
+                                    "items"
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "when"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "o"
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      {
+                                        "sym": "r"
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            {
+                              "sym": "_res"
+                            }
+                          ]
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "else"
+                        },
+                        [
+                          {
+                            "sym": "length"
+                          },
+                          [
+                            {
+                              "sym": "let"
+                            },
+                            [
+                              [
+                                {
+                                  "sym": "_res"
+                                },
+                                [
+                                  {
+                                    "sym": "quote"
+                                  },
+                                  []
+                                ]
+                              ]
+                            ],
+                            [
+                              {
+                                "sym": "for"
+                              },
+                              [
+                                [
+                                  {
+                                    "sym": "r"
+                                  },
+                                  [
+                                    {
+                                      "sym": "hash-ref"
+                                    },
+                                    {
+                                      "sym": "g"
+                                    },
+                                    "items"
+                                  ]
+                                ]
+                              ],
+                              [
+                                {
+                                  "sym": "when"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "o"
+                                ],
+                                [
+                                  {
+                                    "sym": "set!"
+                                  },
+                                  {
+                                    "sym": "_res"
+                                  },
+                                  [
+                                    {
+                                      "sym": "append"
+                                    },
+                                    {
+                                      "sym": "_res"
+                                    },
+                                    [
+                                      {
+                                        "sym": "list"
+                                      },
+                                      {
+                                        "sym": "r"
+                                      }
+                                    ]
+                                  ]
+                                ]
+                              ]
+                            ],
+                            {
+                              "sym": "_res"
+                            }
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "val"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Group Left Join ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "s"
+            },
+            {
+              "sym": "stats"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    "name"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "orders:"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    "count"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_multi_join.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_multi_join.rkt.json
@@ -1,0 +1,701 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nations"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "A"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "B"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "suppliers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "nation",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "nation",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "partsupp"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "part",
+            100,
+            "supplier",
+            1,
+            "cost",
+            10,
+            "qty",
+            2
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "part",
+            100,
+            "supplier",
+            2,
+            "cost",
+            20,
+            "qty",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "part",
+            200,
+            "supplier",
+            1,
+            "cost",
+            5,
+            "qty",
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "filtered"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "ps"
+                },
+                {
+                  "sym": "partsupp"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "for"
+              },
+              [
+                [
+                  {
+                    "sym": "s"
+                  },
+                  {
+                    "sym": "suppliers"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "n"
+                    },
+                    {
+                      "sym": "nations"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "and"
+                    },
+                    [
+                      {
+                        "sym": "and"
+                      },
+                      [
+                        {
+                          "sym": "="
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "s"
+                          },
+                          "id"
+                        ],
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "ps"
+                          },
+                          "supplier"
+                        ]
+                      ],
+                      [
+                        {
+                          "sym": "="
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "n"
+                          },
+                          "id"
+                        ],
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "s"
+                          },
+                          "nation"
+                        ]
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "="
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "n"
+                        },
+                        "name"
+                      ],
+                      "A"
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "append"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "list"
+                        },
+                        [
+                          {
+                            "sym": "hash"
+                          },
+                          "part",
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "ps"
+                            },
+                            "part"
+                          ],
+                          "value",
+                          [
+                            {
+                              "sym": "*"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "ps"
+                              },
+                              "cost"
+                            ],
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "ps"
+                              },
+                              "qty"
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "grouped"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "x"
+                },
+                {
+                  "sym": "filtered"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "x"
+                    },
+                    "part"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "x"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "part",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "g"
+                      },
+                      "key"
+                    ],
+                    "total",
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "quote"
+                              },
+                              []
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "for"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "r"
+                              },
+                              [
+                                {
+                                  "sym": "hash-ref"
+                                },
+                                {
+                                  "sym": "g"
+                                },
+                                "items"
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "set!"
+                            },
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "append"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "list"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "r"
+                                  },
+                                  "value"
+                                ]
+                              ]
+                            ]
+                          ]
+                        ],
+                        {
+                          "sym": "_res"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "grouped"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_multi_join_sort.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_multi_join_sort.rkt.json
@@ -1,0 +1,192 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nation"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "n_nationkey",
+            1,
+            "n_name",
+            "BRAZIL"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customer"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "c_custkey",
+            1,
+            "c_name",
+            "Alice",
+            "c_acctbal",
+            100,
+            "c_nationkey",
+            1,
+            "c_address",
+            "123 St",
+            "c_phone",
+            "123-456",
+            "c_comment",
+            "Loyal"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "o_orderkey",
+            1000,
+            "o_custkey",
+            1,
+            "o_orderdate",
+            "1993-10-15"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "o_orderkey",
+            2000,
+            "o_custkey",
+            1,
+            "o_orderdate",
+            "1994-01-02"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "lineitem"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "l_orderkey",
+            1000,
+            "l_returnflag",
+            "R",
+            "l_extendedprice",
+            1000,
+            "l_discount",
+            0.1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "l_orderkey",
+            2000,
+            "l_returnflag",
+            "N",
+            "l_extendedprice",
+            500,
+            "l_discount",
+            0
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "start_date"
+        },
+        "1993-10-01"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "end_date"
+        },
+        "1994-01-01"
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_multi_sort.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_multi_sort.rkt.json
@@ -1,0 +1,536 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            "x",
+            "b",
+            1,
+            "val",
+            2
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            "x",
+            "b",
+            2,
+            "val",
+            3
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            "y",
+            "b",
+            1,
+            "val",
+            4
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            "y",
+            "b",
+            2,
+            "val",
+            1
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "grouped"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "i"
+                },
+                {
+                  "sym": "items"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "a",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "i"
+                      },
+                      "a"
+                    ],
+                    "b",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "i"
+                      },
+                      "b"
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "i"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "val"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "a",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "key"
+                      ],
+                      "a"
+                    ],
+                    "b",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "g"
+                        },
+                        "key"
+                      ],
+                      "b"
+                    ],
+                    "total",
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      [
+                        {
+                          "sym": "for*/list"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "x"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "x"
+                          },
+                          "val"
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "key"
+                  },
+                  [
+                    {
+                      "sym": "-"
+                    },
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      [
+                        {
+                          "sym": "for*/list"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "x"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "g"
+                              },
+                              "items"
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "x"
+                          },
+                          "val"
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "cons"
+                      },
+                      {
+                        "sym": "key"
+                      },
+                      {
+                        "sym": "val"
+                      }
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              {
+                "sym": "\u003c"
+              },
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "grouped"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_by_sort.rkt.json
+++ b/tests/json-ast/x/rkt/group_by_sort.rkt.json
@@ -1,0 +1,574 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "a",
+            "val",
+            3
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "a",
+            "val",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "b",
+            "val",
+            5
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "cat",
+            "b",
+            "val",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "grouped"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "i"
+                },
+                {
+                  "sym": "items"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "i"
+                    },
+                    "cat"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "i"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "val"
+                  },
+                  [
+                    {
+                      "sym": "hash"
+                    },
+                    "cat",
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "g"
+                      },
+                      "key"
+                    ],
+                    "total",
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "quote"
+                              },
+                              []
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "for"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "x"
+                              },
+                              [
+                                {
+                                  "sym": "hash-ref"
+                                },
+                                {
+                                  "sym": "g"
+                                },
+                                "items"
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "set!"
+                            },
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "append"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "list"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "x"
+                                  },
+                                  "val"
+                                ]
+                              ]
+                            ]
+                          ]
+                        ],
+                        {
+                          "sym": "_res"
+                        }
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "key"
+                  },
+                  [
+                    {
+                      "sym": "-"
+                    },
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "quote"
+                              },
+                              []
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "for"
+                          },
+                          [
+                            [
+                              {
+                                "sym": "x"
+                              },
+                              [
+                                {
+                                  "sym": "hash-ref"
+                                },
+                                {
+                                  "sym": "g"
+                                },
+                                "items"
+                              ]
+                            ]
+                          ],
+                          [
+                            {
+                              "sym": "set!"
+                            },
+                            {
+                              "sym": "_res"
+                            },
+                            [
+                              {
+                                "sym": "append"
+                              },
+                              {
+                                "sym": "_res"
+                              },
+                              [
+                                {
+                                  "sym": "list"
+                                },
+                                [
+                                  {
+                                    "sym": "hash-ref"
+                                  },
+                                  {
+                                    "sym": "x"
+                                  },
+                                  "val"
+                                ]
+                              ]
+                            ]
+                          ]
+                        ],
+                        {
+                          "sym": "_res"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "cons"
+                      },
+                      {
+                        "sym": "key"
+                      },
+                      {
+                        "sym": "val"
+                      }
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              {
+                "sym": "\u003c"
+              },
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "grouped"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/group_items_iteration.rkt.json
+++ b/tests/json-ast/x/rkt/group_items_iteration.rkt.json
@@ -1,0 +1,702 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "data"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "tag",
+            "a",
+            "val",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "tag",
+            "a",
+            "val",
+            2
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "tag",
+            "b",
+            "val",
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "groups"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_groups"
+              },
+              [
+                {
+                  "sym": "make-hash"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "d"
+                },
+                {
+                  "sym": "data"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let*"
+              },
+              [
+                [
+                  {
+                    "sym": "_key"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "d"
+                    },
+                    "tag"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "_g"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_groups"
+                    },
+                    {
+                      "sym": "_key"
+                    },
+                    [
+                      {
+                        "sym": "lambda"
+                      },
+                      [],
+                      [
+                        {
+                          "sym": "let"
+                        },
+                        [
+                          [
+                            {
+                              "sym": "h"
+                            },
+                            [
+                              {
+                                "sym": "make-hash"
+                              }
+                            ]
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "key",
+                          {
+                            "sym": "_key"
+                          }
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "h"
+                          },
+                          "items",
+                          [
+                            {
+                              "sym": "quote"
+                            },
+                            []
+                          ]
+                        ],
+                        [
+                          {
+                            "sym": "hash-set!"
+                          },
+                          {
+                            "sym": "_groups"
+                          },
+                          {
+                            "sym": "_key"
+                          },
+                          {
+                            "sym": "h"
+                          }
+                        ],
+                        {
+                          "sym": "h"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "hash-set!"
+                },
+                {
+                  "sym": "_g"
+                },
+                "items",
+                [
+                  {
+                    "sym": "append"
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "_g"
+                    },
+                    "items"
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "d"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "g"
+                },
+                [
+                  {
+                    "sym": "hash-values"
+                  },
+                  {
+                    "sym": "_groups"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "val"
+                  },
+                  {
+                    "sym": "g"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "val"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "tmp"
+        },
+        [
+          {
+            "sym": "list"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "g"
+            },
+            {
+              "sym": "groups"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "define"
+          },
+          {
+            "sym": "total"
+          },
+          0
+        ],
+        [
+          {
+            "sym": "for"
+          },
+          [
+            [
+              {
+                "sym": "x"
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "g"
+                },
+                "items"
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "total"
+            },
+            [
+              {
+                "sym": "+"
+              },
+              {
+                "sym": "total"
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "x"
+                },
+                "val"
+              ]
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "set!"
+          },
+          {
+            "sym": "tmp"
+          },
+          [
+            {
+              "sym": "append"
+            },
+            {
+              "sym": "tmp"
+            },
+            [
+              {
+                "sym": "list"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "tag",
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "g"
+                  },
+                  "key"
+                ],
+                "total",
+                {
+                  "sym": "total"
+                }
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "r"
+                },
+                {
+                  "sym": "tmp"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "cons"
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "r"
+                      },
+                      "tag"
+                    ],
+                    {
+                      "sym": "r"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "a"
+                  },
+                  {
+                    "sym": "b"
+                  }
+                ],
+                [
+                  {
+                    "sym": "cond"
+                  },
+                  [
+                    [
+                      {
+                        "sym": "and"
+                      },
+                      [
+                        {
+                          "sym": "number?"
+                        },
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "number?"
+                        },
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "\u003c"
+                      },
+                      {
+                        "sym": "a"
+                      },
+                      {
+                        "sym": "b"
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      {
+                        "sym": "and"
+                      },
+                      [
+                        {
+                          "sym": "string?"
+                        },
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "string?"
+                        },
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "string\u003c?"
+                      },
+                      {
+                        "sym": "a"
+                      },
+                      {
+                        "sym": "b"
+                      }
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "else"
+                    },
+                    [
+                      {
+                        "sym": "string\u003c?"
+                      },
+                      [
+                        {
+                          "sym": "format"
+                        },
+                        "~a",
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "format"
+                        },
+                        "~a",
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "result"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/if_else.rkt.json
+++ b/tests/json-ast/x/rkt/if_else.rkt.json
@@ -1,0 +1,92 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        5
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "if"
+        },
+        [
+          {
+            "sym": "\u003e"
+          },
+          {
+            "sym": "x"
+          },
+          3
+        ],
+        [
+          {
+            "sym": "begin"
+          },
+          [
+            {
+              "sym": "displayln"
+            },
+            "big"
+          ]
+        ],
+        [
+          {
+            "sym": "begin"
+          },
+          [
+            {
+              "sym": "displayln"
+            },
+            "small"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/if_then_else.rkt.json
+++ b/tests/json-ast/x/rkt/if_then_else.rkt.json
@@ -1,0 +1,92 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        12
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "msg"
+        },
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "\u003e"
+            },
+            {
+              "sym": "x"
+            },
+            10
+          ],
+          "yes",
+          "no"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "msg"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/if_then_else_nested.rkt.json
+++ b/tests/json-ast/x/rkt/if_then_else_nested.rkt.json
@@ -1,0 +1,107 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        8
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "msg"
+        },
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "\u003e"
+            },
+            {
+              "sym": "x"
+            },
+            10
+          ],
+          "big",
+          [
+            {
+              "sym": "if"
+            },
+            [
+              {
+                "sym": "\u003e"
+              },
+              {
+                "sym": "x"
+              },
+              5
+            ],
+            "medium",
+            "small"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "msg"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/in_operator.rkt.json
+++ b/tests/json-ast/x/rkt/in_operator.rkt.json
@@ -1,0 +1,120 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "xs"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "member"
+              },
+              2,
+              {
+                "sym": "xs"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "not"
+              },
+              [
+                {
+                  "sym": "member"
+                },
+                5,
+                {
+                  "sym": "xs"
+                }
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/in_operator_extended.rkt.json
+++ b/tests/json-ast/x/rkt/in_operator_extended.rkt.json
@@ -1,0 +1,311 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "xs"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "ys"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "x"
+                },
+                {
+                  "sym": "xs"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "when"
+              },
+              [
+                {
+                  "sym": "="
+                },
+                [
+                  {
+                    "sym": "modulo"
+                  },
+                  {
+                    "sym": "x"
+                  },
+                  2
+                ],
+                1
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    {
+                      "sym": "x"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "member"
+              },
+              1,
+              {
+                "sym": "ys"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "member"
+              },
+              2,
+              {
+                "sym": "ys"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          "a"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s"
+        },
+        "hello"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "ell"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "foo"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/inner_join.rkt.json
+++ b/tests/json-ast/x/rkt/inner_join.rkt.json
@@ -1,0 +1,431 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            3,
+            "name",
+            "Charlie"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1,
+            "total",
+            250
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2,
+            "total",
+            125
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            1,
+            "total",
+            300
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            103,
+            "customerId",
+            4,
+            "total",
+            80
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "for"
+              },
+              [
+                [
+                  {
+                    "sym": "c"
+                  },
+                  {
+                    "sym": "customers"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "when"
+                },
+                [
+                  {
+                    "sym": "="
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "o"
+                    },
+                    "customerId"
+                  ],
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "c"
+                    },
+                    "id"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "set!"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "append"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "list"
+                      },
+                      [
+                        {
+                          "sym": "hash"
+                        },
+                        "orderId",
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "o"
+                          },
+                          "id"
+                        ],
+                        "customerName",
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "c"
+                          },
+                          "name"
+                        ],
+                        "total",
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "o"
+                          },
+                          "total"
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Orders with customer info ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "entry"
+            },
+            {
+              "sym": "result"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "Order"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "orderId"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "by"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "customerName"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "- $"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "total"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/join_multi.rkt.json
+++ b/tests/json-ast/x/rkt/join_multi.rkt.json
@@ -1,0 +1,360 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "orderId",
+            100,
+            "sku",
+            "a"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "orderId",
+            101,
+            "sku",
+            "b"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "for*/list"
+          },
+          [
+            [
+              {
+                "sym": "o"
+              },
+              {
+                "sym": "orders"
+              }
+            ],
+            [
+              {
+                "sym": "c"
+              },
+              {
+                "sym": "customers"
+              }
+            ],
+            [
+              {
+                "sym": "i"
+              },
+              {
+                "sym": "items"
+              }
+            ]
+          ],
+          {
+            "sym": "when"
+          },
+          [
+            {
+              "sym": "and"
+            },
+            [
+              {
+                "sym": "="
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "o"
+                },
+                "customerId"
+              ],
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "c"
+                },
+                "id"
+              ]
+            ],
+            [
+              {
+                "sym": "="
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "o"
+                },
+                "id"
+              ],
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "i"
+                },
+                "orderId"
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "c"
+              },
+              "name"
+            ],
+            "sku",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "i"
+              },
+              "sku"
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Multi Join ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "r"
+            },
+            {
+              "sym": "result"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "r"
+                    },
+                    "name"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "bought item"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "r"
+                    },
+                    "sku"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/json_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/json_builtin.rkt.json
@@ -1,0 +1,188 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "to-jsexpr"
+          },
+          {
+            "sym": "v"
+          }
+        ],
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              {
+                "sym": "v"
+              }
+            ],
+            [
+              {
+                "sym": "for/hash"
+              },
+              [
+                [
+                  [
+                    {
+                      "sym": "k"
+                    },
+                    {
+                      "sym": "val"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "in-hash"
+                    },
+                    {
+                      "sym": "v"
+                    }
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "values"
+                },
+                [
+                  {
+                    "sym": "if"
+                  },
+                  [
+                    {
+                      "sym": "string?"
+                    },
+                    {
+                      "sym": "k"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "string-\u003esymbol"
+                    },
+                    {
+                      "sym": "k"
+                    }
+                  ],
+                  {
+                    "sym": "k"
+                  }
+                ],
+                [
+                  {
+                    "sym": "to-jsexpr"
+                  },
+                  {
+                    "sym": "val"
+                  }
+                ]
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "list?"
+              },
+              {
+                "sym": "v"
+              }
+            ],
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "to-jsexpr"
+              },
+              {
+                "sym": "v"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            {
+              "sym": "v"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1,
+          "b",
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "jsexpr-\u003estring"
+          },
+          [
+            {
+              "sym": "to-jsexpr"
+            },
+            {
+              "sym": "m"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/left_join.rkt.json
+++ b/tests/json-ast/x/rkt/left_join.rkt.json
@@ -1,0 +1,492 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1,
+            "total",
+            250
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            3,
+            "total",
+            80
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "matched"
+                  },
+                  false
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "c"
+                    },
+                    {
+                      "sym": "customers"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "="
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "o"
+                      },
+                      "customerId"
+                    ],
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "c"
+                      },
+                      "id"
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "matched"
+                    },
+                    true
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "append"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "list"
+                        },
+                        [
+                          {
+                            "sym": "hash"
+                          },
+                          "orderId",
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "o"
+                            },
+                            "id"
+                          ],
+                          "customer",
+                          {
+                            "sym": "c"
+                          },
+                          "total",
+                          [
+                            {
+                              "sym": "hash-ref"
+                            },
+                            {
+                              "sym": "o"
+                            },
+                            "total"
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "not"
+                    },
+                    {
+                      "sym": "matched"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "let"
+                    },
+                    [
+                      [
+                        {
+                          "sym": "c"
+                        },
+                        false
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "set!"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "append"
+                        },
+                        {
+                          "sym": "_res"
+                        },
+                        [
+                          {
+                            "sym": "list"
+                          },
+                          [
+                            {
+                              "sym": "hash"
+                            },
+                            "orderId",
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "o"
+                              },
+                              "id"
+                            ],
+                            "customer",
+                            {
+                              "sym": "c"
+                            },
+                            "total",
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "o"
+                              },
+                              "total"
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Left Join ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "entry"
+            },
+            {
+              "sym": "result"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "filter"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "s"
+                  }
+                ],
+                [
+                  {
+                    "sym": "not"
+                  },
+                  [
+                    {
+                      "sym": "string=?"
+                    },
+                    {
+                      "sym": "s"
+                    },
+                    ""
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "Order"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "orderId"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "customer"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "customer"
+                  ]
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  "total"
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "entry"
+                    },
+                    "total"
+                  ]
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/left_join_multi.rkt.json
+++ b/tests/json-ast/x/rkt/left_join_multi.rkt.json
@@ -1,0 +1,135 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "orderId",
+            100,
+            "sku",
+            "a"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/len_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/len_builtin.rkt.json
@@ -1,0 +1,127 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "string?"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ],
+            [
+              {
+                "sym": "string-length"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ],
+            [
+              {
+                "sym": "hash-count"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            [
+              {
+                "sym": "length"
+              },
+              [
+                {
+                  "sym": "list"
+                },
+                1,
+                2,
+                3
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/len_map.rkt.json
+++ b/tests/json-ast/x/rkt/len_map.rkt.json
@@ -1,0 +1,132 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "string?"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "a",
+                1,
+                "b",
+                2
+              ]
+            ],
+            [
+              {
+                "sym": "string-length"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "a",
+                1,
+                "b",
+                2
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "a",
+                1,
+                "b",
+                2
+              ]
+            ],
+            [
+              {
+                "sym": "hash-count"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "a",
+                1,
+                "b",
+                2
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            [
+              {
+                "sym": "length"
+              },
+              [
+                {
+                  "sym": "hash"
+                },
+                "a",
+                1,
+                "b",
+                2
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/len_string.rkt.json
+++ b/tests/json-ast/x/rkt/len_string.rkt.json
@@ -1,0 +1,92 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "string?"
+              },
+              "mochi"
+            ],
+            [
+              {
+                "sym": "string-length"
+              },
+              "mochi"
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              "mochi"
+            ],
+            [
+              {
+                "sym": "hash-count"
+              },
+              "mochi"
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            [
+              {
+                "sym": "length"
+              },
+              "mochi"
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/let_and_print.rkt.json
+++ b/tests/json-ast/x/rkt/let_and_print.rkt.json
@@ -1,0 +1,85 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "a"
+        },
+        10
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "b"
+        },
+        20
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "+"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/list_assign.rkt.json
+++ b/tests/json-ast/x/rkt/list_assign.rkt.json
@@ -1,0 +1,98 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list-set"
+          },
+          {
+            "sym": "nums"
+          },
+          1,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "list-ref"
+          },
+          {
+            "sym": "nums"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/list_index.rkt.json
+++ b/tests/json-ast/x/rkt/list_index.rkt.json
@@ -1,0 +1,77 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "xs"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          10,
+          20,
+          30
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "list-ref"
+          },
+          {
+            "sym": "xs"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/list_nested_assign.rkt.json
+++ b/tests/json-ast/x/rkt/list_nested_assign.rkt.json
@@ -1,0 +1,107 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "matrix"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2
+          ],
+          [
+            {
+              "sym": "list"
+            },
+            3,
+            4
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "matrix"
+        },
+        5
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "list-ref"
+          },
+          [
+            {
+              "sym": "list-ref"
+            },
+            {
+              "sym": "matrix"
+            },
+            1
+          ],
+          0
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/list_set_ops.rkt.json
+++ b/tests/json-ast/x/rkt/list_set_ops.rkt.json
@@ -1,0 +1,267 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "union"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2
+          ],
+          [
+            {
+              "sym": "list"
+            },
+            2,
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "except"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2,
+            3
+          ],
+          [
+            {
+              "sym": "list"
+            },
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "intersect"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2,
+            3
+          ],
+          [
+            {
+              "sym": "list"
+            },
+            2,
+            4
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "cond"
+          },
+          [
+            [
+              {
+                "sym": "string?"
+              },
+              [
+                {
+                  "sym": "union"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2
+                ],
+                [
+                  {
+                    "sym": "list"
+                  },
+                  2,
+                  3
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "string-length"
+              },
+              [
+                {
+                  "sym": "union"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2
+                ],
+                [
+                  {
+                    "sym": "list"
+                  },
+                  2,
+                  3
+                ]
+              ]
+            ]
+          ],
+          [
+            [
+              {
+                "sym": "hash?"
+              },
+              [
+                {
+                  "sym": "union"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2
+                ],
+                [
+                  {
+                    "sym": "list"
+                  },
+                  2,
+                  3
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "hash-count"
+              },
+              [
+                {
+                  "sym": "union"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2
+                ],
+                [
+                  {
+                    "sym": "list"
+                  },
+                  2,
+                  3
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "else"
+            },
+            [
+              {
+                "sym": "length"
+              },
+              [
+                {
+                  "sym": "union"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  1,
+                  2
+                ],
+                [
+                  {
+                    "sym": "list"
+                  },
+                  2,
+                  3
+                ]
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/load_jsonl.rkt.json
+++ b/tests/json-ast/x/rkt/load_jsonl.rkt.json
@@ -1,0 +1,219 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            30,
+            "email",
+            "alice@example.com"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            15,
+            "email",
+            "bob@example.com"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "age",
+            20,
+            "email",
+            "charlie@example.com"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "adults"
+        },
+        [
+          {
+            "sym": "for/list"
+          },
+          [
+            [
+              {
+                "sym": "p"
+              },
+              {
+                "sym": "people"
+              }
+            ],
+            {
+              "sym": "when"
+            },
+            [
+              {
+                "sym": "\u003e="
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "p"
+                },
+                "age"
+              ],
+              18
+            ]
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "p"
+              },
+              "name"
+            ],
+            "email",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "p"
+              },
+              "email"
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "a"
+            },
+            {
+              "sym": "adults"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "x"
+                  }
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  {
+                    "sym": "x"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "a"
+                  },
+                  "name"
+                ],
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "a"
+                  },
+                  "email"
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/load_yaml.rkt.json
+++ b/tests/json-ast/x/rkt/load_yaml.rkt.json
@@ -1,0 +1,219 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            30,
+            "email",
+            "alice@example.com"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            15,
+            "email",
+            "bob@example.com"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "age",
+            20,
+            "email",
+            "charlie@example.com"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "adults"
+        },
+        [
+          {
+            "sym": "for/list"
+          },
+          [
+            [
+              {
+                "sym": "p"
+              },
+              {
+                "sym": "people"
+              }
+            ],
+            {
+              "sym": "when"
+            },
+            [
+              {
+                "sym": "\u003e="
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "p"
+                },
+                "age"
+              ],
+              18
+            ]
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "p"
+              },
+              "name"
+            ],
+            "email",
+            [
+              {
+                "sym": "hash-ref"
+              },
+              {
+                "sym": "p"
+              },
+              "email"
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "a"
+            },
+            {
+              "sym": "adults"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "string-join"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "x"
+                  }
+                ],
+                [
+                  {
+                    "sym": "format"
+                  },
+                  "~a",
+                  {
+                    "sym": "x"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "list"
+                },
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "a"
+                  },
+                  "name"
+                ],
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "a"
+                  },
+                  "email"
+                ]
+              ]
+            ],
+            " "
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_assign.rkt.json
+++ b/tests/json-ast/x/rkt/map_assign.rkt.json
@@ -1,0 +1,98 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "scores"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "alice",
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "scores"
+        },
+        [
+          {
+            "sym": "hash-set"
+          },
+          {
+            "sym": "scores"
+          },
+          "bob",
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          {
+            "sym": "scores"
+          },
+          "bob"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_in_operator.rkt.json
+++ b/tests/json-ast/x/rkt/map_in_operator.rkt.json
@@ -1,0 +1,96 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          1,
+          "a",
+          2,
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_index.rkt.json
+++ b/tests/json-ast/x/rkt/map_index.rkt.json
@@ -1,0 +1,78 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1,
+          "b",
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          {
+            "sym": "m"
+          },
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_int_key.rkt.json
+++ b/tests/json-ast/x/rkt/map_int_key.rkt.json
@@ -1,0 +1,78 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          1,
+          "a",
+          2,
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          {
+            "sym": "m"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_literal_dynamic.rkt.json
+++ b/tests/json-ast/x/rkt/map_literal_dynamic.rkt.json
@@ -1,0 +1,169 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        3
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "y"
+        },
+        4
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          {
+            "sym": "x"
+          },
+          "b",
+          {
+            "sym": "y"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "filter"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "s"
+                }
+              ],
+              [
+                {
+                  "sym": "not"
+                },
+                [
+                  {
+                    "sym": "string=?"
+                  },
+                  {
+                    "sym": "s"
+                  },
+                  ""
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "m"
+                  },
+                  "a"
+                ]
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "m"
+                  },
+                  "b"
+                ]
+              ]
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_membership.rkt.json
+++ b/tests/json-ast/x/rkt/map_membership.rkt.json
@@ -1,0 +1,96 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1,
+          "b",
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          "a"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-has-key?"
+          },
+          {
+            "sym": "m"
+          },
+          "c"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/map_nested_assign.rkt.json
+++ b/tests/json-ast/x/rkt/map_nested_assign.rkt.json
@@ -1,0 +1,101 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "data"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "outer",
+          [
+            {
+              "sym": "hash"
+            },
+            "inner",
+            1
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "data"
+        },
+        2
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          [
+            {
+              "sym": "hash-ref"
+            },
+            {
+              "sym": "data"
+            },
+            "outer"
+          ],
+          "inner"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/match_expr.rkt.json
+++ b/tests/json-ast/x/rkt/match_expr.rkt.json
@@ -1,0 +1,85 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        2
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "label"
+        },
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "x"
+          },
+          [
+            1,
+            "one"
+          ],
+          [
+            2,
+            "two"
+          ],
+          [
+            3,
+            "three"
+          ],
+          [
+            {
+              "sym": "_"
+            },
+            "unknown"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "label"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/match_full.rkt.json
+++ b/tests/json-ast/x/rkt/match_full.rkt.json
@@ -1,0 +1,270 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        2
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "label"
+        },
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "x"
+          },
+          [
+            1,
+            "one"
+          ],
+          [
+            2,
+            "two"
+          ],
+          [
+            3,
+            "three"
+          ],
+          [
+            {
+              "sym": "_"
+            },
+            "unknown"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "label"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "day"
+        },
+        "sun"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "mood"
+        },
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "day"
+          },
+          [
+            "mon",
+            "tired"
+          ],
+          [
+            "fri",
+            "excited"
+          ],
+          [
+            "sun",
+            "relaxed"
+          ],
+          [
+            {
+              "sym": "_"
+            },
+            "normal"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "mood"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "ok"
+        },
+        true
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "status"
+        },
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "ok"
+          },
+          [
+            true,
+            "confirmed"
+          ],
+          [
+            false,
+            "denied"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "status"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "classify"
+          },
+          {
+            "sym": "n"
+          }
+        ],
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "n"
+          },
+          [
+            0,
+            "zero"
+          ],
+          [
+            1,
+            "one"
+          ],
+          [
+            {
+              "sym": "_"
+            },
+            "many"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "classify"
+          },
+          0
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "classify"
+          },
+          5
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/math_ops.rkt.json
+++ b/tests/json-ast/x/rkt/math_ops.rkt.json
@@ -1,0 +1,87 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "*"
+          },
+          6,
+          7
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "quotient"
+          },
+          7,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "modulo"
+          },
+          7,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/membership.rkt.json
+++ b/tests/json-ast/x/rkt/membership.rkt.json
@@ -1,0 +1,115 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "member"
+              },
+              2,
+              {
+                "sym": "nums"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "not"
+          },
+          [
+            {
+              "sym": "not"
+            },
+            [
+              {
+                "sym": "member"
+              },
+              4,
+              {
+                "sym": "nums"
+              }
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/min_max_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/min_max_builtin.rkt.json
@@ -1,0 +1,127 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          3,
+          1,
+          4
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "null?"
+            },
+            {
+              "sym": "nums"
+            }
+          ],
+          0,
+          [
+            {
+              "sym": "apply"
+            },
+            {
+              "sym": "min"
+            },
+            {
+              "sym": "nums"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "null?"
+            },
+            {
+              "sym": "nums"
+            }
+          ],
+          0,
+          [
+            {
+              "sym": "apply"
+            },
+            {
+              "sym": "max"
+            },
+            {
+              "sym": "nums"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/mix_go_python.rkt.json
+++ b/tests/json-ast/x/rkt/mix_go_python.rkt.json
@@ -1,0 +1,400 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "strings_TrimSpace"
+          },
+          {
+            "sym": "s"
+          }
+        ],
+        [
+          {
+            "sym": "string-trim"
+          },
+          {
+            "sym": "s"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "strings_ToUpper"
+          },
+          {
+            "sym": "s"
+          }
+        ],
+        [
+          {
+            "sym": "string-upcase"
+          },
+          {
+            "sym": "s"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_pi"
+        },
+        {
+          "sym": "pi"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_e"
+        },
+        [
+          {
+            "sym": "exp"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_pow"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ],
+        [
+          {
+            "sym": "expt"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sin"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sin"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_log"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "log"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "rawName"
+        },
+        "   alice  "
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "radius"
+        },
+        3
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "name"
+        },
+        [
+          {
+            "sym": "strings_ToUpper"
+          },
+          [
+            {
+              "sym": "strings_TrimSpace"
+            },
+            {
+              "sym": "rawName"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "area"
+        },
+        [
+          {
+            "sym": "*"
+          },
+          {
+            "sym": "math_pi"
+          },
+          [
+            {
+              "sym": "math_pow"
+            },
+            {
+              "sym": "radius"
+            },
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "Hello",
+              [
+                {
+                  "sym": "string-append"
+                },
+                {
+                  "sym": "name"
+                },
+                "!"
+              ]
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "The area of a circle with radius",
+              {
+                "sym": "radius"
+              },
+              "is",
+              {
+                "sym": "area"
+              }
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/nested_function.rkt.json
+++ b/tests/json-ast/x/rkt/nested_function.rkt.json
@@ -1,0 +1,101 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "outer"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "define"
+          },
+          [
+            {
+              "sym": "inner"
+            },
+            {
+              "sym": "y"
+            }
+          ],
+          [
+            {
+              "sym": "+"
+            },
+            {
+              "sym": "x"
+            },
+            {
+              "sym": "y"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "inner"
+          },
+          5
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "outer"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/order_by_map.rkt.json
+++ b/tests/json-ast/x/rkt/order_by_map.rkt.json
@@ -1,0 +1,227 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "data"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            1,
+            "b",
+            2
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            1,
+            "b",
+            1
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "a",
+            0,
+            "b",
+            5
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "sorted"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "x"
+                },
+                {
+                  "sym": "data"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "cons"
+                    },
+                    [
+                      {
+                        "sym": "hash"
+                      },
+                      "a",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "x"
+                        },
+                        "a"
+                      ],
+                      "b",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "x"
+                        },
+                        "b"
+                      ]
+                    ],
+                    {
+                      "sym": "x"
+                    }
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              {
+                "sym": "\u003c"
+              },
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "sorted"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/outer_join.rkt.json
+++ b/tests/json-ast/x/rkt/outer_join.rkt.json
@@ -1,0 +1,465 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            3,
+            "name",
+            "Charlie"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            4,
+            "name",
+            "Diana"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1,
+            "total",
+            250
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2,
+            "total",
+            125
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            1,
+            "total",
+            300
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            103,
+            "customerId",
+            5,
+            "total",
+            80
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "matched"
+                  },
+                  false
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "c"
+                    },
+                    {
+                      "sym": "customers"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "="
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "o"
+                      },
+                      "customerId"
+                    ],
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "c"
+                      },
+                      "id"
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "matched"
+                    },
+                    true
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "append"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "list"
+                        },
+                        [
+                          {
+                            "sym": "hash"
+                          },
+                          "order",
+                          {
+                            "sym": "o"
+                          },
+                          "customer",
+                          {
+                            "sym": "c"
+                          }
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "not"
+                    },
+                    {
+                      "sym": "matched"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "let"
+                    },
+                    [
+                      [
+                        {
+                          "sym": "c"
+                        },
+                        false
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "set!"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "append"
+                        },
+                        {
+                          "sym": "_res"
+                        },
+                        [
+                          {
+                            "sym": "list"
+                          },
+                          [
+                            {
+                              "sym": "hash"
+                            },
+                            "order",
+                            {
+                              "sym": "o"
+                            },
+                            "customer",
+                            {
+                              "sym": "c"
+                            }
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "c"
+                },
+                {
+                  "sym": "customers"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "unless"
+              },
+              [
+                {
+                  "sym": "for/or"
+                },
+                [
+                  [
+                    {
+                      "sym": "o"
+                    },
+                    {
+                      "sym": "orders"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "="
+                  },
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "o"
+                    },
+                    "customerId"
+                  ],
+                  [
+                    {
+                      "sym": "hash-ref"
+                    },
+                    {
+                      "sym": "c"
+                    },
+                    "id"
+                  ]
+                ]
+              ],
+              [
+                {
+                  "sym": "let"
+                },
+                [
+                  [
+                    {
+                      "sym": "o"
+                    },
+                    false
+                  ]
+                ],
+                [
+                  {
+                    "sym": "set!"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "append"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "list"
+                      },
+                      [
+                        {
+                          "sym": "hash"
+                        },
+                        "order",
+                        {
+                          "sym": "o"
+                        },
+                        "customer",
+                        {
+                          "sym": "c"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ],
+        {
+          "sym": "_res"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/partial_application.rkt.json
+++ b/tests/json-ast/x/rkt/partial_application.rkt.json
@@ -1,0 +1,103 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "add"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ],
+        [
+          {
+            "sym": "+"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "add5"
+        },
+        [
+          {
+            "sym": "add"
+          },
+          5
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "add5"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/print_hello.rkt.json
+++ b/tests/json-ast/x/rkt/print_hello.rkt.json
@@ -1,0 +1,49 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "hello"
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/pure_fold.rkt.json
+++ b/tests/json-ast/x/rkt/pure_fold.rkt.json
@@ -1,0 +1,86 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "triple"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "*"
+          },
+          {
+            "sym": "x"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "triple"
+          },
+          [
+            {
+              "sym": "+"
+            },
+            1,
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/pure_global_fold.rkt.json
+++ b/tests/json-ast/x/rkt/pure_global_fold.rkt.json
@@ -1,0 +1,95 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "k"
+        },
+        2
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "inc"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "+"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "k"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "inc"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/python_auto.rkt.json
+++ b/tests/json-ast/x/rkt/python_auto.rkt.json
@@ -1,0 +1,191 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_pi"
+        },
+        {
+          "sym": "pi"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_e"
+        },
+        [
+          {
+            "sym": "exp"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_pow"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ],
+        [
+          {
+            "sym": "expt"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sin"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sin"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_log"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "log"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "math_sqrt"
+          },
+          16
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "math_pi"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/python_math.rkt.json
+++ b/tests/json-ast/x/rkt/python_math.rkt.json
@@ -1,0 +1,466 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_pi"
+        },
+        {
+          "sym": "pi"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "math_e"
+        },
+        [
+          {
+            "sym": "exp"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sqrt"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_pow"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ],
+        [
+          {
+            "sym": "expt"
+          },
+          {
+            "sym": "x"
+          },
+          {
+            "sym": "y"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_sin"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "sin"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "math_log"
+          },
+          {
+            "sym": "x"
+          }
+        ],
+        [
+          {
+            "sym": "log"
+          },
+          {
+            "sym": "x"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "r"
+        },
+        3
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "area"
+        },
+        [
+          {
+            "sym": "*"
+          },
+          {
+            "sym": "math_pi"
+          },
+          [
+            {
+              "sym": "math_pow"
+            },
+            {
+              "sym": "r"
+            },
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "root"
+        },
+        [
+          {
+            "sym": "math_sqrt"
+          },
+          49
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "sin45"
+        },
+        [
+          {
+            "sym": "math_sin"
+          },
+          [
+            {
+              "sym": "/"
+            },
+            {
+              "sym": "math_pi"
+            },
+            4
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "log_e"
+        },
+        [
+          {
+            "sym": "math_log"
+          },
+          {
+            "sym": "math_e"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "Circle area with r =",
+              {
+                "sym": "r"
+              },
+              "=\u003e",
+              {
+                "sym": "area"
+              }
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "Square root of 49:",
+              {
+                "sym": "root"
+              }
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "sin(π/4):",
+              {
+                "sym": "sin45"
+              }
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-join"
+          },
+          [
+            {
+              "sym": "map"
+            },
+            [
+              {
+                "sym": "lambda"
+              },
+              [
+                {
+                  "sym": "x"
+                }
+              ],
+              [
+                {
+                  "sym": "format"
+                },
+                "~a",
+                {
+                  "sym": "x"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "list"
+              },
+              "log(e):",
+              {
+                "sym": "log_e"
+              }
+            ]
+          ],
+          " "
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/query_sum_select.rkt.json
+++ b/tests/json-ast/x/rkt/query_sum_select.rkt.json
@@ -1,0 +1,165 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "nums"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          1,
+          2,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "n"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "when"
+              },
+              [
+                {
+                  "sym": "\u003e"
+                },
+                {
+                  "sym": "n"
+                },
+                1
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "append"
+                  },
+                  {
+                    "sym": "_res"
+                  },
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "apply"
+                      },
+                      {
+                        "sym": "+"
+                      },
+                      {
+                        "sym": "n"
+                      }
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "result"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/record_assign.rkt.json
+++ b/tests/json-ast/x/rkt/record_assign.rkt.json
@@ -1,0 +1,123 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "inc"
+          },
+          {
+            "sym": "c"
+          }
+        ],
+        [
+          {
+            "sym": "set!"
+          },
+          {
+            "sym": "c"
+          },
+          [
+            {
+              "sym": "hash-set"
+            },
+            {
+              "sym": "c"
+            },
+            "n",
+            [
+              {
+                "sym": "+"
+              },
+              [
+                {
+                  "sym": "hash-ref"
+                },
+                {
+                  "sym": "c"
+                },
+                "n"
+              ],
+              1
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "c"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "n",
+          0
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "inc"
+        },
+        {
+          "sym": "c"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          {
+            "sym": "c"
+          },
+          "n"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/right_join.rkt.json
+++ b/tests/json-ast/x/rkt/right_join.rkt.json
@@ -1,0 +1,629 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "customers"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            1,
+            "name",
+            "Alice"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            2,
+            "name",
+            "Bob"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            3,
+            "name",
+            "Charlie"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            4,
+            "name",
+            "Diana"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "orders"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            100,
+            "customerId",
+            1,
+            "total",
+            250
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            101,
+            "customerId",
+            2,
+            "total",
+            125
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "id",
+            102,
+            "customerId",
+            1,
+            "total",
+            300
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "o"
+                },
+                {
+                  "sym": "orders"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "let"
+              },
+              [
+                [
+                  {
+                    "sym": "matched"
+                  },
+                  false
+                ]
+              ],
+              [
+                {
+                  "sym": "for"
+                },
+                [
+                  [
+                    {
+                      "sym": "c"
+                    },
+                    {
+                      "sym": "customers"
+                    }
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "="
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "o"
+                      },
+                      "customerId"
+                    ],
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "c"
+                      },
+                      "id"
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "matched"
+                    },
+                    true
+                  ],
+                  [
+                    {
+                      "sym": "set!"
+                    },
+                    {
+                      "sym": "_res"
+                    },
+                    [
+                      {
+                        "sym": "append"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "list"
+                        },
+                        [
+                          {
+                            "sym": "hash"
+                          },
+                          "customerName",
+                          [
+                            {
+                              "sym": "if"
+                            },
+                            {
+                              "sym": "c"
+                            },
+                            [
+                              {
+                                "sym": "hash-ref"
+                              },
+                              {
+                                "sym": "c"
+                              },
+                              "name"
+                            ],
+                            false
+                          ],
+                          "order",
+                          {
+                            "sym": "o"
+                          }
+                        ]
+                      ]
+                    ]
+                  ]
+                ],
+                [
+                  {
+                    "sym": "when"
+                  },
+                  [
+                    {
+                      "sym": "not"
+                    },
+                    {
+                      "sym": "matched"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "let"
+                    },
+                    [
+                      [
+                        {
+                          "sym": "c"
+                        },
+                        false
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "set!"
+                      },
+                      {
+                        "sym": "_res"
+                      },
+                      [
+                        {
+                          "sym": "append"
+                        },
+                        {
+                          "sym": "_res"
+                        },
+                        [
+                          {
+                            "sym": "list"
+                          },
+                          [
+                            {
+                              "sym": "hash"
+                            },
+                            "customerName",
+                            [
+                              {
+                                "sym": "if"
+                              },
+                              {
+                                "sym": "c"
+                              },
+                              [
+                                {
+                                  "sym": "hash-ref"
+                                },
+                                {
+                                  "sym": "c"
+                                },
+                                "name"
+                              ],
+                              false
+                            ],
+                            "order",
+                            {
+                              "sym": "o"
+                            }
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "--- Right Join using syntax ---"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "entry"
+            },
+            {
+              "sym": "result"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "hash-ref"
+            },
+            {
+              "sym": "entry"
+            },
+            "order"
+          ],
+          [
+            {
+              "sym": "begin"
+            },
+            [
+              {
+                "sym": "displayln"
+              },
+              [
+                {
+                  "sym": "string-join"
+                },
+                [
+                  {
+                    "sym": "filter"
+                  },
+                  [
+                    {
+                      "sym": "lambda"
+                    },
+                    [
+                      {
+                        "sym": "s"
+                      }
+                    ],
+                    [
+                      {
+                        "sym": "not"
+                      },
+                      [
+                        {
+                          "sym": "string=?"
+                        },
+                        {
+                          "sym": "s"
+                        },
+                        ""
+                      ]
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      "Customer"
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "entry"
+                        },
+                        "customerName"
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      "has order"
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "entry"
+                          },
+                          "order"
+                        ],
+                        "id"
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      "- $"
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        [
+                          {
+                            "sym": "hash-ref"
+                          },
+                          {
+                            "sym": "entry"
+                          },
+                          "order"
+                        ],
+                        "total"
+                      ]
+                    ]
+                  ]
+                ],
+                " "
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "begin"
+            },
+            [
+              {
+                "sym": "displayln"
+              },
+              [
+                {
+                  "sym": "string-join"
+                },
+                [
+                  {
+                    "sym": "filter"
+                  },
+                  [
+                    {
+                      "sym": "lambda"
+                    },
+                    [
+                      {
+                        "sym": "s"
+                      }
+                    ],
+                    [
+                      {
+                        "sym": "not"
+                      },
+                      [
+                        {
+                          "sym": "string=?"
+                        },
+                        {
+                          "sym": "s"
+                        },
+                        ""
+                      ]
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "list"
+                    },
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      "Customer"
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      [
+                        {
+                          "sym": "hash-ref"
+                        },
+                        {
+                          "sym": "entry"
+                        },
+                        "customerName"
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "format"
+                      },
+                      "~a",
+                      "has no orders"
+                    ]
+                  ]
+                ],
+                " "
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/save_jsonl_stdout.rkt.json
+++ b/tests/json-ast/x/rkt/save_jsonl_stdout.rkt.json
@@ -1,0 +1,92 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            30
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            25
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "for"
+        },
+        [
+          [
+            {
+              "sym": "_row"
+            },
+            {
+              "sym": "people"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          [
+            {
+              "sym": "jsexpr-\u003estring"
+            },
+            {
+              "sym": "_row"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/short_circuit.rkt.json
+++ b/tests/json-ast/x/rkt/short_circuit.rkt.json
@@ -1,0 +1,110 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "boom"
+          },
+          {
+            "sym": "a"
+          },
+          {
+            "sym": "b"
+          }
+        ],
+        [
+          {
+            "sym": "displayln"
+          },
+          "boom"
+        ],
+        true
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "and"
+          },
+          false,
+          [
+            {
+              "sym": "boom"
+            },
+            1,
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "or"
+          },
+          true,
+          [
+            {
+              "sym": "boom"
+            },
+            1,
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/slice.rkt.json
+++ b/tests/json-ast/x/rkt/slice.rkt.json
@@ -1,0 +1,87 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "sublist"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2,
+            3
+          ],
+          1,
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "sublist"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2,
+            3
+          ],
+          0,
+          2
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "substring"
+          },
+          "hello",
+          1,
+          4
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/sort_stable.rkt.json
+++ b/tests/json-ast/x/rkt/sort_stable.rkt.json
@@ -1,0 +1,328 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "items"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "n",
+            1,
+            "v",
+            "a"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "n",
+            1,
+            "v",
+            "b"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "n",
+            2,
+            "v",
+            "c"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "let"
+          },
+          [
+            [
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "quote"
+                },
+                []
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "i"
+                },
+                {
+                  "sym": "items"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "set!"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "append"
+                },
+                {
+                  "sym": "_res"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  [
+                    {
+                      "sym": "cons"
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "i"
+                      },
+                      "n"
+                    ],
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "i"
+                      },
+                      "v"
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "sort"
+              },
+              {
+                "sym": "_res"
+              },
+              [
+                {
+                  "sym": "lambda"
+                },
+                [
+                  {
+                    "sym": "a"
+                  },
+                  {
+                    "sym": "b"
+                  }
+                ],
+                [
+                  {
+                    "sym": "cond"
+                  },
+                  [
+                    [
+                      {
+                        "sym": "and"
+                      },
+                      [
+                        {
+                          "sym": "number?"
+                        },
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "number?"
+                        },
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "\u003c"
+                      },
+                      {
+                        "sym": "a"
+                      },
+                      {
+                        "sym": "b"
+                      }
+                    ]
+                  ],
+                  [
+                    [
+                      {
+                        "sym": "and"
+                      },
+                      [
+                        {
+                          "sym": "string?"
+                        },
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "string?"
+                        },
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ],
+                    [
+                      {
+                        "sym": "string\u003c?"
+                      },
+                      {
+                        "sym": "a"
+                      },
+                      {
+                        "sym": "b"
+                      }
+                    ]
+                  ],
+                  [
+                    {
+                      "sym": "else"
+                    },
+                    [
+                      {
+                        "sym": "string\u003c?"
+                      },
+                      [
+                        {
+                          "sym": "format"
+                        },
+                        "~a",
+                        {
+                          "sym": "a"
+                        }
+                      ],
+                      [
+                        {
+                          "sym": "format"
+                        },
+                        "~a",
+                        {
+                          "sym": "b"
+                        }
+                      ]
+                    ]
+                  ]
+                ]
+              ],
+              {
+                "sym": "key"
+              },
+              {
+                "sym": "car"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "_res"
+            },
+            [
+              {
+                "sym": "map"
+              },
+              {
+                "sym": "cdr"
+              },
+              {
+                "sym": "_res"
+              }
+            ]
+          ],
+          {
+            "sym": "_res"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "result"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/str_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/str_builtin.rkt.json
@@ -1,0 +1,55 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "format"
+          },
+          "~a",
+          123
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_compare.rkt.json
+++ b/tests/json-ast/x/rkt/string_compare.rkt.json
@@ -1,0 +1,103 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string\u003c?"
+          },
+          "a",
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string\u003c=?"
+          },
+          "a",
+          "a"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string\u003e?"
+          },
+          "b",
+          "a"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string\u003e=?"
+          },
+          "b",
+          "b"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_concat.rkt.json
+++ b/tests/json-ast/x/rkt/string_concat.rkt.json
@@ -1,0 +1,55 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-append"
+          },
+          "hello ",
+          "world"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_contains.rkt.json
+++ b/tests/json-ast/x/rkt/string_contains.rkt.json
@@ -1,0 +1,88 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s"
+        },
+        "catch"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "cat"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "dog"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_in_operator.rkt.json
+++ b/tests/json-ast/x/rkt/string_in_operator.rkt.json
@@ -1,0 +1,88 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s"
+        },
+        "catch"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "cat"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-contains?"
+          },
+          {
+            "sym": "s"
+          },
+          "dog"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_index.rkt.json
+++ b/tests/json-ast/x/rkt/string_index.rkt.json
@@ -1,0 +1,70 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s"
+        },
+        "mochi"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "string-ref"
+          },
+          {
+            "sym": "s"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/string_prefix_slice.rkt.json
+++ b/tests/json-ast/x/rkt/string_prefix_slice.rkt.json
@@ -1,0 +1,221 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "prefix"
+        },
+        "fore"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s1"
+        },
+        "forest"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "="
+          },
+          [
+            {
+              "sym": "substring"
+            },
+            {
+              "sym": "s1"
+            },
+            0,
+            [
+              {
+                "sym": "cond"
+              },
+              [
+                [
+                  {
+                    "sym": "string?"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ],
+                [
+                  {
+                    "sym": "string-length"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "sym": "hash?"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ],
+                [
+                  {
+                    "sym": "hash-count"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "else"
+                },
+                [
+                  {
+                    "sym": "length"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "prefix"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "s2"
+        },
+        "desert"
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "="
+          },
+          [
+            {
+              "sym": "substring"
+            },
+            {
+              "sym": "s2"
+            },
+            0,
+            [
+              {
+                "sym": "cond"
+              },
+              [
+                [
+                  {
+                    "sym": "string?"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ],
+                [
+                  {
+                    "sym": "string-length"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ],
+              [
+                [
+                  {
+                    "sym": "hash?"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ],
+                [
+                  {
+                    "sym": "hash-count"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ],
+              [
+                {
+                  "sym": "else"
+                },
+                [
+                  {
+                    "sym": "length"
+                  },
+                  {
+                    "sym": "prefix"
+                  }
+                ]
+              ]
+            ]
+          ],
+          {
+            "sym": "prefix"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/substring_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/substring_builtin.rkt.json
@@ -1,0 +1,56 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "substring"
+          },
+          "mochi",
+          1,
+          4
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/sum_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/sum_builtin.rkt.json
@@ -1,0 +1,64 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "apply"
+          },
+          {
+            "sym": "+"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            1,
+            2,
+            3
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/tail_recursion.rkt.json
+++ b/tests/json-ast/x/rkt/tail_recursion.rkt.json
@@ -1,0 +1,122 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "sum_rec"
+          },
+          {
+            "sym": "n"
+          },
+          {
+            "sym": "acc"
+          }
+        ],
+        [
+          {
+            "sym": "if"
+          },
+          [
+            {
+              "sym": "="
+            },
+            {
+              "sym": "n"
+            },
+            0
+          ],
+          [
+            {
+              "sym": "begin"
+            },
+            {
+              "sym": "acc"
+            }
+          ]
+        ],
+        [
+          {
+            "sym": "sum_rec"
+          },
+          [
+            {
+              "sym": "-"
+            },
+            {
+              "sym": "n"
+            },
+            1
+          ],
+          [
+            {
+              "sym": "+"
+            },
+            {
+              "sym": "acc"
+            },
+            {
+              "sym": "n"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "sum_rec"
+          },
+          10,
+          0
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/test_block.rkt.json
+++ b/tests/json-ast/x/rkt/test_block.rkt.json
@@ -1,0 +1,49 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "ok"
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/tree_sum.rkt.json
+++ b/tests/json-ast/x/rkt/tree_sum.rkt.json
@@ -1,0 +1,157 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "racket/math"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "sum_tree"
+          },
+          {
+            "sym": "t"
+          }
+        ],
+        [
+          {
+            "sym": "match"
+          },
+          {
+            "sym": "t"
+          },
+          [
+            {
+              "sym": "Leaf"
+            },
+            0
+          ],
+          [
+            [
+              {
+                "sym": "Node"
+              },
+              {
+                "sym": "left"
+              },
+              {
+                "sym": "value"
+              },
+              {
+                "sym": "right"
+              }
+            ],
+            [
+              {
+                "sym": "+"
+              },
+              [
+                {
+                  "sym": "+"
+                },
+                [
+                  {
+                    "sym": "sum_tree"
+                  },
+                  {
+                    "sym": "left"
+                  }
+                ],
+                {
+                  "sym": "value"
+                }
+              ],
+              [
+                {
+                  "sym": "sum_tree"
+                },
+                {
+                  "sym": "right"
+                }
+              ]
+            ]
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "t"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "left",
+          {
+            "sym": "Leaf"
+          },
+          "value",
+          1,
+          "right",
+          [
+            {
+              "sym": "hash"
+            },
+            "left",
+            {
+              "sym": "Leaf"
+            },
+            "value",
+            2,
+            "right",
+            {
+              "sym": "Leaf"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "sum_tree"
+          },
+          {
+            "sym": "t"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/two-sum.rkt.json
+++ b/tests/json-ast/x/rkt/two-sum.rkt.json
@@ -1,0 +1,307 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        [
+          {
+            "sym": "twoSum"
+          },
+          {
+            "sym": "nums"
+          },
+          {
+            "sym": "target"
+          }
+        ],
+        [
+          {
+            "sym": "define"
+          },
+          {
+            "sym": "n"
+          },
+          [
+            {
+              "sym": "cond"
+            },
+            [
+              [
+                {
+                  "sym": "string?"
+                },
+                {
+                  "sym": "nums"
+                }
+              ],
+              [
+                {
+                  "sym": "string-length"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ],
+            [
+              [
+                {
+                  "sym": "hash?"
+                },
+                {
+                  "sym": "nums"
+                }
+              ],
+              [
+                {
+                  "sym": "hash-count"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ],
+            [
+              {
+                "sym": "else"
+              },
+              [
+                {
+                  "sym": "length"
+                },
+                {
+                  "sym": "nums"
+                }
+              ]
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "for"
+          },
+          [
+            [
+              {
+                "sym": "i"
+              },
+              [
+                {
+                  "sym": "in-range"
+                },
+                0,
+                {
+                  "sym": "n"
+                }
+              ]
+            ]
+          ],
+          [
+            {
+              "sym": "for"
+            },
+            [
+              [
+                {
+                  "sym": "j"
+                },
+                [
+                  {
+                    "sym": "in-range"
+                  },
+                  [
+                    {
+                      "sym": "+"
+                    },
+                    {
+                      "sym": "i"
+                    },
+                    1
+                  ],
+                  {
+                    "sym": "n"
+                  }
+                ]
+              ]
+            ],
+            [
+              {
+                "sym": "if"
+              },
+              [
+                {
+                  "sym": "="
+                },
+                [
+                  {
+                    "sym": "+"
+                  },
+                  [
+                    {
+                      "sym": "list-ref"
+                    },
+                    {
+                      "sym": "nums"
+                    },
+                    {
+                      "sym": "i"
+                    }
+                  ],
+                  [
+                    {
+                      "sym": "list-ref"
+                    },
+                    {
+                      "sym": "nums"
+                    },
+                    {
+                      "sym": "j"
+                    }
+                  ]
+                ],
+                {
+                  "sym": "target"
+                }
+              ],
+              [
+                {
+                  "sym": "begin"
+                },
+                [
+                  {
+                    "sym": "list"
+                  },
+                  {
+                    "sym": "i"
+                  },
+                  {
+                    "sym": "j"
+                  }
+                ]
+              ]
+            ]
+          ]
+        ],
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "-"
+            },
+            1
+          ],
+          [
+            {
+              "sym": "-"
+            },
+            1
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "result"
+        },
+        [
+          {
+            "sym": "twoSum"
+          },
+          [
+            {
+              "sym": "list"
+            },
+            2,
+            7,
+            11,
+            15
+          ],
+          9
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "list-ref"
+          },
+          {
+            "sym": "result"
+          },
+          0
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "list-ref"
+          },
+          {
+            "sym": "result"
+          },
+          1
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/typed_let.rkt.json
+++ b/tests/json-ast/x/rkt/typed_let.rkt.json
@@ -1,0 +1,47 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "y"
+        },
+        0
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "y"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/typed_var.rkt.json
+++ b/tests/json-ast/x/rkt/typed_var.rkt.json
@@ -1,0 +1,47 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        },
+        {
+          "sym": "json"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        0
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "x"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/unary_neg.rkt.json
+++ b/tests/json-ast/x/rkt/unary_neg.rkt.json
@@ -1,0 +1,75 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "-"
+          },
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "+"
+          },
+          5,
+          [
+            {
+              "sym": "-"
+            },
+            2
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/update_stmt.rkt.json
+++ b/tests/json-ast/x/rkt/update_stmt.rkt.json
@@ -1,0 +1,215 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "list"
+          },
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Alice",
+            "age",
+            17,
+            "status",
+            "minor"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            25,
+            "status",
+            "unknown"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Charlie",
+            "age",
+            18,
+            "status",
+            "unknown"
+          ],
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Diana",
+            "age",
+            16,
+            "status",
+            "minor"
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "people"
+        },
+        [
+          {
+            "sym": "for/list"
+          },
+          [
+            [
+              {
+                "sym": "item"
+              },
+              {
+                "sym": "people"
+              }
+            ]
+          ],
+          [
+            {
+              "sym": "begin"
+            },
+            [
+              {
+                "sym": "when"
+              },
+              [
+                {
+                  "sym": "\u003e="
+                },
+                [
+                  {
+                    "sym": "hash-ref"
+                  },
+                  {
+                    "sym": "item"
+                  },
+                  "age"
+                ],
+                18
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "item"
+                },
+                [
+                  {
+                    "sym": "hash-set"
+                  },
+                  {
+                    "sym": "item"
+                  },
+                  "status",
+                  "adult"
+                ]
+              ],
+              [
+                {
+                  "sym": "set!"
+                },
+                {
+                  "sym": "item"
+                },
+                [
+                  {
+                    "sym": "hash-set"
+                  },
+                  {
+                    "sym": "item"
+                  },
+                  "age",
+                  [
+                    {
+                      "sym": "+"
+                    },
+                    [
+                      {
+                        "sym": "hash-ref"
+                      },
+                      {
+                        "sym": "item"
+                      },
+                      "age"
+                    ],
+                    1
+                  ]
+                ]
+              ]
+            ],
+            {
+              "sym": "item"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        "ok"
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/user_type_literal.rkt.json
+++ b/tests/json-ast/x/rkt/user_type_literal.rkt.json
@@ -1,0 +1,92 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "book"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "title",
+          "Go",
+          "author",
+          [
+            {
+              "sym": "hash"
+            },
+            "name",
+            "Bob",
+            "age",
+            42
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "hash-ref"
+          },
+          [
+            {
+              "sym": "hash-ref"
+            },
+            {
+              "sym": "book"
+            },
+            "author"
+          ],
+          "name"
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/values_builtin.rkt.json
+++ b/tests/json-ast/x/rkt/values_builtin.rkt.json
@@ -1,0 +1,79 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "m"
+        },
+        [
+          {
+            "sym": "hash"
+          },
+          "a",
+          1,
+          "b",
+          2,
+          "c",
+          3
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        [
+          {
+            "sym": "values"
+          },
+          {
+            "sym": "m"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/var_assignment.rkt.json
+++ b/tests/json-ast/x/rkt/var_assignment.rkt.json
@@ -1,0 +1,77 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "x"
+        },
+        1
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "set!"
+        },
+        {
+          "sym": "x"
+        },
+        2
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "displayln"
+        },
+        {
+          "sym": "x"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tests/json-ast/x/rkt/while_loop.rkt.json
+++ b/tests/json-ast/x/rkt/while_loop.rkt.json
@@ -1,0 +1,109 @@
+{
+  "forms": [
+    {
+      "datum": [
+        {
+          "sym": "require"
+        },
+        {
+          "sym": "racket/list"
+        },
+        {
+          "sym": "racket/string"
+        }
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "struct"
+        },
+        {
+          "sym": "group"
+        },
+        [
+          {
+            "sym": "key"
+          },
+          {
+            "sym": "items"
+          }
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "define"
+        },
+        {
+          "sym": "i"
+        },
+        0
+      ],
+      "line": 0,
+      "col": 0
+    },
+    {
+      "datum": [
+        {
+          "sym": "let"
+        },
+        {
+          "sym": "loop"
+        },
+        [],
+        [
+          {
+            "sym": "when"
+          },
+          [
+            {
+              "sym": "\u003c"
+            },
+            {
+              "sym": "i"
+            },
+            3
+          ],
+          [
+            {
+              "sym": "displayln"
+            },
+            {
+              "sym": "i"
+            }
+          ],
+          [
+            {
+              "sym": "set!"
+            },
+            {
+              "sym": "i"
+            },
+            [
+              {
+                "sym": "+"
+              },
+              {
+                "sym": "i"
+              },
+              1
+            ]
+          ],
+          [
+            {
+              "sym": "loop"
+            }
+          ]
+        ]
+      ],
+      "line": 0,
+      "col": 0
+    }
+  ]
+}

--- a/tools/json-ast/x/rkt/inspect.go
+++ b/tools/json-ast/x/rkt/inspect.go
@@ -1,0 +1,22 @@
+//go:build slow
+
+package rkt
+
+import (
+	rktparse "mochi/tools/a2mochi/x/rkt"
+)
+
+// Program represents a parsed Racket source file.
+type Program struct {
+	Forms []rktparse.Form `json:"forms"`
+}
+
+// Inspect parses the provided Racket source code and returns a Program
+// describing its structure using the official Racket parser.
+func Inspect(src string) (*Program, error) {
+	prog, err := rktparse.Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	return &Program{Forms: prog.Forms}, nil
+}

--- a/tools/json-ast/x/rkt/inspect_test.go
+++ b/tools/json-ast/x/rkt/inspect_test.go
@@ -1,0 +1,89 @@
+//go:build slow
+
+package rkt_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	rack "mochi/compiler/x/racket"
+	rkt "mochi/tools/json-ast/x/rkt"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func ensureRacket(t *testing.T) {
+	if err := rack.EnsureRacket(); err != nil {
+		t.Skipf("racket not installed: %v", err)
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureRacket(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "rkt")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "rkt")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.rkt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".rkt")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := rkt.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".rkt.json")
+			if *update {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Fatalf("missing golden: %v", err)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- support inspecting Racket source
- add golden tests for Racket AST inspection

## Testing
- `go test ./tools/json-ast/... -tags slow`


------
https://chatgpt.com/codex/tasks/task_e_6889165acb048320a94e59d4fd06dc6f