### PR TITLE
Add Rust AST inspection

### DIFF
--- a/tests/json-ast/x/rs/append_builtin.rs.json
+++ b/tests/json-ast/x/rs/append_builtin.rs.json
@@ -1,0 +1,602 @@
+{
+  "file": {
+    "kind": "SOURCE_FILE",
+    "start": 0,
+    "end": 179,
+    "children": [
+      {
+        "kind": "FN",
+        "start": 0,
+        "end": 178,
+        "children": [
+          {
+            "kind": "COMMENT",
+            "start": 0,
+            "end": 67
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 67,
+            "end": 68
+          },
+          {
+            "kind": "FN_KW",
+            "start": 68,
+            "end": 70
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 70,
+            "end": 71
+          },
+          {
+            "kind": "NAME",
+            "start": 71,
+            "end": 75,
+            "children": [
+              {
+                "kind": "IDENT",
+                "start": 71,
+                "end": 75
+              }
+            ]
+          },
+          {
+            "kind": "PARAM_LIST",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "L_PAREN",
+                "start": 75,
+                "end": 76
+              },
+              {
+                "kind": "R_PAREN",
+                "start": 76,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 77,
+            "end": 78
+          },
+          {
+            "kind": "BLOCK_EXPR",
+            "start": 78,
+            "end": 178,
+            "children": [
+              {
+                "kind": "STMT_LIST",
+                "start": 78,
+                "end": 178,
+                "children": [
+                  {
+                    "kind": "L_CURLY",
+                    "start": 78,
+                    "end": 79
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 79,
+                    "end": 84
+                  },
+                  {
+                    "kind": "LET_STMT",
+                    "start": 84,
+                    "end": 113,
+                    "children": [
+                      {
+                        "kind": "LET_KW",
+                        "start": 84,
+                        "end": 87
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 87,
+                        "end": 88
+                      },
+                      {
+                        "kind": "IDENT_PAT",
+                        "start": 88,
+                        "end": 89,
+                        "children": [
+                          {
+                            "kind": "NAME",
+                            "start": 88,
+                            "end": 89,
+                            "children": [
+                              {
+                                "kind": "IDENT",
+                                "start": 88,
+                                "end": 89
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "COLON",
+                        "start": 89,
+                        "end": 90
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 90,
+                        "end": 91
+                      },
+                      {
+                        "kind": "PATH_TYPE",
+                        "start": 91,
+                        "end": 99,
+                        "children": [
+                          {
+                            "kind": "PATH",
+                            "start": 91,
+                            "end": 99,
+                            "children": [
+                              {
+                                "kind": "PATH_SEGMENT",
+                                "start": 91,
+                                "end": 99,
+                                "children": [
+                                  {
+                                    "kind": "NAME_REF",
+                                    "start": 91,
+                                    "end": 94,
+                                    "children": [
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 91,
+                                        "end": 94
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "GENERIC_ARG_LIST",
+                                    "start": 94,
+                                    "end": 99,
+                                    "children": [
+                                      {
+                                        "kind": "L_ANGLE",
+                                        "start": 94,
+                                        "end": 95
+                                      },
+                                      {
+                                        "kind": "TYPE_ARG",
+                                        "start": 95,
+                                        "end": 98,
+                                        "children": [
+                                          {
+                                            "kind": "PATH_TYPE",
+                                            "start": 95,
+                                            "end": 98,
+                                            "children": [
+                                              {
+                                                "kind": "PATH",
+                                                "start": 95,
+                                                "end": 98,
+                                                "children": [
+                                                  {
+                                                    "kind": "PATH_SEGMENT",
+                                                    "start": 95,
+                                                    "end": 98,
+                                                    "children": [
+                                                      {
+                                                        "kind": "NAME_REF",
+                                                        "start": 95,
+                                                        "end": 98,
+                                                        "children": [
+                                                          {
+                                                            "kind": "IDENT",
+                                                            "start": 95,
+                                                            "end": 98
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "R_ANGLE",
+                                        "start": 98,
+                                        "end": 99
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 99,
+                        "end": 100
+                      },
+                      {
+                        "kind": "EQ",
+                        "start": 100,
+                        "end": 101
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 101,
+                        "end": 102
+                      },
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 102,
+                        "end": 112,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 102,
+                            "end": 112,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 102,
+                                "end": 105,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 102,
+                                    "end": 105,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 102,
+                                        "end": 105,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 102,
+                                            "end": 105
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 105,
+                                "end": 106
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 106,
+                                "end": 112,
+                                "children": [
+                                  {
+                                    "kind": "L_BRACK",
+                                    "start": 106,
+                                    "end": 107
+                                  },
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 107,
+                                    "end": 108
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 108,
+                                    "end": 109
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 109,
+                                    "end": 110
+                                  },
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 110,
+                                    "end": 111
+                                  },
+                                  {
+                                    "kind": "R_BRACK",
+                                    "start": 111,
+                                    "end": 112
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 112,
+                        "end": 113
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 113,
+                    "end": 118
+                  },
+                  {
+                    "kind": "EXPR_STMT",
+                    "start": 118,
+                    "end": 176,
+                    "children": [
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 118,
+                        "end": 175,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 118,
+                            "end": 175,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 118,
+                                "end": 125,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 118,
+                                    "end": 125,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 118,
+                                        "end": 125,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 118,
+                                            "end": 125
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 125,
+                                "end": 126
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 126,
+                                "end": 175,
+                                "children": [
+                                  {
+                                    "kind": "L_PAREN",
+                                    "start": 126,
+                                    "end": 127
+                                  },
+                                  {
+                                    "kind": "STRING",
+                                    "start": 127,
+                                    "end": 133
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 133,
+                                    "end": 134
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 134,
+                                    "end": 135
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 135,
+                                    "end": 174,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 135,
+                                        "end": 136
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 136,
+                                        "end": 137
+                                      },
+                                      {
+                                        "kind": "LET_KW",
+                                        "start": 137,
+                                        "end": 140
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 140,
+                                        "end": 141
+                                      },
+                                      {
+                                        "kind": "MUT_KW",
+                                        "start": 141,
+                                        "end": 144
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 144,
+                                        "end": 145
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 145,
+                                        "end": 146
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 146,
+                                        "end": 147
+                                      },
+                                      {
+                                        "kind": "EQ",
+                                        "start": 147,
+                                        "end": 148
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 148,
+                                        "end": 149
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 149,
+                                        "end": 150
+                                      },
+                                      {
+                                        "kind": "DOT",
+                                        "start": 150,
+                                        "end": 151
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 151,
+                                        "end": 156
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 156,
+                                        "end": 158,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 156,
+                                            "end": 157
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 157,
+                                            "end": 158
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "SEMICOLON",
+                                        "start": 158,
+                                        "end": 159
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 159,
+                                        "end": 160
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 160,
+                                        "end": 161
+                                      },
+                                      {
+                                        "kind": "DOT",
+                                        "start": 161,
+                                        "end": 162
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 162,
+                                        "end": 166
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 166,
+                                        "end": 169,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 166,
+                                            "end": 167
+                                          },
+                                          {
+                                            "kind": "INT_NUMBER",
+                                            "start": 167,
+                                            "end": 168
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 168,
+                                            "end": 169
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "SEMICOLON",
+                                        "start": 169,
+                                        "end": 170
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 170,
+                                        "end": 171
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 171,
+                                        "end": 172
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 172,
+                                        "end": 173
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 173,
+                                        "end": 174
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "R_PAREN",
+                                    "start": 174,
+                                    "end": 175
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 175,
+                        "end": 176
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 176,
+                    "end": 177
+                  },
+                  {
+                    "kind": "R_CURLY",
+                    "start": 177,
+                    "end": 178
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "WHITESPACE",
+        "start": 178,
+        "end": 179
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/rs/avg_builtin.rs.json
+++ b/tests/json-ast/x/rs/avg_builtin.rs.json
@@ -1,0 +1,572 @@
+{
+  "file": {
+    "kind": "SOURCE_FILE",
+    "start": 0,
+    "end": 196,
+    "children": [
+      {
+        "kind": "FN",
+        "start": 0,
+        "end": 195,
+        "children": [
+          {
+            "kind": "COMMENT",
+            "start": 0,
+            "end": 67
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 67,
+            "end": 68
+          },
+          {
+            "kind": "FN_KW",
+            "start": 68,
+            "end": 70
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 70,
+            "end": 71
+          },
+          {
+            "kind": "NAME",
+            "start": 71,
+            "end": 75,
+            "children": [
+              {
+                "kind": "IDENT",
+                "start": 71,
+                "end": 75
+              }
+            ]
+          },
+          {
+            "kind": "PARAM_LIST",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "L_PAREN",
+                "start": 75,
+                "end": 76
+              },
+              {
+                "kind": "R_PAREN",
+                "start": 76,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 77,
+            "end": 78
+          },
+          {
+            "kind": "BLOCK_EXPR",
+            "start": 78,
+            "end": 195,
+            "children": [
+              {
+                "kind": "STMT_LIST",
+                "start": 78,
+                "end": 195,
+                "children": [
+                  {
+                    "kind": "L_CURLY",
+                    "start": 78,
+                    "end": 79
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 79,
+                    "end": 84
+                  },
+                  {
+                    "kind": "EXPR_STMT",
+                    "start": 84,
+                    "end": 193,
+                    "children": [
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 84,
+                        "end": 192,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 84,
+                            "end": 192,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 84,
+                                "end": 91,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 84,
+                                    "end": 91,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 84,
+                                        "end": 91,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 84,
+                                            "end": 91
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 91,
+                                "end": 92
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 92,
+                                "end": 192,
+                                "children": [
+                                  {
+                                    "kind": "L_PAREN",
+                                    "start": 92,
+                                    "end": 93
+                                  },
+                                  {
+                                    "kind": "STRING",
+                                    "start": 93,
+                                    "end": 97
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 97,
+                                    "end": 98
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 98,
+                                    "end": 99
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 99,
+                                    "end": 191,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 99,
+                                        "end": 100
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 100,
+                                        "end": 101
+                                      },
+                                      {
+                                        "kind": "LET_KW",
+                                        "start": 101,
+                                        "end": 104
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 104,
+                                        "end": 105
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 105,
+                                        "end": 108
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 108,
+                                        "end": 109
+                                      },
+                                      {
+                                        "kind": "EQ",
+                                        "start": 109,
+                                        "end": 110
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 110,
+                                        "end": 111
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 111,
+                                        "end": 114
+                                      },
+                                      {
+                                        "kind": "BANG",
+                                        "start": 114,
+                                        "end": 115
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 115,
+                                        "end": 124,
+                                        "children": [
+                                          {
+                                            "kind": "L_BRACK",
+                                            "start": 115,
+                                            "end": 116
+                                          },
+                                          {
+                                            "kind": "INT_NUMBER",
+                                            "start": 116,
+                                            "end": 117
+                                          },
+                                          {
+                                            "kind": "COMMA",
+                                            "start": 117,
+                                            "end": 118
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 118,
+                                            "end": 119
+                                          },
+                                          {
+                                            "kind": "INT_NUMBER",
+                                            "start": 119,
+                                            "end": 120
+                                          },
+                                          {
+                                            "kind": "COMMA",
+                                            "start": 120,
+                                            "end": 121
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 121,
+                                            "end": 122
+                                          },
+                                          {
+                                            "kind": "INT_NUMBER",
+                                            "start": 122,
+                                            "end": 123
+                                          },
+                                          {
+                                            "kind": "R_BRACK",
+                                            "start": 123,
+                                            "end": 124
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "SEMICOLON",
+                                        "start": 124,
+                                        "end": 125
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 125,
+                                        "end": 126
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 126,
+                                        "end": 129
+                                      },
+                                      {
+                                        "kind": "DOT",
+                                        "start": 129,
+                                        "end": 130
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 130,
+                                        "end": 134
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 134,
+                                        "end": 136,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 134,
+                                            "end": 135
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 135,
+                                            "end": 136
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "DOT",
+                                        "start": 136,
+                                        "end": 137
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 137,
+                                        "end": 140
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 140,
+                                        "end": 155,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 140,
+                                            "end": 141
+                                          },
+                                          {
+                                            "kind": "PIPE",
+                                            "start": 141,
+                                            "end": 142
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 142,
+                                            "end": 143
+                                          },
+                                          {
+                                            "kind": "PIPE",
+                                            "start": 143,
+                                            "end": 144
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 144,
+                                            "end": 145
+                                          },
+                                          {
+                                            "kind": "STAR",
+                                            "start": 145,
+                                            "end": 146
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 146,
+                                            "end": 147
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 147,
+                                            "end": 148
+                                          },
+                                          {
+                                            "kind": "AS_KW",
+                                            "start": 148,
+                                            "end": 150
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 150,
+                                            "end": 151
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 151,
+                                            "end": 154
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 154,
+                                            "end": 155
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "DOT",
+                                        "start": 155,
+                                        "end": 156
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 156,
+                                        "end": 159
+                                      },
+                                      {
+                                        "kind": "COLON",
+                                        "start": 159,
+                                        "end": 160
+                                      },
+                                      {
+                                        "kind": "COLON",
+                                        "start": 160,
+                                        "end": 161
+                                      },
+                                      {
+                                        "kind": "L_ANGLE",
+                                        "start": 161,
+                                        "end": 162
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 162,
+                                        "end": 165
+                                      },
+                                      {
+                                        "kind": "R_ANGLE",
+                                        "start": 165,
+                                        "end": 166
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 166,
+                                        "end": 168,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 166,
+                                            "end": 167
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 167,
+                                            "end": 168
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 168,
+                                        "end": 169
+                                      },
+                                      {
+                                        "kind": "SLASH",
+                                        "start": 169,
+                                        "end": 170
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 170,
+                                        "end": 171
+                                      },
+                                      {
+                                        "kind": "TOKEN_TREE",
+                                        "start": 171,
+                                        "end": 189,
+                                        "children": [
+                                          {
+                                            "kind": "L_PAREN",
+                                            "start": 171,
+                                            "end": 172
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 172,
+                                            "end": 175
+                                          },
+                                          {
+                                            "kind": "DOT",
+                                            "start": 175,
+                                            "end": 176
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 176,
+                                            "end": 179
+                                          },
+                                          {
+                                            "kind": "TOKEN_TREE",
+                                            "start": 179,
+                                            "end": 181,
+                                            "children": [
+                                              {
+                                                "kind": "L_PAREN",
+                                                "start": 179,
+                                                "end": 180
+                                              },
+                                              {
+                                                "kind": "R_PAREN",
+                                                "start": 180,
+                                                "end": 181
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 181,
+                                            "end": 182
+                                          },
+                                          {
+                                            "kind": "AS_KW",
+                                            "start": 182,
+                                            "end": 184
+                                          },
+                                          {
+                                            "kind": "WHITESPACE",
+                                            "start": 184,
+                                            "end": 185
+                                          },
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 185,
+                                            "end": 188
+                                          },
+                                          {
+                                            "kind": "R_PAREN",
+                                            "start": 188,
+                                            "end": 189
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 189,
+                                        "end": 190
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 190,
+                                        "end": 191
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "R_PAREN",
+                                    "start": 191,
+                                    "end": 192
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 192,
+                        "end": 193
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 193,
+                    "end": 194
+                  },
+                  {
+                    "kind": "R_CURLY",
+                    "start": 194,
+                    "end": 195
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "WHITESPACE",
+        "start": 195,
+        "end": 196
+      }
+    ]
+  }
+}

--- a/tests/json-ast/x/rs/basic_compare.rs.json
+++ b/tests/json-ast/x/rs/basic_compare.rs.json
@@ -1,0 +1,1002 @@
+{
+  "file": {
+    "kind": "SOURCE_FILE",
+    "start": 0,
+    "end": 257,
+    "children": [
+      {
+        "kind": "FN",
+        "start": 0,
+        "end": 256,
+        "children": [
+          {
+            "kind": "COMMENT",
+            "start": 0,
+            "end": 67
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 67,
+            "end": 68
+          },
+          {
+            "kind": "FN_KW",
+            "start": 68,
+            "end": 70
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 70,
+            "end": 71
+          },
+          {
+            "kind": "NAME",
+            "start": 71,
+            "end": 75,
+            "children": [
+              {
+                "kind": "IDENT",
+                "start": 71,
+                "end": 75
+              }
+            ]
+          },
+          {
+            "kind": "PARAM_LIST",
+            "start": 75,
+            "end": 77,
+            "children": [
+              {
+                "kind": "L_PAREN",
+                "start": 75,
+                "end": 76
+              },
+              {
+                "kind": "R_PAREN",
+                "start": 76,
+                "end": 77
+              }
+            ]
+          },
+          {
+            "kind": "WHITESPACE",
+            "start": 77,
+            "end": 78
+          },
+          {
+            "kind": "BLOCK_EXPR",
+            "start": 78,
+            "end": 256,
+            "children": [
+              {
+                "kind": "STMT_LIST",
+                "start": 78,
+                "end": 256,
+                "children": [
+                  {
+                    "kind": "L_CURLY",
+                    "start": 78,
+                    "end": 79
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 79,
+                    "end": 84
+                  },
+                  {
+                    "kind": "LET_STMT",
+                    "start": 84,
+                    "end": 106,
+                    "children": [
+                      {
+                        "kind": "LET_KW",
+                        "start": 84,
+                        "end": 87
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 87,
+                        "end": 88
+                      },
+                      {
+                        "kind": "IDENT_PAT",
+                        "start": 88,
+                        "end": 89,
+                        "children": [
+                          {
+                            "kind": "NAME",
+                            "start": 88,
+                            "end": 89,
+                            "children": [
+                              {
+                                "kind": "IDENT",
+                                "start": 88,
+                                "end": 89
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "COLON",
+                        "start": 89,
+                        "end": 90
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 90,
+                        "end": 91
+                      },
+                      {
+                        "kind": "PATH_TYPE",
+                        "start": 91,
+                        "end": 94,
+                        "children": [
+                          {
+                            "kind": "PATH",
+                            "start": 91,
+                            "end": 94,
+                            "children": [
+                              {
+                                "kind": "PATH_SEGMENT",
+                                "start": 91,
+                                "end": 94,
+                                "children": [
+                                  {
+                                    "kind": "NAME_REF",
+                                    "start": 91,
+                                    "end": 94,
+                                    "children": [
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 91,
+                                        "end": 94
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 94,
+                        "end": 95
+                      },
+                      {
+                        "kind": "EQ",
+                        "start": 95,
+                        "end": 96
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 96,
+                        "end": 97
+                      },
+                      {
+                        "kind": "PAREN_EXPR",
+                        "start": 97,
+                        "end": 105,
+                        "children": [
+                          {
+                            "kind": "L_PAREN",
+                            "start": 97,
+                            "end": 98
+                          },
+                          {
+                            "kind": "BIN_EXPR",
+                            "start": 98,
+                            "end": 104,
+                            "children": [
+                              {
+                                "kind": "LITERAL",
+                                "start": 98,
+                                "end": 100,
+                                "children": [
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 98,
+                                    "end": 100
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "WHITESPACE",
+                                "start": 100,
+                                "end": 101
+                              },
+                              {
+                                "kind": "MINUS",
+                                "start": 101,
+                                "end": 102
+                              },
+                              {
+                                "kind": "WHITESPACE",
+                                "start": 102,
+                                "end": 103
+                              },
+                              {
+                                "kind": "LITERAL",
+                                "start": 103,
+                                "end": 104,
+                                "children": [
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 103,
+                                    "end": 104
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "R_PAREN",
+                            "start": 104,
+                            "end": 105
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 105,
+                        "end": 106
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 106,
+                    "end": 111
+                  },
+                  {
+                    "kind": "LET_STMT",
+                    "start": 111,
+                    "end": 132,
+                    "children": [
+                      {
+                        "kind": "LET_KW",
+                        "start": 111,
+                        "end": 114
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 114,
+                        "end": 115
+                      },
+                      {
+                        "kind": "IDENT_PAT",
+                        "start": 115,
+                        "end": 116,
+                        "children": [
+                          {
+                            "kind": "NAME",
+                            "start": 115,
+                            "end": 116,
+                            "children": [
+                              {
+                                "kind": "IDENT",
+                                "start": 115,
+                                "end": 116
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "COLON",
+                        "start": 116,
+                        "end": 117
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 117,
+                        "end": 118
+                      },
+                      {
+                        "kind": "PATH_TYPE",
+                        "start": 118,
+                        "end": 121,
+                        "children": [
+                          {
+                            "kind": "PATH",
+                            "start": 118,
+                            "end": 121,
+                            "children": [
+                              {
+                                "kind": "PATH_SEGMENT",
+                                "start": 118,
+                                "end": 121,
+                                "children": [
+                                  {
+                                    "kind": "NAME_REF",
+                                    "start": 118,
+                                    "end": 121,
+                                    "children": [
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 118,
+                                        "end": 121
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 121,
+                        "end": 122
+                      },
+                      {
+                        "kind": "EQ",
+                        "start": 122,
+                        "end": 123
+                      },
+                      {
+                        "kind": "WHITESPACE",
+                        "start": 123,
+                        "end": 124
+                      },
+                      {
+                        "kind": "PAREN_EXPR",
+                        "start": 124,
+                        "end": 131,
+                        "children": [
+                          {
+                            "kind": "L_PAREN",
+                            "start": 124,
+                            "end": 125
+                          },
+                          {
+                            "kind": "BIN_EXPR",
+                            "start": 125,
+                            "end": 130,
+                            "children": [
+                              {
+                                "kind": "LITERAL",
+                                "start": 125,
+                                "end": 126,
+                                "children": [
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 125,
+                                    "end": 126
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "WHITESPACE",
+                                "start": 126,
+                                "end": 127
+                              },
+                              {
+                                "kind": "PLUS",
+                                "start": 127,
+                                "end": 128
+                              },
+                              {
+                                "kind": "WHITESPACE",
+                                "start": 128,
+                                "end": 129
+                              },
+                              {
+                                "kind": "LITERAL",
+                                "start": 129,
+                                "end": 130,
+                                "children": [
+                                  {
+                                    "kind": "INT_NUMBER",
+                                    "start": 129,
+                                    "end": 130
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "R_PAREN",
+                            "start": 130,
+                            "end": 131
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 131,
+                        "end": 132
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 132,
+                    "end": 137
+                  },
+                  {
+                    "kind": "EXPR_STMT",
+                    "start": 137,
+                    "end": 155,
+                    "children": [
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 137,
+                        "end": 154,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 137,
+                            "end": 154,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 137,
+                                "end": 144,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 137,
+                                    "end": 144,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 137,
+                                        "end": 144,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 137,
+                                            "end": 144
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 144,
+                                "end": 145
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 145,
+                                "end": 154,
+                                "children": [
+                                  {
+                                    "kind": "L_PAREN",
+                                    "start": 145,
+                                    "end": 146
+                                  },
+                                  {
+                                    "kind": "STRING",
+                                    "start": 146,
+                                    "end": 150
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 150,
+                                    "end": 151
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 151,
+                                    "end": 152
+                                  },
+                                  {
+                                    "kind": "IDENT",
+                                    "start": 152,
+                                    "end": 153
+                                  },
+                                  {
+                                    "kind": "R_PAREN",
+                                    "start": 153,
+                                    "end": 154
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 154,
+                        "end": 155
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 155,
+                    "end": 160
+                  },
+                  {
+                    "kind": "EXPR_STMT",
+                    "start": 160,
+                    "end": 205,
+                    "children": [
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 160,
+                        "end": 204,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 160,
+                            "end": 204,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 160,
+                                "end": 167,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 160,
+                                    "end": 167,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 160,
+                                        "end": 167,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 160,
+                                            "end": 167
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 167,
+                                "end": 168
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 168,
+                                "end": 204,
+                                "children": [
+                                  {
+                                    "kind": "L_PAREN",
+                                    "start": 168,
+                                    "end": 169
+                                  },
+                                  {
+                                    "kind": "STRING",
+                                    "start": 169,
+                                    "end": 173
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 173,
+                                    "end": 174
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 174,
+                                    "end": 175
+                                  },
+                                  {
+                                    "kind": "IF_KW",
+                                    "start": 175,
+                                    "end": 177
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 177,
+                                    "end": 178
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 178,
+                                    "end": 186,
+                                    "children": [
+                                      {
+                                        "kind": "L_PAREN",
+                                        "start": 178,
+                                        "end": 179
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 179,
+                                        "end": 180
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 180,
+                                        "end": 181
+                                      },
+                                      {
+                                        "kind": "EQ",
+                                        "start": 181,
+                                        "end": 182
+                                      },
+                                      {
+                                        "kind": "EQ",
+                                        "start": 182,
+                                        "end": 183
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 183,
+                                        "end": 184
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 184,
+                                        "end": 185
+                                      },
+                                      {
+                                        "kind": "R_PAREN",
+                                        "start": 185,
+                                        "end": 186
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 186,
+                                    "end": 187
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 187,
+                                    "end": 192,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 187,
+                                        "end": 188
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 188,
+                                        "end": 189
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 189,
+                                        "end": 190
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 190,
+                                        "end": 191
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 191,
+                                        "end": 192
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 192,
+                                    "end": 193
+                                  },
+                                  {
+                                    "kind": "ELSE_KW",
+                                    "start": 193,
+                                    "end": 197
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 197,
+                                    "end": 198
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 198,
+                                    "end": 203,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 198,
+                                        "end": 199
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 199,
+                                        "end": 200
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 200,
+                                        "end": 201
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 201,
+                                        "end": 202
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 202,
+                                        "end": 203
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "R_PAREN",
+                                    "start": 203,
+                                    "end": 204
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 204,
+                        "end": 205
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 205,
+                    "end": 210
+                  },
+                  {
+                    "kind": "EXPR_STMT",
+                    "start": 210,
+                    "end": 254,
+                    "children": [
+                      {
+                        "kind": "MACRO_EXPR",
+                        "start": 210,
+                        "end": 253,
+                        "children": [
+                          {
+                            "kind": "MACRO_CALL",
+                            "start": 210,
+                            "end": 253,
+                            "children": [
+                              {
+                                "kind": "PATH",
+                                "start": 210,
+                                "end": 217,
+                                "children": [
+                                  {
+                                    "kind": "PATH_SEGMENT",
+                                    "start": 210,
+                                    "end": 217,
+                                    "children": [
+                                      {
+                                        "kind": "NAME_REF",
+                                        "start": 210,
+                                        "end": 217,
+                                        "children": [
+                                          {
+                                            "kind": "IDENT",
+                                            "start": 210,
+                                            "end": 217
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "kind": "BANG",
+                                "start": 217,
+                                "end": 218
+                              },
+                              {
+                                "kind": "TOKEN_TREE",
+                                "start": 218,
+                                "end": 253,
+                                "children": [
+                                  {
+                                    "kind": "L_PAREN",
+                                    "start": 218,
+                                    "end": 219
+                                  },
+                                  {
+                                    "kind": "STRING",
+                                    "start": 219,
+                                    "end": 223
+                                  },
+                                  {
+                                    "kind": "COMMA",
+                                    "start": 223,
+                                    "end": 224
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 224,
+                                    "end": 225
+                                  },
+                                  {
+                                    "kind": "IF_KW",
+                                    "start": 225,
+                                    "end": 227
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 227,
+                                    "end": 228
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 228,
+                                    "end": 235,
+                                    "children": [
+                                      {
+                                        "kind": "L_PAREN",
+                                        "start": 228,
+                                        "end": 229
+                                      },
+                                      {
+                                        "kind": "IDENT",
+                                        "start": 229,
+                                        "end": 230
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 230,
+                                        "end": 231
+                                      },
+                                      {
+                                        "kind": "L_ANGLE",
+                                        "start": 231,
+                                        "end": 232
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 232,
+                                        "end": 233
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 233,
+                                        "end": 234
+                                      },
+                                      {
+                                        "kind": "R_PAREN",
+                                        "start": 234,
+                                        "end": 235
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 235,
+                                    "end": 236
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 236,
+                                    "end": 241,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 236,
+                                        "end": 237
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 237,
+                                        "end": 238
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 238,
+                                        "end": 239
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 239,
+                                        "end": 240
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 240,
+                                        "end": 241
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 241,
+                                    "end": 242
+                                  },
+                                  {
+                                    "kind": "ELSE_KW",
+                                    "start": 242,
+                                    "end": 246
+                                  },
+                                  {
+                                    "kind": "WHITESPACE",
+                                    "start": 246,
+                                    "end": 247
+                                  },
+                                  {
+                                    "kind": "TOKEN_TREE",
+                                    "start": 247,
+                                    "end": 252,
+                                    "children": [
+                                      {
+                                        "kind": "L_CURLY",
+                                        "start": 247,
+                                        "end": 248
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 248,
+                                        "end": 249
+                                      },
+                                      {
+                                        "kind": "INT_NUMBER",
+                                        "start": 249,
+                                        "end": 250
+                                      },
+                                      {
+                                        "kind": "WHITESPACE",
+                                        "start": 250,
+                                        "end": 251
+                                      },
+                                      {
+                                        "kind": "R_CURLY",
+                                        "start": 251,
+                                        "end": 252
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "kind": "R_PAREN",
+                                    "start": 252,
+                                    "end": 253
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "SEMICOLON",
+                        "start": 253,
+                        "end": 254
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "WHITESPACE",
+                    "start": 254,
+                    "end": 255
+                  },
+                  {
+                    "kind": "R_CURLY",
+                    "start": 255,
+                    "end": 256
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "WHITESPACE",
+        "start": 256,
+        "end": 257
+      }
+    ]
+  }
+}

--- a/tools/json-ast/x/rs/inspect.go
+++ b/tools/json-ast/x/rs/inspect.go
@@ -1,0 +1,142 @@
+package rs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Node represents a node in the Rust syntax tree.
+type Node struct {
+	Kind     string  `json:"kind"`
+	Start    int     `json:"start"`
+	End      int     `json:"end"`
+	Children []*Node `json:"children,omitempty"`
+}
+
+// Program represents a parsed Rust source file.
+type Program struct {
+	File *Node `json:"file"`
+}
+
+// Inspect parses the given Rust source code using rust-analyzer and returns
+// a Program describing its syntax tree.
+func Inspect(src string) (*Program, error) {
+	if _, err := exec.LookPath("rust-analyzer"); err != nil {
+		return nil, fmt.Errorf("rust-analyzer not installed: %w", err)
+	}
+	out, err := runRustAnalyzerParse("rust-analyzer", src)
+	if err != nil {
+		return nil, err
+	}
+	tree := parseTree(out)
+	return &Program{File: tree}, nil
+}
+
+func runRustAnalyzerParse(cmd, src string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, cmd, "parse")
+	c.Stdin = strings.NewReader(src)
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return "", fmt.Errorf("%v: %s", err, msg)
+		}
+		return "", err
+	}
+	return stdout.String(), nil
+}
+
+type rawNode struct {
+	kind     string
+	start    int
+	end      int
+	children []*rawNode
+}
+
+func parseLine(line string) (indent int, kind string, start, end int, ok bool) {
+	i := 0
+	for i < len(line) && line[i] == ' ' {
+		i++
+	}
+	indent = i / 2
+	rest := line[i:]
+	at := strings.IndexByte(rest, '@')
+	if at < 0 {
+		return
+	}
+	kind = rest[:at]
+	rest = rest[at+1:]
+	dots := strings.Index(rest, "..")
+	if dots < 0 {
+		return
+	}
+	s, err := strconv.Atoi(rest[:dots])
+	if err != nil {
+		return
+	}
+	start = s
+	rest = rest[dots+2:]
+	endStr := rest
+	if sp := strings.IndexByte(rest, ' '); sp >= 0 {
+		endStr = rest[:sp]
+	}
+	e, err := strconv.Atoi(endStr)
+	if err != nil {
+		return
+	}
+	end = e
+	ok = true
+	return
+}
+
+func parseTree(out string) *Node {
+	root := &rawNode{kind: "ROOT"}
+	stack := []*rawNode{root}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent, kind, start, end, ok := parseLine(line)
+		if !ok {
+			continue
+		}
+		n := &rawNode{kind: kind, start: start, end: end}
+		for len(stack) > indent+1 {
+			stack = stack[:len(stack)-1]
+		}
+		parent := stack[len(stack)-1]
+		parent.children = append(parent.children, n)
+		stack = append(stack, n)
+	}
+	if len(root.children) > 0 {
+		return toNode(root.children[0])
+	}
+	return toNode(root)
+}
+
+func toNode(n *rawNode) *Node {
+	if n == nil {
+		return nil
+	}
+	out := &Node{Kind: n.kind, Start: n.start, End: n.end}
+	for _, c := range n.children {
+		out.Children = append(out.Children, toNode(c))
+	}
+	return out
+}
+
+// MarshalJSON implements json.Marshaler for Program, to ensure stable output.
+func (p *Program) MarshalJSON() ([]byte, error) {
+	type Alias Program
+	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(p)})
+}

--- a/tools/json-ast/x/rs/inspect_test.go
+++ b/tools/json-ast/x/rs/inspect_test.go
@@ -1,0 +1,96 @@
+//go:build slow
+
+package rs_test
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	rs "mochi/tools/json-ast/x/rs"
+)
+
+var update = flag.Bool("update", false, "update golden files")
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("cannot determine working directory")
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("go.mod not found")
+	return ""
+}
+
+func shouldUpdate() bool {
+	f := flag.Lookup("update")
+	return f != nil && f.Value.String() == "true"
+}
+
+func ensureRustAnalyzer(t *testing.T) {
+	if _, err := exec.LookPath("rust-analyzer"); err != nil {
+		t.Skip("rust-analyzer not installed")
+	}
+}
+
+func TestInspect_Golden(t *testing.T) {
+	ensureRustAnalyzer(t)
+	root := repoRoot(t)
+	srcDir := filepath.Join(root, "tests", "transpiler", "x", "rs")
+	outDir := filepath.Join(root, "tests", "json-ast", "x", "rs")
+	os.MkdirAll(outDir, 0o755)
+
+	files, err := filepath.Glob(filepath.Join(srcDir, "*.rs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(files)
+
+	for _, src := range files {
+		name := strings.TrimSuffix(filepath.Base(src), ".rs")
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(src)
+			if err != nil {
+				t.Fatalf("read src: %v", err)
+			}
+			prog, err := rs.Inspect(string(data))
+			if err != nil {
+				t.Fatalf("inspect: %v", err)
+			}
+			out, err := json.MarshalIndent(prog, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			out = append(out, '\n')
+			goldenPath := filepath.Join(outDir, name+".rs.json")
+			if shouldUpdate() {
+				if err := os.WriteFile(goldenPath, out, 0644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+			}
+			want, err := os.ReadFile(goldenPath)
+			if err != nil {
+				t.Skip("missing golden")
+				return
+			}
+			if string(out) != string(want) {
+				t.Fatalf("golden mismatch\n--- Got ---\n%s\n--- Want ---\n%s", out, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement Rust parsing via `rust-analyzer` in `tools/json-ast/x/rs`
- add golden tests for Rust AST inspection
- store a few generated golden files

## Testing
- `go test ./tools/json-ast/x/rs -tags slow`
- `go test ./... | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688918a887208320a63dc7d267a964da